### PR TITLE
build: bump to alpha

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@
     { name = "Nathaniel Starkman", email = "nstarman@users.noreply.github.com" },
   ]
   classifiers = [
-    "Development Status :: 1 - Planning",
+    "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
Probably move to beta once more quax primitives are registered. Then we'll have good support for dotting together vectors, etc.