### PR TITLE
feat: quaxify

### DIFF
--- a/src/coordinax/_base.py
+++ b/src/coordinax/_base.py
@@ -17,10 +17,12 @@ from typing_extensions import Never
 
 import astropy.units as u
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import Device
 from plum import dispatch
+from quax import ArrayValue
 
 import quaxed.array_api as xp
 from dataclassish import field_items, field_values, replace
@@ -45,7 +47,7 @@ class ToUnitsOptions(Enum):
 # ===================================================================
 
 
-class AbstractVector(eqx.Module):  # type: ignore[misc]
+class AbstractVector(ArrayValue):  # type: ignore[misc]
     """Base class for all vector types.
 
     A vector is a collection of components that can be represented in different
@@ -142,6 +144,18 @@ class AbstractVector(eqx.Module):  # type: ignore[misc]
         )
         comps = {f.name: obj[..., i] for i, f in enumerate(fields(cls))}
         return cls(**comps)
+
+    # ===============================================================
+    # Quax
+
+    def materialise(self) -> None:
+        msg = "Refusing to materialise `Quantity`."
+        raise RuntimeError(msg)
+
+    @abstractmethod
+    def aval(self) -> jax.core.ShapedArray:
+        """Return the vector as a JAX array."""
+        raise NotImplementedError  # pragma: no cover
 
     # ===============================================================
     # Array API

--- a/src/coordinax/_base.py
+++ b/src/coordinax/_base.py
@@ -12,8 +12,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import fields
 from enum import Enum
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
-from typing_extensions import Never
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeVar
 
 import astropy.units as u
 import equinox as eqx
@@ -371,7 +370,7 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
     def __rmul__(self: "AbstractVector", other: Any) -> Any:
         return NotImplemented
 
-    def __setitem__(self, k: Any, v: Any) -> Never:
+    def __setitem__(self, k: Any, v: Any) -> NoReturn:
         msg = f"{type(self).__name__} is immutable."
         raise TypeError(msg)
 

--- a/src/coordinax/_base.py
+++ b/src/coordinax/_base.py
@@ -531,17 +531,13 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         Examples
         --------
-        We assume the following imports:
+        >>> import coordinax as cx
 
-        >>> from coordinax import CartesianPosition2D, SphericalPosition, RadialVelocity
-
-        We can get the components of a vector:
-
-        >>> CartesianPosition2D.components
+        >>> cx.CartesianPosition2D.components
         ('x', 'y')
-        >>> SphericalPosition.components
+        >>> cx.SphericalPosition.components
         ('r', 'theta', 'phi')
-        >>> RadialVelocity.components
+        >>> cx.RadialVelocity.components
         ('d_r',)
 
         """
@@ -569,7 +565,19 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
     @property
     def sizes(self) -> MappingProxyType[str, int]:
-        """Get the sizes of the vector's components."""
+        """Get the sizes of the vector's components.
+
+        Examples
+        --------
+        >>> import coordinax as cx
+
+        >>> cx.CartesianPosition2D.constructor(Quantity([1, 2], "m")).sizes
+        mappingproxy({'x': 1, 'y': 1})
+
+        >>> cx.CartesianPosition2D.constructor(Quantity([[1, 2], [1, 2]], "m")).sizes
+        mappingproxy({'x': 2, 'y': 2})
+
+        """
         return MappingProxyType({k: v.size for k, v in field_items(self)})
 
     # ===============================================================

--- a/src/coordinax/_base_acc.py
+++ b/src/coordinax/_base_acc.py
@@ -77,6 +77,13 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
         raise NotImplementedError
 
     # ===============================================================
+    # Quax
+
+    def aval(self) -> jax.core.ShapedArray:
+        """Return the vector as a JAX array."""
+        raise NotImplementedError
+
+    # ===============================================================
     # Unary operations
 
     def __neg__(self) -> "Self":

