### PR TITLE
feat: base definition of represent_as

### DIFF
--- a/src/coordinax/__init__.py
+++ b/src/coordinax/__init__.py
@@ -18,6 +18,7 @@ from . import (
     _d4,
     _dn,
     _exceptions,
+    _funcs,
     _transform,
     _typing,
     _utils,
@@ -33,6 +34,7 @@ from ._d3 import *
 from ._d4 import *
 from ._dn import *
 from ._exceptions import *
+from ._funcs import *
 from ._transform import *
 from ._typing import *
 from ._utils import *
@@ -40,6 +42,7 @@ from ._version import version as __version__
 from .setup_package import RUNTIME_TYPECHECKER
 
 __all__ = ["__version__", "operators"]
+__all__ += _funcs.__all__
 __all__ += _base.__all__
 __all__ += _base_pos.__all__
 __all__ += _base_vel.__all__
@@ -73,5 +76,6 @@ del (
     _d3,
     _d4,
     _dn,
+    _funcs,
     RUNTIME_TYPECHECKER,
 )

--- a/src/coordinax/_funcs.py
+++ b/src/coordinax/_funcs.py
@@ -1,0 +1,13 @@
+"""Copyright (c) 2023 coordinax maintainers. All rights reserved."""
+
+__all__ = ["represent_as"]
+
+from typing import Any
+
+from plum import dispatch
+
+
+@dispatch.abstract  # type: ignore[misc]
+def represent_as(current: Any, target: type[Any], /, **kwargs: Any) -> Any:
+    """Transform the current vector to the target vector."""
+    raise NotImplementedError

--- a/src/coordinax/_funcs.py
+++ b/src/coordinax/_funcs.py
@@ -10,4 +10,4 @@ from plum import dispatch
 @dispatch.abstract  # type: ignore[misc]
 def represent_as(current: Any, target: type[Any], /, **kwargs: Any) -> Any:
     """Transform the current vector to the target vector."""
-    raise NotImplementedError
+    raise NotImplementedError  # pragma: no cover


### PR DESCRIPTION
Users will see no practical change as represent_as is defined in multiple places and managed by multiple dispatch.