### PR TITLE
refactor: move _cartesian_cls to subclasses

### DIFF
--- a/src/coordinax/_base.py
+++ b/src/coordinax/_base.py
@@ -52,26 +52,6 @@ class AbstractVector(eqx.Module):  # type: ignore[misc]
     types. All fields of the vector are expected to be components of the vector.
     """
 
-    @classproperty
-    @classmethod
-    @abstractmethod
-    def _cartesian_cls(cls) -> type["AbstractVector"]:
-        """Return the corresponding Cartesian vector class.
-
-        Examples
-        --------
-        >>> from coordinax import RadialPosition, SphericalPosition
-
-        >>> RadialPosition._cartesian_cls
-        <class 'coordinax...CartesianPosition1D'>
-
-        >>> SphericalPosition._cartesian_cls
-        <class 'coordinax...CartesianPosition3D'>
-
-        """
-        # TODO: something nicer than this for getting the corresponding class
-        raise NotImplementedError
-
     # ---------------------------------------------------------------
     # Constructors
 

--- a/src/coordinax/_base_acc.py
+++ b/src/coordinax/_base_acc.py
@@ -39,6 +39,26 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
     @classproperty
     @classmethod
     @abstractmethod
+    def _cartesian_cls(cls) -> type["AbstractVector"]:
+        """Return the corresponding Cartesian vector class.
+
+        Examples
+        --------
+        >>> from coordinax import CartesianAcceleration3D, SphericalAcceleration
+
+        >>> CartesianAcceleration3D._cartesian_cls
+        <class 'coordinax...CartesianAcceleration3D'>
+
+        >>> SphericalAcceleration._cartesian_cls
+        <class 'coordinax...CartesianAcceleration3D'>
+
+        """
+        # TODO: something nicer than this for getting the corresponding class
+        raise NotImplementedError
+
+    @classproperty
+    @classmethod
+    @abstractmethod
     def integral_cls(cls) -> type[AbstractVelocity]:
         """Return the corresponding vector class.
 

--- a/src/coordinax/_base_pos.py
+++ b/src/coordinax/_base_pos.py
@@ -43,6 +43,26 @@ class AbstractPosition(AbstractVector):  # pylint: disable=abstract-method
     @classproperty
     @classmethod
     @abstractmethod
+    def _cartesian_cls(cls) -> type["AbstractVector"]:
+        """Return the corresponding Cartesian vector class.
+
+        Examples
+        --------
+        >>> from coordinax import RadialPosition, SphericalPosition
+
+        >>> RadialPosition._cartesian_cls
+        <class 'coordinax...CartesianPosition1D'>
+
+        >>> SphericalPosition._cartesian_cls
+        <class 'coordinax...CartesianPosition3D'>
+
+        """
+        # TODO: something nicer than this for getting the corresponding class
+        raise NotImplementedError
+
+    @classproperty
+    @classmethod
+    @abstractmethod
     def differential_cls(cls) -> type["AbstractVelocity"]:
         """Return the corresponding differential vector class.
 

--- a/src/coordinax/_base_vel.py
+++ b/src/coordinax/_base_vel.py
@@ -37,6 +37,26 @@ class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
     @classproperty
     @classmethod
     @abstractmethod
+    def _cartesian_cls(cls) -> type["AbstractVector"]:
+        """Return the corresponding Cartesian vector class.
+
+        Examples
+        --------
+        >>> from coordinax import RadialVelocity, SphericalVelocity
+
+        >>> RadialVelocity._cartesian_cls
+        <class 'coordinax...CartesianVelocity1D'>
+
+        >>> SphericalVelocity._cartesian_cls
+        <class 'coordinax...CartesianVelocity3D'>
+
+        """
+        # TODO: something nicer than this for getting the corresponding class
+        raise NotImplementedError
+
+    @classproperty
+    @classmethod
+    @abstractmethod
     def integral_cls(cls) -> type["AbstractPosition"]:
         """Return the corresponding vector class.
 


### PR DESCRIPTION
It’s not a part of the abstract base class.