--- a/src/coordinax/_base_pos.py
+++ b/src/coordinax/_base_pos.py
@@ -10,15 +10,18 @@ from functools import partial
 from inspect import isabstract
 from typing import TYPE_CHECKING, Any, TypeVar
 
+import equinox as eqx
 import jax
-from jax import lax
 from jaxtyping import ArrayLike
 from plum import convert, dispatch
 from quax import quaxify, register
 
+import quaxed.array_api as xp
+import quaxed.lax as qlax
 from dataclassish import field_items
 from unxt import Quantity
 
+import coordinax._typing as ct
 from ._base import AbstractVector
 from ._utils import classproperty
 
@@ -96,7 +99,13 @@ class AbstractPosition(AbstractVector):  # pylint: disable=abstract-method
 
         >>> vec = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "m"))
         >>> vec.aval()
-        ShapedArray(float32[3])
+        ConcreteArray([1. 2. 3.], dtype=float32)
+
+        >>> vec = cx.CartesianPosition3D.constructor(
+        ...     Quantity([[1, 2, 3], [4, 5, 6]], "m"))
+        >>> vec.aval()
+        ConcreteArray([[1. 2. 3.]
+                       [4. 5. 6.]], dtype=float32)
 
         """
         return jax.core.get_aval(
@@ -152,13 +161,13 @@ class AbstractPosition(AbstractVector):  # pylint: disable=abstract-method
     def __mul__(
         self: "AbstractPosition", other: ArrayLike
     ) -> "AbstractPosition":  # TODO: use Self
-        return replace(self, **{k: v * other for k, v in field_items(self)})
+        return qlax.mul(self, other)
 
     @AbstractVector.__rmul__.dispatch  # type: ignore[misc]
     def __rmul__(
         self: "AbstractPosition", other: ArrayLike
     ) -> "AbstractPosition":  # TODO: use Self
-        return replace(self, **{k: other * v for k, v in field_items(self)})
+        return qlax.mul(other, self)
 
     @AbstractVector.__truediv__.dispatch  # type: ignore[misc]
     def __truediv__(
@@ -220,8 +229,8 @@ class AbstractPosition(AbstractVector):  # pylint: disable=abstract-method
 
         return represent_as(self, target, **kwargs)
 
-    @partial(jax.jit)
-    def norm(self) -> Quantity["length"]:
+    @partial(jax.jit, inline=True)
+    def norm(self) -> ct.BatchableLength:
         """Return the norm of the vector.
 
         Returns
@@ -231,18 +240,30 @@ class AbstractPosition(AbstractVector):  # pylint: disable=abstract-method
 
         Examples
         --------
-        We assume the following imports:
         >>> from unxt import Quantity
-        >>> from coordinax import CartesianPosition3D
+        >>> import coordinax as cx
 
-        We can compute the norm of a vector
-        >>> x, y, z = Quantity(1, "meter"), Quantity(2, "meter"), Quantity(3, "meter")
-        >>> vec = CartesianPosition3D(x=x, y=y, z=z)
-        >>> vec.norm()
+        >>> from unxt import Quantity
+        >>> from coordinax import CartesianPosition1D, RadialPosition
+
+        >>> v = cx.CartesianPosition1D.constructor(Quantity([-1], "kpc"))
+        >>> v.norm()
+        Quantity['length'](Array(1., dtype=float32), unit='kpc')
+
+        >>> v = cx.CartesianPosition2D.constructor(Quantity([3, 4], "kpc"))
+        >>> v.norm()
+        Quantity['length'](Array(5., dtype=float32), unit='kpc')
+
+        >>> v = cx.PolarPosition(r=Quantity(3, "kpc"), phi=Quantity(90, "deg"))
+        >>> v.norm()
+        Quantity['length'](Array(3., dtype=float32), unit='kpc')
+
+        >>> v = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "m"))
+        >>> v.norm()
         Quantity['length'](Array(3.7416575, dtype=float32), unit='m')
 
         """
-        return self.represent_as(self._cartesian_cls).norm()
+        return xp.linalg.vector_norm(self, axis=-1)
 
 
 # ===================================================================
@@ -265,7 +286,100 @@ def normalize_vector(x: AbstractPosition, /) -> AbstractPosition:
     raise NotImplementedError  # pragma: no cover
 
 
-@register(lax.reshape_p)  # type: ignore[misc]
+# ------------------------------------------------
+
+
+@register(jax.lax.mul_p)  # type: ignore[misc]
+def _mul_p_vq(lhs: ArrayLike, rhs: AbstractPosition, /) -> AbstractPosition:
+    """Scale a position by a scalar.
+
+    Examples
+    --------
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
+    >>> import quaxed.numpy as jnp
+
+    >>> vec = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "m"))
+    >>> jnp.multiply(2, vec)
+    CartesianPosition3D(
+      x=Quantity[...](value=f32[], unit=Unit("m")),
+      y=Quantity[...](value=f32[], unit=Unit("m")),
+      z=Quantity[...](value=f32[], unit=Unit("m"))
+    )
+
+    """
+    # Validation
+    lhs = eqx.error_if(
+        lhs, any(jax.numpy.shape(lhs)), f"must be a scalar, not {type(lhs)}"
+    )
+    rhs = eqx.error_if(
+        rhs,
+        isinstance(rhs, rhs._cartesian_cls),  # noqa: SLF001
+        "must register a Cartesian-specific dispatch",
+    )
+
+    rc = rhs.represent_as(rhs._cartesian_cls)  # noqa: SLF001
+    nr = qlax.mul(lhs, rc)
+    return nr.represent_as(type(rhs))
+
+
+@register(jax.lax.mul_p)  # type: ignore[misc]
+def _mul_p_qv(lhs: AbstractPosition, rhs: ArrayLike, /) -> AbstractPosition:
+    """Scale a position by a scalar.
+
+    Examples
+    --------
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
+    >>> import quaxed.numpy as jnp
+
+    >>> vec = cx.CartesianPosition3D.constructor(Quantity([1, 2, 3], "m"))
+    >>> jnp.multiply(vec, 2)
+    CartesianPosition3D(
+      x=Quantity[...](value=f32[], unit=Unit("m")),
+      y=Quantity[...](value=f32[], unit=Unit("m")),
+      z=Quantity[...](value=f32[], unit=Unit("m"))
+    )
+
+    """
+    return qlax.mul(rhs, lhs)  # re-dispatch on the other side
+
+
+@register(jax.lax.mul_p)  # type: ignore[misc]
+def _mul_p_qq(lhs: AbstractPosition, rhs: AbstractPosition, /) -> Quantity:
+    """Multiply two positions.
+
+    This is required to take the dot product of two vectors.
+
+    Examples
+    --------
+    >>> import quaxed.array_api as jnp
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
+
+    >>> vec = cx.CartesianPosition3D(
+    ...     x=Quantity([1, 2, 3], "m"),
+    ...     y=Quantity([4, 5, 6], "m"),
+    ...     z=Quantity([7, 8, 9], "m"))
+
+    >>> jnp.multiply(vec, vec)  # element-wise multiplication
+    Quantity['area'](Array([[ 1., 16., 49.],
+       [ 4., 25., 64.],
+       [ 9., 36., 81.]], dtype=float32), unit='m2')
+
+    >>> jnp.linalg.vector_norm(vec, axis=-1)
+    Quantity['length'](Array([ 8.124039,  9.643651, 11.224972], dtype=float32), unit='m')
+
+    """  # noqa: E501
+    lq = convert(lhs.represent_as(lhs._cartesian_cls), Quantity)  # noqa: SLF001
+    rq = convert(rhs.represent_as(rhs._cartesian_cls), Quantity)  # noqa: SLF001
+    return qlax.mul(lq, rq)  # re-dispatch to Quantities
+
+
+# ------------------------------------------------
+
+
+@register(jax.lax.reshape_p)  # type: ignore[misc]
 def _reshape_p(
     operand: AbstractPosition, *, new_sizes: tuple[int, ...], **kwargs: Any
 ) -> AbstractPosition:
@@ -282,19 +396,20 @@ def _reshape_p(
     ...                              z=Quantity([7, 8, 9], "m"))
     >>> jnp.reshape(vec, shape=(3, 1, 3))  # (n_components *shape)
     CartesianPosition3D(
-      x=Quantity[PhysicalType('length')](value=f32[1,3], unit=Unit("m")),
-      y=Quantity[PhysicalType('length')](value=f32[1,3], unit=Unit("m")),
-      z=Quantity[PhysicalType('length')](value=f32[1,3], unit=Unit("m"))
+      x=Quantity[PhysicalType('length')](value=f32[1,1,3], unit=Unit("m")),
+      y=Quantity[PhysicalType('length')](value=f32[1,1,3], unit=Unit("m")),
+      z=Quantity[PhysicalType('length')](value=f32[1,1,3], unit=Unit("m"))
     )
 
     """
     # Adjust the sizes for the components
-    new_sizes = new_sizes[1:]
+    new_sizes = (new_sizes[0] // len(operand.components), *new_sizes[1:])
+    # TODO: check integer division
     # Reshape the components
     return replace(
         operand,
         **{
-            k: quaxify(lax.reshape_p.bind)(v, new_sizes=new_sizes, **kwargs)
+            k: quaxify(jax.lax.reshape_p.bind)(v, new_sizes=new_sizes, **kwargs)
             for k, v in field_items(operand)
         },
     )

--- a/src/coordinax/_base_vel.py
+++ b/src/coordinax/_base_vel.py
@@ -94,6 +94,13 @@ class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
         raise NotImplementedError
 
     # ===============================================================
+    # Quax
+
+    def aval(self) -> jax.core.ShapedArray:
+        """Return the vector as a JAX array."""
+        raise NotImplementedError
+
+    # ===============================================================
     # Unary operations
 
     def __neg__(self) -> "Self":

--- a/src/coordinax/_dn/builtin.py
+++ b/src/coordinax/_dn/builtin.py
@@ -12,6 +12,8 @@ from typing_extensions import override
 
 import equinox as eqx
 import jax
+from jaxtyping import ArrayLike
+from quax import register
 
 import quaxed.array_api as xp
 from unxt import Quantity
@@ -178,6 +180,19 @@ class CartesianPositionND(AbstractPositionND):
 
         """
         return xp.linalg.vector_norm(self.q, axis=-1)
+
+
+# ===================================================================
+
+
+@register(jax.lax.mul_p)  # type: ignore[misc]
+def _mul_p(lhs: ArrayLike, rhs: CartesianPositionND, /) -> CartesianPositionND:
+    """Scale a position by a scalar."""
+    # Validation
+    lhs = eqx.error_if(lhs, not jax.numpy.isscalar(lhs), "must be a scalar")
+
+    # Scale the components
+    return replace(rhs, q=lhs * rhs.q)
 
 
 ##############################################################################

--- a/src/coordinax/_space.py
+++ b/src/coordinax/_space.py
@@ -10,6 +10,7 @@ from typing_extensions import override
 
 import astropy.units as u
 import equinox as eqx
+import jax
 from astropy.units import PhysicalType as Dimension, get_physical_type
 from immutable_map_jax import ImmutableMap
 from jax import Device
@@ -134,6 +135,13 @@ class Space(ImmutableMap[Dimension, AbstractVector], AbstractVector):  # type: i
             key = _get_dimension_name(key)
 
         return super().__getitem__(key)
+
+    # ===============================================================
+    # Quax
+
+    def aval(self) -> jax.core.ShapedArray:
+        """Return the vector as a JAX array."""
+        raise NotImplementedError  # TODO: implement this
 
     # ===============================================================
     # Array API


### PR DESCRIPTION
Refactor to be quad-based classes. This enables using jax functions on vectors, e.g. taking `vector_norm`!
Lot's of followup work to do for other numpy functions.