### PR TITLE
feat: rename pos vel acc

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,22 @@ import coordinax as cx
 import jax.numpy as jnp
 from unxt import Quantity
 
-q = cx.CartesianPosition3D(
+q = cx.CartesianPos3D(
     x=Quantity(jnp.arange(0, 10.0), "km"),
     y=Quantity(jnp.arange(5, 15.0), "km"),
     z=Quantity(jnp.arange(10, 20.0), "km"),
 )
 print(q)
-# <CartesianPosition3D (x[km], y[km], z[km])
+# <CartesianPos3D (x[km], y[km], z[km])
 #     [[ 0.  5. 10.]
 #      [ 1.  6. 11.]
 #      ...
 #      [ 8. 13. 18.]
 #      [ 9. 14. 19.]]>
 
-q2 = cx.represent_as(q, cx.SphericalPosition)
+q2 = cx.represent_as(q, cx.SphericalPos)
 print(q2)
-# <SphericalPosition (r[km], theta[rad], phi[rad])
+# <SphericalPos (r[km], theta[rad], phi[rad])
 #     [[11.18   0.464  1.571]
 #      [12.57   0.505  1.406]
 #      ...

--- a/README.md
+++ b/README.md
@@ -53,22 +53,22 @@ print(q2)
 #      [23.601  0.703  1.019]
 #      [25.259  0.719  0.999]]>
 
-p = cx.CartesianVelocity3D(
+p = cx.CartesianVel3D(
     d_x=Quantity(jnp.arange(0, 10.0), "m/s"),
     d_y=Quantity(jnp.arange(5, 15.0), "m/s"),
     d_z=Quantity(jnp.arange(10, 20.0), "m/s"),
 )
 print(p)
-# <CartesianVelocity3D (d_x[m / s], d_y[m / s], d_z[m / s])
+# <CartesianVel3D (d_x[m / s], d_y[m / s], d_z[m / s])
 #     [[ 0.  5. 10.]
 #      [ 1.  6. 11.]
 #      ...
 #      [ 8. 13. 18.]
 #      [ 9. 14. 19.]]>
 
-p2 = cx.represent_as(p, cx.SphericalVelocity, q)
+p2 = cx.represent_as(p, cx.SphericalVel, q)
 print(p2)
-# <SphericalVelocity (d_r[m / s], d_theta[m rad / (km s)], d_phi[m rad / (km s)])
+# <SphericalVel (d_r[m / s], d_theta[m rad / (km s)], d_phi[m rad / (km s)])
 #     [[ 1.118e+01 -3.886e-16  0.000e+00]
 #      [ 1.257e+01 -1.110e-16  0.000e+00]
 #      ...

--- a/src/coordinax/_interop/coordinax_interop_astropy/constructors.py
+++ b/src/coordinax/_interop/coordinax_interop_astropy/constructors.py
@@ -36,9 +36,9 @@ def from_(
     >>> import coordinax as cx
 
     >>> xs = {"x": Quantity(1, "m"), "y": Quantity(2, "m"), "z": Quantity(3, "m")}
-    >>> vec = cx.CartesianPosition3D.from_(xs)
+    >>> vec = cx.CartesianPos3D.from_(xs)
     >>> vec
-    CartesianPosition3D(
+    CartesianPos3D(
         x=Quantity[PhysicalType('length')](value=f32[], unit=Unit("m")),
         y=Quantity[PhysicalType('length')](value=f32[], unit=Unit("m")),
         z=Quantity[PhysicalType('length')](value=f32[], unit=Unit("m"))
@@ -46,9 +46,9 @@ def from_(
 
     >>> xs = {"x": Quantity([1, 2], "m"), "y": Quantity([3, 4], "m"),
     ...       "z": Quantity([5, 6], "m")}
-    >>> vec = cx.CartesianPosition3D.from_(xs)
+    >>> vec = cx.CartesianPos3D.from_(xs)
     >>> vec
-    CartesianPosition3D(
+    CartesianPos3D(
         x=Quantity[PhysicalType('length')](value=f32[2], unit=Unit("m")),
         y=Quantity[PhysicalType('length')](value=f32[2], unit=Unit("m")),
         z=Quantity[PhysicalType('length')](value=f32[2], unit=Unit("m"))
@@ -61,10 +61,10 @@ def from_(
 #####################################################################
 
 
-@cx.AbstractPosition3D.from_._f.dispatch(precedence=-1)  # noqa: SLF001
+@cx.AbstractPos3D.from_._f.dispatch(precedence=-1)  # noqa: SLF001
 def from_(
-    cls: type[cx.AbstractPosition3D], obj: apyc.CartesianRepresentation, /
-) -> cx.CartesianPosition3D:
+    cls: type[cx.AbstractPos3D], obj: apyc.CartesianRepresentation, /
+) -> cx.CartesianPos3D:
     """Construct from a :class:`astropy.coordinates.CartesianRepresentation`.
 
     Examples
@@ -73,18 +73,18 @@ def from_(
     >>> from astropy.coordinates import CartesianRepresentation
 
     >>> cart = CartesianRepresentation(1, 2, 3, unit="kpc")
-    >>> vec = cx.AbstractPosition3D.from_(cart)
+    >>> vec = cx.AbstractPos3D.from_(cart)
     >>> vec.x
     Quantity['length'](Array(1., dtype=float32), unit='kpc')
 
     """
-    return cx.CartesianPosition3D.from_(obj)
+    return cx.CartesianPos3D.from_(obj)
 
 
-@cx.AbstractPosition3D.from_._f.dispatch(precedence=-1)  # noqa: SLF001
+@cx.AbstractPos3D.from_._f.dispatch(precedence=-1)  # noqa: SLF001
 def from_(
-    cls: type[cx.AbstractPosition3D], obj: apyc.CylindricalRepresentation, /
-) -> cx.CylindricalPosition:
+    cls: type[cx.AbstractPos3D], obj: apyc.CylindricalRepresentation, /
+) -> cx.CylindricalPos:
     """Construct from a :class:`astropy.coordinates.CylindricalRepresentation`.
 
     Examples
@@ -95,18 +95,18 @@ def from_(
 
     >>> cyl = CylindricalRepresentation(rho=1 * u.kpc, phi=2 * u.deg,
     ...                                 z=30 * u.pc)
-    >>> vec = cx.AbstractPosition3D.from_(cyl)
+    >>> vec = cx.AbstractPos3D.from_(cyl)
     >>> vec.rho
     Quantity['length'](Array(1., dtype=float32), unit='kpc')
 
     """
-    return cx.CylindricalPosition.from_(obj)
+    return cx.CylindricalPos.from_(obj)
 
 
-@cx.AbstractPosition3D.from_._f.dispatch(precedence=-1)  # noqa: SLF001
+@cx.AbstractPos3D.from_._f.dispatch(precedence=-1)  # noqa: SLF001
 def from_(
-    cls: type[cx.AbstractPosition3D], obj: apyc.PhysicsSphericalRepresentation, /
-) -> cx.SphericalPosition:
+    cls: type[cx.AbstractPos3D], obj: apyc.PhysicsSphericalRepresentation, /
+) -> cx.SphericalPos:
     """Construct from a :class:`astropy.coordinates.PhysicsSphericalRepresentation`.
 
     Examples
@@ -117,18 +117,18 @@ def from_(
 
     >>> sph = PhysicsSphericalRepresentation(r=1 * u.kpc, theta=2 * u.deg,
     ...                                      phi=3 * u.deg)
-    >>> vec = cx.AbstractPosition3D.from_(sph)
+    >>> vec = cx.AbstractPos3D.from_(sph)
     >>> vec.r
     Distance(Array(1., dtype=float32), unit='kpc')
 
     """
-    return cx.SphericalPosition.from_(obj)
+    return cx.SphericalPos.from_(obj)
 
 
-@cx.AbstractPosition3D.from_._f.dispatch(precedence=-1)  # noqa: SLF001
+@cx.AbstractPos3D.from_._f.dispatch(precedence=-1)  # noqa: SLF001
 def from_(
-    cls: type[cx.AbstractPosition3D], obj: apyc.SphericalRepresentation, /
-) -> cx.LonLatSphericalPosition:
+    cls: type[cx.AbstractPos3D], obj: apyc.SphericalRepresentation, /
+) -> cx.LonLatSphericalPos:
     """Construct from a :class:`astropy.coordinates.SphericalRepresentation`.
 
     Examples
@@ -139,21 +139,21 @@ def from_(
 
     >>> sph = SphericalRepresentation(lon=3 * u.deg, lat=2 * u.deg,
     ...                               distance=1 * u.kpc)
-    >>> vec = cx.AbstractPosition3D.from_(sph)
+    >>> vec = cx.AbstractPos3D.from_(sph)
     >>> vec.distance
     Distance(Array(1., dtype=float32), unit='kpc')
 
     """
-    return cx.LonLatSphericalPosition.from_(obj)
+    return cx.LonLatSphericalPos.from_(obj)
 
 
 # -------------------------------------------------------------------
 
 
-@cx.CartesianPosition3D.from_._f.dispatch  # noqa: SLF001
+@cx.CartesianPos3D.from_._f.dispatch  # noqa: SLF001
 def from_(
-    cls: type[cx.CartesianPosition3D], obj: apyc.BaseRepresentation, /
-) -> cx.CartesianPosition3D:
+    cls: type[cx.CartesianPos3D], obj: apyc.BaseRepresentation, /
+) -> cx.CartesianPos3D:
     """Construct from a :class:`astropy.coordinates.BaseRepresentation`.
 
     Examples
@@ -162,7 +162,7 @@ def from_(
     >>> from astropy.coordinates import CartesianRepresentation
 
     >>> cart = CartesianRepresentation(1, 2, 3, unit="kpc")
-    >>> vec = cx.CartesianPosition3D.from_(cart)
+    >>> vec = cx.CartesianPos3D.from_(cart)
     >>> vec.x
     Quantity['length'](Array(1., dtype=float32), unit='kpc')
 
@@ -171,10 +171,10 @@ def from_(
     return cls(x=obj.x, y=obj.y, z=obj.z)
 
 
-@cx.CylindricalPosition.from_._f.dispatch  # noqa: SLF001
+@cx.CylindricalPos.from_._f.dispatch  # noqa: SLF001
 def from_(
-    cls: type[cx.CylindricalPosition], obj: apyc.BaseRepresentation, /
-) -> cx.CylindricalPosition:
+    cls: type[cx.CylindricalPos], obj: apyc.BaseRepresentation, /
+) -> cx.CylindricalPos:
     """Construct from a :class:`astropy.coordinates.BaseRepresentation`.
 
     Examples
@@ -185,7 +185,7 @@ def from_(
 
     >>> cyl = CylindricalRepresentation(rho=1 * u.kpc, phi=2 * u.deg,
     ...                                 z=30 * u.pc)
-    >>> vec = cx.CylindricalPosition.from_(cyl)
+    >>> vec = cx.CylindricalPos.from_(cyl)
     >>> vec.rho
     Quantity['length'](Array(1., dtype=float32), unit='kpc')
 
@@ -194,10 +194,10 @@ def from_(
     return cls(rho=obj.rho, phi=obj.phi, z=obj.z)
 
 
-@cx.SphericalPosition.from_._f.dispatch  # noqa: SLF001
+@cx.SphericalPos.from_._f.dispatch  # noqa: SLF001
 def from_(
-    cls: type[cx.SphericalPosition], obj: apyc.BaseRepresentation, /
-) -> cx.SphericalPosition:
+    cls: type[cx.SphericalPos], obj: apyc.BaseRepresentation, /
+) -> cx.SphericalPos:
     """Construct from a :class:`astropy.coordinates.BaseRepresentation`.
 
     Examples
@@ -208,7 +208,7 @@ def from_(
 
     >>> sph = PhysicsSphericalRepresentation(r=1 * u.kpc, theta=2 * u.deg,
     ...                                      phi=3 * u.deg)
-    >>> vec = cx.SphericalPosition.from_(sph)
+    >>> vec = cx.SphericalPos.from_(sph)
     >>> vec.r
     Distance(Array(1., dtype=float32), unit='kpc')
 
@@ -217,10 +217,10 @@ def from_(
     return cls(r=obj.r, theta=obj.theta, phi=obj.phi)
 
 
-@cx.LonLatSphericalPosition.from_._f.dispatch  # noqa: SLF001
+@cx.LonLatSphericalPos.from_._f.dispatch  # noqa: SLF001
 def from_(
-    cls: type[cx.LonLatSphericalPosition], obj: apyc.BaseRepresentation, /
-) -> cx.LonLatSphericalPosition:
+    cls: type[cx.LonLatSphericalPos], obj: apyc.BaseRepresentation, /
+) -> cx.LonLatSphericalPos:
     """Construct from a :class:`astropy.coordinates.BaseRepresentation`.
 
     Examples
@@ -231,7 +231,7 @@ def from_(
 
     >>> sph = SphericalRepresentation(lon=3 * u.deg, lat=2 * u.deg,
     ...                               distance=1 * u.kpc)
-    >>> vec = cx.LonLatSphericalPosition.from_(sph)
+    >>> vec = cx.LonLatSphericalPos.from_(sph)
     >>> vec.distance
     Distance(Array(1., dtype=float32), unit='kpc')
 
@@ -505,18 +505,18 @@ def from_(cls: type[cx.AbstractVector], obj: u.Quantity, /) -> cx.AbstractVector
     >>> import coordinax as cx
 
     >>> xs = Quantity([1, 2, 3], "meter")
-    >>> vec = cx.CartesianPosition3D.from_(xs)
+    >>> vec = cx.CartesianPos3D.from_(xs)
     >>> vec
-    CartesianPosition3D(
+    CartesianPos3D(
         x=Quantity[PhysicalType('length')](value=f32[], unit=Unit("m")),
         y=Quantity[PhysicalType('length')](value=f32[], unit=Unit("m")),
         z=Quantity[PhysicalType('length')](value=f32[], unit=Unit("m"))
     )
 
     >>> xs = Quantity(jnp.array([[1, 2, 3], [4, 5, 6]]), "meter")
-    >>> vec = cx.CartesianPosition3D.from_(xs)
+    >>> vec = cx.CartesianPos3D.from_(xs)
     >>> vec
-    CartesianPosition3D(
+    CartesianPos3D(
         x=Quantity[PhysicalType('length')](value=f32[2], unit=Unit("m")),
         y=Quantity[PhysicalType('length')](value=f32[2], unit=Unit("m")),
         z=Quantity[PhysicalType('length')](value=f32[2], unit=Unit("m"))
@@ -545,7 +545,7 @@ def from_(cls: type[cx.AbstractVector], obj: u.Quantity, /) -> cx.AbstractVector
     >>> vec
     FourVector(
         t=Quantity[PhysicalType('time')](value=f32[], unit=Unit("m s / km")),
-        q=CartesianPosition3D( ... )
+        q=CartesianPos3D( ... )
     )
 
     >>> xs = Quantity(jnp.array([[0, 1, 2, 3], [10, 4, 5, 6]]), "meter")
@@ -553,7 +553,7 @@ def from_(cls: type[cx.AbstractVector], obj: u.Quantity, /) -> cx.AbstractVector
     >>> vec
     FourVector(
         t=Quantity[PhysicalType('time')](value=f32[2], unit=Unit("m s / km")),
-        q=CartesianPosition3D( ... )
+        q=CartesianPos3D( ... )
     )
     >>> vec.x
     Quantity['length'](Array([1., 4.], dtype=float32), unit='m')

--- a/src/coordinax/_interop/coordinax_interop_astropy/constructors.py
+++ b/src/coordinax/_interop/coordinax_interop_astropy/constructors.py
@@ -532,9 +532,9 @@ def from_(cls: type[cx.AbstractVector], obj: u.Quantity, /) -> cx.AbstractVector
       d_z=Quantity[...]( value=f32[], unit=Unit("m / s") )
     )
 
-    >>> vec = cx.CartesianAcceleration3D.from_(Quantity([1, 2, 3], "m/s2"))
+    >>> vec = cx.CartesianAcc3D.from_(Quantity([1, 2, 3], "m/s2"))
     >>> vec
-    CartesianAcceleration3D(
+    CartesianAcc3D(
       d2_x=Quantity[...](value=f32[], unit=Unit("m / s2")),
       d2_y=Quantity[...](value=f32[], unit=Unit("m / s2")),
       d2_z=Quantity[...](value=f32[], unit=Unit("m / s2"))

--- a/src/coordinax/_interop/coordinax_interop_astropy/constructors.py
+++ b/src/coordinax/_interop/coordinax_interop_astropy/constructors.py
@@ -243,10 +243,10 @@ def from_(
 #####################################################################
 
 
-@cx.AbstractVelocity3D.from_._f.dispatch  # noqa: SLF001
+@cx.AbstractVel3D.from_._f.dispatch  # noqa: SLF001
 def from_(
-    cls: type[cx.AbstractVelocity3D], obj: apyc.CartesianDifferential, /
-) -> cx.CartesianVelocity3D:
+    cls: type[cx.AbstractVel3D], obj: apyc.CartesianDifferential, /
+) -> cx.CartesianVel3D:
     """Construct from a :class:`astropy.coordinates.CartesianDifferential`.
 
     Examples
@@ -256,18 +256,18 @@ def from_(
     >>> from astropy.coordinates import CartesianDifferential
 
     >>> dcart = CartesianDifferential(1, 2, 3, unit="km/s")
-    >>> dif = cx.AbstractVelocity3D.from_(dcart)
+    >>> dif = cx.AbstractVel3D.from_(dcart)
     >>> dif.d_x
     Quantity['speed'](Array(1., dtype=float32), unit='km / s')
 
     """
-    return cx.CartesianVelocity3D.from_(obj)
+    return cx.CartesianVel3D.from_(obj)
 
 
-@cx.AbstractVelocity3D.from_._f.dispatch  # noqa: SLF001
+@cx.AbstractVel3D.from_._f.dispatch  # noqa: SLF001
 def from_(
-    cls: type[cx.AbstractVelocity3D], obj: apyc.CylindricalDifferential, /
-) -> cx.CylindricalVelocity:
+    cls: type[cx.AbstractVel3D], obj: apyc.CylindricalDifferential, /
+) -> cx.CylindricalVel:
     """Construct from a :class:`astropy.coordinates.CylindricalDifferential`.
 
     Examples
@@ -278,18 +278,18 @@ def from_(
 
     >>> dcyl = apyc.CylindricalDifferential(d_rho=1 * u.km / u.s, d_phi=2 * u.mas/u.yr,
     ...                                     d_z=2 * u.km / u.s)
-    >>> dif = cx.AbstractVelocity3D.from_(dcyl)
+    >>> dif = cx.AbstractVel3D.from_(dcyl)
     >>> dif.d_rho
     Quantity['speed'](Array(1., dtype=float32), unit='km / s')
 
     """
-    return cx.CylindricalVelocity.from_(obj)
+    return cx.CylindricalVel.from_(obj)
 
 
-@cx.AbstractVelocity3D.from_._f.dispatch  # noqa: SLF001
+@cx.AbstractVel3D.from_._f.dispatch  # noqa: SLF001
 def from_(
-    cls: type[cx.AbstractVelocity3D], obj: apyc.PhysicsSphericalDifferential, /
-) -> cx.SphericalVelocity:
+    cls: type[cx.AbstractVel3D], obj: apyc.PhysicsSphericalDifferential, /
+) -> cx.SphericalVel:
     """Construct from a :class:`astropy.coordinates.PhysicsSphericalDifferential`.
 
     Examples
@@ -300,18 +300,18 @@ def from_(
 
     >>> dsph = PhysicsSphericalDifferential(d_r=1 * u.km / u.s, d_theta=2 * u.mas/u.yr,
     ...                                     d_phi=3 * u.mas/u.yr)
-    >>> dif = cx.AbstractVelocity3D.from_(dsph)
+    >>> dif = cx.AbstractVel3D.from_(dsph)
     >>> dif.d_r
     Quantity['speed'](Array(1., dtype=float32), unit='km / s')
 
     """
-    return cx.SphericalVelocity.from_(obj)
+    return cx.SphericalVel.from_(obj)
 
 
-@cx.AbstractVelocity3D.from_._f.dispatch  # noqa: SLF001
+@cx.AbstractVel3D.from_._f.dispatch  # noqa: SLF001
 def from_(
-    cls: type[cx.AbstractVelocity3D], obj: apyc.SphericalDifferential, /
-) -> cx.LonLatSphericalVelocity:
+    cls: type[cx.AbstractVel3D], obj: apyc.SphericalDifferential, /
+) -> cx.LonLatSphericalVel:
     """Construct from a :class:`astropy.coordinates.SphericalDifferential`.
 
     Examples
@@ -323,18 +323,18 @@ def from_(
     >>> dsph = SphericalDifferential(d_distance=1 * u.km / u.s,
     ...                              d_lon=2 * u.mas/u.yr,
     ...                              d_lat=3 * u.mas/u.yr)
-    >>> dif = cx.AbstractVelocity3D.from_(dsph)
+    >>> dif = cx.AbstractVel3D.from_(dsph)
     >>> dif.d_distance
     Quantity['speed'](Array(1., dtype=float32), unit='km / s')
 
     """
-    return cx.LonLatSphericalVelocity.from_(obj)
+    return cx.LonLatSphericalVel.from_(obj)
 
 
-@cx.AbstractVelocity3D.from_._f.dispatch  # noqa: SLF001
+@cx.AbstractVel3D.from_._f.dispatch  # noqa: SLF001
 def from_(
-    cls: type[cx.AbstractVelocity3D], obj: apyc.SphericalCosLatDifferential, /
-) -> cx.LonCosLatSphericalVelocity:
+    cls: type[cx.AbstractVel3D], obj: apyc.SphericalCosLatDifferential, /
+) -> cx.LonCosLatSphericalVel:
     """Construct from a :class:`astropy.coordinates.SphericalCosLatDifferential`.
 
     Examples
@@ -346,9 +346,9 @@ def from_(
     >>> dsph = SphericalCosLatDifferential(d_distance=1 * u.km / u.s,
     ...                                    d_lon_coslat=2 * u.mas/u.yr,
     ...                                    d_lat=3 * u.mas/u.yr)
-    >>> dif = cx.AbstractVelocity3D.from_(dsph)
+    >>> dif = cx.AbstractVel3D.from_(dsph)
     >>> dif
-    LonCosLatSphericalVelocity(
+    LonCosLatSphericalVel(
       d_lon_coslat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
       d_lat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
       d_distance=Quantity[...]( value=f32[], unit=Unit("km / s") )
@@ -357,16 +357,16 @@ def from_(
     Quantity['speed'](Array(1., dtype=float32), unit='km / s')
 
     """
-    return cx.LonCosLatSphericalVelocity.from_(obj)
+    return cx.LonCosLatSphericalVel.from_(obj)
 
 
 # -------------------------------------------------------------------
 
 
-@cx.CartesianVelocity3D.from_._f.dispatch  # noqa: SLF001
+@cx.CartesianVel3D.from_._f.dispatch  # noqa: SLF001
 def from_(
-    cls: type[cx.CartesianVelocity3D], obj: apyc.CartesianDifferential, /
-) -> cx.CartesianVelocity3D:
+    cls: type[cx.CartesianVel3D], obj: apyc.CartesianDifferential, /
+) -> cx.CartesianVel3D:
     """Construct from a :class:`astropy.coordinates.CartesianDifferential`.
 
     Examples
@@ -376,7 +376,7 @@ def from_(
     >>> from astropy.coordinates import CartesianDifferential
 
     >>> dcart = CartesianDifferential(1, 2, 3, unit="km/s")
-    >>> dif = cx.CartesianVelocity3D.from_(dcart)
+    >>> dif = cx.CartesianVel3D.from_(dcart)
     >>> dif.d_x
     Quantity['speed'](Array(1., dtype=float32), unit='km / s')
 
@@ -384,11 +384,11 @@ def from_(
     return cls(d_x=obj.d_x, d_y=obj.d_y, d_z=obj.d_z)
 
 
-@cx.CylindricalVelocity.from_._f.dispatch  # noqa: SLF001
+@cx.CylindricalVel.from_._f.dispatch  # noqa: SLF001
 def from_(
-    cls: type[cx.CylindricalVelocity], obj: apyc.CylindricalDifferential, /
-) -> cx.CylindricalVelocity:
-    """Construct from a :class:`astropy.coordinates.CylindricalVelocity`.
+    cls: type[cx.CylindricalVel], obj: apyc.CylindricalDifferential, /
+) -> cx.CylindricalVel:
+    """Construct from a :class:`astropy.coordinates.CylindricalVel`.
 
     Examples
     --------
@@ -398,7 +398,7 @@ def from_(
 
     >>> dcyl = apyc.CylindricalDifferential(d_rho=1 * u.km / u.s, d_phi=2 * u.mas/u.yr,
     ...                                     d_z=2 * u.km / u.s)
-    >>> dif = cx.CylindricalVelocity.from_(dcyl)
+    >>> dif = cx.CylindricalVel.from_(dcyl)
     >>> dif.d_rho
     Quantity['speed'](Array(1., dtype=float32), unit='km / s')
 
@@ -406,10 +406,10 @@ def from_(
     return cls(d_rho=obj.d_rho, d_phi=obj.d_phi, d_z=obj.d_z)
 
 
-@cx.SphericalVelocity.from_._f.dispatch  # noqa: SLF001
+@cx.SphericalVel.from_._f.dispatch  # noqa: SLF001
 def from_(
-    cls: type[cx.SphericalVelocity], obj: apyc.PhysicsSphericalDifferential, /
-) -> cx.SphericalVelocity:
+    cls: type[cx.SphericalVel], obj: apyc.PhysicsSphericalDifferential, /
+) -> cx.SphericalVel:
     """Construct from a :class:`astropy.coordinates.PhysicsSphericalDifferential`.
 
     Examples
@@ -420,7 +420,7 @@ def from_(
 
     >>> dsph = PhysicsSphericalDifferential(d_r=1 * u.km / u.s, d_theta=2 * u.mas/u.yr,
     ...                                     d_phi=3 * u.mas/u.yr)
-    >>> dif = cx.SphericalVelocity.from_(dsph)
+    >>> dif = cx.SphericalVel.from_(dsph)
     >>> dif.d_r
     Quantity['speed'](Array(1., dtype=float32), unit='km / s')
 
@@ -428,11 +428,11 @@ def from_(
     return cls(d_r=obj.d_r, d_phi=obj.d_phi, d_theta=obj.d_theta)
 
 
-@cx.LonLatSphericalVelocity.from_._f.dispatch  # noqa: SLF001
+@cx.LonLatSphericalVel.from_._f.dispatch  # noqa: SLF001
 def from_(
-    cls: type[cx.LonLatSphericalVelocity], obj: apyc.SphericalDifferential, /
-) -> cx.LonLatSphericalVelocity:
-    """Construct from a :class:`astropy.coordinates.SphericalVelocity`.
+    cls: type[cx.LonLatSphericalVel], obj: apyc.SphericalDifferential, /
+) -> cx.LonLatSphericalVel:
+    """Construct from a :class:`astropy.coordinates.SphericalVel`.
 
     Examples
     --------
@@ -443,7 +443,7 @@ def from_(
     >>> dsph = SphericalDifferential(d_distance=1 * u.km / u.s,
     ...                              d_lon=2 * u.mas/u.yr,
     ...                              d_lat=3 * u.mas/u.yr)
-    >>> dif = cx.LonLatSphericalVelocity.from_(dsph)
+    >>> dif = cx.LonLatSphericalVel.from_(dsph)
     >>> dif.d_distance
     Quantity['speed'](Array(1., dtype=float32), unit='km / s')
 
@@ -451,10 +451,10 @@ def from_(
     return cls(d_distance=obj.d_distance, d_lon=obj.d_lon, d_lat=obj.d_lat)
 
 
-@cx.LonCosLatSphericalVelocity.from_._f.dispatch  # noqa: SLF001
+@cx.LonCosLatSphericalVel.from_._f.dispatch  # noqa: SLF001
 def from_(
-    cls: type[cx.LonCosLatSphericalVelocity], obj: apyc.SphericalCosLatDifferential, /
-) -> cx.LonCosLatSphericalVelocity:
+    cls: type[cx.LonCosLatSphericalVel], obj: apyc.SphericalCosLatDifferential, /
+) -> cx.LonCosLatSphericalVel:
     """Construct from a :class:`astropy.coordinates.SphericalCosLatDifferential`.
 
     Examples
@@ -466,9 +466,9 @@ def from_(
     >>> dsph = SphericalCosLatDifferential(d_distance=1 * u.km / u.s,
     ...                                    d_lon_coslat=2 * u.mas/u.yr,
     ...                                    d_lat=3 * u.mas/u.yr)
-    >>> dif = cx.LonCosLatSphericalVelocity.from_(dsph)
+    >>> dif = cx.LonCosLatSphericalVel.from_(dsph)
     >>> dif
-    LonCosLatSphericalVelocity(
+    LonCosLatSphericalVel(
       d_lon_coslat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
       d_lat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
       d_distance=Quantity[...]( value=f32[], unit=Unit("km / s") )
@@ -524,9 +524,9 @@ def from_(cls: type[cx.AbstractVector], obj: u.Quantity, /) -> cx.AbstractVector
     >>> vec.x
     Quantity['length'](Array([1., 4.], dtype=float32), unit='m')
 
-    >>> vec = cx.CartesianVelocity3D.from_(Quantity([1, 2, 3], "m/s"))
+    >>> vec = cx.CartesianVel3D.from_(Quantity([1, 2, 3], "m/s"))
     >>> vec
-    CartesianVelocity3D(
+    CartesianVel3D(
       d_x=Quantity[...]( value=f32[], unit=Unit("m / s") ),
       d_y=Quantity[...]( value=f32[], unit=Unit("m / s") ),
       d_z=Quantity[...]( value=f32[], unit=Unit("m / s") )

--- a/src/coordinax/_interop/coordinax_interop_astropy/converters.py
+++ b/src/coordinax/_interop/coordinax_interop_astropy/converters.py
@@ -20,9 +20,9 @@ import coordinax as cx
 # Quantity
 
 
-@conversion_method(cx.AbstractPosition3D, u.Quantity)  # type: ignore[misc]
-def vec_to_q(obj: cx.AbstractPosition3D, /) -> Shaped[u.Quantity, "*batch 3"]:
-    """`coordinax.AbstractPosition3D` -> `astropy.units.Quantity`.
+@conversion_method(cx.AbstractPos3D, u.Quantity)  # type: ignore[misc]
+def vec_to_q(obj: cx.AbstractPos3D, /) -> Shaped[u.Quantity, "*batch 3"]:
+    """`coordinax.AbstractPos3D` -> `astropy.units.Quantity`.
 
     Examples
     --------
@@ -30,17 +30,17 @@ def vec_to_q(obj: cx.AbstractPosition3D, /) -> Shaped[u.Quantity, "*batch 3"]:
     >>> from plum import convert
     >>> from astropy.units import Quantity
 
-    >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "kpc")
+    >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
     >>> convert(vec, Quantity)
     <Quantity [1., 2., 3.] kpc>
 
-    >>> vec = cx.SphericalPosition(r=Quantity(1, unit="kpc"),
+    >>> vec = cx.SphericalPos(r=Quantity(1, unit="kpc"),
     ...                            theta=Quantity(2, unit="deg"),
     ...                            phi=Quantity(3, unit="deg"))
     >>> convert(vec, Quantity)
     <Quantity [0.03485167, 0.0018265 , 0.99939084] kpc>
 
-    >>> vec = cx.CylindricalPosition(rho=Quantity(1, unit="kpc"),
+    >>> vec = cx.CylindricalPos(rho=Quantity(1, unit="kpc"),
     ...                              phi=Quantity(2, unit="deg"),
     ...                              z=Quantity(3, unit="pc"))
     >>> convert(vec, Quantity)
@@ -74,20 +74,20 @@ def vec_diff_to_q(obj: cx.CartesianVelocity3D, /) -> Shaped[u.Quantity, "*batch 
 
 
 # =====================================
-# CartesianPosition3D
+# CartesianPos3D
 
 
-@conversion_method(cx.CartesianPosition3D, apyc.BaseRepresentation)  # type: ignore[misc]
-@conversion_method(cx.CartesianPosition3D, apyc.CartesianRepresentation)  # type: ignore[misc]
-def cart3_to_apycart3(obj: cx.CartesianPosition3D, /) -> apyc.CartesianRepresentation:
-    """`coordinax.CartesianPosition3D` -> `astropy.CartesianRepresentation`.
+@conversion_method(cx.CartesianPos3D, apyc.BaseRepresentation)  # type: ignore[misc]
+@conversion_method(cx.CartesianPos3D, apyc.CartesianRepresentation)  # type: ignore[misc]
+def cart3_to_apycart3(obj: cx.CartesianPos3D, /) -> apyc.CartesianRepresentation:
+    """`coordinax.CartesianPos3D` -> `astropy.CartesianRepresentation`.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "kpc")
+    >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
     >>> convert(vec, apyc.CartesianRepresentation)
     <CartesianRepresentation (x, y, z) in kpc
         (1., 2., 3.)>
@@ -104,9 +104,9 @@ def cart3_to_apycart3(obj: cx.CartesianPosition3D, /) -> apyc.CartesianRepresent
     )
 
 
-@conversion_method(apyc.CartesianRepresentation, cx.CartesianPosition3D)  # type: ignore[misc]
-def apycart3_to_cart3(obj: apyc.CartesianRepresentation, /) -> cx.CartesianPosition3D:
-    """`astropy.CartesianRepresentation` -> `coordinax.CartesianPosition3D`.
+@conversion_method(apyc.CartesianRepresentation, cx.CartesianPos3D)  # type: ignore[misc]
+def apycart3_to_cart3(obj: apyc.CartesianRepresentation, /) -> cx.CartesianPos3D:
+    """`astropy.CartesianRepresentation` -> `coordinax.CartesianPos3D`.
 
     Examples
     --------
@@ -115,34 +115,34 @@ def apycart3_to_cart3(obj: apyc.CartesianRepresentation, /) -> cx.CartesianPosit
     >>> from astropy.coordinates import CartesianRepresentation
 
     >>> vec = CartesianRepresentation(1, 2, 3, unit="kpc")
-    >>> convert(vec, cx.CartesianPosition3D)
-    CartesianPosition3D(
+    >>> convert(vec, cx.CartesianPos3D)
+    CartesianPos3D(
       x=Quantity[PhysicalType('length')](value=f32[], unit=Unit("kpc")),
       y=Quantity[PhysicalType('length')](value=f32[], unit=Unit("kpc")),
       z=Quantity[PhysicalType('length')](value=f32[], unit=Unit("kpc"))
     )
 
     """
-    return cx.CartesianPosition3D.from_(obj)
+    return cx.CartesianPos3D.from_(obj)
 
 
 # =====================================
-# CylindricalPosition
+# CylindricalPos
 
 
-@conversion_method(cx.CylindricalPosition, apyc.BaseRepresentation)  # type: ignore[misc]
-@conversion_method(cx.CylindricalPosition, apyc.CylindricalRepresentation)  # type: ignore[misc]
-def cyl_to_apycyl(obj: cx.CylindricalPosition, /) -> apyc.CylindricalRepresentation:
-    """`coordinax.CylindricalPosition` -> `astropy.CylindricalRepresentation`.
+@conversion_method(cx.CylindricalPos, apyc.BaseRepresentation)  # type: ignore[misc]
+@conversion_method(cx.CylindricalPos, apyc.CylindricalRepresentation)  # type: ignore[misc]
+def cyl_to_apycyl(obj: cx.CylindricalPos, /) -> apyc.CylindricalRepresentation:
+    """`coordinax.CylindricalPos` -> `astropy.CylindricalRepresentation`.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.CylindricalPosition(rho=Quantity(1, unit="kpc"),
-    ...                            phi=Quantity(2, unit="deg"),
-    ...                            z=Quantity(3, unit="pc"))
+    >>> vec = cx.CylindricalPos(rho=Quantity(1, unit="kpc"),
+    ...                         phi=Quantity(2, unit="deg"),
+    ...                         z=Quantity(3, unit="pc"))
     >>> convert(vec, apyc.CylindricalRepresentation)
     <CylindricalRepresentation (rho, phi, z) in (kpc, deg, pc)
         (1., 2., 3.)>
@@ -159,9 +159,9 @@ def cyl_to_apycyl(obj: cx.CylindricalPosition, /) -> apyc.CylindricalRepresentat
     )
 
 
-@conversion_method(apyc.CylindricalRepresentation, cx.CylindricalPosition)  # type: ignore[misc]
-def apycyl_to_cyl(obj: apyc.CylindricalRepresentation, /) -> cx.CylindricalPosition:
-    """`astropy.CylindricalRepresentation` -> `coordinax.CylindricalPosition`.
+@conversion_method(apyc.CylindricalRepresentation, cx.CylindricalPos)  # type: ignore[misc]
+def apycyl_to_cyl(obj: apyc.CylindricalRepresentation, /) -> cx.CylindricalPos:
+    """`astropy.CylindricalRepresentation` -> `coordinax.CylindricalPos`.
 
     Examples
     --------
@@ -170,34 +170,34 @@ def apycyl_to_cyl(obj: apyc.CylindricalRepresentation, /) -> cx.CylindricalPosit
     >>> from astropy.coordinates import CylindricalRepresentation
 
     >>> cyl = CylindricalRepresentation(rho=1 * u.kpc, phi=2 * u.deg, z=30 * u.pc)
-    >>> convert(cyl, cx.CylindricalPosition)
-    CylindricalPosition(
+    >>> convert(cyl, cx.CylindricalPos)
+    CylindricalPos(
         rho=Quantity[...](value=f32[], unit=Unit("kpc")),
         phi=Quantity[...](value=f32[], unit=Unit("deg")),
         z=Quantity[...](value=f32[], unit=Unit("pc"))
     )
 
     """
-    return cx.CylindricalPosition.from_(obj)
+    return cx.CylindricalPos.from_(obj)
 
 
 # =====================================
-# SphericalPosition
+# SphericalPos
 
 
-@conversion_method(cx.SphericalPosition, apyc.BaseRepresentation)  # type: ignore[misc]
-@conversion_method(cx.SphericalPosition, apyc.PhysicsSphericalRepresentation)  # type: ignore[misc]
-def sph_to_apysph(obj: cx.SphericalPosition, /) -> apyc.PhysicsSphericalRepresentation:
-    """`coordinax.SphericalPosition` -> `astropy.PhysicsSphericalRepresentation`.
+@conversion_method(cx.SphericalPos, apyc.BaseRepresentation)  # type: ignore[misc]
+@conversion_method(cx.SphericalPos, apyc.PhysicsSphericalRepresentation)  # type: ignore[misc]
+def sph_to_apysph(obj: cx.SphericalPos, /) -> apyc.PhysicsSphericalRepresentation:
+    """`coordinax.SphericalPos` -> `astropy.PhysicsSphericalRepresentation`.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.SphericalPosition(r=Quantity(1, unit="kpc"),
-    ...                          theta=Quantity(2, unit="deg"),
-    ...                          phi=Quantity(3, unit="deg"))
+    >>> vec = cx.SphericalPos(r=Quantity(1, unit="kpc"),
+    ...                       theta=Quantity(2, unit="deg"),
+    ...                       phi=Quantity(3, unit="deg"))
     >>> convert(vec, apyc.PhysicsSphericalRepresentation)
     <PhysicsSphericalRepresentation (phi, theta, r) in (deg, deg, kpc)
         (3., 2., 1.)>
@@ -210,9 +210,9 @@ def sph_to_apysph(obj: cx.SphericalPosition, /) -> apyc.PhysicsSphericalRepresen
     )
 
 
-@conversion_method(apyc.PhysicsSphericalRepresentation, cx.SphericalPosition)  # type: ignore[misc]
-def apysph_to_sph(obj: apyc.PhysicsSphericalRepresentation, /) -> cx.SphericalPosition:
-    """`astropy.PhysicsSphericalRepresentation` -> `coordinax.SphericalPosition`.
+@conversion_method(apyc.PhysicsSphericalRepresentation, cx.SphericalPos)  # type: ignore[misc]
+def apysph_to_sph(obj: apyc.PhysicsSphericalRepresentation, /) -> cx.SphericalPos:
+    """`astropy.PhysicsSphericalRepresentation` -> `coordinax.SphericalPos`.
 
     Examples
     --------
@@ -222,36 +222,34 @@ def apysph_to_sph(obj: apyc.PhysicsSphericalRepresentation, /) -> cx.SphericalPo
 
     >>> sph = PhysicsSphericalRepresentation(r=1 * u.kpc, theta=2 * u.deg,
     ...                                      phi=3 * u.deg)
-    >>> convert(sph, cx.SphericalPosition)
-    SphericalPosition(
+    >>> convert(sph, cx.SphericalPos)
+    SphericalPos(
       r=Distance(value=f32[], unit=Unit("kpc")),
       theta=Quantity[...](value=f32[], unit=Unit("deg")),
       phi=Quantity[...](value=f32[], unit=Unit("deg"))
     )
 
     """
-    return cx.SphericalPosition.from_(obj)
+    return cx.SphericalPos.from_(obj)
 
 
 # =====================================
-# LonLatSphericalPosition
+# LonLatSphericalPos
 
 
-@conversion_method(cx.LonLatSphericalPosition, apyc.BaseRepresentation)  # type: ignore[misc]
-@conversion_method(cx.LonLatSphericalPosition, apyc.PhysicsSphericalRepresentation)  # type: ignore[misc]
-def lonlatsph_to_apysph(
-    obj: cx.LonLatSphericalPosition, /
-) -> apyc.SphericalRepresentation:
-    """`coordinax.LonLatSphericalPosition` -> `astropy.SphericalRepresentation`.
+@conversion_method(cx.LonLatSphericalPos, apyc.BaseRepresentation)  # type: ignore[misc]
+@conversion_method(cx.LonLatSphericalPos, apyc.PhysicsSphericalRepresentation)  # type: ignore[misc]
+def lonlatsph_to_apysph(obj: cx.LonLatSphericalPos, /) -> apyc.SphericalRepresentation:
+    """`coordinax.LonLatSphericalPos` -> `astropy.SphericalRepresentation`.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.LonLatSphericalPosition(lon=Quantity(2, unit="deg"),
-    ...                                lat=Quantity(3, unit="deg"),
-    ...                                distance=Quantity(1, unit="kpc"))
+    >>> vec = cx.LonLatSphericalPos(lon=Quantity(2, unit="deg"),
+    ...                             lat=Quantity(3, unit="deg"),
+    ...                             distance=Quantity(1, unit="kpc"))
     >>> convert(vec, apyc.SphericalRepresentation)
     <SphericalRepresentation (lon, lat, distance) in (deg, deg, kpc)
         (2., 3., 1.)>
@@ -264,11 +262,9 @@ def lonlatsph_to_apysph(
     )
 
 
-@conversion_method(apyc.SphericalRepresentation, cx.LonLatSphericalPosition)  # type: ignore[misc]
-def apysph_to_lonlatsph(
-    obj: apyc.SphericalRepresentation, /
-) -> cx.LonLatSphericalPosition:
-    """`astropy.SphericalRepresentation` -> `coordinax.LonLatSphericalPosition`.
+@conversion_method(apyc.SphericalRepresentation, cx.LonLatSphericalPos)  # type: ignore[misc]
+def apysph_to_lonlatsph(obj: apyc.SphericalRepresentation, /) -> cx.LonLatSphericalPos:
+    """`astropy.SphericalRepresentation` -> `coordinax.LonLatSphericalPos`.
 
     Examples
     --------
@@ -278,15 +274,15 @@ def apysph_to_lonlatsph(
 
     >>> sph = SphericalRepresentation(lon=2 * u.deg, lat=3 * u.deg,
     ...                               distance=1 * u.kpc)
-    >>> convert(sph, cx.LonLatSphericalPosition)
-    LonLatSphericalPosition(
+    >>> convert(sph, cx.LonLatSphericalPos)
+    LonLatSphericalPos(
       lon=Quantity[...](value=f32[], unit=Unit("deg")),
       lat=Quantity[...](value=f32[], unit=Unit("deg")),
       distance=Distance(value=f32[], unit=Unit("kpc"))
     )
 
     """
-    return cx.LonLatSphericalPosition.from_(obj)
+    return cx.LonLatSphericalPos.from_(obj)
 
 
 # =====================================

--- a/src/coordinax/_interop/coordinax_interop_astropy/converters.py
+++ b/src/coordinax/_interop/coordinax_interop_astropy/converters.py
@@ -51,9 +51,9 @@ def vec_to_q(obj: cx.AbstractPos3D, /) -> Shaped[u.Quantity, "*batch 3"]:
 
 
 @conversion_method(cx.CartesianAcceleration3D, u.Quantity)  # type: ignore[misc]
-@conversion_method(cx.CartesianVelocity3D, u.Quantity)  # type: ignore[misc]
-def vec_diff_to_q(obj: cx.CartesianVelocity3D, /) -> Shaped[u.Quantity, "*batch 3"]:
-    """`coordinax.CartesianVelocity3D` -> `astropy.units.Quantity`.
+@conversion_method(cx.CartesianVel3D, u.Quantity)  # type: ignore[misc]
+def vec_diff_to_q(obj: cx.CartesianVel3D, /) -> Shaped[u.Quantity, "*batch 3"]:
+    """`coordinax.CartesianVel3D` -> `astropy.units.Quantity`.
 
     Examples
     --------
@@ -61,7 +61,7 @@ def vec_diff_to_q(obj: cx.CartesianVelocity3D, /) -> Shaped[u.Quantity, "*batch 
     >>> from plum import convert
     >>> from astropy.units import Quantity
 
-    >>> dif = cx.CartesianVelocity3D.from_([1, 2, 3], "km/s")
+    >>> dif = cx.CartesianVel3D.from_([1, 2, 3], "km/s")
     >>> convert(dif, Quantity)
     <Quantity [1., 2., 3.] km / s>
 
@@ -286,20 +286,20 @@ def apysph_to_lonlatsph(obj: apyc.SphericalRepresentation, /) -> cx.LonLatSpheri
 
 
 # =====================================
-# CartesianVelocity3D
+# CartesianVel3D
 
 
-@conversion_method(cx.CartesianVelocity3D, apyc.BaseDifferential)  # type: ignore[misc]
-@conversion_method(cx.CartesianVelocity3D, apyc.CartesianDifferential)  # type: ignore[misc]
-def diffcart3_to_apycart3(obj: cx.CartesianVelocity3D, /) -> apyc.CartesianDifferential:
-    """`coordinax.CartesianVelocity3D` -> `astropy.CartesianDifferential`.
+@conversion_method(cx.CartesianVel3D, apyc.BaseDifferential)  # type: ignore[misc]
+@conversion_method(cx.CartesianVel3D, apyc.CartesianDifferential)  # type: ignore[misc]
+def diffcart3_to_apycart3(obj: cx.CartesianVel3D, /) -> apyc.CartesianDifferential:
+    """`coordinax.CartesianVel3D` -> `astropy.CartesianDifferential`.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> dif = cx.CartesianVelocity3D.from_([1, 2, 3], "km/s")
+    >>> dif = cx.CartesianVel3D.from_([1, 2, 3], "km/s")
     >>> convert(dif, apyc.CartesianDifferential)
     <CartesianDifferential (d_x, d_y, d_z) in km / s
         (1., 2., 3.)>
@@ -313,10 +313,10 @@ def diffcart3_to_apycart3(obj: cx.CartesianVelocity3D, /) -> apyc.CartesianDiffe
 
 
 @conversion_method(  # type: ignore[misc]
-    apyc.CartesianDifferential, cx.CartesianVelocity3D
+    apyc.CartesianDifferential, cx.CartesianVel3D
 )
-def apycart3_to_diffcart3(obj: apyc.CartesianDifferential, /) -> cx.CartesianVelocity3D:
-    """`astropy.CartesianDifferential` -> `coordinax.CartesianVelocity3D`.
+def apycart3_to_diffcart3(obj: apyc.CartesianDifferential, /) -> cx.CartesianVel3D:
+    """`astropy.CartesianDifferential` -> `coordinax.CartesianVel3D`.
 
     Examples
     --------
@@ -325,25 +325,25 @@ def apycart3_to_diffcart3(obj: apyc.CartesianDifferential, /) -> cx.CartesianVel
     >>> from astropy.coordinates import CartesianDifferential
 
     >>> dcart = CartesianDifferential(1, 2, 3, unit="km/s")
-    >>> convert(dcart, cx.CartesianVelocity3D)
-    CartesianVelocity3D(
+    >>> convert(dcart, cx.CartesianVel3D)
+    CartesianVel3D(
       d_x=Quantity[...]( value=f32[], unit=Unit("km / s") ),
       d_y=Quantity[...]( value=f32[], unit=Unit("km / s") ),
       d_z=Quantity[...]( value=f32[], unit=Unit("km / s") )
     )
 
     """
-    return cx.CartesianVelocity3D.from_(obj)
+    return cx.CartesianVel3D.from_(obj)
 
 
 # =====================================
-# CylindricalVelocity
+# CylindricalVel
 
 
-@conversion_method(cx.CylindricalVelocity, apyc.BaseDifferential)  # type: ignore[misc]
-@conversion_method(cx.CylindricalVelocity, apyc.CylindricalDifferential)  # type: ignore[misc]
-def diffcyl_to_apycyl(obj: cx.CylindricalVelocity, /) -> apyc.CylindricalDifferential:
-    """`coordinax.CylindricalVelocity` -> `astropy.CylindricalDifferential`.
+@conversion_method(cx.CylindricalVel, apyc.BaseDifferential)  # type: ignore[misc]
+@conversion_method(cx.CylindricalVel, apyc.CylindricalDifferential)  # type: ignore[misc]
+def diffcyl_to_apycyl(obj: cx.CylindricalVel, /) -> apyc.CylindricalDifferential:
+    """`coordinax.CylindricalVel` -> `astropy.CylindricalDifferential`.
 
     Examples
     --------
@@ -351,7 +351,7 @@ def diffcyl_to_apycyl(obj: cx.CylindricalVelocity, /) -> apyc.CylindricalDiffere
     >>> import coordinax as cx
     >>> import astropy.coordinates as apyc
 
-    >>> dif = cx.CylindricalVelocity(d_rho=Quantity(1, unit="km/s"),
+    >>> dif = cx.CylindricalVel(d_rho=Quantity(1, unit="km/s"),
     ...                                  d_phi=Quantity(2, unit="mas/yr"),
     ...                                  d_z=Quantity(3, unit="km/s"))
     >>> convert(dif, apyc.CylindricalDifferential)
@@ -371,10 +371,10 @@ def diffcyl_to_apycyl(obj: cx.CylindricalVelocity, /) -> apyc.CylindricalDiffere
 
 
 @conversion_method(  # type: ignore[misc]
-    apyc.CylindricalDifferential, cx.CylindricalVelocity
+    apyc.CylindricalDifferential, cx.CylindricalVel
 )
-def apycyl_to_diffcyl(obj: apyc.CylindricalDifferential, /) -> cx.CylindricalVelocity:
-    """`astropy.CylindricalVelocity` -> `coordinax.CylindricalVelocity`.
+def apycyl_to_diffcyl(obj: apyc.CylindricalDifferential, /) -> cx.CylindricalVel:
+    """`astropy.CylindricalVel` -> `coordinax.CylindricalVel`.
 
     Examples
     --------
@@ -384,34 +384,32 @@ def apycyl_to_diffcyl(obj: apyc.CylindricalDifferential, /) -> cx.CylindricalVel
 
     >>> dcyl = apyc.CylindricalDifferential(d_rho=1 * u.km / u.s, d_phi=2 * u.mas/u.yr,
     ...                                     d_z=2 * u.km / u.s)
-    >>> convert(dcyl, cx.CylindricalVelocity)
-    CylindricalVelocity(
+    >>> convert(dcyl, cx.CylindricalVel)
+    CylindricalVel(
       d_rho=Quantity[...]( value=f32[], unit=Unit("km / s") ),
       d_phi=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
       d_z=Quantity[...]( value=f32[], unit=Unit("km / s") )
     )
 
     """
-    return cx.CylindricalVelocity.from_(obj)
+    return cx.CylindricalVel.from_(obj)
 
 
 # =====================================
-# SphericalVelocity
+# SphericalVel
 
 
-@conversion_method(cx.SphericalVelocity, apyc.BaseDifferential)  # type: ignore[misc]
-@conversion_method(cx.SphericalVelocity, apyc.PhysicsSphericalDifferential)  # type: ignore[misc]
-def diffsph_to_apysph(
-    obj: cx.SphericalVelocity, /
-) -> apyc.PhysicsSphericalDifferential:
-    """SphericalVelocity -> `astropy.PhysicsSphericalDifferential`.
+@conversion_method(cx.SphericalVel, apyc.BaseDifferential)  # type: ignore[misc]
+@conversion_method(cx.SphericalVel, apyc.PhysicsSphericalDifferential)  # type: ignore[misc]
+def diffsph_to_apysph(obj: cx.SphericalVel, /) -> apyc.PhysicsSphericalDifferential:
+    """SphericalVel -> `astropy.PhysicsSphericalDifferential`.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> dif = cx.SphericalVelocity(d_r=Quantity(1, unit="km/s"),
+    >>> dif = cx.SphericalVel(d_r=Quantity(1, unit="km/s"),
     ...                                d_theta=Quantity(2, unit="mas/yr"),
     ...                                d_phi=Quantity(3, unit="mas/yr"))
     >>> convert(dif, apyc.PhysicsSphericalDifferential)
@@ -431,12 +429,10 @@ def diffsph_to_apysph(
 
 
 @conversion_method(  # type: ignore[misc]
-    apyc.PhysicsSphericalDifferential, cx.SphericalVelocity
+    apyc.PhysicsSphericalDifferential, cx.SphericalVel
 )
-def apysph_to_diffsph(
-    obj: apyc.PhysicsSphericalDifferential, /
-) -> cx.SphericalVelocity:
-    """`astropy.PhysicsSphericalDifferential` -> SphericalVelocity.
+def apysph_to_diffsph(obj: apyc.PhysicsSphericalDifferential, /) -> cx.SphericalVel:
+    """`astropy.PhysicsSphericalDifferential` -> SphericalVel.
 
     Examples
     --------
@@ -446,34 +442,34 @@ def apysph_to_diffsph(
 
     >>> dif = PhysicsSphericalDifferential(d_r=1 * u.km / u.s, d_theta=2 * u.mas/u.yr,
     ...                                    d_phi=3 * u.mas/u.yr)
-    >>> convert(dif, cx.SphericalVelocity)
-    SphericalVelocity(
+    >>> convert(dif, cx.SphericalVel)
+    SphericalVel(
       d_r=Quantity[...]( value=f32[], unit=Unit("km / s") ),
       d_theta=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
       d_phi=Quantity[...]( value=f32[], unit=Unit("mas / yr") )
     )
 
     """
-    return cx.SphericalVelocity.from_(obj)
+    return cx.SphericalVel.from_(obj)
 
 
 # =====================================
-# LonLatSphericalVelocity
+# LonLatSphericalVel
 
 
-@conversion_method(cx.LonLatSphericalVelocity, apyc.BaseDifferential)  # type: ignore[misc]
-@conversion_method(cx.LonLatSphericalVelocity, apyc.SphericalDifferential)  # type: ignore[misc]
+@conversion_method(cx.LonLatSphericalVel, apyc.BaseDifferential)  # type: ignore[misc]
+@conversion_method(cx.LonLatSphericalVel, apyc.SphericalDifferential)  # type: ignore[misc]
 def difflonlatsph_to_apysph(
-    obj: cx.LonLatSphericalVelocity, /
+    obj: cx.LonLatSphericalVel, /
 ) -> apyc.SphericalDifferential:
-    """LonLatSphericalVelocity -> `astropy.SphericalVelocity`.
+    """LonLatSphericalVel -> `astropy.SphericalVel`.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> dif = cx.LonLatSphericalVelocity(d_distance=Quantity(1, unit="km/s"),
+    >>> dif = cx.LonLatSphericalVel(d_distance=Quantity(1, unit="km/s"),
     ...                                      d_lat=Quantity(2, unit="mas/yr"),
     ...                                      d_lon=Quantity(3, unit="mas/yr"))
     >>> convert(dif, apyc.SphericalDifferential)
@@ -493,12 +489,12 @@ def difflonlatsph_to_apysph(
 
 
 @conversion_method(  # type: ignore[misc]
-    apyc.SphericalDifferential, cx.LonLatSphericalVelocity
+    apyc.SphericalDifferential, cx.LonLatSphericalVel
 )
 def apysph_to_difflonlatsph(
     obj: apyc.SphericalDifferential, /
-) -> cx.LonLatSphericalVelocity:
-    """`astropy.coordinates.SphericalDifferential` -> LonLatSphericalVelocity.
+) -> cx.LonLatSphericalVel:
+    """`astropy.coordinates.SphericalDifferential` -> LonLatSphericalVel.
 
     Examples
     --------
@@ -508,34 +504,34 @@ def apysph_to_difflonlatsph(
 
     >>> dif = SphericalDifferential(d_distance=1 * u.km / u.s, d_lat=2 * u.mas/u.yr,
     ...                             d_lon=3 * u.mas/u.yr)
-    >>> convert(dif, cx.LonLatSphericalVelocity)
-    LonLatSphericalVelocity(
+    >>> convert(dif, cx.LonLatSphericalVel)
+    LonLatSphericalVel(
       d_lon=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
       d_lat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
       d_distance=Quantity[...]( value=f32[], unit=Unit("km / s") )
     )
 
     """
-    return cx.LonLatSphericalVelocity.from_(obj)
+    return cx.LonLatSphericalVel.from_(obj)
 
 
 # =====================================
-# LonCosLatSphericalVelocity
+# LonCosLatSphericalVel
 
 
-@conversion_method(cx.LonCosLatSphericalVelocity, apyc.BaseDifferential)  # type: ignore[misc]
-@conversion_method(cx.LonCosLatSphericalVelocity, apyc.SphericalCosLatDifferential)  # type: ignore[misc]
+@conversion_method(cx.LonCosLatSphericalVel, apyc.BaseDifferential)  # type: ignore[misc]
+@conversion_method(cx.LonCosLatSphericalVel, apyc.SphericalCosLatDifferential)  # type: ignore[misc]
 def diffloncoslatsph_to_apysph(
-    obj: cx.LonCosLatSphericalVelocity, /
+    obj: cx.LonCosLatSphericalVel, /
 ) -> apyc.SphericalCosLatDifferential:
-    """LonCosLatSphericalVelocity -> `astropy.SphericalCosLatDifferential`.
+    """LonCosLatSphericalVel -> `astropy.SphericalCosLatDifferential`.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> dif = cx.LonCosLatSphericalVelocity(d_distance=Quantity(1, unit="km/s"),
+    >>> dif = cx.LonCosLatSphericalVel(d_distance=Quantity(1, unit="km/s"),
     ...                                         d_lat=Quantity(2, unit="mas/yr"),
     ...                                         d_lon_coslat=Quantity(3, unit="mas/yr"))
     >>> convert(dif, apyc.SphericalCosLatDifferential)
@@ -555,12 +551,12 @@ def diffloncoslatsph_to_apysph(
 
 
 @conversion_method(  # type: ignore[misc]
-    apyc.SphericalCosLatDifferential, cx.LonCosLatSphericalVelocity
+    apyc.SphericalCosLatDifferential, cx.LonCosLatSphericalVel
 )
 def apysph_to_diffloncoslatsph(
     obj: apyc.SphericalCosLatDifferential, /
-) -> cx.LonCosLatSphericalVelocity:
-    """`astropy.SphericalCosLatDifferential` -> LonCosLatSphericalVelocity.
+) -> cx.LonCosLatSphericalVel:
+    """`astropy.SphericalCosLatDifferential` -> LonCosLatSphericalVel.
 
     Examples
     --------
@@ -571,12 +567,12 @@ def apysph_to_diffloncoslatsph(
     >>> dif = SphericalCosLatDifferential(d_distance=1 * u.km / u.s,
     ...                                   d_lat=2 * u.mas/u.yr,
     ...                                   d_lon_coslat=3 * u.mas/u.yr)
-    >>> convert(dif, cx.LonCosLatSphericalVelocity)
-    LonCosLatSphericalVelocity(
+    >>> convert(dif, cx.LonCosLatSphericalVel)
+    LonCosLatSphericalVel(
       d_lon_coslat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
       d_lat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
       d_distance=Quantity[...]( value=f32[], unit=Unit("km / s") )
     )
 
     """
-    return cx.LonCosLatSphericalVelocity.from_(obj)
+    return cx.LonCosLatSphericalVel.from_(obj)

--- a/src/coordinax/_interop/coordinax_interop_astropy/converters.py
+++ b/src/coordinax/_interop/coordinax_interop_astropy/converters.py
@@ -50,7 +50,7 @@ def vec_to_q(obj: cx.AbstractPos3D, /) -> Shaped[u.Quantity, "*batch 3"]:
     return convert(convert(obj, ux.Quantity), u.Quantity)
 
 
-@conversion_method(cx.CartesianAcceleration3D, u.Quantity)  # type: ignore[misc]
+@conversion_method(cx.CartesianAcc3D, u.Quantity)  # type: ignore[misc]
 @conversion_method(cx.CartesianVel3D, u.Quantity)  # type: ignore[misc]
 def vec_diff_to_q(obj: cx.CartesianVel3D, /) -> Shaped[u.Quantity, "*batch 3"]:
     """`coordinax.CartesianVel3D` -> `astropy.units.Quantity`.
@@ -65,7 +65,7 @@ def vec_diff_to_q(obj: cx.CartesianVel3D, /) -> Shaped[u.Quantity, "*batch 3"]:
     >>> convert(dif, Quantity)
     <Quantity [1., 2., 3.] km / s>
 
-    >>> dif2 = cx.CartesianAcceleration3D.from_([1, 2, 3], "km/s2")
+    >>> dif2 = cx.CartesianAcc3D.from_([1, 2, 3], "km/s2")
     >>> convert(dif2, Quantity)
     <Quantity [1., 2., 3.] km / s2>
 

--- a/src/coordinax/_src/base/__init__.py
+++ b/src/coordinax/_src/base/__init__.py
@@ -6,8 +6,8 @@ __all__ = [
     "ToUnitsOptions",
     # Pos
     "AbstractPos",
-    # Velocity
-    "AbstractVelocity",
+    # Vel
+    "AbstractVel",
     # Acceleration
     "AbstractAcceleration",
 ]
@@ -15,7 +15,7 @@ __all__ = [
 from .base import AbstractVector, ToUnitsOptions
 from .base_acc import AbstractAcceleration
 from .base_pos import AbstractPos
-from .base_vel import AbstractVelocity
+from .base_vel import AbstractVel
 
 # isort: split
 from . import (

--- a/src/coordinax/_src/base/__init__.py
+++ b/src/coordinax/_src/base/__init__.py
@@ -8,12 +8,12 @@ __all__ = [
     "AbstractPos",
     # Vel
     "AbstractVel",
-    # Acceleration
-    "AbstractAcceleration",
+    # Acc
+    "AbstractAcc",
 ]
 
 from .base import AbstractVector, ToUnitsOptions
-from .base_acc import AbstractAcceleration
+from .base_acc import AbstractAcc
 from .base_pos import AbstractPos
 from .base_vel import AbstractVel
 

--- a/src/coordinax/_src/base/__init__.py
+++ b/src/coordinax/_src/base/__init__.py
@@ -4,8 +4,8 @@ __all__ = [
     # Base
     "AbstractVector",
     "ToUnitsOptions",
-    # Position
-    "AbstractPosition",
+    # Pos
+    "AbstractPos",
     # Velocity
     "AbstractVelocity",
     # Acceleration
@@ -14,7 +14,7 @@ __all__ = [
 
 from .base import AbstractVector, ToUnitsOptions
 from .base_acc import AbstractAcceleration
-from .base_pos import AbstractPosition
+from .base_pos import AbstractPos
 from .base_vel import AbstractVelocity
 
 # isort: split

--- a/src/coordinax/_src/base/__init__.py
+++ b/src/coordinax/_src/base/__init__.py
@@ -4,11 +4,11 @@ __all__ = [
     # Base
     "AbstractVector",
     "ToUnitsOptions",
-    # Pos
+    # Position
     "AbstractPos",
-    # Vel
+    # Velocity
     "AbstractVel",
-    # Acc
+    # Acceleration
     "AbstractAcc",
 ]
 

--- a/src/coordinax/_src/base/base.py
+++ b/src/coordinax/_src/base/base.py
@@ -84,9 +84,9 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         >>> import coordinax as cx
 
         >>> xs = {"x": Quantity(1, "m"), "y": Quantity(2, "m"), "z": Quantity(3, "m")}
-        >>> vec = cx.CartesianPosition3D.from_(xs)
+        >>> vec = cx.CartesianPos3D.from_(xs)
         >>> vec
-        CartesianPosition3D(
+        CartesianPos3D(
             x=Quantity[...](value=f32[], unit=Unit("m")),
             y=Quantity[...](value=f32[], unit=Unit("m")),
             z=Quantity[...](value=f32[], unit=Unit("m"))
@@ -94,9 +94,9 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         >>> xs = {"x": Quantity([1, 2], "m"), "y": Quantity([3, 4], "m"),
         ...       "z": Quantity([5, 6], "m")}
-        >>> vec = cx.CartesianPosition3D.from_(xs)
+        >>> vec = cx.CartesianPos3D.from_(xs)
         >>> vec
-        CartesianPosition3D(
+        CartesianPos3D(
             x=Quantity[...](value=f32[2], unit=Unit("m")),
             y=Quantity[...](value=f32[2], unit=Unit("m")),
             z=Quantity[...](value=f32[2], unit=Unit("m"))
@@ -127,18 +127,18 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         >>> from unxt import Quantity
         >>> import coordinax as cx
 
-        >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "meter")
+        >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "meter")
         >>> vec
-        CartesianPosition3D(
+        CartesianPos3D(
             x=Quantity[...](value=f32[], unit=Unit("m")),
             y=Quantity[...](value=f32[], unit=Unit("m")),
             z=Quantity[...](value=f32[], unit=Unit("m"))
         )
 
         >>> xs = jnp.array([[1, 2, 3], [4, 5, 6]])
-        >>> vec = cx.CartesianPosition3D.from_(xs, "meter")
+        >>> vec = cx.CartesianPos3D.from_(xs, "meter")
         >>> vec
-        CartesianPosition3D(
+        CartesianPos3D(
             x=Quantity[...](value=f32[2], unit=Unit("m")),
             y=Quantity[...](value=f32[2], unit=Unit("m")),
             z=Quantity[...](value=f32[2], unit=Unit("m"))
@@ -159,11 +159,11 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         Examples
         --------
         >>> import coordinax as cx
-        >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "m")
+        >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "m")
 
         >>> try: vec.materialise()
         ... except RuntimeError as e: print(e)
-        Refusing to materialise `CartesianPosition3D`.
+        Refusing to materialise `CartesianPos3D`.
 
         """
         msg = f"Refusing to materialise `{type(self).__name__}`."
@@ -193,9 +193,9 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         We can transpose a vector:
 
-        >>> vec = cx.CartesianPosition3D(x=Quantity([[0, 1], [2, 3]], "m"),
-        ...                              y=Quantity([[0, 1], [2, 3]], "m"),
-        ...                              z=Quantity([[0, 1], [2, 3]], "m"))
+        >>> vec = cx.CartesianPos3D(x=Quantity([[0, 1], [2, 3]], "m"),
+        ...                         y=Quantity([[0, 1], [2, 3]], "m"),
+        ...                         z=Quantity([[0, 1], [2, 3]], "m"))
         >>> vec.mT.x
         Quantity['length'](Array([[0., 2.],
                                   [1., 3.]], dtype=float32), unit='m')
@@ -216,11 +216,11 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         We can get the number of dimensions of a vector:
 
-        >>> vec = cx.CartesianPosition2D.from_([1, 2], "m")
+        >>> vec = cx.CartesianPos2D.from_([1, 2], "m")
         >>> vec.ndim
         0
 
-        >>> vec = cx.CartesianPosition2D.from_([[1, 2], [3, 4]], "m")
+        >>> vec = cx.CartesianPos2D.from_([[1, 2], [3, 4]], "m")
         >>> vec.ndim
         1
 
@@ -228,8 +228,8 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         see this by creating a 2D vector in which the components have
         different shapes:
 
-        >>> vec = cx.CartesianPosition2D(x=Quantity([[1, 2], [3, 4]], "m"),
-        ...                              y=Quantity(0, "m"))
+        >>> vec = cx.CartesianPos2D(x=Quantity([[1, 2], [3, 4]], "m"),
+        ...                         y=Quantity(0, "m"))
         >>> vec.ndim
         2
 
@@ -252,11 +252,11 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         We can get the shape of a vector:
 
-        >>> vec = cx.CartesianPosition1D(x=Quantity([1, 2], "m"))
+        >>> vec = cx.CartesianPos1D(x=Quantity([1, 2], "m"))
         >>> vec.shape
         (2,)
 
-        >>> vec = cx.CartesianPosition1D(x=Quantity([[1, 2], [3, 4]], "m"))
+        >>> vec = cx.CartesianPos1D(x=Quantity([[1, 2], [3, 4]], "m"))
         >>> vec.shape
         (2, 2)
 
@@ -264,8 +264,8 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         see this by creating a 2D vector in which the components have
         different shapes:
 
-        >>> vec = cx.CartesianPosition2D(x=Quantity([[1, 2], [3, 4]], "m"),
-        ...                              y=Quantity(0, "m"))
+        >>> vec = cx.CartesianPos2D(x=Quantity([[1, 2], [3, 4]], "m"),
+        ...                         y=Quantity(0, "m"))
         >>> vec.shape
         (2, 2)
 
@@ -285,11 +285,11 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         We can get the size of a vector:
 
-        >>> vec = cx.CartesianPosition2D.from_([1, 2], "m")
+        >>> vec = cx.CartesianPos2D.from_([1, 2], "m")
         >>> vec.size
         1
 
-        >>> vec = cx.CartesianPosition2D.from_([[1, 2], [3, 4]], "m")
+        >>> vec = cx.CartesianPos2D.from_([[1, 2], [3, 4]], "m")
         >>> vec.size
         2
 
@@ -297,8 +297,8 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         see this by creating a 2D vector in which the components have
         different shapes:
 
-        >>> vec = cx.CartesianPosition2D(x=Quantity([[1, 2], [3, 4]], "m"),
-        ...                              y=Quantity(0, "m"))
+        >>> vec = cx.CartesianPos2D(x=Quantity([[1, 2], [3, 4]], "m"),
+        ...                         y=Quantity(0, "m"))
         >>> vec.size
         4
 
@@ -318,9 +318,9 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         We can transpose a vector:
 
-        >>> vec = cx.CartesianPosition3D(x=Quantity([[0, 1], [2, 3]], "m"),
-        ...                              y=Quantity([[0, 1], [2, 3]], "m"),
-        ...                              z=Quantity([[0, 1], [2, 3]], "m"))
+        >>> vec = cx.CartesianPos3D(x=Quantity([[0, 1], [2, 3]], "m"),
+        ...                         y=Quantity([[0, 1], [2, 3]], "m"),
+        ...                         z=Quantity([[0, 1], [2, 3]], "m"))
         >>> vec.T.x
         Quantity['length'](Array([[0., 2.],
                                   [1., 3.]], dtype=float32), unit='m')
@@ -416,17 +416,17 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         Scalar vectors have length 0:
 
-        >>> vec = cx.CartesianPosition1D.from_([1], "m")
+        >>> vec = cx.CartesianPos1D.from_([1], "m")
         >>> len(vec)
         0
 
         Vectors with certain lengths:
 
-        >>> vec = cx.CartesianPosition1D(Quantity([1], "m"))
+        >>> vec = cx.CartesianPos1D(Quantity([1], "m"))
         >>> len(vec)
         1
 
-        >>> vec = cx.CartesianPosition1D(Quantity([1, 2], "m"))
+        >>> vec = cx.CartesianPos1D(Quantity([1, 2], "m"))
         >>> len(vec)
         2
 
@@ -439,7 +439,7 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         Examples
         --------
         >>> import coordinax as cx
-        >>> vec = cx.CartesianPosition2D.from_([3, 4], "m")
+        >>> vec = cx.CartesianPos2D.from_([3, 4], "m")
         >>> abs(vec)
         Quantity['length'](Array(5., dtype=float32), unit='m')
 
@@ -452,7 +452,7 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         Examples
         --------
         >>> import coordinax as cx
-        >>> vec = cx.CartesianPosition2D.from_([3, 4], "m")
+        >>> vec = cx.CartesianPos2D.from_([3, 4], "m")
         >>> vec.__array_namespace__()
         <module 'quaxed.numpy' from ...>
 
@@ -481,8 +481,8 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         We can slice a vector:
 
-        >>> vec = cx.CartesianPosition2D(x=Quantity([[1, 2], [3, 4]], "m"),
-        ...                              y=Quantity(0, "m"))
+        >>> vec = cx.CartesianPos2D(x=Quantity([[1, 2], [3, 4]], "m"),
+        ...                         y=Quantity(0, "m"))
         >>> vec[0].x
         Quantity['length'](Array([1., 2.], dtype=float32), unit='m')
 
@@ -499,10 +499,9 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         Examples
         --------
-        >>> from unxt import Quantity
         >>> import coordinax as cx
 
-        >>> vec = cx.CartesianPosition3D.from_(Quantity([1, 2, 3], "m"))
+        >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "m")
         >>> (vec * 2).x
         Quantity['length'](Array(2., dtype=float32), unit='m')
 
@@ -518,10 +517,9 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         Examples
         --------
-        >>> from unxt import Quantity
         >>> import coordinax as cx
 
-        >>> vec = cx.CartesianPosition3D.from_(Quantity([1, 2, 3], "m"))
+        >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "m")
         >>> (2 * vec).x
         Quantity['length'](Array(2., dtype=float32), unit='m')
 
@@ -554,19 +552,15 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         Examples
         --------
-        We assume the following imports:
-
         >>> from jax import devices
         >>> from unxt import Quantity
         >>> import coordinax as cx
 
         We can move a vector to a new device:
 
-        >>> vec = cx.CartesianPosition1D(Quantity([1, 2], "m"))
+        >>> vec = cx.CartesianPos1D(Quantity([1, 2], "m"))
         >>> vec.to_device(devices()[0])
-        CartesianPosition1D(
-            x=Quantity[PhysicalType('length')](value=f32[2], unit=Unit("m"))
-        )
+        CartesianPos1D(x=Quantity[PhysicalType('length')](value=f32[2], unit=Unit("m")))
 
         """
         return replace(self, **{k: v.to_device(device) for k, v in field_items(self)})
@@ -586,10 +580,10 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         We can flatten a vector:
 
-        >>> vec = cx.CartesianPosition2D(x=Quantity([[1, 2], [3, 4]], "m"),
-        ...                              y=Quantity(0, "m"))
+        >>> vec = cx.CartesianPos2D(x=Quantity([[1, 2], [3, 4]], "m"),
+        ...                         y=Quantity(0, "m"))
         >>> vec.flatten()
-        CartesianPosition2D(
+        CartesianPos2D(
             x=Quantity[...](value=f32[4], unit=Unit("m")),
             y=Quantity[...](value=f32[1], unit=Unit("m"))
         )
@@ -621,11 +615,11 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         We can reshape a vector:
 
-        >>> vec = cx.CartesianPosition2D(x=Quantity([[1, 2], [3, 4]], "m"),
-        ...                              y=Quantity(0, "m"))
+        >>> vec = cx.CartesianPos2D(x=Quantity([[1, 2], [3, 4]], "m"),
+        ...                         y=Quantity(0, "m"))
 
         >>> vec.reshape(4)
-        CartesianPosition2D(
+        CartesianPos2D(
             x=Quantity[...](value=f32[4], unit=Unit("m")),
             y=Quantity[...](value=f32[4], unit=Unit("m"))
         )
@@ -672,8 +666,8 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         We can get the vector as a mapping:
 
-        >>> vec = cx.CartesianPosition2D(x=Quantity([[1, 2], [3, 4]], "m"),
-        ...                              y=Quantity(0, "m"))
+        >>> vec = cx.CartesianPos2D(x=Quantity([[1, 2], [3, 4]], "m"),
+        ...                         y=Quantity(0, "m"))
         >>> vec.asdict()
         {'x': Quantity['length'](Array([[1., 2.], [3., 4.]], dtype=float32), unit='m'),
          'y': Quantity['length'](Array(0., dtype=float32), unit='m')}
@@ -690,9 +684,9 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         --------
         >>> import coordinax as cx
 
-        >>> cx.CartesianPosition2D.components
+        >>> cx.CartesianPos2D.components
         ('x', 'y')
-        >>> cx.SphericalPosition.components
+        >>> cx.SphericalPos.components
         ('r', 'theta', 'phi')
         >>> cx.RadialVelocity.components
         ('d_r',)
@@ -728,10 +722,10 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         --------
         >>> import coordinax as cx
 
-        >>> cx.CartesianPosition2D.from_([1, 2], "m").sizes
+        >>> cx.CartesianPos2D.from_([1, 2], "m").sizes
         mappingproxy({'x': 1, 'y': 1})
 
-        >>> cx.CartesianPosition2D.from_([[1, 2], [1, 2]], "m").sizes
+        >>> cx.CartesianPos2D.from_([[1, 2], [1, 2]], "m").sizes
         mappingproxy({'x': 2, 'y': 2})
 
         """
@@ -763,9 +757,9 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         >>> usys = unitsystem(u.m, u.s, u.kg, u.rad)
 
-        >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "km")
+        >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "km")
         >>> vec.to_units(usys)
-        CartesianPosition3D(
+        CartesianPos3D(
             x=Quantity[...](value=f32[], unit=Unit("m")),
             y=Quantity[...](value=f32[], unit=Unit("m")),
             z=Quantity[...](value=f32[], unit=Unit("m"))
@@ -797,19 +791,19 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         We can convert a vector to the given units:
 
-        >>> cart = cx.CartesianPosition2D(x=Quantity(1, "m"), y=Quantity(2, "km"))
+        >>> cart = cx.CartesianPos2D(x=Quantity(1, "m"), y=Quantity(2, "km"))
         >>> cart.to_units({"length": "km"})
-        CartesianPosition2D(
+        CartesianPos2D(
             x=Quantity[...](value=f32[], unit=Unit("km")),
             y=Quantity[...](value=f32[], unit=Unit("km"))
         )
 
         This also works for vectors with different units:
 
-        >>> sph = cx.SphericalPosition(r=Quantity(1, "m"), theta=Quantity(45, "deg"),
-        ...                            phi=Quantity(3, "rad"))
+        >>> sph = cx.SphericalPos(r=Quantity(1, "m"), theta=Quantity(45, "deg"),
+        ...                       phi=Quantity(3, "rad"))
         >>> sph.to_units({"length": "km", "angle": "deg"})
-        SphericalPosition(
+        SphericalPos(
             r=Distance(value=f32[], unit=Unit("km")),
             theta=Quantity[...](value=f32[], unit=Unit("deg")),
             phi=Quantity[...](value=f32[], unit=Unit("deg")) )
@@ -843,20 +837,20 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
 
         We can convert a vector to the given units:
 
-        >>> cart = cx.CartesianPosition2D(x=Quantity(1, "m"), y=Quantity(2, "km"))
+        >>> cart = cx.CartesianPos2D(x=Quantity(1, "m"), y=Quantity(2, "km"))
 
         If all you want is to convert to consistent units, you can use
         ``"consistent"``:
 
         >>> cart.to_units(cx.ToUnitsOptions.consistent)
-        CartesianPosition2D(
+        CartesianPos2D(
             x=Quantity[...](value=f32[], unit=Unit("m")),
             y=Quantity[...](value=f32[], unit=Unit("m"))
         )
 
-        >>> sph = cart.represent_as(cx.SphericalPosition)
+        >>> sph = cart.represent_as(cx.SphericalPos)
         >>> sph.to_units(cx.ToUnitsOptions.consistent)
-        SphericalPosition(
+        SphericalPos(
             r=Distance(value=f32[], unit=Unit("m")),
             theta=Quantity[...](value=f32[], unit=Unit("rad")),
             phi=Quantity[...](value=f32[], unit=Unit("rad"))
@@ -887,9 +881,9 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         >>> from unxt import Quantity
         >>> import coordinax as cx
 
-        >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "m")
+        >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "m")
         >>> str(vec)
-        '<CartesianPosition3D (x[m], y[m], z[m])\n    [1. 2. 3.]>'
+        '<CartesianPos3D (x[m], y[m], z[m])\n    [1. 2. 3.]>'
 
         """
         cls_name = type(self).__name__
@@ -925,27 +919,27 @@ def from_(cls: type[AbstractVector], obj: AbstractVector, /) -> AbstractVector:
     --------
     >>> import coordinax as cx
 
-    Positions:
+    Poss:
 
-    >>> q = cx.CartesianPosition3D.from_([1, 2, 3], "km")
+    >>> q = cx.CartesianPos3D.from_([1, 2, 3], "km")
 
-    >>> cart = cx.CartesianPosition3D.from_(q)
+    >>> cart = cx.CartesianPos3D.from_(q)
     >>> cart
-    CartesianPosition3D(
+    CartesianPos3D(
       x=Quantity[...](value=f32[], unit=Unit("km")),
       y=Quantity[...](value=f32[], unit=Unit("km")),
       z=Quantity[...](value=f32[], unit=Unit("km"))
     )
 
-    >>> cx.AbstractPosition3D.from_(cart) is cart
+    >>> cx.AbstractPos3D.from_(cart) is cart
     True
 
-    >>> sph = cart.represent_as(cx.SphericalPosition)
-    >>> cx.AbstractPosition3D.from_(sph) is sph
+    >>> sph = cart.represent_as(cx.SphericalPos)
+    >>> cx.AbstractPos3D.from_(sph) is sph
     True
 
-    >>> cyl = cart.represent_as(cx.CylindricalPosition)
-    >>> cx.AbstractPosition3D.from_(cyl) is cyl
+    >>> cyl = cart.represent_as(cx.CylindricalPos)
+    >>> cx.AbstractPos3D.from_(cyl) is cyl
     True
 
     Velocities:

--- a/src/coordinax/_src/base/base.py
+++ b/src/coordinax/_src/base/base.py
@@ -350,8 +350,8 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         >>> vel1 == vel2
         Array([ True, False,  True], dtype=bool)
 
-        >>> acc1 = cx.CartesianAcceleration1D(Quantity([1, 2, 3], "km/s2"))
-        >>> acc2 = cx.CartesianAcceleration1D(Quantity([1, 0, 3], "km/s2"))
+        >>> acc1 = cx.CartesianAcc1D(Quantity([1, 2, 3], "km/s2"))
+        >>> acc2 = cx.CartesianAcc1D(Quantity([1, 0, 3], "km/s2"))
         >>> jnp.equal(acc1, acc2)
         Array([ True,  False,  True], dtype=bool)
         >>> acc1 == acc2
@@ -364,8 +364,8 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         >>> vel1 == vel2
         Array([ True, False,  True], dtype=bool)
 
-        >>> acc1 = cx.RadialAcceleration(Quantity([1, 2, 3], "km/s2"))
-        >>> acc2 = cx.RadialAcceleration(Quantity([1, 0, 3], "km/s2"))
+        >>> acc1 = cx.RadialAcc(Quantity([1, 2, 3], "km/s2"))
+        >>> acc2 = cx.RadialAcc(Quantity([1, 0, 3], "km/s2"))
         >>> jnp.equal(acc1, acc2)
         Array([ True,  False,  True], dtype=bool)
         >>> acc1 == acc2
@@ -380,8 +380,8 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         >>> vel1 == vel2
         Array([ True, False], dtype=bool)
 
-        >>> acc1 = cx.CartesianAcceleration2D.from_([[1, 3], [2, 4]], "km/s2")
-        >>> acc2 = cx.CartesianAcceleration2D.from_([[1, 3], [0, 4]], "km/s2")
+        >>> acc1 = cx.CartesianAcc2D.from_([[1, 3], [2, 4]], "km/s2")
+        >>> acc2 = cx.CartesianAcc2D.from_([[1, 3], [0, 4]], "km/s2")
         >>> acc1.d2_x
         Quantity['acceleration'](Array([1., 2.], dtype=float32), unit='km / s2')
         >>> jnp.equal(acc1, acc2)
@@ -919,7 +919,7 @@ def from_(cls: type[AbstractVector], obj: AbstractVector, /) -> AbstractVector:
     --------
     >>> import coordinax as cx
 
-    Poss:
+    Positions:
 
     >>> q = cx.CartesianPos3D.from_([1, 2, 3], "km")
 
@@ -962,16 +962,16 @@ def from_(cls: type[AbstractVector], obj: AbstractVector, /) -> AbstractVector:
 
     >>> p = cx.CartesianVel3D.from_([1, 1, 1], "km/s")
 
-    >>> cart = cx.CartesianAcceleration3D.from_([1, 2, 3], "km/s2")
-    >>> cx.AbstractAcceleration3D.from_(cart) is cart
+    >>> cart = cx.CartesianAcc3D.from_([1, 2, 3], "km/s2")
+    >>> cx.AbstractAcc3D.from_(cart) is cart
     True
 
-    >>> sph = cart.represent_as(cx.SphericalAcceleration, p, q)
-    >>> cx.AbstractAcceleration3D.from_(sph) is sph
+    >>> sph = cart.represent_as(cx.SphericalAcc, p, q)
+    >>> cx.AbstractAcc3D.from_(sph) is sph
     True
 
-    >>> cyl = cart.represent_as(cx.CylindricalAcceleration, p, q)
-    >>> cx.AbstractAcceleration3D.from_(cyl) is cyl
+    >>> cyl = cart.represent_as(cx.CylindricalAcc, p, q)
+    >>> cx.AbstractAcc3D.from_(cyl) is cyl
     True
 
     """

--- a/src/coordinax/_src/base/base.py
+++ b/src/coordinax/_src/base/base.py
@@ -343,8 +343,8 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         Positions are covered by a separate dispatch. So here we show velocities
         and accelerations:
 
-        >>> vel1 = cx.CartesianVelocity1D(Quantity([1, 2, 3], "km/s"))
-        >>> vel2 = cx.CartesianVelocity1D(Quantity([1, 0, 3], "km/s"))
+        >>> vel1 = cx.CartesianVel1D(Quantity([1, 2, 3], "km/s"))
+        >>> vel2 = cx.CartesianVel1D(Quantity([1, 0, 3], "km/s"))
         >>> jnp.equal(vel1, vel2)
         Array([ True,  False,  True], dtype=bool)
         >>> vel1 == vel2
@@ -357,8 +357,8 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         >>> acc1 == acc2
         Array([ True, False,  True], dtype=bool)
 
-        >>> vel1 = cx.RadialVelocity(Quantity([1, 2, 3], "km/s"))
-        >>> vel2 = cx.RadialVelocity(Quantity([1, 0, 3], "km/s"))
+        >>> vel1 = cx.RadialVel(Quantity([1, 2, 3], "km/s"))
+        >>> vel2 = cx.RadialVel(Quantity([1, 0, 3], "km/s"))
         >>> jnp.equal(vel1, vel2)
         Array([ True,  False,  True], dtype=bool)
         >>> vel1 == vel2
@@ -371,8 +371,8 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         >>> acc1 == acc2
         Array([ True, False,  True], dtype=bool)
 
-        >>> vel1 = cx.CartesianVelocity2D.from_([[1, 3], [2, 4]], "km/s")
-        >>> vel2 = cx.CartesianVelocity2D.from_([[1, 3], [0, 4]], "km/s")
+        >>> vel1 = cx.CartesianVel2D.from_([[1, 3], [2, 4]], "km/s")
+        >>> vel2 = cx.CartesianVel2D.from_([[1, 3], [0, 4]], "km/s")
         >>> vel1.d_x
         Quantity['speed'](Array([1., 2.], dtype=float32), unit='km / s')
         >>> jnp.equal(vel1, vel2)
@@ -389,8 +389,8 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         >>> acc1 == acc2
         Array([ True, False], dtype=bool)
 
-        >>> vel1 = cx.CartesianVelocity3D.from_([[1, 4], [2, 5], [3, 6]], "km/s")
-        >>> vel2 = cx.CartesianVelocity3D.from_([[1, 4], [0, 5], [3, 0]], "km/s")
+        >>> vel1 = cx.CartesianVel3D.from_([[1, 4], [2, 5], [3, 6]], "km/s")
+        >>> vel2 = cx.CartesianVel3D.from_([[1, 4], [0, 5], [3, 0]], "km/s")
         >>> vel1.d_x
         Quantity['speed'](Array([1., 2., 3.], dtype=float32), unit='km / s')
         >>> jnp.equal(vel1, vel2)
@@ -688,7 +688,7 @@ class AbstractVector(ArrayValue):  # type: ignore[misc]
         ('x', 'y')
         >>> cx.SphericalPos.components
         ('r', 'theta', 'phi')
-        >>> cx.RadialVelocity.components
+        >>> cx.RadialVel.components
         ('d_r',)
 
         """
@@ -944,23 +944,23 @@ def from_(cls: type[AbstractVector], obj: AbstractVector, /) -> AbstractVector:
 
     Velocities:
 
-    >>> p = cx.CartesianVelocity3D.from_([1, 2, 3], "km/s")
+    >>> p = cx.CartesianVel3D.from_([1, 2, 3], "km/s")
 
-    >>> cart = cx.CartesianVelocity3D.from_(p)
-    >>> cx.AbstractVelocity3D.from_(cart) is cart
+    >>> cart = cx.CartesianVel3D.from_(p)
+    >>> cx.AbstractVel3D.from_(cart) is cart
     True
 
-    >>> sph = cart.represent_as(cx.SphericalVelocity, q)
-    >>> cx.AbstractVelocity3D.from_(sph) is sph
+    >>> sph = cart.represent_as(cx.SphericalVel, q)
+    >>> cx.AbstractVel3D.from_(sph) is sph
     True
 
-    >>> cyl = cart.represent_as(cx.CylindricalVelocity, q)
-    >>> cx.AbstractVelocity3D.from_(cyl) is cyl
+    >>> cyl = cart.represent_as(cx.CylindricalVel, q)
+    >>> cx.AbstractVel3D.from_(cyl) is cyl
     True
 
     Accelerations:
 
-    >>> p = cx.CartesianVelocity3D.from_([1, 1, 1], "km/s")
+    >>> p = cx.CartesianVel3D.from_([1, 1, 1], "km/s")
 
     >>> cart = cx.CartesianAcceleration3D.from_([1, 2, 3], "km/s2")
     >>> cx.AbstractAcceleration3D.from_(cart) is cart

--- a/src/coordinax/_src/base/base_acc.py
+++ b/src/coordinax/_src/base/base_acc.py
@@ -1,6 +1,6 @@
 """Representation of coordinates in different systems."""
 
-__all__ = ["AbstractAcceleration"]
+__all__ = ["AbstractAcc"]
 
 from abc import abstractmethod
 from functools import partial
@@ -25,12 +25,12 @@ from coordinax._src.utils import classproperty
 if TYPE_CHECKING:
     from typing_extensions import Self
 
-AccT = TypeVar("AccT", bound="AbstractAcceleration")
+AccT = TypeVar("AccT", bound="AbstractAcc")
 
-ACCELERATION_CLASSES: set[type["AbstractAcceleration"]] = set()
+ACCELERATION_CLASSES: set[type["AbstractAcc"]] = set()
 
 
-class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
+class AbstractAcc(AbstractVector):  # pylint: disable=abstract-method
     """Abstract representation of vector differentials in different systems."""
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
@@ -50,11 +50,11 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
         --------
         >>> import coordinax as cx
 
-        >>> cx.CartesianAcceleration3D._cartesian_cls
-        <class 'coordinax...CartesianAcceleration3D'>
+        >>> cx.CartesianAcc3D._cartesian_cls
+        <class 'coordinax...CartesianAcc3D'>
 
-        >>> cx.SphericalAcceleration._cartesian_cls
-        <class 'coordinax...CartesianAcceleration3D'>
+        >>> cx.SphericalAcc._cartesian_cls
+        <class 'coordinax...CartesianAcc3D'>
 
         """
         # TODO: something nicer than this for getting the corresponding class
@@ -70,10 +70,10 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
         --------
         >>> import coordinax as cx
 
-        >>> cx.RadialAcceleration.integral_cls.__name__
+        >>> cx.RadialAcc.integral_cls.__name__
         'RadialVel'
 
-        >>> cx.SphericalAcceleration.integral_cls.__name__
+        >>> cx.SphericalAcc.integral_cls.__name__
         'SphericalVel'
 
         """
@@ -97,11 +97,11 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
         >>> from unxt import Quantity
         >>> import coordinax as cx
 
-        >>> d2r = cx.RadialAcceleration.from_([1], "m/s2")
+        >>> d2r = cx.RadialAcc.from_([1], "m/s2")
         >>> -d2r
-        RadialAcceleration( d2_r=Quantity[...](value=i32[], unit=Unit("m / s2")) )
+        RadialAcc( d2_r=Quantity[...](value=i32[], unit=Unit("m / s2")) )
 
-        >>> d2p = cx.PolarAcceleration(Quantity(1, "m/s2"), Quantity(1, "mas/yr2"))
+        >>> d2p = cx.PolarAcc(Quantity(1, "m/s2"), Quantity(1, "mas/yr2"))
         >>> negd2p = -d2p
         >>> negd2p.d2_r
         Quantity['acceleration'](Array(-1., dtype=float32), unit='m / s2')
@@ -136,7 +136,7 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
 
         Returns
         -------
-        `coordinax.AbstractAcceleration`
+        `coordinax.AbstractAcc`
             The vector represented as the target type.
 
         Examples
@@ -144,10 +144,10 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
         >>> import coordinax as cx
         >>> q = cx.CartesianPos3D.from_([1, 2, 3], "m")
         >>> p = cx.CartesianVel3D.from_([4, 5, 6], "m/s")
-        >>> a = cx.CartesianAcceleration3D.from_([7, 8, 9], "m/s2")
-        >>> sph = a.represent_as(cx.SphericalAcceleration, p, q)
+        >>> a = cx.CartesianAcc3D.from_([7, 8, 9], "m/s2")
+        >>> sph = a.represent_as(cx.SphericalAcc, p, q)
         >>> sph
-        SphericalAcceleration(
+        SphericalAcc(
             d2_r=Quantity[...](value=f32[], unit=Unit("m / s2")),
             d2_theta=Quantity[...]( value=f32[], unit=Unit("rad / s2") ),
             d2_phi=Quantity[...]( value=f32[], unit=Unit("rad / s2") )
@@ -170,7 +170,7 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_acc_time(lhs: AbstractAcceleration, rhs: Quantity["time"]) -> AbstractVel:
+def _mul_acc_time(lhs: AbstractAcc, rhs: Quantity["time"]) -> AbstractVel:
     """Multiply the vector by a :class:`unxt.Quantity`.
 
     Examples
@@ -179,7 +179,7 @@ def _mul_acc_time(lhs: AbstractAcceleration, rhs: Quantity["time"]) -> AbstractV
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> d2r = cx.RadialAcceleration(Quantity(1, "m/s2"))
+    >>> d2r = cx.RadialAcc(Quantity(1, "m/s2"))
     >>> vec = lax.mul(d2r, Quantity(2, "s"))
     >>> vec
     RadialVel( d_r=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
@@ -197,7 +197,7 @@ def _mul_acc_time(lhs: AbstractAcceleration, rhs: Quantity["time"]) -> AbstractV
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_time_acc(lhs: Quantity["time"], rhs: AbstractAcceleration) -> AbstractVel:
+def _mul_time_acc(lhs: Quantity["time"], rhs: AbstractAcc) -> AbstractVel:
     """Multiply a scalar by an acceleration.
 
     Examples
@@ -206,7 +206,7 @@ def _mul_time_acc(lhs: Quantity["time"], rhs: AbstractAcceleration) -> AbstractV
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> d2r = cx.RadialAcceleration(Quantity(1, "m/s2"))
+    >>> d2r = cx.RadialAcc(Quantity(1, "m/s2"))
     >>> vec = lax.mul(Quantity(2, "s"), d2r)
     >>> vec
     RadialVel( d_r=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
@@ -218,7 +218,7 @@ def _mul_time_acc(lhs: Quantity["time"], rhs: AbstractAcceleration) -> AbstractV
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_acc_time2(lhs: AbstractAcceleration, rhs: Quantity["s2"]) -> AbstractPos:
+def _mul_acc_time2(lhs: AbstractAcc, rhs: Quantity["s2"]) -> AbstractPos:
     """Multiply an acceleration by a scalar.
 
     Examples
@@ -227,7 +227,7 @@ def _mul_acc_time2(lhs: AbstractAcceleration, rhs: Quantity["s2"]) -> AbstractPo
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> d2r = cx.RadialAcceleration(Quantity(1, "m/s2"))
+    >>> d2r = cx.RadialAcc(Quantity(1, "m/s2"))
     >>> vec = lax.mul(d2r, Quantity(2, "s2"))
     >>> vec
     RadialPos(r=Distance(value=f32[], unit=Unit("m")))
@@ -245,7 +245,7 @@ def _mul_acc_time2(lhs: AbstractAcceleration, rhs: Quantity["s2"]) -> AbstractPo
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_time2_acc(lhs: Quantity["s2"], rhs: AbstractAcceleration) -> AbstractPos:
+def _mul_time2_acc(lhs: Quantity["s2"], rhs: AbstractAcc) -> AbstractPos:
     """Multiply a scalar by an acceleration.
 
     Examples
@@ -254,7 +254,7 @@ def _mul_time2_acc(lhs: Quantity["s2"], rhs: AbstractAcceleration) -> AbstractPo
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> d2r = cx.RadialAcceleration(Quantity(1, "m/s2"))
+    >>> d2r = cx.RadialAcc(Quantity(1, "m/s2"))
     >>> vec = lax.mul(Quantity(2, "s2"), d2r)
     >>> vec
     RadialPos(r=Distance(value=f32[], unit=Unit("m")))

--- a/src/coordinax/_src/base/base_acc.py
+++ b/src/coordinax/_src/base/base_acc.py
@@ -17,7 +17,7 @@ from quaxed import lax as qlax
 from unxt import Quantity
 
 from .base import AbstractVector
-from .base_pos import AbstractPosition
+from .base_pos import AbstractPos
 from .base_vel import AbstractVelocity
 from coordinax._src.funcs import represent_as
 from coordinax._src.utils import classproperty
@@ -128,7 +128,7 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
             Extra arguments. These are passed to `coordinax.represent_as` and
             might be used, depending on the dispatched method. Generally the
             first argument is the velocity (`coordinax.AbstractVelocity`)
-            followed by the position (`coordinax.AbstractPosition`) at which the
+            followed by the position (`coordinax.AbstractPos`) at which the
             acceleration is defined. In general this is a required argument,
             though it is not for Cartesian-to-Cartesian transforms -- see
             https://en.wikipedia.org/wiki/Tensors_in_curvilinear_coordinates for
@@ -142,7 +142,7 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
         Examples
         --------
         >>> import coordinax as cx
-        >>> q = cx.CartesianPosition3D.from_([1, 2, 3], "m")
+        >>> q = cx.CartesianPos3D.from_([1, 2, 3], "m")
         >>> p = cx.CartesianVelocity3D.from_([4, 5, 6], "m/s")
         >>> a = cx.CartesianAcceleration3D.from_([7, 8, 9], "m/s2")
         >>> sph = a.represent_as(cx.SphericalAcceleration, p, q)
@@ -160,7 +160,7 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
 
     @partial(eqx.filter_jit, inline=True)
     def norm(
-        self, velocity: AbstractVelocity, position: AbstractPosition, /
+        self, velocity: AbstractVelocity, position: AbstractPos, /
     ) -> Quantity["speed"]:
         """Return the norm of the vector."""
         return self.represent_as(self._cartesian_cls, velocity, position).norm()
@@ -218,7 +218,7 @@ def _mul_time_acc(lhs: Quantity["time"], rhs: AbstractAcceleration) -> AbstractV
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_acc_time2(lhs: AbstractAcceleration, rhs: Quantity["s2"]) -> AbstractPosition:
+def _mul_acc_time2(lhs: AbstractAcceleration, rhs: Quantity["s2"]) -> AbstractPos:
     """Multiply an acceleration by a scalar.
 
     Examples
@@ -230,7 +230,7 @@ def _mul_acc_time2(lhs: AbstractAcceleration, rhs: Quantity["s2"]) -> AbstractPo
     >>> d2r = cx.RadialAcceleration(Quantity(1, "m/s2"))
     >>> vec = lax.mul(d2r, Quantity(2, "s2"))
     >>> vec
-    RadialPosition(r=Distance(value=f32[], unit=Unit("m")))
+    RadialPos(r=Distance(value=f32[], unit=Unit("m")))
     >>> vec.r
     Distance(Array(2., dtype=float32), unit='m')
 
@@ -245,7 +245,7 @@ def _mul_acc_time2(lhs: AbstractAcceleration, rhs: Quantity["s2"]) -> AbstractPo
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_time2_acc(lhs: Quantity["s2"], rhs: AbstractAcceleration) -> AbstractPosition:
+def _mul_time2_acc(lhs: Quantity["s2"], rhs: AbstractAcceleration) -> AbstractPos:
     """Multiply a scalar by an acceleration.
 
     Examples
@@ -257,7 +257,7 @@ def _mul_time2_acc(lhs: Quantity["s2"], rhs: AbstractAcceleration) -> AbstractPo
     >>> d2r = cx.RadialAcceleration(Quantity(1, "m/s2"))
     >>> vec = lax.mul(Quantity(2, "s2"), d2r)
     >>> vec
-    RadialPosition(r=Distance(value=f32[], unit=Unit("m")))
+    RadialPos(r=Distance(value=f32[], unit=Unit("m")))
     >>> vec.r
     Distance(Array(2., dtype=float32), unit='m')
 

--- a/src/coordinax/_src/base/base_acc.py
+++ b/src/coordinax/_src/base/base_acc.py
@@ -18,7 +18,7 @@ from unxt import Quantity
 
 from .base import AbstractVector
 from .base_pos import AbstractPos
-from .base_vel import AbstractVelocity
+from .base_vel import AbstractVel
 from coordinax._src.funcs import represent_as
 from coordinax._src.utils import classproperty
 
@@ -63,7 +63,7 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
     @classproperty
     @classmethod
     @abstractmethod
-    def integral_cls(cls) -> type[AbstractVelocity]:
+    def integral_cls(cls) -> type[AbstractVel]:
         """Return the corresponding vector class.
 
         Examples
@@ -71,10 +71,10 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
         >>> import coordinax as cx
 
         >>> cx.RadialAcceleration.integral_cls.__name__
-        'RadialVelocity'
+        'RadialVel'
 
         >>> cx.SphericalAcceleration.integral_cls.__name__
-        'SphericalVelocity'
+        'SphericalVel'
 
         """
         raise NotImplementedError
@@ -122,12 +122,12 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
 
         Parameters
         ----------
-        target : type[`coordinax.AbstractVelocity`]
+        target : type[`coordinax.AbstractVel`]
             The type to represent the vector as.
         *args, **kwargs : Any
             Extra arguments. These are passed to `coordinax.represent_as` and
             might be used, depending on the dispatched method. Generally the
-            first argument is the velocity (`coordinax.AbstractVelocity`)
+            first argument is the velocity (`coordinax.AbstractVel`)
             followed by the position (`coordinax.AbstractPos`) at which the
             acceleration is defined. In general this is a required argument,
             though it is not for Cartesian-to-Cartesian transforms -- see
@@ -143,7 +143,7 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
         --------
         >>> import coordinax as cx
         >>> q = cx.CartesianPos3D.from_([1, 2, 3], "m")
-        >>> p = cx.CartesianVelocity3D.from_([4, 5, 6], "m/s")
+        >>> p = cx.CartesianVel3D.from_([4, 5, 6], "m/s")
         >>> a = cx.CartesianAcceleration3D.from_([7, 8, 9], "m/s2")
         >>> sph = a.represent_as(cx.SphericalAcceleration, p, q)
         >>> sph
@@ -160,7 +160,7 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
 
     @partial(eqx.filter_jit, inline=True)
     def norm(
-        self, velocity: AbstractVelocity, position: AbstractPos, /
+        self, velocity: AbstractVel, position: AbstractPos, /
     ) -> Quantity["speed"]:
         """Return the norm of the vector."""
         return self.represent_as(self._cartesian_cls, velocity, position).norm()
@@ -170,7 +170,7 @@ class AbstractAcceleration(AbstractVector):  # pylint: disable=abstract-method
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_acc_time(lhs: AbstractAcceleration, rhs: Quantity["time"]) -> AbstractVelocity:
+def _mul_acc_time(lhs: AbstractAcceleration, rhs: Quantity["time"]) -> AbstractVel:
     """Multiply the vector by a :class:`unxt.Quantity`.
 
     Examples
@@ -182,7 +182,7 @@ def _mul_acc_time(lhs: AbstractAcceleration, rhs: Quantity["time"]) -> AbstractV
     >>> d2r = cx.RadialAcceleration(Quantity(1, "m/s2"))
     >>> vec = lax.mul(d2r, Quantity(2, "s"))
     >>> vec
-    RadialVelocity( d_r=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
+    RadialVel( d_r=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
     >>> vec.d_r
     Quantity['speed'](Array(2, dtype=int32, ...), unit='m / s')
 
@@ -197,7 +197,7 @@ def _mul_acc_time(lhs: AbstractAcceleration, rhs: Quantity["time"]) -> AbstractV
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_time_acc(lhs: Quantity["time"], rhs: AbstractAcceleration) -> AbstractVelocity:
+def _mul_time_acc(lhs: Quantity["time"], rhs: AbstractAcceleration) -> AbstractVel:
     """Multiply a scalar by an acceleration.
 
     Examples
@@ -209,7 +209,7 @@ def _mul_time_acc(lhs: Quantity["time"], rhs: AbstractAcceleration) -> AbstractV
     >>> d2r = cx.RadialAcceleration(Quantity(1, "m/s2"))
     >>> vec = lax.mul(Quantity(2, "s"), d2r)
     >>> vec
-    RadialVelocity( d_r=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
+    RadialVel( d_r=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
     >>> vec.d_r
     Quantity['speed'](Array(2, dtype=int32, ...), unit='m / s')
 

--- a/src/coordinax/_src/base/base_pos.py
+++ b/src/coordinax/_src/base/base_pos.py
@@ -69,7 +69,7 @@ class AbstractPos(AvalMixin, AbstractVector):  # pylint: disable=abstract-method
     @classproperty
     @classmethod
     @abstractmethod
-    def differential_cls(cls) -> type["AbstractVelocity"]:
+    def differential_cls(cls) -> type["AbstractVel"]:
         """Return the corresponding differential vector class.
 
         Examples
@@ -77,10 +77,10 @@ class AbstractPos(AvalMixin, AbstractVector):  # pylint: disable=abstract-method
         >>> import coordinax as cx
 
         >>> cx.RadialPos.differential_cls.__name__
-        'RadialVelocity'
+        'RadialVel'
 
         >>> cx.SphericalPos.differential_cls.__name__
-        'SphericalVelocity'
+        'SphericalVel'
 
         """
         raise NotImplementedError

--- a/src/coordinax/_src/base/base_pos.py
+++ b/src/coordinax/_src/base/base_pos.py
@@ -1,6 +1,6 @@
 """Representation of coordinates in different systems."""
 
-__all__ = ["AbstractPosition"]
+__all__ = ["AbstractPos"]
 
 from abc import abstractmethod
 from dataclasses import replace
@@ -26,13 +26,13 @@ from coordinax._src import typing as ct
 from coordinax._src.funcs import represent_as
 from coordinax._src.utils import classproperty
 
-PosT = TypeVar("PosT", bound="AbstractPosition")
+PosT = TypeVar("PosT", bound="AbstractPos")
 
 # TODO: figure out public API for this
-POSITION_CLASSES: set[type["AbstractPosition"]] = set()
+POSITION_CLASSES: set[type["AbstractPos"]] = set()
 
 
-class AbstractPosition(AvalMixin, AbstractVector):  # pylint: disable=abstract-method
+class AbstractPos(AvalMixin, AbstractVector):  # pylint: disable=abstract-method
     """Abstract representation of coordinates in different systems."""
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
@@ -56,11 +56,11 @@ class AbstractPosition(AvalMixin, AbstractVector):  # pylint: disable=abstract-m
         --------
         >>> import coordinax as cx
 
-        >>> cx.RadialPosition._cartesian_cls
-        <class 'coordinax...CartesianPosition1D'>
+        >>> cx.RadialPos._cartesian_cls
+        <class 'coordinax...CartesianPos1D'>
 
-        >>> cx.SphericalPosition._cartesian_cls
-        <class 'coordinax...CartesianPosition3D'>
+        >>> cx.SphericalPos._cartesian_cls
+        <class 'coordinax...CartesianPos3D'>
 
         """
         # TODO: something nicer than this for getting the corresponding class
@@ -76,10 +76,10 @@ class AbstractPosition(AvalMixin, AbstractVector):  # pylint: disable=abstract-m
         --------
         >>> import coordinax as cx
 
-        >>> cx.RadialPosition.differential_cls.__name__
+        >>> cx.RadialPos.differential_cls.__name__
         'RadialVelocity'
 
-        >>> cx.SphericalPosition.differential_cls.__name__
+        >>> cx.SphericalPos.differential_cls.__name__
         'SphericalVelocity'
 
         """
@@ -93,7 +93,7 @@ class AbstractPosition(AvalMixin, AbstractVector):  # pylint: disable=abstract-m
     # ===============================================================
     # Binary operations
 
-    def __eq__(self: "AbstractPosition", other: object) -> Any:
+    def __eq__(self: "AbstractPos", other: object) -> Any:
         """Element-wise equality of two positions.
 
         Examples
@@ -103,33 +103,33 @@ class AbstractPosition(AvalMixin, AbstractVector):  # pylint: disable=abstract-m
 
         Showing the broadcasting, then element-wise comparison of two vectors:
 
-        >>> vec1 = cx.CartesianPosition3D.from_([[1, 2, 3], [1, 2, 4]], "m")
-        >>> vec2 = cx.CartesianPosition3D.from_([1, 2, 3], "m")
+        >>> vec1 = cx.CartesianPos3D.from_([[1, 2, 3], [1, 2, 4]], "m")
+        >>> vec2 = cx.CartesianPos3D.from_([1, 2, 3], "m")
         >>> jnp.equal(vec1, vec2)
         Array([ True, False], dtype=bool)
 
         Showing the change of representation:
 
-        >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "m")
-        >>> vec1 = vec.represent_as(cx.SphericalPosition)
-        >>> vec2 = vec.represent_as(cx.MathSphericalPosition)
+        >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "m")
+        >>> vec1 = vec.represent_as(cx.SphericalPos)
+        >>> vec2 = vec.represent_as(cx.MathSphericalPos)
         >>> jnp.equal(vec1, vec2)
         Array(True, dtype=bool)
 
         Quick run-through of each dimensionality:
 
-        >>> vec1 = cx.CartesianPosition1D.from_([1], "m")
-        >>> vec2 = cx.RadialPosition.from_([1], "m")
+        >>> vec1 = cx.CartesianPos1D.from_([1], "m")
+        >>> vec2 = cx.RadialPos.from_([1], "m")
         >>> jnp.equal(vec1, vec2)
         Array(True, dtype=bool)
 
-        >>> vec1 = cx.CartesianPosition2D.from_([2, 0], "m")
-        >>> vec2 = cx.PolarPosition(r=Quantity(2, "m"), phi=Quantity(0, "rad"))
+        >>> vec1 = cx.CartesianPos2D.from_([2, 0], "m")
+        >>> vec2 = cx.PolarPos(r=Quantity(2, "m"), phi=Quantity(0, "rad"))
         >>> jnp.equal(vec1, vec2)
         Array(True, dtype=bool)
 
         """
-        if not isinstance(other, AbstractPosition):
+        if not isinstance(other, AbstractPos):
             return NotImplemented
 
         rhs = other.represent_as(type(self))
@@ -146,7 +146,7 @@ class AbstractPosition(AvalMixin, AbstractVector):  # pylint: disable=abstract-m
 
         Parameters
         ----------
-        target : type[`coordinax.AbstractPosition`]
+        target : type[`coordinax.AbstractPos`]
             The type to represent the vector as.
         *args, **kwargs : Any
             Extra arguments. These are passed to `coordinax.represent_as` and
@@ -154,16 +154,16 @@ class AbstractPosition(AvalMixin, AbstractVector):  # pylint: disable=abstract-m
 
         Returns
         -------
-        `coordinax.AbstractPosition`
+        `coordinax.AbstractPos`
             The vector represented as the target type.
 
         Examples
         --------
         >>> import coordinax as cx
-        >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "m")
-        >>> sph = vec.represent_as(cx.SphericalPosition)
+        >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "m")
+        >>> sph = vec.represent_as(cx.SphericalPos)
         >>> sph
-        SphericalPosition(
+        SphericalPos(
             r=Distance(value=f32[], unit=Unit("m")),
             theta=Quantity[...](value=f32[], unit=Unit("rad")),
             phi=Quantity[...](value=f32[], unit=Unit("rad")) )
@@ -187,19 +187,19 @@ class AbstractPosition(AvalMixin, AbstractVector):  # pylint: disable=abstract-m
         >>> from unxt import Quantity
         >>> import coordinax as cx
 
-        >>> v = cx.CartesianPosition1D.from_([-1], "kpc")
+        >>> v = cx.CartesianPos1D.from_([-1], "kpc")
         >>> v.norm()
         Quantity['length'](Array(1., dtype=float32), unit='kpc')
 
-        >>> v = cx.CartesianPosition2D.from_([3, 4], "kpc")
+        >>> v = cx.CartesianPos2D.from_([3, 4], "kpc")
         >>> v.norm()
         Quantity['length'](Array(5., dtype=float32), unit='kpc')
 
-        >>> v = cx.PolarPosition(r=Quantity(3, "kpc"), phi=Quantity(90, "deg"))
+        >>> v = cx.PolarPos(r=Quantity(3, "kpc"), phi=Quantity(90, "deg"))
         >>> v.norm()
         Quantity['length'](Array(3., dtype=float32), unit='kpc')
 
-        >>> v = cx.CartesianPosition3D.from_([1, 2, 3], "m")
+        >>> v = cx.CartesianPos3D.from_([1, 2, 3], "m")
         >>> v.norm()
         Quantity['length'](Array(3.7416575, dtype=float32), unit='m')
 
@@ -212,7 +212,7 @@ class AbstractPosition(AvalMixin, AbstractVector):  # pylint: disable=abstract-m
 
 
 @register(jax.lax.add_p)  # type: ignore[misc]
-def _add_qq(lhs: AbstractPosition, rhs: AbstractPosition, /) -> AbstractPosition:
+def _add_qq(lhs: AbstractPos, rhs: AbstractPos, /) -> AbstractPos:
     # The base implementation is to convert to Cartesian and perform the
     # operation.  Cartesian coordinates do not have any branch cuts or
     # singularities or ranges that need to be handled, so this is a safe
@@ -232,7 +232,7 @@ def _add_qq(lhs: AbstractPosition, rhs: AbstractPosition, /) -> AbstractPosition
 
 
 @register(jax.lax.div_p)  # type: ignore[misc]
-def _div_pos_v(lhs: AbstractPosition, rhs: ArrayLike) -> AbstractPosition:
+def _div_pos_v(lhs: AbstractPos, rhs: ArrayLike) -> AbstractPos:
     """Divide a vector by a scalar.
 
     Examples
@@ -240,7 +240,7 @@ def _div_pos_v(lhs: AbstractPosition, rhs: ArrayLike) -> AbstractPosition:
     >>> import quaxed.numpy as jnp
     >>> import coordinax as cx
 
-    >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "m")
+    >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "m")
     >>> jnp.divide(vec, 2).x
     Quantity['length'](Array(0.5, dtype=float32), unit='m')
 
@@ -255,7 +255,7 @@ def _div_pos_v(lhs: AbstractPosition, rhs: ArrayLike) -> AbstractPosition:
 
 
 @register(jax.lax.eq_p)  # type: ignore[misc]
-def _eq_pos_pos(lhs: AbstractPosition, rhs: AbstractPosition, /) -> ArrayLike:
+def _eq_pos_pos(lhs: AbstractPos, rhs: AbstractPos, /) -> ArrayLike:
     """Element-wise equality of two positions."""
     return lhs == rhs
 
@@ -264,7 +264,7 @@ def _eq_pos_pos(lhs: AbstractPosition, rhs: AbstractPosition, /) -> ArrayLike:
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_v_pos(lhs: ArrayLike, rhs: AbstractPosition, /) -> AbstractPosition:
+def _mul_v_pos(lhs: ArrayLike, rhs: AbstractPos, /) -> AbstractPos:
     """Scale a position by a scalar.
 
     Examples
@@ -273,9 +273,9 @@ def _mul_v_pos(lhs: ArrayLike, rhs: AbstractPosition, /) -> AbstractPosition:
     >>> import coordinax as cx
     >>> import quaxed.numpy as jnp
 
-    >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "m")
+    >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "m")
     >>> jnp.multiply(2, vec)
-    CartesianPosition3D(
+    CartesianPos3D(
       x=Quantity[...](value=f32[], unit=Unit("m")),
       y=Quantity[...](value=f32[], unit=Unit("m")),
       z=Quantity[...](value=f32[], unit=Unit("m"))
@@ -285,7 +285,7 @@ def _mul_v_pos(lhs: ArrayLike, rhs: AbstractPosition, /) -> AbstractPosition:
     So let's define a new class and try it out:
 
     >>> from typing import ClassVar
-    >>> class MyCartesian(cx.AbstractPosition):
+    >>> class MyCartesian(cx.AbstractPos):
     ...     x: Quantity
     ...     y: Quantity
     ...     z: Quantity
@@ -325,12 +325,12 @@ def _mul_v_pos(lhs: ArrayLike, rhs: AbstractPosition, /) -> AbstractPosition:
     Now a real example. For this we need to define the Cartesian-specific
     dispatches:
 
-    >>> MyCartesian._cartesian_cls = cx.CartesianPosition3D
+    >>> MyCartesian._cartesian_cls = cx.CartesianPos3D
     >>> @dispatch
-    ... def represent_as(current: MyCartesian, target: type[cx.CartesianPosition3D], /) -> cx.CartesianPosition3D:
-    ...     return cx.CartesianPosition3D(x=current.x, y=current.y, z=current.z)
+    ... def represent_as(current: MyCartesian, target: type[cx.CartesianPos3D], /) -> cx.CartesianPos3D:
+    ...     return cx.CartesianPos3D(x=current.x, y=current.y, z=current.z)
     >>> @dispatch
-    ... def represent_as(current: cx.CartesianPosition3D, target: type[MyCartesian], /) -> MyCartesian:
+    ... def represent_as(current: cx.CartesianPos3D, target: type[MyCartesian], /) -> MyCartesian:
     ...     return MyCartesian(x=current.x, y=current.y, z=current.z)
 
     >>> jnp.multiply(2, vec)
@@ -357,7 +357,7 @@ def _mul_v_pos(lhs: ArrayLike, rhs: AbstractPosition, /) -> AbstractPosition:
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_pos_v(lhs: AbstractPosition, rhs: ArrayLike, /) -> AbstractPosition:
+def _mul_pos_v(lhs: AbstractPos, rhs: ArrayLike, /) -> AbstractPos:
     """Scale a position by a scalar.
 
     Examples
@@ -366,9 +366,9 @@ def _mul_pos_v(lhs: AbstractPosition, rhs: ArrayLike, /) -> AbstractPosition:
     >>> import coordinax as cx
     >>> import quaxed.numpy as jnp
 
-    >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "m")
+    >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "m")
     >>> jnp.multiply(vec, 2)
-    CartesianPosition3D(
+    CartesianPos3D(
       x=Quantity[...](value=f32[], unit=Unit("m")),
       y=Quantity[...](value=f32[], unit=Unit("m")),
       z=Quantity[...](value=f32[], unit=Unit("m"))
@@ -379,7 +379,7 @@ def _mul_pos_v(lhs: AbstractPosition, rhs: ArrayLike, /) -> AbstractPosition:
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_pos_pos(lhs: AbstractPosition, rhs: AbstractPosition, /) -> Quantity:
+def _mul_pos_pos(lhs: AbstractPos, rhs: AbstractPos, /) -> Quantity:
     """Multiply two positions.
 
     This is required to take the dot product of two vectors.
@@ -390,7 +390,7 @@ def _mul_pos_pos(lhs: AbstractPosition, rhs: AbstractPosition, /) -> Quantity:
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.CartesianPosition3D(
+    >>> vec = cx.CartesianPos3D(
     ...     x=Quantity([1, 2, 3], "m"),
     ...     y=Quantity([4, 5, 6], "m"),
     ...     z=Quantity([7, 8, 9], "m"))
@@ -413,7 +413,7 @@ def _mul_pos_pos(lhs: AbstractPosition, rhs: AbstractPosition, /) -> Quantity:
 
 
 @register(jax.lax.neg_p)  # type: ignore[misc]
-def _neg_pos(obj: AbstractPosition, /) -> AbstractPosition:
+def _neg_pos(obj: AbstractPos, /) -> AbstractPos:
     """Negate the vector.
 
     The default implementation is to go through Cartesian coordinates.
@@ -421,9 +421,9 @@ def _neg_pos(obj: AbstractPosition, /) -> AbstractPosition:
     Examples
     --------
     >>> import coordinax as cx
-    >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "m")
+    >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "m")
     >>> -vec
-    CartesianPosition3D(
+    CartesianPos3D(
         x=Quantity[PhysicalType('length')](value=f32[], unit=Unit("m")),
         y=Quantity[PhysicalType('length')](value=f32[], unit=Unit("m")),
         z=Quantity[PhysicalType('length')](value=f32[], unit=Unit("m"))
@@ -442,8 +442,8 @@ def _neg_pos(obj: AbstractPosition, /) -> AbstractPosition:
 
 @register(jax.lax.reshape_p)  # type: ignore[misc]
 def _reshape_pos(
-    operand: AbstractPosition, *, new_sizes: tuple[int, ...], **kwargs: Any
-) -> AbstractPosition:
+    operand: AbstractPos, *, new_sizes: tuple[int, ...], **kwargs: Any
+) -> AbstractPos:
     """Reshape the components of the vector.
 
     Examples
@@ -452,11 +452,11 @@ def _reshape_pos(
     >>> import coordinax as cx
     >>> import quaxed.numpy as jnp
 
-    >>> vec = cx.CartesianPosition3D(x=Quantity([1, 2, 3], "m"),
-    ...                              y=Quantity([4, 5, 6], "m"),
-    ...                              z=Quantity([7, 8, 9], "m"))
+    >>> vec = cx.CartesianPos3D(x=Quantity([1, 2, 3], "m"),
+    ...                         y=Quantity([4, 5, 6], "m"),
+    ...                         z=Quantity([7, 8, 9], "m"))
     >>> jnp.reshape(vec, shape=(3, 1, 3))  # (n_components *shape)
-    CartesianPosition3D(
+    CartesianPos3D(
       x=Quantity[PhysicalType('length')](value=f32[1,1,3], unit=Unit("m")),
       y=Quantity[PhysicalType('length')](value=f32[1,1,3], unit=Unit("m")),
       z=Quantity[PhysicalType('length')](value=f32[1,1,3], unit=Unit("m"))
@@ -480,7 +480,7 @@ def _reshape_pos(
 
 
 @register(jax.lax.sub_p)  # type: ignore[misc]
-def _sub_qq(lhs: AbstractPosition, rhs: AbstractPosition) -> AbstractPosition:
+def _sub_qq(lhs: AbstractPos, rhs: AbstractPos) -> AbstractPos:
     """Add another object to this vector."""
     # The base implementation is to convert to Cartesian and perform the
     # operation.  Cartesian coordinates do not have any branch cuts or

--- a/src/coordinax/_src/base/base_vel.py
+++ b/src/coordinax/_src/base/base_vel.py
@@ -79,7 +79,7 @@ class AbstractVel(AbstractVector):  # pylint: disable=abstract-method
     @classproperty
     @classmethod
     @abstractmethod
-    def differential_cls(cls) -> type["AbstractAcceleration"]:
+    def differential_cls(cls) -> type["AbstractAcc"]:
         """Return the corresponding differential vector class.
 
         Examples
@@ -87,10 +87,10 @@ class AbstractVel(AbstractVector):  # pylint: disable=abstract-method
         >>> import coordinax as cx
 
         >>> cx.RadialVel.differential_cls.__name__
-        'RadialAcceleration'
+        'RadialAcc'
 
         >>> cx.SphericalVel.differential_cls.__name__
-        'SphericalAcceleration'
+        'SphericalAcc'
 
         """
         raise NotImplementedError

--- a/src/coordinax/_src/base/base_vel.py
+++ b/src/coordinax/_src/base/base_vel.py
@@ -16,7 +16,7 @@ from dataclassish import field_items
 from unxt import Quantity
 
 from .base import AbstractVector
-from .base_pos import AbstractPosition
+from .base_pos import AbstractPos
 from coordinax._src.utils import classproperty
 
 if TYPE_CHECKING:
@@ -60,7 +60,7 @@ class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
     @classproperty
     @classmethod
     @abstractmethod
-    def integral_cls(cls) -> type["AbstractPosition"]:
+    def integral_cls(cls) -> type["AbstractPos"]:
         """Return the corresponding vector class.
 
         Examples
@@ -68,10 +68,10 @@ class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
         >>> import coordinax as cx
 
         >>> cx.RadialVelocity.integral_cls.__name__
-        'RadialPosition'
+        'RadialPos'
 
         >>> cx.SphericalVelocity.integral_cls.__name__
-        'SphericalPosition'
+        'SphericalPos'
 
         """
         raise NotImplementedError
@@ -149,7 +149,7 @@ class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
         *args, **kwargs : Any
             Extra arguments. These are passed to `coordinax.represent_as` and
             might be used, depending on the dispatched method. Generally the
-            first argument is the position (`coordinax.AbstractPosition`) at
+            first argument is the position (`coordinax.AbstractPos`) at
             which the velocity is defined. In general this is a required
             argument, though it is not for Cartesian-to-Cartesian transforms --
             see https://en.wikipedia.org/wiki/Tensors_in_curvilinear_coordinates
@@ -163,7 +163,7 @@ class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
         Examples
         --------
         >>> import coordinax as cx
-        >>> q = cx.CartesianPosition3D.from_([1, 2, 3], "m")
+        >>> q = cx.CartesianPos3D.from_([1, 2, 3], "m")
         >>> p = cx.CartesianVelocity3D.from_([4, 5, 6], "m/s")
         >>> sph = p.represent_as(cx.SphericalVelocity, q)
         >>> sph
@@ -181,7 +181,7 @@ class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
         return represent_as(self, target, *args, **kwargs)
 
     @partial(eqx.filter_jit, inline=True)
-    def norm(self, position: AbstractPosition, /) -> Quantity["speed"]:
+    def norm(self, position: AbstractPos, /) -> Quantity["speed"]:
         """Return the norm of the vector."""
         return self.represent_as(self._cartesian_cls, position).norm()
 
@@ -190,7 +190,7 @@ class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_vel_q(self: AbstractVelocity, other: Quantity["time"]) -> AbstractPosition:
+def _mul_vel_q(self: AbstractVelocity, other: Quantity["time"]) -> AbstractPos:
     """Multiply the vector by a time :class:`unxt.Quantity` to get a position.
 
     Examples
@@ -202,7 +202,7 @@ def _mul_vel_q(self: AbstractVelocity, other: Quantity["time"]) -> AbstractPosit
     >>> dr = cx.RadialVelocity(Quantity(1, "m/s"))
     >>> vec = dr * Quantity(2, "s")
     >>> vec
-    RadialPosition(r=Distance(value=f32[], unit=Unit("m")))
+    RadialPos(r=Distance(value=f32[], unit=Unit("m")))
     >>> vec.r
     Distance(Array(2., dtype=float32), unit='m')
 

--- a/src/coordinax/_src/base/base_vel.py
+++ b/src/coordinax/_src/base/base_vel.py
@@ -1,6 +1,6 @@
 """Representation of velocities in different systems."""
 
-__all__ = ["AbstractVelocity"]
+__all__ = ["AbstractVel"]
 
 from abc import abstractmethod
 from functools import partial
@@ -22,12 +22,12 @@ from coordinax._src.utils import classproperty
 if TYPE_CHECKING:
     from typing_extensions import Self
 
-VelT = TypeVar("VelT", bound="AbstractVelocity")
+VelT = TypeVar("VelT", bound="AbstractVel")
 
-DIFFERENTIAL_CLASSES: set[type["AbstractVelocity"]] = set()
+DIFFERENTIAL_CLASSES: set[type["AbstractVel"]] = set()
 
 
-class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
+class AbstractVel(AbstractVector):  # pylint: disable=abstract-method
     """Abstract representation of vector differentials in different systems."""
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
@@ -47,11 +47,11 @@ class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
         --------
         >>> import coordinax as cx
 
-        >>> cx.RadialVelocity._cartesian_cls
-        <class 'coordinax...CartesianVelocity1D'>
+        >>> cx.RadialVel._cartesian_cls
+        <class 'coordinax...CartesianVel1D'>
 
-        >>> cx.SphericalVelocity._cartesian_cls
-        <class 'coordinax...CartesianVelocity3D'>
+        >>> cx.SphericalVel._cartesian_cls
+        <class 'coordinax...CartesianVel3D'>
 
         """
         # TODO: something nicer than this for getting the corresponding class
@@ -67,10 +67,10 @@ class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
         --------
         >>> import coordinax as cx
 
-        >>> cx.RadialVelocity.integral_cls.__name__
+        >>> cx.RadialVel.integral_cls.__name__
         'RadialPos'
 
-        >>> cx.SphericalVelocity.integral_cls.__name__
+        >>> cx.SphericalVel.integral_cls.__name__
         'SphericalPos'
 
         """
@@ -86,10 +86,10 @@ class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
         --------
         >>> import coordinax as cx
 
-        >>> cx.RadialVelocity.differential_cls.__name__
+        >>> cx.RadialVel.differential_cls.__name__
         'RadialAcceleration'
 
-        >>> cx.SphericalVelocity.differential_cls.__name__
+        >>> cx.SphericalVel.differential_cls.__name__
         'SphericalAcceleration'
 
         """
@@ -113,11 +113,11 @@ class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
         >>> from unxt import Quantity
         >>> import coordinax as cx
 
-        >>> dr = cx.RadialVelocity.from_([1], "m/s")
+        >>> dr = cx.RadialVel.from_([1], "m/s")
         >>> -dr
-        RadialVelocity( d_r=Quantity[...]( value=i32[], unit=Unit("m / s") ) )
+        RadialVel( d_r=Quantity[...]( value=i32[], unit=Unit("m / s") ) )
 
-        >>> dp = cx.PolarVelocity(Quantity(1, "m/s"), Quantity(1, "mas/yr"))
+        >>> dp = cx.PolarVel(Quantity(1, "m/s"), Quantity(1, "mas/yr"))
         >>> neg_dp = -dp
         >>> neg_dp.d_r
         Quantity['speed'](Array(-1., dtype=float32), unit='m / s')
@@ -144,7 +144,7 @@ class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
 
         Parameters
         ----------
-        target : type[`coordinax.AbstractVelocity`]
+        target : type[`coordinax.AbstractVel`]
             The type to represent the vector as.
         *args, **kwargs : Any
             Extra arguments. These are passed to `coordinax.represent_as` and
@@ -157,17 +157,17 @@ class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
 
         Returns
         -------
-        `coordinax.AbstractVelocity`
+        `coordinax.AbstractVel`
             The vector represented as the target type.
 
         Examples
         --------
         >>> import coordinax as cx
         >>> q = cx.CartesianPos3D.from_([1, 2, 3], "m")
-        >>> p = cx.CartesianVelocity3D.from_([4, 5, 6], "m/s")
-        >>> sph = p.represent_as(cx.SphericalVelocity, q)
+        >>> p = cx.CartesianVel3D.from_([4, 5, 6], "m/s")
+        >>> sph = p.represent_as(cx.SphericalVel, q)
         >>> sph
-        SphericalVelocity(
+        SphericalVel(
             d_r=Quantity[...)]( value=f32[], unit=Unit("m / s") ),
             d_theta=Quantity[...]( value=f32[], unit=Unit("rad / s") ),
             d_phi=Quantity[...]( value=f32[], unit=Unit("rad / s") )
@@ -190,7 +190,7 @@ class AbstractVelocity(AbstractVector):  # pylint: disable=abstract-method
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_vel_q(self: AbstractVelocity, other: Quantity["time"]) -> AbstractPos:
+def _mul_vel_q(self: AbstractVel, other: Quantity["time"]) -> AbstractPos:
     """Multiply the vector by a time :class:`unxt.Quantity` to get a position.
 
     Examples
@@ -199,7 +199,7 @@ def _mul_vel_q(self: AbstractVelocity, other: Quantity["time"]) -> AbstractPos:
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> dr = cx.RadialVelocity(Quantity(1, "m/s"))
+    >>> dr = cx.RadialVel(Quantity(1, "m/s"))
     >>> vec = dr * Quantity(2, "s")
     >>> vec
     RadialPos(r=Distance(value=f32[], unit=Unit("m")))

--- a/src/coordinax/_src/base/compat.py
+++ b/src/coordinax/_src/base/compat.py
@@ -10,47 +10,47 @@ import quaxed.numpy as xp
 from dataclassish import field_values
 from unxt import AbstractQuantity, Distance, Quantity, UncheckedQuantity
 
-from .base_pos import AbstractPosition
+from .base_pos import AbstractPos
 from coordinax._src.utils import full_shaped
 
 #####################################################################
 # Convert to Quantity
 
 
-@conversion_method(type_from=AbstractPosition, type_to=AbstractQuantity)  # type: ignore[misc]
-def convert_pos_to_absquantity(obj: AbstractPosition, /) -> AbstractQuantity:
-    """`coordinax.AbstractPosition` -> `unxt.AbstractQuantity`.
+@conversion_method(type_from=AbstractPos, type_to=AbstractQuantity)  # type: ignore[misc]
+def convert_pos_to_absquantity(obj: AbstractPos, /) -> AbstractQuantity:
+    """`coordinax.AbstractPos` -> `unxt.AbstractQuantity`.
 
     Examples
     --------
     >>> import coordinax as cx
     >>> from unxt import AbstractQuantity, Quantity
 
-    >>> pos = cx.CartesianPosition1D.from_([1.0], "km")
+    >>> pos = cx.CartesianPos1D.from_([1.0], "km")
     >>> convert(pos, AbstractQuantity)
     Quantity['length'](Array([1.], dtype=float32), unit='km')
 
-    >>> pos = cx.RadialPosition.from_([1.0], "km")
+    >>> pos = cx.RadialPos.from_([1.0], "km")
     >>> convert(pos, AbstractQuantity)
     Quantity['length'](Array([1.], dtype=float32), unit='km')
 
-    >>> pos = cx.CartesianPosition2D.from_([1.0, 2.0], "km")
+    >>> pos = cx.CartesianPos2D.from_([1.0, 2.0], "km")
     >>> convert(pos, AbstractQuantity)
     Quantity['length'](Array([1., 2.], dtype=float32), unit='km')
 
-    >>> pos = cx.PolarPosition(Quantity(1.0, "km"), Quantity(0, "deg"))
+    >>> pos = cx.PolarPos(Quantity(1.0, "km"), Quantity(0, "deg"))
     >>> convert(pos, AbstractQuantity)
     Quantity['length'](Array([1., 0.], dtype=float32), unit='km')
 
-    >>> pos = cx.CartesianPosition3D.from_([1.0, 2.0, 3.0], "km")
+    >>> pos = cx.CartesianPos3D.from_([1.0, 2.0, 3.0], "km")
     >>> convert(pos, AbstractQuantity)
     Quantity['length'](Array([1., 2., 3.], dtype=float32), unit='km')
 
-    >>> pos = cx.SphericalPosition(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "deg"))
+    >>> pos = cx.SphericalPos(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "deg"))
     >>> convert(pos, AbstractQuantity)
     Quantity['length'](Array([0., 0., 1.], dtype=float32), unit='km')
 
-    >>> pos = cx.CylindricalPosition(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "km"))
+    >>> pos = cx.CylindricalPos(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "km"))
     >>> convert(pos, AbstractQuantity)
     Quantity['length'](Array([1., 0., 0.], dtype=float32), unit='km')
 
@@ -59,40 +59,40 @@ def convert_pos_to_absquantity(obj: AbstractPosition, /) -> AbstractQuantity:
     return xp.stack(tuple(field_values(cart)), axis=-1)
 
 
-@conversion_method(type_from=AbstractPosition, type_to=Quantity)  # type: ignore[misc]
-def convert_pos_to_q(obj: AbstractPosition, /) -> Quantity["length"]:
-    """`coordinax.AbstractPosition` -> `unxt.Quantity`.
+@conversion_method(type_from=AbstractPos, type_to=Quantity)  # type: ignore[misc]
+def convert_pos_to_q(obj: AbstractPos, /) -> Quantity["length"]:
+    """`coordinax.AbstractPos` -> `unxt.Quantity`.
 
     Examples
     --------
     >>> import coordinax as cx
     >>> from unxt import AbstractQuantity, Quantity
 
-    >>> pos = cx.CartesianPosition1D.from_([1.0], "km")
+    >>> pos = cx.CartesianPos1D.from_([1.0], "km")
     >>> convert(pos, AbstractQuantity)
     Quantity['length'](Array([1.], dtype=float32), unit='km')
 
-    >>> pos = cx.RadialPosition.from_([1.0], "km")
+    >>> pos = cx.RadialPos.from_([1.0], "km")
     >>> convert(pos, AbstractQuantity)
     Quantity['length'](Array([1.], dtype=float32), unit='km')
 
-    >>> pos = cx.CartesianPosition2D.from_([1.0, 2.0], "km")
+    >>> pos = cx.CartesianPos2D.from_([1.0, 2.0], "km")
     >>> convert(pos, AbstractQuantity)
     Quantity['length'](Array([1., 2.], dtype=float32), unit='km')
 
-    >>> pos = cx.PolarPosition(Quantity(1.0, "km"), Quantity(0, "deg"))
+    >>> pos = cx.PolarPos(Quantity(1.0, "km"), Quantity(0, "deg"))
     >>> convert(pos, AbstractQuantity)
     Quantity['length'](Array([1., 0.], dtype=float32), unit='km')
 
-    >>> pos = cx.CartesianPosition3D.from_([1.0, 2.0, 3.0], "km")
+    >>> pos = cx.CartesianPos3D.from_([1.0, 2.0, 3.0], "km")
     >>> convert(pos, AbstractQuantity)
     Quantity['length'](Array([1., 2., 3.], dtype=float32), unit='km')
 
-    >>> pos = cx.SphericalPosition(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "deg"))
+    >>> pos = cx.SphericalPos(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "deg"))
     >>> convert(pos, AbstractQuantity)
     Quantity['length'](Array([0., 0., 1.], dtype=float32), unit='km')
 
-    >>> pos = cx.CylindricalPosition(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "km"))
+    >>> pos = cx.CylindricalPos(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "km"))
     >>> convert(pos, AbstractQuantity)
     Quantity['length'](Array([1., 0., 0.], dtype=float32), unit='km')
 
@@ -100,42 +100,42 @@ def convert_pos_to_q(obj: AbstractPosition, /) -> Quantity["length"]:
     return convert(convert(obj, AbstractQuantity), Quantity)
 
 
-@conversion_method(type_from=AbstractPosition, type_to=UncheckedQuantity)  # type: ignore[misc]
+@conversion_method(type_from=AbstractPos, type_to=UncheckedQuantity)  # type: ignore[misc]
 def convert_pos_to_uncheckedq(
-    obj: AbstractPosition, /
+    obj: AbstractPos, /
 ) -> Shaped[UncheckedQuantity, "*batch 1"]:
-    """`coordinax.AbstractPosition` -> `unxt.UncheckedQuantity`.
+    """`coordinax.AbstractPos` -> `unxt.UncheckedQuantity`.
 
     Examples
     --------
     >>> import coordinax as cx
     >>> from unxt import AbstractQuantity, Quantity, UncheckedQuantity
 
-    >>> pos = cx.CartesianPosition1D.from_([1.0], "km")
+    >>> pos = cx.CartesianPos1D.from_([1.0], "km")
     >>> convert(pos, UncheckedQuantity)
     UncheckedQuantity(Array([1.], dtype=float32), unit='km')
 
-    >>> pos = cx.RadialPosition.from_([1.0], "km")
+    >>> pos = cx.RadialPos.from_([1.0], "km")
     >>> convert(pos, UncheckedQuantity)
     UncheckedQuantity(Array([1.], dtype=float32), unit='km')
 
-    >>> pos = cx.CartesianPosition2D.from_([1.0, 2.0], "km")
+    >>> pos = cx.CartesianPos2D.from_([1.0, 2.0], "km")
     >>> convert(pos, UncheckedQuantity)
     UncheckedQuantity(Array([1., 2.], dtype=float32), unit='km')
 
-    >>> pos = cx.PolarPosition(Quantity(1.0, "km"), Quantity(0, "deg"))
+    >>> pos = cx.PolarPos(Quantity(1.0, "km"), Quantity(0, "deg"))
     >>> convert(pos, UncheckedQuantity)
     UncheckedQuantity(Array([1., 0.], dtype=float32), unit='km')
 
-    >>> pos = cx.CartesianPosition3D.from_([1.0, 2.0, 3.0], "km")
+    >>> pos = cx.CartesianPos3D.from_([1.0, 2.0, 3.0], "km")
     >>> convert(pos, UncheckedQuantity)
     UncheckedQuantity(Array([1., 2., 3.], dtype=float32), unit='km')
 
-    >>> pos = cx.SphericalPosition(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "deg"))
+    >>> pos = cx.SphericalPos(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "deg"))
     >>> convert(pos, UncheckedQuantity)
     UncheckedQuantity(Array([0., 0., 1.], dtype=float32), unit='km')
 
-    >>> pos = cx.CylindricalPosition(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "km"))
+    >>> pos = cx.CylindricalPos(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "km"))
     >>> convert(pos, UncheckedQuantity)
     UncheckedQuantity(Array([1., 0., 0.], dtype=float32), unit='km')
 
@@ -143,40 +143,40 @@ def convert_pos_to_uncheckedq(
     return convert(convert(obj, AbstractQuantity), UncheckedQuantity)
 
 
-@conversion_method(type_from=AbstractPosition, type_to=Distance)  # type: ignore[misc]
-def convert_pos_to_distance(obj: AbstractPosition, /) -> Shaped[Distance, "*batch 1"]:
-    """`coordinax.AbstractPosition` -> `unxt.Distance`.
+@conversion_method(type_from=AbstractPos, type_to=Distance)  # type: ignore[misc]
+def convert_pos_to_distance(obj: AbstractPos, /) -> Shaped[Distance, "*batch 1"]:
+    """`coordinax.AbstractPos` -> `unxt.Distance`.
 
     Examples
     --------
     >>> import coordinax as cx
     >>> from unxt import AbstractQuantity, Quantity, Distance
 
-    >>> pos = cx.CartesianPosition1D.from_([1.0], "km")
+    >>> pos = cx.CartesianPos1D.from_([1.0], "km")
     >>> convert(pos, Distance)
     Distance(Array([1.], dtype=float32), unit='km')
 
-    >>> pos = cx.RadialPosition.from_([1.0], "km")
+    >>> pos = cx.RadialPos.from_([1.0], "km")
     >>> convert(pos, Distance)
     Distance(Array([1.], dtype=float32), unit='km')
 
-    >>> pos = cx.CartesianPosition2D.from_([1.0, 2.0], "km")
+    >>> pos = cx.CartesianPos2D.from_([1.0, 2.0], "km")
     >>> convert(pos, Distance)
     Distance(Array([1., 2.], dtype=float32), unit='km')
 
-    >>> pos = cx.PolarPosition(Quantity(1.0, "km"), Quantity(0, "deg"))
+    >>> pos = cx.PolarPos(Quantity(1.0, "km"), Quantity(0, "deg"))
     >>> convert(pos, Distance)
     Distance(Array([1., 0.], dtype=float32), unit='km')
 
-    >>> pos = cx.CartesianPosition3D.from_([1.0, 2.0, 3.0], "km")
+    >>> pos = cx.CartesianPos3D.from_([1.0, 2.0, 3.0], "km")
     >>> convert(pos, Distance)
     Distance(Array([1., 2., 3.], dtype=float32), unit='km')
 
-    >>> pos = cx.SphericalPosition(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "deg"))
+    >>> pos = cx.SphericalPos(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "deg"))
     >>> convert(pos, Distance)
     Distance(Array([0., 0., 1.], dtype=float32), unit='km')
 
-    >>> pos = cx.CylindricalPosition(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "km"))
+    >>> pos = cx.CylindricalPos(Quantity(1.0, "km"), Quantity(0, "deg"), Quantity(0, "km"))
     >>> convert(pos, Distance)
     Distance(Array([1., 0., 0.], dtype=float32), unit='km')
 

--- a/src/coordinax/_src/base/mixins.py
+++ b/src/coordinax/_src/base/mixins.py
@@ -27,11 +27,11 @@ class AvalMixin:
 
         1 dimensional vectors:
 
-        >>> vec = cx.CartesianPosition1D.from_([1], "m")
+        >>> vec = cx.CartesianPos1D.from_([1], "m")
         >>> vec.aval()
         ConcreteArray([1.], dtype=float32)
 
-        >>> vec = cx.RadialPosition.from_([1], "m")
+        >>> vec = cx.RadialPos.from_([1], "m")
         >>> vec.aval()
         ConcreteArray([1.], dtype=float32)
 
@@ -53,11 +53,11 @@ class AvalMixin:
 
         2 dimensional vectors:
 
-        >>> vec = cx.CartesianPosition2D.from_([1, 2], "m")
+        >>> vec = cx.CartesianPos2D.from_([1, 2], "m")
         >>> vec.aval()
         ConcreteArray([1. 2.], dtype=float32)
 
-        >>> vec = cx.PolarPosition(r=Quantity(1, "m"), phi=Quantity(0, "rad"))
+        >>> vec = cx.PolarPos(r=Quantity(1, "m"), phi=Quantity(0, "rad"))
         >>> vec.aval()
         ConcreteArray([1. 0.], dtype=float32)
 
@@ -81,16 +81,16 @@ class AvalMixin:
 
         3 dimensional vectors:
 
-        >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "m")
+        >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "m")
         >>> vec.aval()
         ConcreteArray([1. 2. 3.], dtype=float32)
 
-        >>> vec = cx.CartesianPosition3D.from_([[1, 2, 3], [4, 5, 6]], "m")
+        >>> vec = cx.CartesianPos3D.from_([[1, 2, 3], [4, 5, 6]], "m")
         >>> vec.aval()
         ConcreteArray([[1. 2. 3.]
                        [4. 5. 6.]], dtype=float32)
 
-        >>> vec = cx.SphericalPosition(r=Quantity(1, "m"), phi=Quantity(0, "rad"), theta=Quantity(0, "rad"))
+        >>> vec = cx.SphericalPos(r=Quantity(1, "m"), phi=Quantity(0, "rad"), theta=Quantity(0, "rad"))
         >>> vec.aval()
         ConcreteArray([0. 0. 1.], dtype=float32)
 

--- a/src/coordinax/_src/base/mixins.py
+++ b/src/coordinax/_src/base/mixins.py
@@ -43,11 +43,11 @@ class AvalMixin:
         >>> vec.aval()
         ConcreteArray([1], dtype=int32)
 
-        >>> vec = cx.CartesianAcceleration1D.from_([1], "m/s2")
+        >>> vec = cx.CartesianAcc1D.from_([1], "m/s2")
         >>> vec.aval()
         ConcreteArray([1], dtype=int32)
 
-        >>> vec = cx.RadialAcceleration.from_([1], "m/s2")
+        >>> vec = cx.RadialAcc.from_([1], "m/s2")
         >>> vec.aval()
         ConcreteArray([1], dtype=int32)
 
@@ -70,11 +70,11 @@ class AvalMixin:
         ... except NotImplementedError as e: print("nope")
         nope
 
-        >>> vec = cx.CartesianAcceleration2D.from_([1,2], "m/s2")
+        >>> vec = cx.CartesianAcc2D.from_([1,2], "m/s2")
         >>> vec.aval()
         ConcreteArray([1. 2.], dtype=float32)
 
-        >>> vec = cx.PolarAcceleration(d2_r=Quantity(1, "m/s2"), d2_phi=Quantity(0, "rad/s2"))
+        >>> vec = cx.PolarAcc(d2_r=Quantity(1, "m/s2"), d2_phi=Quantity(0, "rad/s2"))
         >>> try: vec.aval()
         ... except NotImplementedError as e: print("nope")
         nope
@@ -103,11 +103,11 @@ class AvalMixin:
         ... except NotImplementedError as e: print("nope")
         nope
 
-        >>> vec = cx.CartesianAcceleration3D.from_([1,2,3], "m/s2")
+        >>> vec = cx.CartesianAcc3D.from_([1,2,3], "m/s2")
         >>> vec.aval()
         ConcreteArray([1. 2. 3.], dtype=float32)
 
-        >>> vec = cx.SphericalAcceleration(d2_r=Quantity(1, "m/s2"), d2_phi=Quantity(0, "rad/s2"), d2_theta=Quantity(0, "rad/s2"))
+        >>> vec = cx.SphericalAcc(d2_r=Quantity(1, "m/s2"), d2_phi=Quantity(0, "rad/s2"), d2_theta=Quantity(0, "rad/s2"))
         >>> try: vec.aval()
         ... except NotImplementedError as e: print("nope")
         nope

--- a/src/coordinax/_src/base/mixins.py
+++ b/src/coordinax/_src/base/mixins.py
@@ -35,11 +35,11 @@ class AvalMixin:
         >>> vec.aval()
         ConcreteArray([1.], dtype=float32)
 
-        >>> vec = cx.CartesianVelocity1D.from_([1], "m/s")
+        >>> vec = cx.CartesianVel1D.from_([1], "m/s")
         >>> vec.aval()
         ConcreteArray([1], dtype=int32)
 
-        >>> vec = cx.RadialVelocity.from_([1], "m/s")
+        >>> vec = cx.RadialVel.from_([1], "m/s")
         >>> vec.aval()
         ConcreteArray([1], dtype=int32)
 
@@ -61,11 +61,11 @@ class AvalMixin:
         >>> vec.aval()
         ConcreteArray([1. 0.], dtype=float32)
 
-        >>> vec = cx.CartesianVelocity2D.from_([1, 2], "m/s")
+        >>> vec = cx.CartesianVel2D.from_([1, 2], "m/s")
         >>> vec.aval()
         ConcreteArray([1. 2.], dtype=float32)
 
-        >>> vec = cx.PolarVelocity(d_r=Quantity(1, "m/s"), d_phi=Quantity(0, "rad/s"))
+        >>> vec = cx.PolarVel(d_r=Quantity(1, "m/s"), d_phi=Quantity(0, "rad/s"))
         >>> try: vec.aval()
         ... except NotImplementedError as e: print("nope")
         nope
@@ -94,11 +94,11 @@ class AvalMixin:
         >>> vec.aval()
         ConcreteArray([0. 0. 1.], dtype=float32)
 
-        >>> vec = cx.CartesianVelocity3D.from_([1,2,3], "m/s")
+        >>> vec = cx.CartesianVel3D.from_([1,2,3], "m/s")
         >>> vec.aval()
         ConcreteArray([1. 2. 3.], dtype=float32)
 
-        >>> vec = cx.SphericalVelocity(d_r=Quantity(1, "m/s"), d_phi=Quantity(0, "rad/s"), d_theta=Quantity(0, "rad/s"))
+        >>> vec = cx.SphericalVel(d_r=Quantity(1, "m/s"), d_phi=Quantity(0, "rad/s"), d_theta=Quantity(0, "rad/s"))
         >>> try: vec.aval()
         ... except NotImplementedError as e: print("nope")
         nope

--- a/src/coordinax/_src/base/register_primitives.py
+++ b/src/coordinax/_src/base/register_primitives.py
@@ -37,7 +37,7 @@ def _broadcast_in_dim_p(
 
     Cartesian 1D position, velocity, and acceleration:
 
-    >>> q = cx.CartesianPosition1D.from_([1], "m")
+    >>> q = cx.CartesianPos1D.from_([1], "m")
     >>> q.x
     Quantity['length'](Array(1., dtype=float32), unit='m')
 
@@ -61,7 +61,7 @@ def _broadcast_in_dim_p(
 
     Radial 1D position, velocity, and acceleration:
 
-    >>> q = cx.RadialPosition.from_([1], "m")
+    >>> q = cx.RadialPos.from_([1], "m")
     >>> q.r
     Distance(Array(1., dtype=float32), unit='m')
 
@@ -85,7 +85,7 @@ def _broadcast_in_dim_p(
 
     Cartesian 2D position, velocity, and acceleration:
 
-    >>> q = cx.CartesianPosition2D.from_([1, 2], "m")
+    >>> q = cx.CartesianPos2D.from_([1, 2], "m")
     >>> q.x
     Quantity['length'](Array(1., dtype=float32), unit='m')
 
@@ -109,7 +109,7 @@ def _broadcast_in_dim_p(
 
     Cartesian 3D position, velocity, and acceleration:
 
-    >>> q = cx.CartesianPosition3D.from_([1, 2, 3], "m")
+    >>> q = cx.CartesianPos3D.from_([1, 2, 3], "m")
     >>> q.x
     Quantity['length'](Array(1., dtype=float32), unit='m')
 

--- a/src/coordinax/_src/base/register_primitives.py
+++ b/src/coordinax/_src/base/register_primitives.py
@@ -44,7 +44,7 @@ def _broadcast_in_dim_p(
     >>> jnp.broadcast_to(q, (1, 1)).x
     Quantity['length'](Array([1.], dtype=float32), unit='m')
 
-    >>> p = cx.CartesianVelocity1D.from_([1], "m/s")
+    >>> p = cx.CartesianVel1D.from_([1], "m/s")
     >>> p.d_x
     Quantity['speed'](Array(1, dtype=int32), unit='m / s')
 
@@ -68,7 +68,7 @@ def _broadcast_in_dim_p(
     >>> jnp.broadcast_to(q, (1, 1)).r
     Distance(Array([1.], dtype=float32), unit='m')
 
-    >>> p = cx.RadialVelocity.from_([1], "m/s")
+    >>> p = cx.RadialVel.from_([1], "m/s")
     >>> p.d_r
     Quantity['speed'](Array(1, dtype=int32), unit='m / s')
 
@@ -92,7 +92,7 @@ def _broadcast_in_dim_p(
     >>> jnp.broadcast_to(q, (1, 2)).x
     Quantity['length'](Array([1.], dtype=float32), unit='m')
 
-    >>> p = cx.CartesianVelocity2D.from_([1, 2], "m/s")
+    >>> p = cx.CartesianVel2D.from_([1, 2], "m/s")
     >>> p.d_x
     Quantity['speed'](Array(1., dtype=float32), unit='m / s')
 
@@ -116,7 +116,7 @@ def _broadcast_in_dim_p(
     >>> jnp.broadcast_to(q, (1, 3)).x
     Quantity['length'](Array([1.], dtype=float32), unit='m')
 
-    >>> p = cx.CartesianVelocity3D.from_([1, 2, 3], "m/s")
+    >>> p = cx.CartesianVel3D.from_([1, 2, 3], "m/s")
     >>> p.d_x
     Quantity['speed'](Array(1., dtype=float32), unit='m / s')
 

--- a/src/coordinax/_src/base/register_primitives.py
+++ b/src/coordinax/_src/base/register_primitives.py
@@ -51,7 +51,7 @@ def _broadcast_in_dim_p(
     >>> jnp.broadcast_to(p, (1, 1)).d_x
     Quantity['speed'](Array([1], dtype=int32), unit='m / s')
 
-    >>> a = cx.CartesianAcceleration1D.from_([1], "m/s2")
+    >>> a = cx.CartesianAcc1D.from_([1], "m/s2")
     >>> a.d2_x
      Quantity['acceleration'](Array(1, dtype=int32), unit='m / s2')
 
@@ -75,7 +75,7 @@ def _broadcast_in_dim_p(
     >>> jnp.broadcast_to(p, (1, 1)).d_r
     Quantity['speed'](Array([1], dtype=int32), unit='m / s')
 
-    >>> a = cx.RadialAcceleration.from_([1], "m/s2")
+    >>> a = cx.RadialAcc.from_([1], "m/s2")
     >>> a.d2_r
     Quantity['acceleration'](Array(1, dtype=int32), unit='m / s2')
 
@@ -99,7 +99,7 @@ def _broadcast_in_dim_p(
     >>> jnp.broadcast_to(p, (1, 2)).d_x
     Quantity['speed'](Array([1.], dtype=float32), unit='m / s')
 
-    >>> a = cx.CartesianAcceleration2D.from_([1, 2], "m/s2")
+    >>> a = cx.CartesianAcc2D.from_([1, 2], "m/s2")
     >>> a.d2_x
     Quantity['acceleration'](Array(1., dtype=float32), unit='m / s2')
 
@@ -123,7 +123,7 @@ def _broadcast_in_dim_p(
     >>> jnp.broadcast_to(p, (1, 3)).d_x
     Quantity['speed'](Array([1.], dtype=float32), unit='m / s')
 
-    >>> a = cx.CartesianAcceleration3D.from_([1, 2, 3], "m/s2")
+    >>> a = cx.CartesianAcc3D.from_([1, 2, 3], "m/s2")
     >>> a.d2_x
     Quantity['acceleration'](Array(1., dtype=float32), unit='m / s2')
 

--- a/src/coordinax/_src/compat.py
+++ b/src/coordinax/_src/compat.py
@@ -15,7 +15,7 @@ from unxt import AbstractQuantity, Quantity, UncheckedQuantity
 from coordinax._src.base.base import AbstractVector
 from coordinax._src.d1.cartesian import (
     CartesianAcceleration1D,
-    CartesianPosition1D,
+    CartesianPos1D,
     CartesianVelocity1D,
 )
 from coordinax._src.d1.radial import RadialAcceleration, RadialVelocity
@@ -224,7 +224,7 @@ Q1: TypeAlias = Shaped[Quantity["length"], "*#batch 1"]
 @op_call_dispatch
 def call(self: AbstractOperator, x: Q1, /) -> Q1:
     """Dispatch to the operator's `__call__` method."""
-    return self(CartesianPosition1D.from_(x))
+    return self(CartesianPos1D.from_(x))
 
 
 @op_call_dispatch
@@ -232,5 +232,5 @@ def call(
     self: AbstractOperator, x: Q1, t: TimeBatchOrScalar, /
 ) -> tuple[Q1, TimeBatchOrScalar]:
     """Dispatch to the operator's `__call__` method."""
-    vec, t = self(CartesianPosition1D.from_(x), t)
+    vec, t = self(CartesianPos1D.from_(x), t)
     return convert(vec, Quantity), t

--- a/src/coordinax/_src/compat.py
+++ b/src/coordinax/_src/compat.py
@@ -13,14 +13,10 @@ from dataclassish import field_values
 from unxt import AbstractQuantity, Quantity, UncheckedQuantity
 
 from coordinax._src.base.base import AbstractVector
-from coordinax._src.d1.cartesian import (
-    CartesianAcceleration1D,
-    CartesianPos1D,
-    CartesianVel1D,
-)
-from coordinax._src.d1.radial import RadialAcceleration, RadialVel
-from coordinax._src.d2.cartesian import CartesianAcceleration2D, CartesianVel2D
-from coordinax._src.d3.cartesian import CartesianAcceleration3D, CartesianVel3D
+from coordinax._src.d1.cartesian import CartesianAcc1D, CartesianPos1D, CartesianVel1D
+from coordinax._src.d1.radial import RadialAcc, RadialVel
+from coordinax._src.d2.cartesian import CartesianAcc2D, CartesianVel2D
+from coordinax._src.d3.cartesian import CartesianAcc3D, CartesianVel3D
 from coordinax._src.operators.base import AbstractOperator, op_call_dispatch
 from coordinax._src.typing import TimeBatchOrScalar
 from coordinax._src.utils import full_shaped
@@ -37,14 +33,12 @@ def _vec_diff_to_q(obj: AbstractVector, /) -> AbstractQuantity:
 # -------------------------------------------------------------------
 # 1D
 
-QConvertible1D: TypeAlias = (
-    CartesianVel1D | CartesianAcceleration1D | RadialVel | RadialAcceleration
-)
+QConvertible1D: TypeAlias = CartesianVel1D | CartesianAcc1D | RadialVel | RadialAcc
 
 
-@conversion_method(type_from=RadialAcceleration, type_to=UncheckedQuantity)
+@conversion_method(type_from=RadialAcc, type_to=UncheckedQuantity)
 @conversion_method(type_from=RadialVel, type_to=UncheckedQuantity)
-@conversion_method(type_from=CartesianAcceleration1D, type_to=UncheckedQuantity)
+@conversion_method(type_from=CartesianAcc1D, type_to=UncheckedQuantity)
 @conversion_method(type_from=CartesianVel1D, type_to=UncheckedQuantity)
 def vec_diff1d_to_uncheckedq(
     obj: QConvertible1D, /
@@ -61,7 +55,7 @@ def vec_diff1d_to_uncheckedq(
     >>> convert(cart_vel, UncheckedQuantity)
     UncheckedQuantity(Array([1], dtype=int32), unit='km / s')
 
-    >>> cart_acc = cx.CartesianAcceleration1D.from_([1], "km/s2")
+    >>> cart_acc = cx.CartesianAcc1D.from_([1], "km/s2")
     >>> convert(cart_acc, UncheckedQuantity)
     UncheckedQuantity(Array([1], dtype=int32), unit='km / s2')
 
@@ -69,7 +63,7 @@ def vec_diff1d_to_uncheckedq(
     >>> convert(rad_vel, UncheckedQuantity)
     UncheckedQuantity(Array([1], dtype=int32), unit='km / s')
 
-    >>> rad_acc = cx.RadialAcceleration.from_([1], "km/s2")
+    >>> rad_acc = cx.RadialAcc.from_([1], "km/s2")
     >>> convert(rad_acc, UncheckedQuantity)
     UncheckedQuantity(Array([1], dtype=int32), unit='km / s2')
 
@@ -77,9 +71,9 @@ def vec_diff1d_to_uncheckedq(
     return convert(_vec_diff_to_q(obj), UncheckedQuantity)
 
 
-@conversion_method(type_from=RadialAcceleration, type_to=Quantity)
+@conversion_method(type_from=RadialAcc, type_to=Quantity)
 @conversion_method(type_from=RadialVel, type_to=Quantity)
-@conversion_method(type_from=CartesianAcceleration1D, type_to=Quantity)
+@conversion_method(type_from=CartesianAcc1D, type_to=Quantity)
 @conversion_method(type_from=CartesianVel1D, type_to=Quantity)
 def vec_diff1d_to_uncheckedq(obj: QConvertible1D, /) -> Shaped[Quantity, "*batch 1"]:
     """1D Differentials -> `unxt.Quantity`.
@@ -94,7 +88,7 @@ def vec_diff1d_to_uncheckedq(obj: QConvertible1D, /) -> Shaped[Quantity, "*batch
     >>> convert(cart_vel, Quantity)
     Quantity['speed'](Array([1], dtype=int32), unit='km / s')
 
-    >>> cart_acc = cx.CartesianAcceleration1D.from_([1], "km/s2")
+    >>> cart_acc = cx.CartesianAcc1D.from_([1], "km/s2")
     >>> convert(cart_acc, Quantity)
     Quantity['acceleration'](Array([1], dtype=int32), unit='km / s2')
 
@@ -102,7 +96,7 @@ def vec_diff1d_to_uncheckedq(obj: QConvertible1D, /) -> Shaped[Quantity, "*batch
     >>> convert(rad_vel, Quantity)
     Quantity['speed'](Array([1], dtype=int32), unit='km / s')
 
-    >>> rad_acc = cx.RadialAcceleration.from_([1], "km/s2")
+    >>> rad_acc = cx.RadialAcc.from_([1], "km/s2")
     >>> convert(rad_acc, Quantity)
     Quantity['acceleration'](Array([1], dtype=int32), unit='km / s2')
 
@@ -113,10 +107,10 @@ def vec_diff1d_to_uncheckedq(obj: QConvertible1D, /) -> Shaped[Quantity, "*batch
 # -------------------------------------------------------------------
 # 2D
 
-QConvertible2D: TypeAlias = CartesianVel2D | CartesianAcceleration2D
+QConvertible2D: TypeAlias = CartesianVel2D | CartesianAcc2D
 
 
-@conversion_method(type_from=CartesianAcceleration2D, type_to=UncheckedQuantity)
+@conversion_method(type_from=CartesianAcc2D, type_to=UncheckedQuantity)
 @conversion_method(type_from=CartesianVel2D, type_to=UncheckedQuantity)
 def vec_diff_to_q(obj: QConvertible2D, /) -> Shaped[UncheckedQuantity, "*batch 2"]:
     """2D Differentials -> `unxt.UncheckedQuantity`.
@@ -131,7 +125,7 @@ def vec_diff_to_q(obj: QConvertible2D, /) -> Shaped[UncheckedQuantity, "*batch 2
     >>> convert(vel, UncheckedQuantity)
     UncheckedQuantity(Array([1., 2.], dtype=float32), unit='km / s')
 
-    >>> acc = cx.CartesianAcceleration2D.from_([1, 2], "km/s2")
+    >>> acc = cx.CartesianAcc2D.from_([1, 2], "km/s2")
     >>> convert(acc, UncheckedQuantity)
     UncheckedQuantity(Array([1., 2.], dtype=float32), unit='km / s2')
 
@@ -139,7 +133,7 @@ def vec_diff_to_q(obj: QConvertible2D, /) -> Shaped[UncheckedQuantity, "*batch 2
     return convert(_vec_diff_to_q(obj), UncheckedQuantity)
 
 
-@conversion_method(type_from=CartesianAcceleration2D, type_to=Quantity)
+@conversion_method(type_from=CartesianAcc2D, type_to=Quantity)
 @conversion_method(type_from=CartesianVel2D, type_to=Quantity)
 def vec_diff_to_q(obj: QConvertible2D, /) -> Shaped[Quantity, "*batch 2"]:
     """2D Differentials -> `unxt.Quantity`.
@@ -154,7 +148,7 @@ def vec_diff_to_q(obj: QConvertible2D, /) -> Shaped[Quantity, "*batch 2"]:
     >>> convert(vel, Quantity)
     Quantity['speed'](Array([1., 2.], dtype=float32), unit='km / s')
 
-    >>> acc = cx.CartesianAcceleration2D.from_([1, 2], "km/s2")
+    >>> acc = cx.CartesianAcc2D.from_([1, 2], "km/s2")
     >>> convert(acc, Quantity)
     Quantity['acceleration'](Array([1., 2.], dtype=float32), unit='km / s2')
 
@@ -165,10 +159,10 @@ def vec_diff_to_q(obj: QConvertible2D, /) -> Shaped[Quantity, "*batch 2"]:
 # -------------------------------------------------------------------
 # 3D
 
-QConvertible3D: TypeAlias = CartesianVel3D | CartesianAcceleration3D
+QConvertible3D: TypeAlias = CartesianVel3D | CartesianAcc3D
 
 
-@conversion_method(CartesianAcceleration3D, UncheckedQuantity)
+@conversion_method(CartesianAcc3D, UncheckedQuantity)
 @conversion_method(CartesianVel3D, UncheckedQuantity)
 def vec_diff_to_q(obj: CartesianVel3D, /) -> Shaped[UncheckedQuantity, "*batch 3"]:
     """3D Differentials -> `unxt.UncheckedQuantity`.
@@ -183,7 +177,7 @@ def vec_diff_to_q(obj: CartesianVel3D, /) -> Shaped[UncheckedQuantity, "*batch 3
     >>> convert(vel, UncheckedQuantity)
     UncheckedQuantity(Array([1., 2., 3.], dtype=float32), unit='km / s')
 
-    >>> acc = cx.CartesianAcceleration3D.from_([1, 2, 3], "km/s2")
+    >>> acc = cx.CartesianAcc3D.from_([1, 2, 3], "km/s2")
     >>> convert(acc, UncheckedQuantity)
     UncheckedQuantity(Array([1., 2., 3.], dtype=float32), unit='km / s2')
 
@@ -191,7 +185,7 @@ def vec_diff_to_q(obj: CartesianVel3D, /) -> Shaped[UncheckedQuantity, "*batch 3
     return convert(_vec_diff_to_q(obj), UncheckedQuantity)
 
 
-@conversion_method(CartesianAcceleration3D, Quantity)
+@conversion_method(CartesianAcc3D, Quantity)
 @conversion_method(CartesianVel3D, Quantity)
 def vec_diff_to_q(obj: CartesianVel3D, /) -> Shaped[Quantity, "*batch 3"]:
     """3D Differentials -> `unxt.Quantity`.
@@ -206,7 +200,7 @@ def vec_diff_to_q(obj: CartesianVel3D, /) -> Shaped[Quantity, "*batch 3"]:
     >>> convert(vel, Quantity)
     Quantity['speed'](Array([1., 2., 3.], dtype=float32), unit='km / s')
 
-    >>> acc = cx.CartesianAcceleration3D.from_([1, 2, 3], "km/s2")
+    >>> acc = cx.CartesianAcc3D.from_([1, 2, 3], "km/s2")
     >>> convert(acc, Quantity)
     Quantity['acceleration'](Array([1., 2., 3.], dtype=float32), unit='km / s2')
 

--- a/src/coordinax/_src/compat.py
+++ b/src/coordinax/_src/compat.py
@@ -16,11 +16,11 @@ from coordinax._src.base.base import AbstractVector
 from coordinax._src.d1.cartesian import (
     CartesianAcceleration1D,
     CartesianPos1D,
-    CartesianVelocity1D,
+    CartesianVel1D,
 )
-from coordinax._src.d1.radial import RadialAcceleration, RadialVelocity
-from coordinax._src.d2.cartesian import CartesianAcceleration2D, CartesianVelocity2D
-from coordinax._src.d3.cartesian import CartesianAcceleration3D, CartesianVelocity3D
+from coordinax._src.d1.radial import RadialAcceleration, RadialVel
+from coordinax._src.d2.cartesian import CartesianAcceleration2D, CartesianVel2D
+from coordinax._src.d3.cartesian import CartesianAcceleration3D, CartesianVel3D
 from coordinax._src.operators.base import AbstractOperator, op_call_dispatch
 from coordinax._src.typing import TimeBatchOrScalar
 from coordinax._src.utils import full_shaped
@@ -38,14 +38,14 @@ def _vec_diff_to_q(obj: AbstractVector, /) -> AbstractQuantity:
 # 1D
 
 QConvertible1D: TypeAlias = (
-    CartesianVelocity1D | CartesianAcceleration1D | RadialVelocity | RadialAcceleration
+    CartesianVel1D | CartesianAcceleration1D | RadialVel | RadialAcceleration
 )
 
 
 @conversion_method(type_from=RadialAcceleration, type_to=UncheckedQuantity)
-@conversion_method(type_from=RadialVelocity, type_to=UncheckedQuantity)
+@conversion_method(type_from=RadialVel, type_to=UncheckedQuantity)
 @conversion_method(type_from=CartesianAcceleration1D, type_to=UncheckedQuantity)
-@conversion_method(type_from=CartesianVelocity1D, type_to=UncheckedQuantity)
+@conversion_method(type_from=CartesianVel1D, type_to=UncheckedQuantity)
 def vec_diff1d_to_uncheckedq(
     obj: QConvertible1D, /
 ) -> Shaped[UncheckedQuantity, "*batch 1"]:
@@ -57,7 +57,7 @@ def vec_diff1d_to_uncheckedq(
     >>> from unxt import UncheckedQuantity
     >>> import coordinax as cx
 
-    >>> cart_vel = cx.CartesianVelocity1D.from_([1], "km/s")
+    >>> cart_vel = cx.CartesianVel1D.from_([1], "km/s")
     >>> convert(cart_vel, UncheckedQuantity)
     UncheckedQuantity(Array([1], dtype=int32), unit='km / s')
 
@@ -65,7 +65,7 @@ def vec_diff1d_to_uncheckedq(
     >>> convert(cart_acc, UncheckedQuantity)
     UncheckedQuantity(Array([1], dtype=int32), unit='km / s2')
 
-    >>> rad_vel = cx.RadialVelocity.from_([1], "km/s")
+    >>> rad_vel = cx.RadialVel.from_([1], "km/s")
     >>> convert(rad_vel, UncheckedQuantity)
     UncheckedQuantity(Array([1], dtype=int32), unit='km / s')
 
@@ -78,9 +78,9 @@ def vec_diff1d_to_uncheckedq(
 
 
 @conversion_method(type_from=RadialAcceleration, type_to=Quantity)
-@conversion_method(type_from=RadialVelocity, type_to=Quantity)
+@conversion_method(type_from=RadialVel, type_to=Quantity)
 @conversion_method(type_from=CartesianAcceleration1D, type_to=Quantity)
-@conversion_method(type_from=CartesianVelocity1D, type_to=Quantity)
+@conversion_method(type_from=CartesianVel1D, type_to=Quantity)
 def vec_diff1d_to_uncheckedq(obj: QConvertible1D, /) -> Shaped[Quantity, "*batch 1"]:
     """1D Differentials -> `unxt.Quantity`.
 
@@ -90,7 +90,7 @@ def vec_diff1d_to_uncheckedq(obj: QConvertible1D, /) -> Shaped[Quantity, "*batch
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> cart_vel = cx.CartesianVelocity1D.from_([1], "km/s")
+    >>> cart_vel = cx.CartesianVel1D.from_([1], "km/s")
     >>> convert(cart_vel, Quantity)
     Quantity['speed'](Array([1], dtype=int32), unit='km / s')
 
@@ -98,7 +98,7 @@ def vec_diff1d_to_uncheckedq(obj: QConvertible1D, /) -> Shaped[Quantity, "*batch
     >>> convert(cart_acc, Quantity)
     Quantity['acceleration'](Array([1], dtype=int32), unit='km / s2')
 
-    >>> rad_vel = cx.RadialVelocity.from_([1], "km/s")
+    >>> rad_vel = cx.RadialVel.from_([1], "km/s")
     >>> convert(rad_vel, Quantity)
     Quantity['speed'](Array([1], dtype=int32), unit='km / s')
 
@@ -113,11 +113,11 @@ def vec_diff1d_to_uncheckedq(obj: QConvertible1D, /) -> Shaped[Quantity, "*batch
 # -------------------------------------------------------------------
 # 2D
 
-QConvertible2D: TypeAlias = CartesianVelocity2D | CartesianAcceleration2D
+QConvertible2D: TypeAlias = CartesianVel2D | CartesianAcceleration2D
 
 
 @conversion_method(type_from=CartesianAcceleration2D, type_to=UncheckedQuantity)
-@conversion_method(type_from=CartesianVelocity2D, type_to=UncheckedQuantity)
+@conversion_method(type_from=CartesianVel2D, type_to=UncheckedQuantity)
 def vec_diff_to_q(obj: QConvertible2D, /) -> Shaped[UncheckedQuantity, "*batch 2"]:
     """2D Differentials -> `unxt.UncheckedQuantity`.
 
@@ -127,7 +127,7 @@ def vec_diff_to_q(obj: QConvertible2D, /) -> Shaped[UncheckedQuantity, "*batch 2
     >>> from unxt import UncheckedQuantity
     >>> import coordinax as cx
 
-    >>> vel = cx.CartesianVelocity2D.from_([1, 2], "km/s")
+    >>> vel = cx.CartesianVel2D.from_([1, 2], "km/s")
     >>> convert(vel, UncheckedQuantity)
     UncheckedQuantity(Array([1., 2.], dtype=float32), unit='km / s')
 
@@ -140,7 +140,7 @@ def vec_diff_to_q(obj: QConvertible2D, /) -> Shaped[UncheckedQuantity, "*batch 2
 
 
 @conversion_method(type_from=CartesianAcceleration2D, type_to=Quantity)
-@conversion_method(type_from=CartesianVelocity2D, type_to=Quantity)
+@conversion_method(type_from=CartesianVel2D, type_to=Quantity)
 def vec_diff_to_q(obj: QConvertible2D, /) -> Shaped[Quantity, "*batch 2"]:
     """2D Differentials -> `unxt.Quantity`.
 
@@ -150,7 +150,7 @@ def vec_diff_to_q(obj: QConvertible2D, /) -> Shaped[Quantity, "*batch 2"]:
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vel = cx.CartesianVelocity2D.from_([1, 2], "km/s")
+    >>> vel = cx.CartesianVel2D.from_([1, 2], "km/s")
     >>> convert(vel, Quantity)
     Quantity['speed'](Array([1., 2.], dtype=float32), unit='km / s')
 
@@ -165,12 +165,12 @@ def vec_diff_to_q(obj: QConvertible2D, /) -> Shaped[Quantity, "*batch 2"]:
 # -------------------------------------------------------------------
 # 3D
 
-QConvertible3D: TypeAlias = CartesianVelocity3D | CartesianAcceleration3D
+QConvertible3D: TypeAlias = CartesianVel3D | CartesianAcceleration3D
 
 
 @conversion_method(CartesianAcceleration3D, UncheckedQuantity)
-@conversion_method(CartesianVelocity3D, UncheckedQuantity)
-def vec_diff_to_q(obj: CartesianVelocity3D, /) -> Shaped[UncheckedQuantity, "*batch 3"]:
+@conversion_method(CartesianVel3D, UncheckedQuantity)
+def vec_diff_to_q(obj: CartesianVel3D, /) -> Shaped[UncheckedQuantity, "*batch 3"]:
     """3D Differentials -> `unxt.UncheckedQuantity`.
 
     Examples
@@ -179,7 +179,7 @@ def vec_diff_to_q(obj: CartesianVelocity3D, /) -> Shaped[UncheckedQuantity, "*ba
     >>> from plum import convert
     >>> from unxt import UncheckedQuantity
 
-    >>> vel = cx.CartesianVelocity3D.from_([1, 2, 3], "km/s")
+    >>> vel = cx.CartesianVel3D.from_([1, 2, 3], "km/s")
     >>> convert(vel, UncheckedQuantity)
     UncheckedQuantity(Array([1., 2., 3.], dtype=float32), unit='km / s')
 
@@ -192,8 +192,8 @@ def vec_diff_to_q(obj: CartesianVelocity3D, /) -> Shaped[UncheckedQuantity, "*ba
 
 
 @conversion_method(CartesianAcceleration3D, Quantity)
-@conversion_method(CartesianVelocity3D, Quantity)
-def vec_diff_to_q(obj: CartesianVelocity3D, /) -> Shaped[Quantity, "*batch 3"]:
+@conversion_method(CartesianVel3D, Quantity)
+def vec_diff_to_q(obj: CartesianVel3D, /) -> Shaped[Quantity, "*batch 3"]:
     """3D Differentials -> `unxt.Quantity`.
 
     Examples
@@ -202,7 +202,7 @@ def vec_diff_to_q(obj: CartesianVelocity3D, /) -> Shaped[Quantity, "*batch 3"]:
     >>> from plum import convert
     >>> from unxt import Quantity
 
-    >>> vel = cx.CartesianVelocity3D.from_([1, 2, 3], "km/s")
+    >>> vel = cx.CartesianVel3D.from_([1, 2, 3], "km/s")
     >>> convert(vel, Quantity)
     Quantity['speed'](Array([1., 2., 3.], dtype=float32), unit='km / s')
 

--- a/src/coordinax/_src/d1/base.py
+++ b/src/coordinax/_src/d1/base.py
@@ -1,6 +1,6 @@
 """Representation of coordinates in different systems."""
 
-__all__ = ["AbstractPosition1D", "AbstractVelocity1D", "AbstractAcceleration1D"]
+__all__ = ["AbstractPos1D", "AbstractVelocity1D", "AbstractAcceleration1D"]
 
 
 from abc import abstractmethod
@@ -13,7 +13,7 @@ from unxt import Quantity
 
 from coordinax._src.base import (
     AbstractAcceleration,
-    AbstractPosition,
+    AbstractPos,
     AbstractVector,
     AbstractVelocity,
 )
@@ -22,15 +22,15 @@ from coordinax._src.utils import classproperty
 #####################################################################
 
 
-class AbstractPosition1D(AbstractPosition):
+class AbstractPos1D(AbstractPos):
     """Abstract representation of 1D coordinates in different systems."""
 
     @classproperty
     @classmethod
     def _cartesian_cls(cls) -> type[AbstractVector]:
-        from .cartesian import CartesianPosition1D
+        from .cartesian import CartesianPos1D
 
-        return CartesianPosition1D
+        return CartesianPos1D
 
     @classproperty
     @classmethod
@@ -42,12 +42,12 @@ class AbstractPosition1D(AbstractPosition):
 # -------------------------------------------------------------------
 
 
-@AbstractPosition1D.from_._f.dispatch  # type: ignore[attr-defined, misc]  # noqa: SLF001
+@AbstractPos1D.from_._f.dispatch  # type: ignore[attr-defined, misc]  # noqa: SLF001
 def from_(
-    cls: type[AbstractPosition1D],
+    cls: type[AbstractPos1D],
     obj: Shaped[Quantity["length"], "*batch"] | Shaped[Quantity["length"], "*batch 1"],
     /,
-) -> AbstractPosition1D:
+) -> AbstractPos1D:
     """Construct a 1D position.
 
     Examples
@@ -55,17 +55,17 @@ def from_(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> cx.CartesianPosition1D.from_(Quantity(1, "meter"))
-    CartesianPosition1D( x=Quantity[...](value=f32[], unit=Unit("m")) )
+    >>> cx.CartesianPos1D.from_(Quantity(1, "meter"))
+    CartesianPos1D(x=Quantity[...](value=f32[], unit=Unit("m")))
 
-    >>> cx.CartesianPosition1D.from_(Quantity([1], "meter"))
-    CartesianPosition1D( x=Quantity[...](value=f32[], unit=Unit("m")) )
+    >>> cx.CartesianPos1D.from_(Quantity([1], "meter"))
+    CartesianPos1D(x=Quantity[...](value=f32[], unit=Unit("m")))
 
-    >>> cx.RadialPosition.from_(Quantity(1, "meter"))
-    RadialPosition(r=Distance(value=f32[], unit=Unit("m")))
+    >>> cx.RadialPos.from_(Quantity(1, "meter"))
+    RadialPos(r=Distance(value=f32[], unit=Unit("m")))
 
-    >>> cx.RadialPosition.from_(Quantity([1], "meter"))
-    RadialPosition(r=Distance(value=f32[], unit=Unit("m")))
+    >>> cx.RadialPos.from_(Quantity([1], "meter"))
+    RadialPos(r=Distance(value=f32[], unit=Unit("m")))
 
     """
     comps = {f.name: jnp.atleast_1d(obj)[..., i] for i, f in enumerate(fields(cls))}
@@ -88,7 +88,7 @@ class AbstractVelocity1D(AbstractVelocity):
     @classproperty
     @classmethod
     @abstractmethod
-    def integral_cls(cls) -> type[AbstractPosition1D]:
+    def integral_cls(cls) -> type[AbstractPos1D]:
         raise NotImplementedError
 
     @classproperty

--- a/src/coordinax/_src/d1/base.py
+++ b/src/coordinax/_src/d1/base.py
@@ -1,6 +1,6 @@
 """Representation of coordinates in different systems."""
 
-__all__ = ["AbstractPos1D", "AbstractVel1D", "AbstractAcceleration1D"]
+__all__ = ["AbstractPos1D", "AbstractVel1D", "AbstractAcc1D"]
 
 
 from abc import abstractmethod
@@ -11,12 +11,7 @@ from jaxtyping import Shaped
 import quaxed.numpy as jnp
 from unxt import Quantity
 
-from coordinax._src.base import (
-    AbstractAcceleration,
-    AbstractPos,
-    AbstractVector,
-    AbstractVel,
-)
+from coordinax._src.base import AbstractAcc, AbstractPos, AbstractVector, AbstractVel
 from coordinax._src.utils import classproperty
 
 #####################################################################
@@ -94,7 +89,7 @@ class AbstractVel1D(AbstractVel):
     @classproperty
     @classmethod
     @abstractmethod
-    def differential_cls(cls) -> type[AbstractAcceleration]:
+    def differential_cls(cls) -> type[AbstractAcc]:
         raise NotImplementedError
 
 
@@ -134,15 +129,15 @@ def from_(
 #####################################################################
 
 
-class AbstractAcceleration1D(AbstractAcceleration):
+class AbstractAcc1D(AbstractAcc):
     """Abstract representation of 1D acceleration in different systems."""
 
     @classproperty
     @classmethod
     def _cartesian_cls(cls) -> type[AbstractVector]:
-        from .cartesian import CartesianAcceleration1D
+        from .cartesian import CartesianAcc1D
 
-        return CartesianAcceleration1D
+        return CartesianAcc1D
 
     @classproperty
     @classmethod
@@ -154,13 +149,13 @@ class AbstractAcceleration1D(AbstractAcceleration):
 # -------------------------------------------------------------------
 
 
-@AbstractAcceleration1D.from_._f.dispatch  # type: ignore[attr-defined, misc]  # noqa: SLF001
+@AbstractAcc1D.from_._f.dispatch  # type: ignore[attr-defined, misc]  # noqa: SLF001
 def from_(
-    cls: type[AbstractAcceleration1D],
+    cls: type[AbstractAcc1D],
     obj: Shaped[Quantity["acceleration"], "*batch"]
     | Shaped[Quantity["acceleration"], "*batch 1"],
     /,
-) -> AbstractAcceleration1D:
+) -> AbstractAcc1D:
     """Construct a 1D acceleration.
 
     Examples
@@ -168,17 +163,17 @@ def from_(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> cx.CartesianAcceleration1D.from_(Quantity(1, "m/s2"))
-    CartesianAcceleration1D( d2_x=... )
+    >>> cx.CartesianAcc1D.from_(Quantity(1, "m/s2"))
+    CartesianAcc1D( d2_x=... )
 
-    >>> cx.CartesianAcceleration1D.from_(Quantity([1], "m/s2"))
-    CartesianAcceleration1D( d2_x=Quantity[...](value=i32[], unit=Unit("m / s2")) )
+    >>> cx.CartesianAcc1D.from_(Quantity([1], "m/s2"))
+    CartesianAcc1D( d2_x=Quantity[...](value=i32[], unit=Unit("m / s2")) )
 
-    >>> cx.RadialAcceleration.from_(Quantity(1, "m/s2"))
-    RadialAcceleration( d2_r=... )
+    >>> cx.RadialAcc.from_(Quantity(1, "m/s2"))
+    RadialAcc( d2_r=... )
 
-    >>> cx.RadialAcceleration.from_(Quantity([1], "m/s2"))
-    RadialAcceleration( d2_r=Quantity[...](value=i32[], unit=Unit("m / s2")) )
+    >>> cx.RadialAcc.from_(Quantity([1], "m/s2"))
+    RadialAcc( d2_r=Quantity[...](value=i32[], unit=Unit("m / s2")) )
 
     """
     comps = {f.name: jnp.atleast_1d(obj)[..., i] for i, f in enumerate(fields(cls))}

--- a/src/coordinax/_src/d1/base.py
+++ b/src/coordinax/_src/d1/base.py
@@ -1,6 +1,6 @@
 """Representation of coordinates in different systems."""
 
-__all__ = ["AbstractPos1D", "AbstractVelocity1D", "AbstractAcceleration1D"]
+__all__ = ["AbstractPos1D", "AbstractVel1D", "AbstractAcceleration1D"]
 
 
 from abc import abstractmethod
@@ -15,7 +15,7 @@ from coordinax._src.base import (
     AbstractAcceleration,
     AbstractPos,
     AbstractVector,
-    AbstractVelocity,
+    AbstractVel,
 )
 from coordinax._src.utils import classproperty
 
@@ -35,7 +35,7 @@ class AbstractPos1D(AbstractPos):
     @classproperty
     @classmethod
     @abstractmethod
-    def differential_cls(cls) -> type["AbstractVelocity1D"]:
+    def differential_cls(cls) -> type["AbstractVel1D"]:
         raise NotImplementedError
 
 
@@ -75,15 +75,15 @@ def from_(
 #####################################################################
 
 
-class AbstractVelocity1D(AbstractVelocity):
+class AbstractVel1D(AbstractVel):
     """Abstract representation of 1D differentials in different systems."""
 
     @classproperty
     @classmethod
     def _cartesian_cls(cls) -> type[AbstractVector]:
-        from .cartesian import CartesianVelocity1D
+        from .cartesian import CartesianVel1D
 
-        return CartesianVelocity1D
+        return CartesianVel1D
 
     @classproperty
     @classmethod
@@ -101,12 +101,12 @@ class AbstractVelocity1D(AbstractVelocity):
 # -------------------------------------------------------------------
 
 
-@AbstractVelocity1D.from_._f.dispatch  # type: ignore[attr-defined, misc]  # noqa: SLF001
+@AbstractVel1D.from_._f.dispatch  # type: ignore[attr-defined, misc]  # noqa: SLF001
 def from_(
-    cls: type[AbstractVelocity1D],
+    cls: type[AbstractVel1D],
     obj: Shaped[Quantity["speed"], "*batch"] | Shaped[Quantity["speed"], "*batch 1"],
     /,
-) -> AbstractVelocity1D:
+) -> AbstractVel1D:
     """Construct a 1D velocity.
 
     Examples
@@ -114,17 +114,17 @@ def from_(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> cx.CartesianVelocity1D.from_(Quantity(1, "m/s"))
-    CartesianVelocity1D( d_x=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
+    >>> cx.CartesianVel1D.from_(Quantity(1, "m/s"))
+    CartesianVel1D( d_x=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
 
-    >>> cx.CartesianVelocity1D.from_(Quantity([1], "m/s"))
-    CartesianVelocity1D( d_x=Quantity[...]( value=i32[], unit=Unit("m / s") ) )
+    >>> cx.CartesianVel1D.from_(Quantity([1], "m/s"))
+    CartesianVel1D( d_x=Quantity[...]( value=i32[], unit=Unit("m / s") ) )
 
-    >>> cx.RadialVelocity.from_(Quantity(1, "m/s"))
-    RadialVelocity( d_r=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
+    >>> cx.RadialVel.from_(Quantity(1, "m/s"))
+    RadialVel( d_r=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
 
-    >>> cx.RadialVelocity.from_(Quantity([1], "m/s"))
-    RadialVelocity( d_r=Quantity[...]( value=i32[], unit=Unit("m / s") ) )
+    >>> cx.RadialVel.from_(Quantity([1], "m/s"))
+    RadialVel( d_r=Quantity[...]( value=i32[], unit=Unit("m / s") ) )
 
     """
     comps = {f.name: jnp.atleast_1d(obj)[..., i] for i, f in enumerate(fields(cls))}
@@ -147,7 +147,7 @@ class AbstractAcceleration1D(AbstractAcceleration):
     @classproperty
     @classmethod
     @abstractmethod
-    def integral_cls(cls) -> type[AbstractVelocity1D]:
+    def integral_cls(cls) -> type[AbstractVel1D]:
         raise NotImplementedError
 
 

--- a/src/coordinax/_src/d1/cartesian.py
+++ b/src/coordinax/_src/d1/cartesian.py
@@ -1,7 +1,7 @@
 """Carteisan vector."""
 
 __all__ = [
-    "CartesianPosition1D",
+    "CartesianPos1D",
     "CartesianVelocity1D",
     "CartesianAcceleration1D",
 ]
@@ -21,25 +21,23 @@ from quaxed import lax as qlax
 from unxt import Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration1D, AbstractPosition1D, AbstractVelocity1D
-from coordinax._src.base import AbstractPosition
+from .base import AbstractAcceleration1D, AbstractPos1D, AbstractVelocity1D
+from coordinax._src.base import AbstractPos
 from coordinax._src.base.mixins import AvalMixin
 from coordinax._src.utils import classproperty
 
 
 @final
-class CartesianPosition1D(AbstractPosition1D):
+class CartesianPos1D(AbstractPos1D):
     """Cartesian vector representation.
 
     Examples
     --------
     >>> import coordinax as cx
 
-    >>> vec = cx.CartesianPosition1D.from_([2], "m")
+    >>> vec = cx.CartesianPos1D.from_([2], "m")
     >>> vec
-    CartesianPosition1D(
-      x=Quantity[PhysicalType('length')](value=f32[], unit=Unit("m"))
-    )
+    CartesianPos1D(x=Quantity[PhysicalType('length')](value=f32[], unit=Unit("m")))
 
     Vectors support the basic math operations:
 
@@ -70,20 +68,20 @@ class CartesianPosition1D(AbstractPosition1D):
 
 
 @register(jax.lax.add_p)  # type: ignore[misc]
-def _add_qq(lhs: CartesianPosition1D, rhs: AbstractPosition, /) -> CartesianPosition1D:
-    """Add a vector to a CartesianPosition1D.
+def _add_qq(lhs: CartesianPos1D, rhs: AbstractPos, /) -> CartesianPos1D:
+    """Add a vector to a CartesianPos1D.
 
     Examples
     --------
     >>> import quaxed.numpy as jnp
     >>> import coordinax as cx
 
-    >>> q = cx.CartesianPosition1D.from_([1], "kpc")
-    >>> r = cx.RadialPosition.from_([1], "kpc")
+    >>> q = cx.CartesianPos1D.from_([1], "kpc")
+    >>> r = cx.RadialPos.from_([1], "kpc")
 
     >>> qpr = jnp.add(q, r)
     >>> qpr
-    CartesianPosition1D(
+    CartesianPos1D(
         x=Quantity[PhysicalType('length')](value=f32[], unit=Unit("kpc"))
     )
     >>> qpr.x
@@ -93,12 +91,12 @@ def _add_qq(lhs: CartesianPosition1D, rhs: AbstractPosition, /) -> CartesianPosi
     Quantity['length'](Array(2., dtype=float32), unit='kpc')
 
     """
-    cart = rhs.represent_as(CartesianPosition1D)
+    cart = rhs.represent_as(CartesianPos1D)
     return jax.tree.map(qlax.add, lhs, cart)
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_ac1(lhs: ArrayLike, rhs: CartesianPosition1D, /) -> CartesianPosition1D:
+def _mul_ac1(lhs: ArrayLike, rhs: CartesianPos1D, /) -> CartesianPos1D:
     """Scale a position by a scalar.
 
     Examples
@@ -107,7 +105,7 @@ def _mul_ac1(lhs: ArrayLike, rhs: CartesianPosition1D, /) -> CartesianPosition1D
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> v = cx.CartesianPosition1D(x=Quantity(1, "m"))
+    >>> v = cx.CartesianPos1D(x=Quantity(1, "m"))
     >>> jnp.multiply(2, v).x
     Quantity['length'](Array(2., dtype=float32), unit='m')
 
@@ -125,13 +123,13 @@ def _mul_ac1(lhs: ArrayLike, rhs: CartesianPosition1D, /) -> CartesianPosition1D
 
 
 @register(jax.lax.neg_p)  # type: ignore[misc]
-def _neg_p_cart1d_pos(obj: CartesianPosition1D, /) -> CartesianPosition1D:
-    """Negate the `coordinax.CartesianPosition1D`.
+def _neg_p_cart1d_pos(obj: CartesianPos1D, /) -> CartesianPos1D:
+    """Negate the `coordinax.CartesianPos1D`.
 
     Examples
     --------
     >>> import coordinax as cx
-    >>> q = cx.CartesianPosition1D.from_([1], "km")
+    >>> q = cx.CartesianPos1D.from_([1], "km")
     >>> (-q).x
     Quantity['length'](Array(-1., dtype=float32), unit='km')
 
@@ -140,23 +138,20 @@ def _neg_p_cart1d_pos(obj: CartesianPosition1D, /) -> CartesianPosition1D:
 
 
 @register(jax.lax.sub_p)  # type: ignore[misc]
-def _sub_q1d_pos(
-    self: CartesianPosition1D, other: AbstractPosition, /
-) -> CartesianPosition1D:
+def _sub_q1d_pos(self: CartesianPos1D, other: AbstractPos, /) -> CartesianPos1D:
     """Subtract two vectors.
 
     Examples
     --------
     >>> import quaxed.numpy as jnp
-    >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> q = cx.CartesianPosition1D.from_(Quantity([1], "kpc"))
-    >>> r = cx.RadialPosition.from_(Quantity([1], "kpc"))
+    >>> q = cx.CartesianPos1D.from_([1], "kpc")
+    >>> r = cx.RadialPos.from_([1], "kpc")
 
     >>> qmr = jnp.subtract(q, r)
     >>> qmr
-    CartesianPosition1D(
+    CartesianPos1D(
        x=Quantity[PhysicalType('length')](value=f32[], unit=Unit("kpc"))
     )
     >>> qmr.x
@@ -166,7 +161,7 @@ def _sub_q1d_pos(
     Quantity['length'](Array(0., dtype=float32), unit='kpc')
 
     """
-    cart = other.represent_as(CartesianPosition1D)
+    cart = other.represent_as(CartesianPos1D)
     return jax.tree.map(qlax.sub, self, cart)
 
 
@@ -183,8 +178,8 @@ class CartesianVelocity1D(AvalMixin, AbstractVelocity1D):
     @override
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[CartesianPosition1D]:
-        return CartesianPosition1D
+    def integral_cls(cls) -> type[CartesianPos1D]:
+        return CartesianPos1D
 
     @override
     @classproperty
@@ -194,7 +189,7 @@ class CartesianVelocity1D(AvalMixin, AbstractVelocity1D):
 
     @override
     @partial(eqx.filter_jit, inline=True)
-    def norm(self, _: AbstractPosition1D | None = None, /) -> ct.BatchableSpeed:
+    def norm(self, _: AbstractPos1D | None = None, /) -> ct.BatchableSpeed:
         """Return the norm of the vector.
 
         Examples
@@ -294,7 +289,7 @@ class CartesianAcceleration1D(AvalMixin, AbstractAcceleration1D):
 
     @override
     @partial(eqx.filter_jit, inline=True)
-    def norm(self, _: AbstractPosition1D | None = None, /) -> ct.BatchableAcc:
+    def norm(self, _: AbstractPos1D | None = None, /) -> ct.BatchableAcc:
         """Return the norm of the vector.
 
         Examples

--- a/src/coordinax/_src/d1/cartesian.py
+++ b/src/coordinax/_src/d1/cartesian.py
@@ -1,10 +1,6 @@
 """Carteisan vector."""
 
-__all__ = [
-    "CartesianPos1D",
-    "CartesianVel1D",
-    "CartesianAcceleration1D",
-]
+__all__ = ["CartesianPos1D", "CartesianVel1D", "CartesianAcc1D"]
 
 from dataclasses import replace
 from functools import partial
@@ -21,7 +17,7 @@ from quaxed import lax as qlax
 from unxt import Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration1D, AbstractPos1D, AbstractVel1D
+from .base import AbstractAcc1D, AbstractPos1D, AbstractVel1D
 from coordinax._src.base import AbstractPos
 from coordinax._src.base.mixins import AvalMixin
 from coordinax._src.utils import classproperty
@@ -184,8 +180,8 @@ class CartesianVel1D(AvalMixin, AbstractVel1D):
     @override
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["CartesianAcceleration1D"]:
-        return CartesianAcceleration1D
+    def differential_cls(cls) -> type["CartesianAcc1D"]:
+        return CartesianAcc1D
 
     @override
     @partial(eqx.filter_jit, inline=True)
@@ -271,7 +267,7 @@ def _mul_vcart(lhs: ArrayLike, rhs: CartesianVel1D, /) -> CartesianVel1D:
 
 
 @final
-class CartesianAcceleration1D(AvalMixin, AbstractAcceleration1D):
+class CartesianAcc1D(AvalMixin, AbstractAcc1D):
     """Cartesian differential representation."""
 
     d2_x: ct.BatchableAcc = eqx.field(converter=Quantity["acceleration"].from_)
@@ -294,7 +290,7 @@ class CartesianAcceleration1D(AvalMixin, AbstractAcceleration1D):
         --------
         >>> from unxt import Quantity
         >>> import coordinax as cx
-        >>> q = cx.CartesianAcceleration1D.from_([-1], "km/s2")
+        >>> q = cx.CartesianAcc1D.from_([-1], "km/s2")
         >>> q.norm()
         Quantity['acceleration'](Array(1, dtype=int32), unit='km / s2')
 
@@ -303,9 +299,7 @@ class CartesianAcceleration1D(AvalMixin, AbstractAcceleration1D):
 
 
 @register(jax.lax.add_p)  # type: ignore[misc]
-def _add_aa(
-    lhs: CartesianAcceleration1D, rhs: CartesianAcceleration1D, /
-) -> CartesianAcceleration1D:
+def _add_aa(lhs: CartesianAcc1D, rhs: CartesianAcc1D, /) -> CartesianAcc1D:
     """Add two Cartesian accelerations.
 
     Examples
@@ -314,10 +308,10 @@ def _add_aa(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> v = cx.CartesianAcceleration1D.from_([1], "km/s2")
+    >>> v = cx.CartesianAcc1D.from_([1], "km/s2")
     >>> vec = jnp.add(v, v)
     >>> vec
-    CartesianAcceleration1D(
+    CartesianAcc1D(
         d2_x=Quantity[...](value=i32[], unit=Unit("km / s2"))
     )
     >>> vec.d2_x
@@ -331,7 +325,7 @@ def _add_aa(
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_aq(lhs: ArrayLike, rhs: CartesianAcceleration1D, /) -> CartesianAcceleration1D:
+def _mul_aq(lhs: ArrayLike, rhs: CartesianAcc1D, /) -> CartesianAcc1D:
     """Scale an acceleration by a scalar.
 
     Examples
@@ -340,10 +334,10 @@ def _mul_aq(lhs: ArrayLike, rhs: CartesianAcceleration1D, /) -> CartesianAcceler
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> v = cx.CartesianAcceleration1D(d2_x=Quantity(1, "m/s2"))
+    >>> v = cx.CartesianAcc1D(d2_x=Quantity(1, "m/s2"))
     >>> vec = jnp.multiply(2, v)
     >>> vec
-    CartesianAcceleration1D( d2_x=... )
+    CartesianAcc1D( d2_x=... )
 
     >>> vec.d2_x
     Quantity['acceleration'](Array(2, dtype=int32, ...), unit='m / s2')
@@ -362,9 +356,7 @@ def _mul_aq(lhs: ArrayLike, rhs: CartesianAcceleration1D, /) -> CartesianAcceler
 
 
 @register(jax.lax.sub_p)  # type: ignore[misc]
-def _sub_a1_a1(
-    self: CartesianAcceleration1D, other: CartesianAcceleration1D, /
-) -> CartesianAcceleration1D:
+def _sub_a1_a1(self: CartesianAcc1D, other: CartesianAcc1D, /) -> CartesianAcc1D:
     """Subtract two 1-D cartesian accelerations.
 
     Examples
@@ -373,11 +365,11 @@ def _sub_a1_a1(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> v1 = cx.CartesianAcceleration1D(d2_x=Quantity(1, "m/s2"))
-    >>> v2 = cx.CartesianAcceleration1D(d2_x=Quantity(2, "m/s2"))
+    >>> v1 = cx.CartesianAcc1D(d2_x=Quantity(1, "m/s2"))
+    >>> v2 = cx.CartesianAcc1D(d2_x=Quantity(2, "m/s2"))
     >>> vec = lax.sub(v1, v2)
     >>> vec
-    CartesianAcceleration1D( d2_x=... )
+    CartesianAcc1D( d2_x=... )
 
     >>> vec.d2_x
     Quantity['acceleration'](Array(-1, dtype=int32, ...), unit='m / s2')

--- a/src/coordinax/_src/d1/cartesian.py
+++ b/src/coordinax/_src/d1/cartesian.py
@@ -2,7 +2,7 @@
 
 __all__ = [
     "CartesianPos1D",
-    "CartesianVelocity1D",
+    "CartesianVel1D",
     "CartesianAcceleration1D",
 ]
 
@@ -21,7 +21,7 @@ from quaxed import lax as qlax
 from unxt import Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration1D, AbstractPos1D, AbstractVelocity1D
+from .base import AbstractAcceleration1D, AbstractPos1D, AbstractVel1D
 from coordinax._src.base import AbstractPos
 from coordinax._src.base.mixins import AvalMixin
 from coordinax._src.utils import classproperty
@@ -59,8 +59,8 @@ class CartesianPos1D(AbstractPos1D):
 
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["CartesianVelocity1D"]:
-        return CartesianVelocity1D
+    def differential_cls(cls) -> type["CartesianVel1D"]:
+        return CartesianVel1D
 
 
 # -------------------------------------------------------------------
@@ -169,7 +169,7 @@ def _sub_q1d_pos(self: CartesianPos1D, other: AbstractPos, /) -> CartesianPos1D:
 
 
 @final
-class CartesianVelocity1D(AvalMixin, AbstractVelocity1D):
+class CartesianVel1D(AvalMixin, AbstractVel1D):
     """Cartesian differential representation."""
 
     d_x: ct.BatchableSpeed = eqx.field(converter=Quantity["speed"].from_)
@@ -196,7 +196,7 @@ class CartesianVelocity1D(AvalMixin, AbstractVelocity1D):
         --------
         >>> from unxt import Quantity
         >>> import coordinax as cx
-        >>> q = cx.CartesianVelocity1D.from_([-1], "km/s")
+        >>> q = cx.CartesianVel1D.from_([-1], "km/s")
         >>> q.norm()
         Quantity['speed'](Array(1, dtype=int32), unit='km / s')
 
@@ -209,9 +209,7 @@ class CartesianVelocity1D(AvalMixin, AbstractVelocity1D):
 
 
 @register(jax.lax.add_p)  # type: ignore[misc]
-def _add_pp(
-    lhs: CartesianVelocity1D, rhs: CartesianVelocity1D, /
-) -> CartesianVelocity1D:
+def _add_pp(lhs: CartesianVel1D, rhs: CartesianVel1D, /) -> CartesianVel1D:
     """Add two Cartesian velocities.
 
     Examples
@@ -220,10 +218,10 @@ def _add_pp(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> v = cx.CartesianVelocity1D.from_([1], "km/s")
+    >>> v = cx.CartesianVel1D.from_([1], "km/s")
     >>> vec = jnp.add(v, v)
     >>> vec
-    CartesianVelocity1D(
+    CartesianVel1D(
        d_x=Quantity[...]( value=i32[], unit=Unit("km / s") )
     )
     >>> vec.d_x
@@ -237,7 +235,7 @@ def _add_pp(
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_vcart(lhs: ArrayLike, rhs: CartesianVelocity1D, /) -> CartesianVelocity1D:
+def _mul_vcart(lhs: ArrayLike, rhs: CartesianVel1D, /) -> CartesianVel1D:
     """Scale a velocity by a scalar.
 
     Examples
@@ -246,10 +244,10 @@ def _mul_vcart(lhs: ArrayLike, rhs: CartesianVelocity1D, /) -> CartesianVelocity
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> v = cx.CartesianVelocity1D(d_x=Quantity(1, "m/s"))
+    >>> v = cx.CartesianVel1D(d_x=Quantity(1, "m/s"))
     >>> vec = jnp.multiply(2, v)
     >>> vec
-    CartesianVelocity1D(
+    CartesianVel1D(
       d_x=Quantity[...]( value=...i32[], unit=Unit("m / s") )
     )
 
@@ -281,8 +279,8 @@ class CartesianAcceleration1D(AvalMixin, AbstractAcceleration1D):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[CartesianVelocity1D]:
-        return CartesianVelocity1D
+    def integral_cls(cls) -> type[CartesianVel1D]:
+        return CartesianVel1D
 
     # -----------------------------------------------------
     # Methods

--- a/src/coordinax/_src/d1/compat.py
+++ b/src/coordinax/_src/d1/compat.py
@@ -10,7 +10,7 @@ from plum import convert
 
 from unxt import Quantity
 
-from .cartesian import CartesianPosition1D
+from .cartesian import CartesianPos1D
 from coordinax._src.operators.base import AbstractOperator, op_call_dispatch
 from coordinax._src.typing import TimeBatchOrScalar
 
@@ -20,7 +20,7 @@ Q1: TypeAlias = Shaped[Quantity["length"], "*#batch 1"]
 @op_call_dispatch
 def call(self: AbstractOperator, x: Q1, /) -> Q1:
     """Dispatch to the operator's `__call__` method."""
-    return self(CartesianPosition1D.from_(x))
+    return self(CartesianPos1D.from_(x))
 
 
 @op_call_dispatch
@@ -28,5 +28,5 @@ def call(
     self: AbstractOperator, x: Q1, t: TimeBatchOrScalar, /
 ) -> tuple[Q1, TimeBatchOrScalar]:
     """Dispatch to the operator's `__call__` method."""
-    vec, t = self(CartesianPosition1D.from_(x), t)
+    vec, t = self(CartesianPos1D.from_(x), t)
     return convert(vec, Quantity), t

--- a/src/coordinax/_src/d1/radial.py
+++ b/src/coordinax/_src/d1/radial.py
@@ -1,6 +1,6 @@
 """Carteisan vector."""
 
-__all__ = ["RadialPos", "RadialVelocity", "RadialAcceleration"]
+__all__ = ["RadialPos", "RadialVel", "RadialAcceleration"]
 
 from functools import partial
 from typing import final
@@ -13,7 +13,7 @@ from dataclassish.converters import Unless
 from unxt import AbstractDistance, Distance, Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration1D, AbstractPos1D, AbstractVelocity1D
+from .base import AbstractAcceleration1D, AbstractPos1D, AbstractVel1D
 from coordinax._src.checks import check_r_non_negative
 from coordinax._src.utils import classproperty
 
@@ -33,12 +33,12 @@ class RadialPos(AbstractPos1D):
 
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["RadialVelocity"]:
-        return RadialVelocity
+    def differential_cls(cls) -> type["RadialVel"]:
+        return RadialVel
 
 
 @final
-class RadialVelocity(AbstractVelocity1D):
+class RadialVel(AbstractVel1D):
     """Radial differential representation."""
 
     d_r: ct.BatchableSpeed = eqx.field(converter=Quantity["speed"].from_)
@@ -69,8 +69,8 @@ class RadialAcceleration(AbstractAcceleration1D):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[RadialVelocity]:
-        return RadialVelocity
+    def integral_cls(cls) -> type[RadialVel]:
+        return RadialVel
 
     def aval(self) -> jax.core.ShapedArray:
         """Return the vector as a JAX array."""

--- a/src/coordinax/_src/d1/radial.py
+++ b/src/coordinax/_src/d1/radial.py
@@ -1,6 +1,6 @@
 """Carteisan vector."""
 
-__all__ = ["RadialPosition", "RadialVelocity", "RadialAcceleration"]
+__all__ = ["RadialPos", "RadialVelocity", "RadialAcceleration"]
 
 from functools import partial
 from typing import final
@@ -13,13 +13,13 @@ from dataclassish.converters import Unless
 from unxt import AbstractDistance, Distance, Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration1D, AbstractPosition1D, AbstractVelocity1D
+from .base import AbstractAcceleration1D, AbstractPos1D, AbstractVelocity1D
 from coordinax._src.checks import check_r_non_negative
 from coordinax._src.utils import classproperty
 
 
 @final
-class RadialPosition(AbstractPosition1D):
+class RadialPos(AbstractPos1D):
     """Radial vector representation."""
 
     r: ct.BatchableDistance = eqx.field(
@@ -46,8 +46,8 @@ class RadialVelocity(AbstractVelocity1D):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[RadialPosition]:
-        return RadialPosition
+    def integral_cls(cls) -> type[RadialPos]:
+        return RadialPos
 
     @classproperty
     @classmethod

--- a/src/coordinax/_src/d1/radial.py
+++ b/src/coordinax/_src/d1/radial.py
@@ -1,6 +1,6 @@
 """Carteisan vector."""
 
-__all__ = ["RadialPos", "RadialVel", "RadialAcceleration"]
+__all__ = ["RadialPos", "RadialVel", "RadialAcc"]
 
 from functools import partial
 from typing import final
@@ -13,7 +13,7 @@ from dataclassish.converters import Unless
 from unxt import AbstractDistance, Distance, Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration1D, AbstractPos1D, AbstractVel1D
+from .base import AbstractAcc1D, AbstractPos1D, AbstractVel1D
 from coordinax._src.checks import check_r_non_negative
 from coordinax._src.utils import classproperty
 
@@ -51,8 +51,8 @@ class RadialVel(AbstractVel1D):
 
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["RadialAcceleration"]:
-        return RadialAcceleration
+    def differential_cls(cls) -> type["RadialAcc"]:
+        return RadialAcc
 
     def aval(self) -> jax.core.ShapedArray:
         """Return the vector as a JAX array."""
@@ -61,7 +61,7 @@ class RadialVel(AbstractVel1D):
 
 
 @final
-class RadialAcceleration(AbstractAcceleration1D):
+class RadialAcc(AbstractAcc1D):
     """Radial differential representation."""
 
     d2_r: ct.BatchableAcc = eqx.field(converter=Quantity["acceleration"].from_)

--- a/src/coordinax/_src/d1/transform.py
+++ b/src/coordinax/_src/d1/transform.py
@@ -6,10 +6,10 @@ from typing import Any
 
 from plum import dispatch
 
-from .base import AbstractAcceleration1D, AbstractPos1D, AbstractVelocity1D
-from .cartesian import CartesianAcceleration1D, CartesianPos1D, CartesianVelocity1D
-from .radial import RadialAcceleration, RadialPos, RadialVelocity
-from coordinax._src.base import AbstractPos, AbstractVelocity
+from .base import AbstractAcceleration1D, AbstractPos1D, AbstractVel1D
+from .cartesian import CartesianAcceleration1D, CartesianPos1D, CartesianVel1D
+from .radial import RadialAcceleration, RadialPos, RadialVel
+from coordinax._src.base import AbstractPos, AbstractVel
 
 ###############################################################################
 # 1D
@@ -46,28 +46,28 @@ def represent_as(
 
 
 @dispatch.multi(
-    (CartesianVelocity1D, type[CartesianVelocity1D], AbstractPos),
-    (RadialVelocity, type[RadialVelocity], AbstractPos),
+    (CartesianVel1D, type[CartesianVel1D], AbstractPos),
+    (RadialVel, type[RadialVel], AbstractPos),
 )
 def represent_as(
-    current: AbstractVelocity1D,
-    target: type[AbstractVelocity1D],
+    current: AbstractVel1D,
+    target: type[AbstractVel1D],
     position: AbstractPos,
     /,
     **kwargs: Any,
-) -> AbstractVelocity1D:
+) -> AbstractVel1D:
     """Self transform of 1D Velocities."""
     return current
 
 
 # Special-case where self-transform doesn't need position
 @dispatch.multi(
-    (CartesianVelocity1D, type[CartesianVelocity1D]),
-    (RadialVelocity, type[RadialVelocity]),
+    (CartesianVel1D, type[CartesianVel1D]),
+    (RadialVel, type[RadialVel]),
 )
 def represent_as(
-    current: AbstractVelocity1D, target: type[AbstractVelocity1D], /, **kwargs: Any
-) -> AbstractVelocity1D:
+    current: AbstractVel1D, target: type[AbstractVel1D], /, **kwargs: Any
+) -> AbstractVel1D:
     """Self transform of 1D Velocities."""
     return current
 
@@ -76,15 +76,15 @@ def represent_as(
     (
         CartesianAcceleration1D,
         type[CartesianAcceleration1D],
-        AbstractVelocity,
+        AbstractVel,
         AbstractPos,
     ),
-    (RadialAcceleration, type[RadialAcceleration], AbstractVelocity, AbstractPos),
+    (RadialAcceleration, type[RadialAcceleration], AbstractVel, AbstractPos),
 )
 def represent_as(
     current: AbstractAcceleration1D,
     target: type[AbstractAcceleration1D],
-    velocity: AbstractVelocity,
+    velocity: AbstractVel,
     position: AbstractPos,
     /,
     **kwargs: Any,
@@ -139,14 +139,14 @@ def represent_as(
 
 
 # =============================================================================
-# CartesianVelocity1D
+# CartesianVel1D
 
 
 @dispatch
 def represent_as(
-    current: CartesianVelocity1D, target: type[CartesianVelocity1D], /
-) -> CartesianVelocity1D:
-    """CartesianVelocity1D -> CartesianVelocity1D with no position.
+    current: CartesianVel1D, target: type[CartesianVel1D], /
+) -> CartesianVel1D:
+    """CartesianVel1D -> CartesianVel1D with no position.
 
     Cartesian coordinates are an affine coordinate system and so the
     transformation of an n-th order derivative vector in this system do not
@@ -158,8 +158,8 @@ def represent_as(
     Examples
     --------
     >>> import coordinax as cx
-    >>> v = cx.CartesianVelocity1D.from_([1], "m/s")
-    >>> cx.represent_as(v, cx.CartesianVelocity1D) is v
+    >>> v = cx.CartesianVel1D.from_([1], "m/s")
+    >>> cx.represent_as(v, cx.CartesianVel1D) is v
     True
 
     """

--- a/src/coordinax/_src/d1/transform.py
+++ b/src/coordinax/_src/d1/transform.py
@@ -6,9 +6,9 @@ from typing import Any
 
 from plum import dispatch
 
-from .base import AbstractAcceleration1D, AbstractPos1D, AbstractVel1D
-from .cartesian import CartesianAcceleration1D, CartesianPos1D, CartesianVel1D
-from .radial import RadialAcceleration, RadialPos, RadialVel
+from .base import AbstractAcc1D, AbstractPos1D, AbstractVel1D
+from .cartesian import CartesianAcc1D, CartesianPos1D, CartesianVel1D
+from .radial import RadialAcc, RadialPos, RadialVel
 from coordinax._src.base import AbstractPos, AbstractVel
 
 ###############################################################################
@@ -74,37 +74,37 @@ def represent_as(
 
 @dispatch.multi(
     (
-        CartesianAcceleration1D,
-        type[CartesianAcceleration1D],
+        CartesianAcc1D,
+        type[CartesianAcc1D],
         AbstractVel,
         AbstractPos,
     ),
-    (RadialAcceleration, type[RadialAcceleration], AbstractVel, AbstractPos),
+    (RadialAcc, type[RadialAcc], AbstractVel, AbstractPos),
 )
 def represent_as(
-    current: AbstractAcceleration1D,
-    target: type[AbstractAcceleration1D],
+    current: AbstractAcc1D,
+    target: type[AbstractAcc1D],
     velocity: AbstractVel,
     position: AbstractPos,
     /,
     **kwargs: Any,
-) -> AbstractAcceleration1D:
-    """Self transform of 1D Accelerations."""
+) -> AbstractAcc1D:
+    """Self transform of 1D Accs."""
     return current
 
 
 # Special-case where self-transform doesn't need velocity or position
 @dispatch.multi(
-    (CartesianAcceleration1D, type[CartesianAcceleration1D]),
-    (RadialAcceleration, type[RadialAcceleration]),
+    (CartesianAcc1D, type[CartesianAcc1D]),
+    (RadialAcc, type[RadialAcc]),
 )
 def represent_as(
-    current: AbstractAcceleration1D,
-    target: type[AbstractAcceleration1D],
+    current: AbstractAcc1D,
+    target: type[AbstractAcc1D],
     /,
     **kwargs: Any,
-) -> AbstractAcceleration1D:
-    """Self transform of 1D Accelerations."""
+) -> AbstractAcc1D:
+    """Self transform of 1D Accs."""
     return current
 
 
@@ -167,14 +167,14 @@ def represent_as(
 
 
 # =============================================================================
-# CartesianAcceleration1D
+# CartesianAcc1D
 
 
 @dispatch
 def represent_as(
-    current: CartesianAcceleration1D, target: type[CartesianAcceleration1D], /
-) -> CartesianAcceleration1D:
-    """CartesianAcceleration1D -> CartesianAcceleration1D with no position.
+    current: CartesianAcc1D, target: type[CartesianAcc1D], /
+) -> CartesianAcc1D:
+    """CartesianAcc1D -> CartesianAcc1D with no position.
 
     Cartesian coordinates are an affine coordinate system and so the
     transformation of an n-th order derivative vector in this system do not
@@ -186,8 +186,8 @@ def represent_as(
     Examples
     --------
     >>> import coordinax as cx
-    >>> a = cx.CartesianAcceleration1D.from_([1], "m/s2")
-    >>> cx.represent_as(a, cx.CartesianAcceleration1D) is a
+    >>> a = cx.CartesianAcc1D.from_([1], "m/s2")
+    >>> cx.represent_as(a, cx.CartesianAcc1D) is a
     True
 
     """

--- a/src/coordinax/_src/d1/transform.py
+++ b/src/coordinax/_src/d1/transform.py
@@ -6,10 +6,10 @@ from typing import Any
 
 from plum import dispatch
 
-from .base import AbstractAcceleration1D, AbstractPosition1D, AbstractVelocity1D
-from .cartesian import CartesianAcceleration1D, CartesianPosition1D, CartesianVelocity1D
-from .radial import RadialAcceleration, RadialPosition, RadialVelocity
-from coordinax._src.base import AbstractPosition, AbstractVelocity
+from .base import AbstractAcceleration1D, AbstractPos1D, AbstractVelocity1D
+from .cartesian import CartesianAcceleration1D, CartesianPos1D, CartesianVelocity1D
+from .radial import RadialAcceleration, RadialPos, RadialVelocity
+from coordinax._src.base import AbstractPos, AbstractVelocity
 
 ###############################################################################
 # 1D
@@ -17,21 +17,21 @@ from coordinax._src.base import AbstractPosition, AbstractVelocity
 
 @dispatch
 def represent_as(
-    current: AbstractPosition1D, target: type[AbstractPosition1D], /, **kwargs: Any
-) -> AbstractPosition1D:
-    """AbstractPosition1D -> Cartesian1D -> AbstractPosition1D.
+    current: AbstractPos1D, target: type[AbstractPos1D], /, **kwargs: Any
+) -> AbstractPos1D:
+    """AbstractPos1D -> Cartesian1D -> AbstractPos1D.
 
     This is the base case for the transformation of 1D vectors.
     """
-    cart1d = represent_as(current, CartesianPosition1D)
+    cart1d = represent_as(current, CartesianPos1D)
     return represent_as(cart1d, target)
 
 
 # TODO: use multi, with precedence
 @dispatch(precedence=1)
 def represent_as(
-    current: CartesianPosition1D, target: type[CartesianPosition1D], /, **kwargs: Any
-) -> CartesianPosition1D:
+    current: CartesianPos1D, target: type[CartesianPos1D], /, **kwargs: Any
+) -> CartesianPos1D:
     """Self transform of 1D vectors."""
     return current
 
@@ -39,20 +39,20 @@ def represent_as(
 # TODO: use multi, with precedence
 @dispatch(precedence=1)
 def represent_as(
-    current: RadialPosition, target: type[RadialPosition], /, **kwargs: Any
-) -> RadialPosition:
+    current: RadialPos, target: type[RadialPos], /, **kwargs: Any
+) -> RadialPos:
     """Self transform of 1D vectors."""
     return current
 
 
 @dispatch.multi(
-    (CartesianVelocity1D, type[CartesianVelocity1D], AbstractPosition),
-    (RadialVelocity, type[RadialVelocity], AbstractPosition),
+    (CartesianVelocity1D, type[CartesianVelocity1D], AbstractPos),
+    (RadialVelocity, type[RadialVelocity], AbstractPos),
 )
 def represent_as(
     current: AbstractVelocity1D,
     target: type[AbstractVelocity1D],
-    position: AbstractPosition,
+    position: AbstractPos,
     /,
     **kwargs: Any,
 ) -> AbstractVelocity1D:
@@ -77,15 +77,15 @@ def represent_as(
         CartesianAcceleration1D,
         type[CartesianAcceleration1D],
         AbstractVelocity,
-        AbstractPosition,
+        AbstractPos,
     ),
-    (RadialAcceleration, type[RadialAcceleration], AbstractVelocity, AbstractPosition),
+    (RadialAcceleration, type[RadialAcceleration], AbstractVelocity, AbstractPos),
 )
 def represent_as(
     current: AbstractAcceleration1D,
     target: type[AbstractAcceleration1D],
     velocity: AbstractVelocity,
-    position: AbstractPosition,
+    position: AbstractPos,
     /,
     **kwargs: Any,
 ) -> AbstractAcceleration1D:
@@ -109,14 +109,14 @@ def represent_as(
 
 
 # =============================================================================
-# CartesianPosition1D
+# CartesianPos1D
 
 
 @dispatch
 def represent_as(
-    current: CartesianPosition1D, target: type[RadialPosition], /, **kwargs: Any
-) -> RadialPosition:
-    """CartesianPosition1D -> RadialPosition.
+    current: CartesianPos1D, target: type[RadialPos], /, **kwargs: Any
+) -> RadialPos:
+    """CartesianPos1D -> RadialPos.
 
     The `x` coordinate is converted to the radial coordinate `r`.
     """
@@ -124,14 +124,14 @@ def represent_as(
 
 
 # =============================================================================
-# RadialPosition
+# RadialPos
 
 
 @dispatch
 def represent_as(
-    current: RadialPosition, target: type[CartesianPosition1D], /, **kwargs: Any
-) -> CartesianPosition1D:
-    """RadialPosition -> CartesianPosition1D.
+    current: RadialPos, target: type[CartesianPos1D], /, **kwargs: Any
+) -> CartesianPos1D:
+    """RadialPos -> CartesianPos1D.
 
     The `r` coordinate is converted to the `x` coordinate of the 1D system.
     """

--- a/src/coordinax/_src/d2/base.py
+++ b/src/coordinax/_src/d2/base.py
@@ -1,6 +1,6 @@
 """Representation of coordinates in different systems."""
 
-__all__ = ["AbstractPos2D", "AbstractVelocity2D", "AbstractAcceleration2D"]
+__all__ = ["AbstractPos2D", "AbstractVel2D", "AbstractAcceleration2D"]
 
 
 from abc import abstractmethod
@@ -9,7 +9,7 @@ from coordinax._src.base import (
     AbstractAcceleration,
     AbstractPos,
     AbstractVector,
-    AbstractVelocity,
+    AbstractVel,
 )
 from coordinax._src.utils import classproperty
 
@@ -27,22 +27,22 @@ class AbstractPos2D(AbstractPos):
     @classproperty
     @classmethod
     @abstractmethod
-    def differential_cls(cls) -> type["AbstractVelocity2D"]:
+    def differential_cls(cls) -> type["AbstractVel2D"]:
         raise NotImplementedError
 
 
 #####################################################################
 
 
-class AbstractVelocity2D(AbstractVelocity):
+class AbstractVel2D(AbstractVel):
     """Abstract representation of 2D vector differentials."""
 
     @classproperty
     @classmethod
     def _cartesian_cls(cls) -> type[AbstractVector]:
-        from .cartesian import CartesianVelocity2D
+        from .cartesian import CartesianVel2D
 
-        return CartesianVelocity2D
+        return CartesianVel2D
 
     @classproperty
     @classmethod
@@ -73,5 +73,5 @@ class AbstractAcceleration2D(AbstractAcceleration):
     @classproperty
     @classmethod
     @abstractmethod
-    def integral_cls(cls) -> type[AbstractVelocity2D]:
+    def integral_cls(cls) -> type[AbstractVel2D]:
         raise NotImplementedError

--- a/src/coordinax/_src/d2/base.py
+++ b/src/coordinax/_src/d2/base.py
@@ -1,12 +1,12 @@
 """Representation of coordinates in different systems."""
 
-__all__ = ["AbstractPos2D", "AbstractVel2D", "AbstractAcceleration2D"]
+__all__ = ["AbstractPos2D", "AbstractVel2D", "AbstractAcc2D"]
 
 
 from abc import abstractmethod
 
 from coordinax._src.base import (
-    AbstractAcceleration,
+    AbstractAcc,
     AbstractPos,
     AbstractVector,
     AbstractVel,
@@ -53,22 +53,22 @@ class AbstractVel2D(AbstractVel):
     @classproperty
     @classmethod
     @abstractmethod
-    def differential_cls(cls) -> type[AbstractAcceleration]:
+    def differential_cls(cls) -> type[AbstractAcc]:
         raise NotImplementedError
 
 
 #####################################################################
 
 
-class AbstractAcceleration2D(AbstractAcceleration):
+class AbstractAcc2D(AbstractAcc):
     """Abstract representation of 2D vector accelerations."""
 
     @classproperty
     @classmethod
     def _cartesian_cls(cls) -> type[AbstractVector]:
-        from .cartesian import CartesianAcceleration2D
+        from .cartesian import CartesianAcc2D
 
-        return CartesianAcceleration2D
+        return CartesianAcc2D
 
     @classproperty
     @classmethod

--- a/src/coordinax/_src/d2/base.py
+++ b/src/coordinax/_src/d2/base.py
@@ -1,28 +1,28 @@
 """Representation of coordinates in different systems."""
 
-__all__ = ["AbstractPosition2D", "AbstractVelocity2D", "AbstractAcceleration2D"]
+__all__ = ["AbstractPos2D", "AbstractVelocity2D", "AbstractAcceleration2D"]
 
 
 from abc import abstractmethod
 
 from coordinax._src.base import (
     AbstractAcceleration,
-    AbstractPosition,
+    AbstractPos,
     AbstractVector,
     AbstractVelocity,
 )
 from coordinax._src.utils import classproperty
 
 
-class AbstractPosition2D(AbstractPosition):
+class AbstractPos2D(AbstractPos):
     """Abstract representation of 2D coordinates in different systems."""
 
     @classproperty
     @classmethod
     def _cartesian_cls(cls) -> type[AbstractVector]:
-        from .cartesian import CartesianPosition2D
+        from .cartesian import CartesianPos2D
 
-        return CartesianPosition2D
+        return CartesianPos2D
 
     @classproperty
     @classmethod
@@ -47,7 +47,7 @@ class AbstractVelocity2D(AbstractVelocity):
     @classproperty
     @classmethod
     @abstractmethod
-    def integral_cls(cls) -> type[AbstractPosition2D]:
+    def integral_cls(cls) -> type[AbstractPos2D]:
         raise NotImplementedError
 
     @classproperty

--- a/src/coordinax/_src/d2/cartesian.py
+++ b/src/coordinax/_src/d2/cartesian.py
@@ -1,7 +1,7 @@
 """Built-in vector classes."""
 
 __all__ = [
-    "CartesianPosition2D",
+    "CartesianPos2D",
     "CartesianVelocity2D",
     "CartesianAcceleration2D",
 ]
@@ -21,14 +21,14 @@ from quaxed import lax as qlax
 from unxt import AbstractQuantity, Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration2D, AbstractPosition2D, AbstractVelocity2D
-from coordinax._src.base import AbstractPosition
+from .base import AbstractAcceleration2D, AbstractPos2D, AbstractVelocity2D
+from coordinax._src.base import AbstractPos
 from coordinax._src.base.mixins import AvalMixin
 from coordinax._src.utils import classproperty
 
 
 @final
-class CartesianPosition2D(AbstractPosition2D):
+class CartesianPos2D(AbstractPos2D):
     """Cartesian vector representation."""
 
     x: ct.BatchableLength = eqx.field(
@@ -50,10 +50,10 @@ class CartesianPosition2D(AbstractPosition2D):
 # -----------------------------------------------------
 
 
-@CartesianPosition2D.from_._f.dispatch  # type: ignore[attr-defined, misc] # noqa: SLF001
+@CartesianPos2D.from_._f.dispatch  # type: ignore[attr-defined, misc] # noqa: SLF001
 def from_(
-    cls: type[CartesianPosition2D], obj: Shaped[AbstractQuantity, "*batch 2"], /
-) -> CartesianPosition2D:
+    cls: type[CartesianPos2D], obj: Shaped[AbstractQuantity, "*batch 2"], /
+) -> CartesianPos2D:
     """Construct a 2D Cartesian position.
 
     Examples
@@ -61,9 +61,9 @@ def from_(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.CartesianPosition2D.from_(Quantity([1, 2], "m"))
+    >>> vec = cx.CartesianPos2D.from_(Quantity([1, 2], "m"))
     >>> vec
-    CartesianPosition2D(
+    CartesianPos2D(
         x=Quantity[...](value=f32[], unit=Unit("m")),
         y=Quantity[...](value=f32[], unit=Unit("m"))
     )
@@ -77,9 +77,7 @@ def from_(
 
 
 @register(jax.lax.add_p)  # type: ignore[misc]
-def _add_cart2d_pos(
-    lhs: CartesianPosition2D, rhs: AbstractPosition, /
-) -> CartesianPosition2D:
+def _add_cart2d_pos(lhs: CartesianPos2D, rhs: AbstractPos, /) -> CartesianPos2D:
     """Add two vectors.
 
     Examples
@@ -88,8 +86,8 @@ def _add_cart2d_pos(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> cart = cx.CartesianPosition2D.from_(Quantity([1, 2], "kpc"))
-    >>> polr = cx.PolarPosition(r=Quantity(3, "kpc"), phi=Quantity(90, "deg"))
+    >>> cart = cx.CartesianPos2D.from_([1, 2], "kpc")
+    >>> polr = cx.PolarPos(r=Quantity(3, "kpc"), phi=Quantity(90, "deg"))
     >>> (cart + polr).x
     Quantity['length'](Array(0.9999999, dtype=float32), unit='kpc')
 
@@ -97,12 +95,12 @@ def _add_cart2d_pos(
     Quantity['length'](Array(0.9999999, dtype=float32), unit='kpc')
 
     """
-    cart = rhs.represent_as(CartesianPosition2D)
+    cart = rhs.represent_as(CartesianPos2D)
     return jax.tree.map(qlax.add, lhs, cart)
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_v_cart2d(lhs: ArrayLike, rhs: CartesianPosition2D, /) -> CartesianPosition2D:
+def _mul_v_cart2d(lhs: ArrayLike, rhs: CartesianPos2D, /) -> CartesianPos2D:
     """Scale a cartesian 2D position by a scalar.
 
     Examples
@@ -111,7 +109,7 @@ def _mul_v_cart2d(lhs: ArrayLike, rhs: CartesianPosition2D, /) -> CartesianPosit
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> v = cx.CartesianPosition2D.from_(Quantity([3, 4], "m"))
+    >>> v = cx.CartesianPos2D.from_([3, 4], "m")
     >>> jnp.multiply(5, v).x
     Quantity['length'](Array(15., dtype=float32), unit='m')
 
@@ -126,13 +124,13 @@ def _mul_v_cart2d(lhs: ArrayLike, rhs: CartesianPosition2D, /) -> CartesianPosit
 
 
 @register(jax.lax.neg_p)  # type: ignore[misc]
-def _neg_p_cart2d_pos(obj: CartesianPosition2D, /) -> CartesianPosition2D:
-    """Negate the `coordinax.CartesianPosition2D`.
+def _neg_p_cart2d_pos(obj: CartesianPos2D, /) -> CartesianPos2D:
+    """Negate the `coordinax.CartesianPos2D`.
 
     Examples
     --------
     >>> import coordinax as cx
-    >>> q = cx.CartesianPosition2D.from_([1, 2], "km")
+    >>> q = cx.CartesianPos2D.from_([1, 2], "km")
     >>> (-q).x
     Quantity['length'](Array(-1., dtype=float32), unit='km')
 
@@ -141,23 +139,21 @@ def _neg_p_cart2d_pos(obj: CartesianPosition2D, /) -> CartesianPosition2D:
 
 
 @register(jax.lax.sub_p)  # type: ignore[misc]
-def _sub_cart2d_pos2d(
-    lhs: CartesianPosition2D, rhs: AbstractPosition, /
-) -> CartesianPosition2D:
+def _sub_cart2d_pos2d(lhs: CartesianPos2D, rhs: AbstractPos, /) -> CartesianPos2D:
     """Subtract two vectors.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
-    >>> cart = cx.CartesianPosition2D.from_([1, 2], "kpc")
-    >>> polr = cx.PolarPosition(r=Quantity(3, "kpc"), phi=Quantity(90, "deg"))
+    >>> cart = cx.CartesianPos2D.from_([1, 2], "kpc")
+    >>> polr = cx.PolarPos(r=Quantity(3, "kpc"), phi=Quantity(90, "deg"))
 
     >>> (cart - polr).x
     Quantity['length'](Array(1.0000001, dtype=float32), unit='kpc')
 
     """
-    cart = rhs.represent_as(CartesianPosition2D)
+    cart = rhs.represent_as(CartesianPos2D)
     return jax.tree.map(qlax.sub, lhs, cart)
 
 
@@ -180,8 +176,8 @@ class CartesianVelocity2D(AvalMixin, AbstractVelocity2D):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[CartesianPosition2D]:
-        return CartesianPosition2D
+    def integral_cls(cls) -> type[CartesianPos2D]:
+        return CartesianPos2D
 
     @classproperty
     @classmethod

--- a/src/coordinax/_src/d2/cartesian.py
+++ b/src/coordinax/_src/d2/cartesian.py
@@ -2,7 +2,7 @@
 
 __all__ = [
     "CartesianPos2D",
-    "CartesianVelocity2D",
+    "CartesianVel2D",
     "CartesianAcceleration2D",
 ]
 
@@ -21,7 +21,7 @@ from quaxed import lax as qlax
 from unxt import AbstractQuantity, Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration2D, AbstractPos2D, AbstractVelocity2D
+from .base import AbstractAcceleration2D, AbstractPos2D, AbstractVel2D
 from coordinax._src.base import AbstractPos
 from coordinax._src.base.mixins import AvalMixin
 from coordinax._src.utils import classproperty
@@ -43,8 +43,8 @@ class CartesianPos2D(AbstractPos2D):
 
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["CartesianVelocity2D"]:
-        return CartesianVelocity2D
+    def differential_cls(cls) -> type["CartesianVel2D"]:
+        return CartesianVel2D
 
 
 # -----------------------------------------------------
@@ -161,7 +161,7 @@ def _sub_cart2d_pos2d(lhs: CartesianPos2D, rhs: AbstractPos, /) -> CartesianPos2
 
 
 @final
-class CartesianVelocity2D(AvalMixin, AbstractVelocity2D):
+class CartesianVel2D(AvalMixin, AbstractVel2D):
     """Cartesian differential representation."""
 
     d_x: ct.BatchableSpeed = eqx.field(
@@ -188,10 +188,10 @@ class CartesianVelocity2D(AvalMixin, AbstractVelocity2D):
 # -----------------------------------------------------
 
 
-@CartesianVelocity2D.from_._f.dispatch  # type: ignore[attr-defined, misc] # noqa: SLF001
+@CartesianVel2D.from_._f.dispatch  # type: ignore[attr-defined, misc] # noqa: SLF001
 def from_(
-    cls: type[CartesianVelocity2D], obj: Shaped[AbstractQuantity, "*batch 2"], /
-) -> CartesianVelocity2D:
+    cls: type[CartesianVel2D], obj: Shaped[AbstractQuantity, "*batch 2"], /
+) -> CartesianVel2D:
     """Construct a 2D Cartesian velocity.
 
     Examples
@@ -199,9 +199,9 @@ def from_(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.CartesianVelocity2D.from_(Quantity([1, 2], "m/s"))
+    >>> vec = cx.CartesianVel2D.from_(Quantity([1, 2], "m/s"))
     >>> vec
-    CartesianVelocity2D(
+    CartesianVel2D(
       d_x=Quantity[...]( value=f32[], unit=Unit("m / s") ),
       d_y=Quantity[...]( value=f32[], unit=Unit("m / s") )
     )
@@ -215,9 +215,7 @@ def from_(
 
 
 @register(jax.lax.add_p)  # type: ignore[misc]
-def _add_pp(
-    lhs: CartesianVelocity2D, rhs: CartesianVelocity2D, /
-) -> CartesianVelocity2D:
+def _add_pp(lhs: CartesianVel2D, rhs: CartesianVel2D, /) -> CartesianVel2D:
     """Add two Cartesian velocities.
 
     Examples
@@ -226,7 +224,7 @@ def _add_pp(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> v = cx.CartesianVelocity2D.from_(Quantity([1, 2], "km/s"))
+    >>> v = cx.CartesianVel2D.from_([1, 2], "km/s")
     >>> (v + v).d_x
     Quantity['speed'](Array(2., dtype=float32), unit='km / s')
 
@@ -238,7 +236,7 @@ def _add_pp(
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_vp(lhs: ArrayLike, rhts: CartesianVelocity2D, /) -> CartesianVelocity2D:
+def _mul_vp(lhs: ArrayLike, rhts: CartesianVel2D, /) -> CartesianVel2D:
     """Scale a cartesian 2D velocity by a scalar.
 
     Examples
@@ -247,7 +245,7 @@ def _mul_vp(lhs: ArrayLike, rhts: CartesianVelocity2D, /) -> CartesianVelocity2D
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> v = cx.CartesianVelocity2D.from_(Quantity([3, 4], "m/s"))
+    >>> v = cx.CartesianVel2D.from_([3, 4], "m/s")
     >>> (5 * v).d_x
     Quantity['speed'](Array(15., dtype=float32), unit='m / s')
 
@@ -283,14 +281,14 @@ class CartesianAcceleration2D(AvalMixin, AbstractAcceleration2D):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[CartesianVelocity2D]:
-        return CartesianVelocity2D
+    def integral_cls(cls) -> type[CartesianVel2D]:
+        return CartesianVel2D
 
     # -----------------------------------------------------
 
     @override
     @partial(eqx.filter_jit, inline=True)
-    def norm(self, _: AbstractVelocity2D | None = None, /) -> ct.BatchableAcc:
+    def norm(self, _: AbstractVel2D | None = None, /) -> ct.BatchableAcc:
         """Return the norm of the vector.
 
         Examples

--- a/src/coordinax/_src/d2/cartesian.py
+++ b/src/coordinax/_src/d2/cartesian.py
@@ -3,7 +3,7 @@
 __all__ = [
     "CartesianPos2D",
     "CartesianVel2D",
-    "CartesianAcceleration2D",
+    "CartesianAcc2D",
 ]
 
 from dataclasses import fields, replace
@@ -21,7 +21,7 @@ from quaxed import lax as qlax
 from unxt import AbstractQuantity, Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration2D, AbstractPos2D, AbstractVel2D
+from .base import AbstractAcc2D, AbstractPos2D, AbstractVel2D
 from coordinax._src.base import AbstractPos
 from coordinax._src.base.mixins import AvalMixin
 from coordinax._src.utils import classproperty
@@ -181,8 +181,8 @@ class CartesianVel2D(AvalMixin, AbstractVel2D):
 
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["CartesianAcceleration2D"]:
-        return CartesianAcceleration2D
+    def differential_cls(cls) -> type["CartesianAcc2D"]:
+        return CartesianAcc2D
 
 
 # -----------------------------------------------------
@@ -266,7 +266,7 @@ def _mul_vp(lhs: ArrayLike, rhts: CartesianVel2D, /) -> CartesianVel2D:
 
 
 @final
-class CartesianAcceleration2D(AvalMixin, AbstractAcceleration2D):
+class CartesianAcc2D(AvalMixin, AbstractAcc2D):
     """Cartesian acceleration representation."""
 
     d2_x: ct.BatchableSpeed = eqx.field(
@@ -295,7 +295,7 @@ class CartesianAcceleration2D(AvalMixin, AbstractAcceleration2D):
         --------
         >>> from unxt import Quantity
         >>> import coordinax as cx
-        >>> v = cx.CartesianAcceleration2D.from_([3, 4], "km/s2")
+        >>> v = cx.CartesianAcc2D.from_([3, 4], "km/s2")
         >>> v.norm()
         Quantity['acceleration'](Array(5., dtype=float32), unit='km / s2')
 
@@ -306,12 +306,8 @@ class CartesianAcceleration2D(AvalMixin, AbstractAcceleration2D):
 # -----------------------------------------------------
 
 
-@CartesianAcceleration2D.from_._f.dispatch  # type: ignore[attr-defined, misc]  # noqa: SLF001
-def from_(
-    cls: type[CartesianAcceleration2D],
-    obj: AbstractQuantity,
-    /,
-) -> CartesianAcceleration2D:
+@CartesianAcc2D.from_._f.dispatch  # type: ignore[attr-defined, misc]  # noqa: SLF001
+def from_(cls: type[CartesianAcc2D], obj: AbstractQuantity, /) -> CartesianAcc2D:
     """Construct a 2D Cartesian velocity.
 
     Examples
@@ -319,9 +315,9 @@ def from_(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.CartesianAcceleration2D.from_(Quantity([1, 2], "m/s2"))
+    >>> vec = cx.CartesianAcc2D.from_(Quantity([1, 2], "m/s2"))
     >>> vec
-    CartesianAcceleration2D(
+    CartesianAcc2D(
       d2_x=Quantity[...](value=f32[], unit=Unit("m / s2")),
       d2_y=Quantity[...](value=f32[], unit=Unit("m / s2"))
     )
@@ -335,9 +331,7 @@ def from_(
 
 
 @register(jax.lax.add_p)  # type: ignore[misc]
-def _add_aa(
-    lhs: CartesianAcceleration2D, rhs: CartesianAcceleration2D, /
-) -> CartesianAcceleration2D:
+def _add_aa(lhs: CartesianAcc2D, rhs: CartesianAcc2D, /) -> CartesianAcc2D:
     """Add two Cartesian accelerations.
 
     Examples
@@ -346,7 +340,7 @@ def _add_aa(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> v = cx.CartesianAcceleration2D.from_(Quantity([3, 4], "km/s2"))
+    >>> v = cx.CartesianAcc2D.from_([3, 4], "km/s2")
     >>> (v + v).d2_x
     Quantity['acceleration'](Array(6., dtype=float32), unit='km / s2')
 
@@ -358,9 +352,7 @@ def _add_aa(
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_va(
-    lhs: ArrayLike, rhts: CartesianAcceleration2D, /
-) -> CartesianAcceleration2D:
+def _mul_va(lhs: ArrayLike, rhts: CartesianAcc2D, /) -> CartesianAcc2D:
     """Scale a cartesian 2D acceleration by a scalar.
 
     Examples
@@ -369,7 +361,7 @@ def _mul_va(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> v = cx.CartesianAcceleration2D.from_(Quantity([3, 4], "m/s2"))
+    >>> v = cx.CartesianAcc2D.from_([3, 4], "m/s2")
     >>> jnp.multiply(5, v).d2_x
     Quantity['acceleration'](Array(15., dtype=float32), unit='m / s2')
 

--- a/src/coordinax/_src/d2/compat.py
+++ b/src/coordinax/_src/d2/compat.py
@@ -10,7 +10,7 @@ from plum import convert
 
 from unxt import Quantity
 
-from .cartesian import CartesianPosition2D
+from .cartesian import CartesianPos2D
 from coordinax._src.operators.base import AbstractOperator, op_call_dispatch
 from coordinax._src.typing import TimeBatchOrScalar
 
@@ -20,7 +20,7 @@ Q2: TypeAlias = Shaped[Quantity["length"], "*#batch 2"]
 @op_call_dispatch
 def call(self: AbstractOperator, x: Q2, /) -> Q2:
     """Dispatch to the operator's `__call__` method."""
-    return self(CartesianPosition2D.from_(x))
+    return self(CartesianPos2D.from_(x))
 
 
 @op_call_dispatch
@@ -28,5 +28,5 @@ def call(
     self: AbstractOperator, x: Q2, t: TimeBatchOrScalar, /
 ) -> tuple[Q2, TimeBatchOrScalar]:
     """Dispatch to the operator's `__call__` method."""
-    vec, t = self(CartesianPosition2D.from_(x), t)
+    vec, t = self(CartesianPos2D.from_(x), t)
     return convert(vec, Quantity), t

--- a/src/coordinax/_src/d2/polar.py
+++ b/src/coordinax/_src/d2/polar.py
@@ -3,7 +3,7 @@
 __all__ = [
     "PolarPos",
     "PolarVel",
-    "PolarAcceleration",
+    "PolarAcc",
 ]
 
 from functools import partial
@@ -19,7 +19,7 @@ from dataclassish.converters import Unless
 from unxt import AbstractDistance, Distance, Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration2D, AbstractPos2D, AbstractVel2D
+from .base import AbstractAcc2D, AbstractPos2D, AbstractVel2D
 from coordinax._src.checks import check_azimuth_range, check_r_non_negative
 from coordinax._src.converters import converter_azimuth_to_range
 from coordinax._src.utils import classproperty
@@ -119,12 +119,12 @@ class PolarVel(AbstractVel2D):
 
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["PolarAcceleration"]:
-        return PolarAcceleration
+    def differential_cls(cls) -> type["PolarAcc"]:
+        return PolarAcc
 
 
 @final
-class PolarAcceleration(AbstractAcceleration2D):
+class PolarAcc(AbstractAcc2D):
     """Polar acceleration representation."""
 
     d2_r: ct.BatchableAcc = eqx.field(

--- a/src/coordinax/_src/d2/polar.py
+++ b/src/coordinax/_src/d2/polar.py
@@ -1,7 +1,7 @@
 """Built-in vector classes."""
 
 __all__ = [
-    "PolarPosition",
+    "PolarPos",
     "PolarVelocity",
     "PolarAcceleration",
 ]
@@ -19,14 +19,14 @@ from dataclassish.converters import Unless
 from unxt import AbstractDistance, Distance, Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration2D, AbstractPosition2D, AbstractVelocity2D
+from .base import AbstractAcceleration2D, AbstractPos2D, AbstractVelocity2D
 from coordinax._src.checks import check_azimuth_range, check_r_non_negative
 from coordinax._src.converters import converter_azimuth_to_range
 from coordinax._src.utils import classproperty
 
 
 @final
-class PolarPosition(AbstractPosition2D):
+class PolarPos(AbstractPos2D):
     r"""Polar vector representation.
 
     Parameters
@@ -63,7 +63,7 @@ class PolarPosition(AbstractPosition2D):
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_p_vpolar(lhs: ArrayLike, rhs: PolarPosition, /) -> PolarPosition:
+def _mul_p_vpolar(lhs: ArrayLike, rhs: PolarPos, /) -> PolarPos:
     """Scale the polar position by a scalar.
 
     Examples
@@ -72,14 +72,14 @@ def _mul_p_vpolar(lhs: ArrayLike, rhs: PolarPosition, /) -> PolarPosition:
     >>> import coordinax as cx
     >>> import quaxed.numpy as jnp
 
-    >>> v = cx.PolarPosition(r=Quantity(1, "m"), phi=Quantity(90, "deg"))
+    >>> v = cx.PolarPos(r=Quantity(1, "m"), phi=Quantity(90, "deg"))
 
     >>> jnp.linalg.vector_norm(v, axis=-1)
     Quantity['length'](Array(1., dtype=float32), unit='m')
 
     >>> nv = jnp.multiply(2, v)
     >>> nv
-    PolarPosition(
+    PolarPos(
       r=Distance(value=f32[], unit=Unit("m")),
       phi=Quantity[...](value=f32[], unit=Unit("deg"))
     )
@@ -114,8 +114,8 @@ class PolarVelocity(AbstractVelocity2D):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[PolarPosition]:
-        return PolarPosition
+    def integral_cls(cls) -> type[PolarPos]:
+        return PolarPos
 
     @classproperty
     @classmethod

--- a/src/coordinax/_src/d2/polar.py
+++ b/src/coordinax/_src/d2/polar.py
@@ -2,7 +2,7 @@
 
 __all__ = [
     "PolarPos",
-    "PolarVelocity",
+    "PolarVel",
     "PolarAcceleration",
 ]
 
@@ -19,7 +19,7 @@ from dataclassish.converters import Unless
 from unxt import AbstractDistance, Distance, Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration2D, AbstractPos2D, AbstractVelocity2D
+from .base import AbstractAcceleration2D, AbstractPos2D, AbstractVel2D
 from coordinax._src.checks import check_azimuth_range, check_r_non_negative
 from coordinax._src.converters import converter_azimuth_to_range
 from coordinax._src.utils import classproperty
@@ -58,8 +58,8 @@ class PolarPos(AbstractPos2D):
 
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["PolarVelocity"]:
-        return PolarVelocity
+    def differential_cls(cls) -> type["PolarVel"]:
+        return PolarVel
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
@@ -99,7 +99,7 @@ def _mul_p_vpolar(lhs: ArrayLike, rhs: PolarPos, /) -> PolarPos:
 
 
 @final
-class PolarVelocity(AbstractVelocity2D):
+class PolarVel(AbstractVel2D):
     """Polar differential representation."""
 
     d_r: ct.BatchableSpeed = eqx.field(
@@ -139,5 +139,5 @@ class PolarAcceleration(AbstractAcceleration2D):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[PolarVelocity]:
-        return PolarVelocity
+    def integral_cls(cls) -> type[PolarVel]:
+        return PolarVel

--- a/src/coordinax/_src/d2/spherical.py
+++ b/src/coordinax/_src/d2/spherical.py
@@ -2,7 +2,7 @@
 
 __all__ = [
     "TwoSpherePos",
-    "TwoSphereVelocity",
+    "TwoSphereVel",
     "TwoSphereAcceleration",
 ]
 
@@ -15,7 +15,7 @@ import equinox as eqx
 from unxt import Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration2D, AbstractPos2D, AbstractVelocity2D
+from .base import AbstractAcceleration2D, AbstractPos2D, AbstractVel2D
 from coordinax._src.checks import check_azimuth_range, check_polar_range
 from coordinax._src.converters import converter_azimuth_to_range
 from coordinax._src.utils import classproperty
@@ -61,7 +61,7 @@ class TwoSpherePos(AbstractPos2D):
     This coordinate has corresponding velocity class:
 
     >>> s2.differential_cls
-    <class 'coordinax._src.d2.spherical.TwoSphereVelocity'>
+    <class 'coordinax._src.d2.spherical.TwoSphereVel'>
 
     """
 
@@ -85,16 +85,16 @@ class TwoSpherePos(AbstractPos2D):
     @override
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["TwoSphereVelocity"]:
-        return TwoSphereVelocity
+    def differential_cls(cls) -> type["TwoSphereVel"]:
+        return TwoSphereVel
 
 
 #####################################################################
 
 
 @final
-class TwoSphereVelocity(AbstractVelocity2D):
-    r"""Velocity on the 2-Sphere.
+class TwoSphereVel(AbstractVel2D):
+    r"""Vel on the 2-Sphere.
 
     The space of coordinates on the unit sphere is called the 2-sphere or $S^2$.
     It is a two-dimensional surface embedded in three-dimensional space, defined
@@ -116,7 +116,7 @@ class TwoSphereVelocity(AbstractVelocity2D):
 
     See Also
     --------
-    `coordinax.SphericalVelocity`
+    `coordinax.SphericalVel`
         The counterpart in $R^3$, adding the polar distance coordinate $d_r$.
 
     Examples
@@ -126,7 +126,7 @@ class TwoSphereVelocity(AbstractVelocity2D):
 
     We can construct a 2-spherical velocity:
 
-    >>> s2 = cx.TwoSphereVelocity(d_theta=Quantity(0, "deg/s"),
+    >>> s2 = cx.TwoSphereVel(d_theta=Quantity(0, "deg/s"),
     ...                           d_phi=Quantity(2, "deg/s"))
 
     This coordinate has corresponding position and acceleration class:
@@ -164,7 +164,7 @@ class TwoSphereVelocity(AbstractVelocity2D):
 
 @final
 class TwoSphereAcceleration(AbstractAcceleration2D):
-    r"""Velocity on the 2-Sphere.
+    r"""Vel on the 2-Sphere.
 
     The space of coordinates on the unit sphere is called the 2-sphere or $S^2$.
     It is a two-dimensional surface embedded in three-dimensional space, defined
@@ -202,7 +202,7 @@ class TwoSphereAcceleration(AbstractAcceleration2D):
     This coordinate has corresponding velocity class:
 
     >>> s2.integral_cls
-    <class 'coordinax._src.d2.spherical.TwoSphereVelocity'>
+    <class 'coordinax._src.d2.spherical.TwoSphereVel'>
 
     """
 
@@ -219,5 +219,5 @@ class TwoSphereAcceleration(AbstractAcceleration2D):
     @override
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[TwoSphereVelocity]:
-        return TwoSphereVelocity
+    def integral_cls(cls) -> type[TwoSphereVel]:
+        return TwoSphereVel

--- a/src/coordinax/_src/d2/spherical.py
+++ b/src/coordinax/_src/d2/spherical.py
@@ -3,7 +3,7 @@
 __all__ = [
     "TwoSpherePos",
     "TwoSphereVel",
-    "TwoSphereAcceleration",
+    "TwoSphereAcc",
 ]
 
 from functools import partial
@@ -15,7 +15,7 @@ import equinox as eqx
 from unxt import Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration2D, AbstractPos2D, AbstractVel2D
+from .base import AbstractAcc2D, AbstractPos2D, AbstractVel2D
 from coordinax._src.checks import check_azimuth_range, check_polar_range
 from coordinax._src.converters import converter_azimuth_to_range
 from coordinax._src.utils import classproperty
@@ -135,7 +135,7 @@ class TwoSphereVel(AbstractVel2D):
     <class 'coordinax._src.d2.spherical.TwoSpherePos'>
 
     >>> s2.differential_cls
-    <class 'coordinax._src.d2.spherical.TwoSphereAcceleration'>
+    <class 'coordinax._src.d2.spherical.TwoSphereAcc'>
 
     """
 
@@ -158,12 +158,12 @@ class TwoSphereVel(AbstractVel2D):
     @override
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["TwoSphereAcceleration"]:
-        return TwoSphereAcceleration
+    def differential_cls(cls) -> type["TwoSphereAcc"]:
+        return TwoSphereAcc
 
 
 @final
-class TwoSphereAcceleration(AbstractAcceleration2D):
+class TwoSphereAcc(AbstractAcc2D):
     r"""Vel on the 2-Sphere.
 
     The space of coordinates on the unit sphere is called the 2-sphere or $S^2$.
@@ -186,7 +186,7 @@ class TwoSphereAcceleration(AbstractAcceleration2D):
 
     See Also
     --------
-    `coordinax.SphericalAcceleration`
+    `coordinax.SphericalAcc`
         The counterpart in $R^3$, adding the polar distance coordinate $d_r$.
 
     Examples
@@ -196,7 +196,7 @@ class TwoSphereAcceleration(AbstractAcceleration2D):
 
     We can construct a 2-spherical acceleration:
 
-    >>> s2 = cx.TwoSphereAcceleration(d2_theta=Quantity(0, "deg/s2"),
+    >>> s2 = cx.TwoSphereAcc(d2_theta=Quantity(0, "deg/s2"),
     ...                               d2_phi=Quantity(2, "deg/s2"))
 
     This coordinate has corresponding velocity class:

--- a/src/coordinax/_src/d2/spherical.py
+++ b/src/coordinax/_src/d2/spherical.py
@@ -1,7 +1,7 @@
 """Built-in vector classes."""
 
 __all__ = [
-    "TwoSpherePosition",
+    "TwoSpherePos",
     "TwoSphereVelocity",
     "TwoSphereAcceleration",
 ]
@@ -15,16 +15,16 @@ import equinox as eqx
 from unxt import Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration2D, AbstractPosition2D, AbstractVelocity2D
+from .base import AbstractAcceleration2D, AbstractPos2D, AbstractVelocity2D
 from coordinax._src.checks import check_azimuth_range, check_polar_range
 from coordinax._src.converters import converter_azimuth_to_range
 from coordinax._src.utils import classproperty
 
 
-# TODO: should this be named TwoSphericalPosition or S(phere)(ical)2Position
+# TODO: should this be named TwoSphericalPos or S(phere)(ical)2Pos
 @final
-class TwoSpherePosition(AbstractPosition2D):
-    r"""Position on the 2-Sphere.
+class TwoSpherePos(AbstractPos2D):
+    r"""Pos on the 2-Sphere.
 
     The space of coordinates on the unit sphere is called the 2-sphere or $S^2$.
     It is a two-dimensional surface embedded in three-dimensional space, defined
@@ -46,7 +46,7 @@ class TwoSpherePosition(AbstractPosition2D):
 
     See Also
     --------
-    `coordinax.SphericalPosition`
+    `coordinax.SphericalPos`
         The counterpart in $R^3$, adding the polar distance coordinate $r$.
 
     Examples
@@ -56,7 +56,7 @@ class TwoSpherePosition(AbstractPosition2D):
 
     We can construct a 2-spherical coordinate:
 
-    >>> s2 = cx.TwoSpherePosition(theta=Quantity(0, "deg"), phi=Quantity(180, "deg"))
+    >>> s2 = cx.TwoSpherePos(theta=Quantity(0, "deg"), phi=Quantity(180, "deg"))
 
     This coordinate has corresponding velocity class:
 
@@ -132,7 +132,7 @@ class TwoSphereVelocity(AbstractVelocity2D):
     This coordinate has corresponding position and acceleration class:
 
     >>> s2.integral_cls
-    <class 'coordinax._src.d2.spherical.TwoSpherePosition'>
+    <class 'coordinax._src.d2.spherical.TwoSpherePos'>
 
     >>> s2.differential_cls
     <class 'coordinax._src.d2.spherical.TwoSphereAcceleration'>
@@ -152,8 +152,8 @@ class TwoSphereVelocity(AbstractVelocity2D):
     @override
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[TwoSpherePosition]:
-        return TwoSpherePosition
+    def integral_cls(cls) -> type[TwoSpherePos]:
+        return TwoSpherePos
 
     @override
     @classproperty

--- a/src/coordinax/_src/d2/transform.py
+++ b/src/coordinax/_src/d2/transform.py
@@ -8,9 +8,9 @@ from plum import dispatch
 
 import quaxed.numpy as xp
 
-from .base import AbstractPos2D, AbstractVelocity2D
-from .cartesian import CartesianAcceleration2D, CartesianPos2D, CartesianVelocity2D
-from .polar import PolarPos, PolarVelocity
+from .base import AbstractPos2D, AbstractVel2D
+from .cartesian import CartesianAcceleration2D, CartesianPos2D, CartesianVel2D
+from .polar import PolarPos, PolarVel
 from coordinax._src.base import AbstractPos
 
 
@@ -37,16 +37,16 @@ def represent_as(
 
 
 @dispatch.multi(
-    (CartesianVelocity2D, type[CartesianVelocity2D], AbstractPos),
-    (PolarVelocity, type[PolarVelocity], AbstractPos),
+    (CartesianVel2D, type[CartesianVel2D], AbstractPos),
+    (PolarVel, type[PolarVel], AbstractPos),
 )
 def represent_as(
-    current: AbstractVelocity2D,
-    target: type[AbstractVelocity2D],
+    current: AbstractVel2D,
+    target: type[AbstractVel2D],
     position: AbstractPos,
     /,
     **kwargs: Any,
-) -> AbstractVelocity2D:
+) -> AbstractVel2D:
     """Self transform of 2D Differentials."""
     return current
 
@@ -84,14 +84,14 @@ def represent_as(
 
 
 # =============================================================================
-# CartesianVelocity2D
+# CartesianVel2D
 
 
 @dispatch
 def represent_as(
-    current: CartesianVelocity2D, target: type[CartesianVelocity2D], /
-) -> CartesianVelocity2D:
-    """CartesianVelocity2D -> CartesianVelocity2D with no position.
+    current: CartesianVel2D, target: type[CartesianVel2D], /
+) -> CartesianVel2D:
+    """CartesianVel2D -> CartesianVel2D with no position.
 
     Cartesian coordinates are an affine coordinate system and so the
     transformation of an n-th order derivative vector in this system do not
@@ -103,8 +103,8 @@ def represent_as(
     Examples
     --------
     >>> import coordinax as cx
-    >>> v = cx.CartesianVelocity2D.from_([1, 1], "m/s")
-    >>> cx.represent_as(v, cx.CartesianVelocity2D) is v
+    >>> v = cx.CartesianVel2D.from_([1, 1], "m/s")
+    >>> cx.represent_as(v, cx.CartesianVel2D) is v
     True
 
     """

--- a/src/coordinax/_src/d2/transform.py
+++ b/src/coordinax/_src/d2/transform.py
@@ -8,42 +8,42 @@ from plum import dispatch
 
 import quaxed.numpy as xp
 
-from .base import AbstractPosition2D, AbstractVelocity2D
-from .cartesian import CartesianAcceleration2D, CartesianPosition2D, CartesianVelocity2D
-from .polar import PolarPosition, PolarVelocity
-from coordinax._src.base import AbstractPosition
+from .base import AbstractPos2D, AbstractVelocity2D
+from .cartesian import CartesianAcceleration2D, CartesianPos2D, CartesianVelocity2D
+from .polar import PolarPos, PolarVelocity
+from coordinax._src.base import AbstractPos
 
 
 @dispatch
 def represent_as(
-    current: AbstractPosition2D, target: type[AbstractPosition2D], /, **kwargs: Any
-) -> AbstractPosition2D:
-    """AbstractPosition2D -> Cartesian2D -> AbstractPosition2D.
+    current: AbstractPos2D, target: type[AbstractPos2D], /, **kwargs: Any
+) -> AbstractPos2D:
+    """AbstractPos2D -> Cartesian2D -> AbstractPos2D.
 
     This is the base case for the transformation of 2D vectors.
     """
-    return represent_as(represent_as(current, CartesianPosition2D), target)
+    return represent_as(represent_as(current, CartesianPos2D), target)
 
 
 @dispatch.multi(
-    (CartesianPosition2D, type[CartesianPosition2D]),
-    (PolarPosition, type[PolarPosition]),
+    (CartesianPos2D, type[CartesianPos2D]),
+    (PolarPos, type[PolarPos]),
 )
 def represent_as(
-    current: AbstractPosition2D, target: type[AbstractPosition2D], /, **kwargs: Any
-) -> AbstractPosition2D:
+    current: AbstractPos2D, target: type[AbstractPos2D], /, **kwargs: Any
+) -> AbstractPos2D:
     """Self transform of 2D vectors."""
     return current
 
 
 @dispatch.multi(
-    (CartesianVelocity2D, type[CartesianVelocity2D], AbstractPosition),
-    (PolarVelocity, type[PolarVelocity], AbstractPosition),
+    (CartesianVelocity2D, type[CartesianVelocity2D], AbstractPos),
+    (PolarVelocity, type[PolarVelocity], AbstractPos),
 )
 def represent_as(
     current: AbstractVelocity2D,
     target: type[AbstractVelocity2D],
-    position: AbstractPosition,
+    position: AbstractPos,
     /,
     **kwargs: Any,
 ) -> AbstractVelocity2D:
@@ -52,14 +52,14 @@ def represent_as(
 
 
 # =============================================================================
-# CartesianPosition2D
+# CartesianPos2D
 
 
 @dispatch
 def represent_as(
-    current: CartesianPosition2D, target: type[PolarPosition], /, **kwargs: Any
-) -> PolarPosition:
-    """CartesianPosition2D -> PolarPosition.
+    current: CartesianPos2D, target: type[PolarPos], /, **kwargs: Any
+) -> PolarPos:
+    """CartesianPos2D -> PolarPos.
 
     The `x` and `y` coordinates are converted to the radial coordinate `r` and
     the angular coordinate `phi`.
@@ -70,14 +70,14 @@ def represent_as(
 
 
 # =============================================================================
-# PolarPosition
+# PolarPos
 
 
 @dispatch
 def represent_as(
-    current: PolarPosition, target: type[CartesianPosition2D], /, **kwargs: Any
-) -> CartesianPosition2D:
-    """PolarPosition -> CartesianPosition2D."""
+    current: PolarPos, target: type[CartesianPos2D], /, **kwargs: Any
+) -> CartesianPos2D:
+    """PolarPos -> CartesianPos2D."""
     x = current.r.distance * xp.cos(current.phi)
     y = current.r.distance * xp.sin(current.phi)
     return target(x=x, y=y)

--- a/src/coordinax/_src/d2/transform.py
+++ b/src/coordinax/_src/d2/transform.py
@@ -9,7 +9,7 @@ from plum import dispatch
 import quaxed.numpy as xp
 
 from .base import AbstractPos2D, AbstractVel2D
-from .cartesian import CartesianAcceleration2D, CartesianPos2D, CartesianVel2D
+from .cartesian import CartesianAcc2D, CartesianPos2D, CartesianVel2D
 from .polar import PolarPos, PolarVel
 from coordinax._src.base import AbstractPos
 
@@ -112,14 +112,14 @@ def represent_as(
 
 
 # =============================================================================
-# CartesianAcceleration2D
+# CartesianAcc2D
 
 
 @dispatch
 def represent_as(
-    current: CartesianAcceleration2D, target: type[CartesianAcceleration2D], /
-) -> CartesianAcceleration2D:
-    """CartesianAcceleration2D -> CartesianAcceleration2D with no position.
+    current: CartesianAcc2D, target: type[CartesianAcc2D], /
+) -> CartesianAcc2D:
+    """CartesianAcc2D -> CartesianAcc2D with no position.
 
     Cartesian coordinates are an affine coordinate system and so the
     transformation of an n-th order derivative vector in this system do not
@@ -131,8 +131,8 @@ def represent_as(
     Examples
     --------
     >>> import coordinax as cx
-    >>> a = cx.CartesianAcceleration2D.from_([1, 1], "m/s2")
-    >>> cx.represent_as(a, cx.CartesianAcceleration2D) is a
+    >>> a = cx.CartesianAcc2D.from_([1, 1], "m/s2")
+    >>> cx.represent_as(a, cx.CartesianAcc2D) is a
     True
 
     """

--- a/src/coordinax/_src/d3/base.py
+++ b/src/coordinax/_src/d3/base.py
@@ -1,13 +1,13 @@
 """Representation of coordinates in different systems."""
 
-__all__ = ["AbstractPos3D", "AbstractVel3D", "AbstractAcceleration3D"]
+__all__ = ["AbstractPos3D", "AbstractVel3D", "AbstractAcc3D"]
 
 
 from abc import abstractmethod
 from typing_extensions import override
 
 from coordinax._src.base import (
-    AbstractAcceleration,
+    AbstractAcc,
     AbstractPos,
     AbstractVector,
     AbstractVel,
@@ -52,19 +52,19 @@ class AbstractVel3D(AbstractVel):
     @classproperty
     @classmethod
     @abstractmethod
-    def differential_cls(cls) -> type[AbstractAcceleration]:
+    def differential_cls(cls) -> type[AbstractAcc]:
         raise NotImplementedError
 
 
-class AbstractAcceleration3D(AbstractAcceleration):
+class AbstractAcc3D(AbstractAcc):
     """Abstract representation of 3D vector accelerations."""
 
     @classproperty
     @classmethod
     def _cartesian_cls(cls) -> type[AbstractVector]:
-        from .cartesian import CartesianAcceleration3D
+        from .cartesian import CartesianAcc3D
 
-        return CartesianAcceleration3D
+        return CartesianAcc3D
 
     @classproperty
     @classmethod

--- a/src/coordinax/_src/d3/base.py
+++ b/src/coordinax/_src/d3/base.py
@@ -1,6 +1,6 @@
 """Representation of coordinates in different systems."""
 
-__all__ = ["AbstractPosition3D", "AbstractVelocity3D", "AbstractAcceleration3D"]
+__all__ = ["AbstractPos3D", "AbstractVelocity3D", "AbstractAcceleration3D"]
 
 
 from abc import abstractmethod
@@ -8,23 +8,23 @@ from typing_extensions import override
 
 from coordinax._src.base import (
     AbstractAcceleration,
-    AbstractPosition,
+    AbstractPos,
     AbstractVector,
     AbstractVelocity,
 )
 from coordinax._src.utils import classproperty
 
 
-class AbstractPosition3D(AbstractPosition):
+class AbstractPos3D(AbstractPos):
     """Abstract representation of 3D coordinates in different systems."""
 
     @override
     @classproperty
     @classmethod
     def _cartesian_cls(cls) -> type[AbstractVector]:
-        from .cartesian import CartesianPosition3D
+        from .cartesian import CartesianPos3D
 
-        return CartesianPosition3D
+        return CartesianPos3D
 
     @classproperty
     @classmethod
@@ -46,7 +46,7 @@ class AbstractVelocity3D(AbstractVelocity):
     @classproperty
     @classmethod
     @abstractmethod
-    def integral_cls(cls) -> type[AbstractPosition3D]:
+    def integral_cls(cls) -> type[AbstractPos3D]:
         raise NotImplementedError
 
     @classproperty

--- a/src/coordinax/_src/d3/base.py
+++ b/src/coordinax/_src/d3/base.py
@@ -1,6 +1,6 @@
 """Representation of coordinates in different systems."""
 
-__all__ = ["AbstractPos3D", "AbstractVelocity3D", "AbstractAcceleration3D"]
+__all__ = ["AbstractPos3D", "AbstractVel3D", "AbstractAcceleration3D"]
 
 
 from abc import abstractmethod
@@ -10,7 +10,7 @@ from coordinax._src.base import (
     AbstractAcceleration,
     AbstractPos,
     AbstractVector,
-    AbstractVelocity,
+    AbstractVel,
 )
 from coordinax._src.utils import classproperty
 
@@ -29,19 +29,19 @@ class AbstractPos3D(AbstractPos):
     @classproperty
     @classmethod
     @abstractmethod
-    def differential_cls(cls) -> type["AbstractVelocity3D"]:
+    def differential_cls(cls) -> type["AbstractVel3D"]:
         raise NotImplementedError
 
 
-class AbstractVelocity3D(AbstractVelocity):
+class AbstractVel3D(AbstractVel):
     """Abstract representation of 3D vector differentials."""
 
     @classproperty
     @classmethod
     def _cartesian_cls(cls) -> type[AbstractVector]:
-        from .cartesian import CartesianVelocity3D
+        from .cartesian import CartesianVel3D
 
-        return CartesianVelocity3D
+        return CartesianVel3D
 
     @classproperty
     @classmethod
@@ -69,5 +69,5 @@ class AbstractAcceleration3D(AbstractAcceleration):
     @classproperty
     @classmethod
     @abstractmethod
-    def integral_cls(cls) -> type[AbstractVelocity3D]:
+    def integral_cls(cls) -> type[AbstractVel3D]:
         raise NotImplementedError

--- a/src/coordinax/_src/d3/base_spherical.py
+++ b/src/coordinax/_src/d3/base_spherical.py
@@ -1,7 +1,7 @@
 """Built-in vector classes."""
 
 __all__ = [
-    "AbstractSphericalPosition",
+    "AbstractSphericalPos",
     "AbstractSphericalVelocity",
     "AbstractSphericalAcceleration",
 ]
@@ -11,7 +11,7 @@ from typing_extensions import override
 
 from unxt import Quantity
 
-from .base import AbstractAcceleration3D, AbstractPosition3D, AbstractVelocity3D
+from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVelocity3D
 from coordinax._src.utils import classproperty
 
 _90d = Quantity(90, "deg")
@@ -19,7 +19,7 @@ _180d = Quantity(180, "deg")
 _360d = Quantity(360, "deg")
 
 
-class AbstractSphericalPosition(AbstractPosition3D):
+class AbstractSphericalPos(AbstractPos3D):
     """Abstract spherical vector representation."""
 
     @override
@@ -36,7 +36,7 @@ class AbstractSphericalVelocity(AbstractVelocity3D):
     @classproperty
     @classmethod
     @abstractmethod
-    def integral_cls(cls) -> type[AbstractSphericalPosition]: ...
+    def integral_cls(cls) -> type[AbstractSphericalPos]: ...
 
     @override
     @classproperty

--- a/src/coordinax/_src/d3/base_spherical.py
+++ b/src/coordinax/_src/d3/base_spherical.py
@@ -2,7 +2,7 @@
 
 __all__ = [
     "AbstractSphericalPos",
-    "AbstractSphericalVelocity",
+    "AbstractSphericalVel",
     "AbstractSphericalAcceleration",
 ]
 
@@ -11,7 +11,7 @@ from typing_extensions import override
 
 from unxt import Quantity
 
-from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVelocity3D
+from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVel3D
 from coordinax._src.utils import classproperty
 
 _90d = Quantity(90, "deg")
@@ -26,10 +26,10 @@ class AbstractSphericalPos(AbstractPos3D):
     @classproperty
     @classmethod
     @abstractmethod
-    def differential_cls(cls) -> "type[AbstractSphericalVelocity]": ...
+    def differential_cls(cls) -> "type[AbstractSphericalVel]": ...
 
 
-class AbstractSphericalVelocity(AbstractVelocity3D):
+class AbstractSphericalVel(AbstractVel3D):
     """Spherical differential representation."""
 
     @override
@@ -52,4 +52,4 @@ class AbstractSphericalAcceleration(AbstractAcceleration3D):
     @classproperty
     @classmethod
     @abstractmethod
-    def integral_cls(cls) -> type[AbstractSphericalVelocity]: ...
+    def integral_cls(cls) -> type[AbstractSphericalVel]: ...

--- a/src/coordinax/_src/d3/base_spherical.py
+++ b/src/coordinax/_src/d3/base_spherical.py
@@ -3,7 +3,7 @@
 __all__ = [
     "AbstractSphericalPos",
     "AbstractSphericalVel",
-    "AbstractSphericalAcceleration",
+    "AbstractSphericalAcc",
 ]
 
 from abc import abstractmethod
@@ -11,7 +11,7 @@ from typing_extensions import override
 
 from unxt import Quantity
 
-from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVel3D
+from .base import AbstractAcc3D, AbstractPos3D, AbstractVel3D
 from coordinax._src.utils import classproperty
 
 _90d = Quantity(90, "deg")
@@ -42,10 +42,10 @@ class AbstractSphericalVel(AbstractVel3D):
     @classproperty
     @classmethod
     @abstractmethod
-    def differential_cls(cls) -> "type[AbstractSphericalAcceleration]": ...
+    def differential_cls(cls) -> "type[AbstractSphericalAcc]": ...
 
 
-class AbstractSphericalAcceleration(AbstractAcceleration3D):
+class AbstractSphericalAcc(AbstractAcc3D):
     """Spherical acceleration representation."""
 
     @override

--- a/src/coordinax/_src/d3/cartesian.py
+++ b/src/coordinax/_src/d3/cartesian.py
@@ -1,7 +1,7 @@
 """Built-in vector classes."""
 
 __all__ = [
-    "CartesianPosition3D",
+    "CartesianPos3D",
     "CartesianVelocity3D",
     "CartesianAcceleration3D",
 ]
@@ -23,18 +23,18 @@ from dataclassish import field_items
 from unxt import AbstractQuantity, Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration3D, AbstractPosition3D, AbstractVelocity3D
+from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVelocity3D
 from .generic import CartesianGeneric3D
-from coordinax._src.base import AbstractPosition
+from coordinax._src.base import AbstractPos
 from coordinax._src.base.mixins import AvalMixin
 from coordinax._src.utils import classproperty
 
 #####################################################################
-# Position
+# Pos
 
 
 @final
-class CartesianPosition3D(AbstractPosition3D):
+class CartesianPos3D(AbstractPos3D):
     """Cartesian vector representation."""
 
     x: ct.BatchableLength = eqx.field(
@@ -64,12 +64,12 @@ class CartesianPosition3D(AbstractPosition3D):
 # Constructors
 
 
-@CartesianPosition3D.from_._f.dispatch  # type: ignore[attr-defined, misc]  # noqa: SLF001
+@CartesianPos3D.from_._f.dispatch  # type: ignore[attr-defined, misc]  # noqa: SLF001
 def from_(
-    cls: type[CartesianPosition3D],
+    cls: type[CartesianPos3D],
     obj: AbstractQuantity,  # TODO: Shaped[AbstractQuantity, "*batch 3"]
     /,
-) -> CartesianPosition3D:
+) -> CartesianPos3D:
     """Construct a 3D Cartesian position.
 
     Examples
@@ -77,9 +77,9 @@ def from_(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.CartesianPosition3D.from_(Quantity([1, 2, 3], "m"))
+    >>> vec = cx.CartesianPos3D.from_(Quantity([1, 2, 3], "m"))
     >>> vec
-    CartesianPosition3D(
+    CartesianPos3D(
       x=Quantity[...](value=f32[], unit=Unit("m")),
       y=Quantity[...](value=f32[], unit=Unit("m")),
       z=Quantity[...](value=f32[], unit=Unit("m"))
@@ -95,36 +95,34 @@ def from_(
 
 
 @register(jax.lax.add_p)  # type: ignore[misc]
-def _add_cart3d_pos(
-    lhs: CartesianPosition3D, rhs: AbstractPosition, /
-) -> CartesianPosition3D:
+def _add_cart3d_pos(lhs: CartesianPos3D, rhs: AbstractPos, /) -> CartesianPos3D:
     """Subtract two vectors.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
-    >>> q = cx.CartesianPosition3D.from_([1, 2, 3], "kpc")
-    >>> s = cx.SphericalPosition(r=Quantity(1, "kpc"), theta=Quantity(90, "deg"),
+    >>> q = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
+    >>> s = cx.SphericalPos(r=Quantity(1, "kpc"), theta=Quantity(90, "deg"),
     ...                          phi=Quantity(0, "deg"))
     >>> (q + s).x
     Quantity['length'](Array(2., dtype=float32), unit='kpc')
 
     """
-    cart = rhs.represent_as(CartesianPosition3D)
+    cart = rhs.represent_as(CartesianPos3D)
     return replace(
         lhs, **{k: qlax.add(v, getattr(cart, k)) for k, v in field_items(lhs)}
     )
 
 
 @register(jax.lax.neg_p)  # type: ignore[misc]
-def _neg_p_cart3d_pos(obj: CartesianPosition3D, /) -> CartesianPosition3D:
-    """Negate the `coordinax.CartesianPosition3D`.
+def _neg_p_cart3d_pos(obj: CartesianPos3D, /) -> CartesianPos3D:
+    """Negate the `coordinax.CartesianPos3D`.
 
     Examples
     --------
     >>> import coordinax as cx
-    >>> q = cx.CartesianPosition3D.from_([1, 2, 3], "kpc")
+    >>> q = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
     >>> (-q).x
     Quantity['length'](Array(-1., dtype=float32), unit='kpc')
 
@@ -133,23 +131,21 @@ def _neg_p_cart3d_pos(obj: CartesianPosition3D, /) -> CartesianPosition3D:
 
 
 @register(jax.lax.sub_p)  # type: ignore[misc]
-def _sub_cart3d_pos(
-    lhs: CartesianPosition3D, rhs: AbstractPosition, /
-) -> CartesianPosition3D:
+def _sub_cart3d_pos(lhs: CartesianPos3D, rhs: AbstractPos, /) -> CartesianPos3D:
     """Subtract two vectors.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
-    >>> q = cx.CartesianPosition3D.from_([1, 2, 3], "kpc")
-    >>> s = cx.SphericalPosition(r=Quantity(1, "kpc"), theta=Quantity(90, "deg"),
+    >>> q = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
+    >>> s = cx.SphericalPos(r=Quantity(1, "kpc"), theta=Quantity(90, "deg"),
     ...                          phi=Quantity(0, "deg"))
     >>> (q - s).x
     Quantity['length'](Array(0., dtype=float32), unit='kpc')
 
     """
-    cart = rhs.represent_as(CartesianPosition3D)
+    cart = rhs.represent_as(CartesianPos3D)
     return jax.tree.map(qlax.sub, lhs, cart)
 
 
@@ -160,7 +156,7 @@ def _sub_cart3d_pos(
 # from coordinax.funcs
 @dispatch  # type: ignore[misc]
 @partial(eqx.filter_jit, inline=True)
-def normalize_vector(obj: CartesianPosition3D, /) -> CartesianGeneric3D:
+def normalize_vector(obj: CartesianPos3D, /) -> CartesianGeneric3D:
     """Return the norm of the vector.
 
     This has length 1.
@@ -179,7 +175,7 @@ def normalize_vector(obj: CartesianPosition3D, /) -> CartesianGeneric3D:
     Examples
     --------
     >>> import coordinax as cx
-    >>> q = cx.CartesianPosition3D.from_([1, 2, 3], "kpc")
+    >>> q = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
     >>> cx.normalize_vector(q)
     CartesianGeneric3D(
       x=Quantity[...]( value=f32[], unit=Unit(dimensionless) ),
@@ -218,8 +214,8 @@ class CartesianVelocity3D(AvalMixin, AbstractVelocity3D):
     @override
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[CartesianPosition3D]:
-        return CartesianPosition3D
+    def integral_cls(cls) -> type[CartesianPos3D]:
+        return CartesianPos3D
 
     @override
     @classproperty
@@ -228,7 +224,7 @@ class CartesianVelocity3D(AvalMixin, AbstractVelocity3D):
         return CartesianAcceleration3D
 
     @partial(eqx.filter_jit, inline=True)
-    def norm(self, _: AbstractPosition3D | None = None, /) -> ct.BatchableSpeed:
+    def norm(self, _: AbstractPos3D | None = None, /) -> ct.BatchableSpeed:
         """Return the norm of the vector.
 
         Examples
@@ -303,7 +299,7 @@ def _sub_v3_v3(
     Examples
     --------
     >>> from unxt import Quantity
-    >>> from coordinax import CartesianPosition3D, CartesianVelocity3D
+    >>> from coordinax import CartesianPos3D, CartesianVelocity3D
     >>> q = CartesianVelocity3D.from_(Quantity([1, 2, 3], "km/s"))
     >>> q2 = q - q
     >>> q2.d_y
@@ -401,7 +397,7 @@ def _add_aa(
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_ac3(lhs: ArrayLike, rhs: CartesianPosition3D, /) -> CartesianPosition3D:
+def _mul_ac3(lhs: ArrayLike, rhs: CartesianPos3D, /) -> CartesianPos3D:
     """Scale a position by a scalar.
 
     Examples
@@ -410,7 +406,7 @@ def _mul_ac3(lhs: ArrayLike, rhs: CartesianPosition3D, /) -> CartesianPosition3D
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> v = cx.CartesianPosition3D.from_([1, 2, 3], "kpc")
+    >>> v = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
     >>> jnp.multiply(2, v).x
     Quantity['length'](Array(2., dtype=float32), unit='kpc')
 

--- a/src/coordinax/_src/d3/cartesian.py
+++ b/src/coordinax/_src/d3/cartesian.py
@@ -30,7 +30,7 @@ from coordinax._src.base.mixins import AvalMixin
 from coordinax._src.utils import classproperty
 
 #####################################################################
-# Pos
+# Position
 
 
 @final
@@ -189,7 +189,7 @@ def normalize_vector(obj: CartesianPos3D, /) -> CartesianGeneric3D:
 
 
 #####################################################################
-# Vel
+# Velocity
 
 
 @final
@@ -305,7 +305,7 @@ def _sub_v3_v3(lhs: CartesianVel3D, other: CartesianVel3D, /) -> CartesianVel3D:
 
 
 #####################################################################
-# Acc
+# Acceleration
 
 
 @final

--- a/src/coordinax/_src/d3/cartesian.py
+++ b/src/coordinax/_src/d3/cartesian.py
@@ -2,7 +2,7 @@
 
 __all__ = [
     "CartesianPos3D",
-    "CartesianVelocity3D",
+    "CartesianVel3D",
     "CartesianAcceleration3D",
 ]
 
@@ -23,7 +23,7 @@ from dataclassish import field_items
 from unxt import AbstractQuantity, Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVelocity3D
+from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVel3D
 from .generic import CartesianGeneric3D
 from coordinax._src.base import AbstractPos
 from coordinax._src.base.mixins import AvalMixin
@@ -55,9 +55,9 @@ class CartesianPos3D(AbstractPos3D):
     @override
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["CartesianVelocity3D"]:
+    def differential_cls(cls) -> type["CartesianVel3D"]:
         """Return the differential of the class."""
-        return CartesianVelocity3D
+        return CartesianVel3D
 
 
 # =====================================================
@@ -189,11 +189,11 @@ def normalize_vector(obj: CartesianPos3D, /) -> CartesianGeneric3D:
 
 
 #####################################################################
-# Velocity
+# Vel
 
 
 @final
-class CartesianVelocity3D(AvalMixin, AbstractVelocity3D):
+class CartesianVel3D(AvalMixin, AbstractVel3D):
     """Cartesian differential representation."""
 
     d_x: ct.BatchableSpeed = eqx.field(
@@ -231,7 +231,7 @@ class CartesianVelocity3D(AvalMixin, AbstractVelocity3D):
         --------
         >>> from unxt import Quantity
         >>> import coordinax as cx
-        >>> c = cx.CartesianVelocity3D.from_([1, 2, 3], "km/s")
+        >>> c = cx.CartesianVel3D.from_([1, 2, 3], "km/s")
         >>> c.norm()
         Quantity['speed'](Array(3.7416575, dtype=float32), unit='km / s')
 
@@ -242,12 +242,12 @@ class CartesianVelocity3D(AvalMixin, AbstractVelocity3D):
 # -----------------------------------------------------
 
 
-@CartesianVelocity3D.from_._f.dispatch  # type: ignore[attr-defined,misc]  # noqa: SLF001
+@CartesianVel3D.from_._f.dispatch  # type: ignore[attr-defined,misc]  # noqa: SLF001
 def from_(
-    cls: type[CartesianVelocity3D],
+    cls: type[CartesianVel3D],
     obj: AbstractQuantity,  # TODO: Shaped[AbstractQuantity, "*batch 3"]
     /,
-) -> CartesianVelocity3D:
+) -> CartesianVel3D:
     """Construct a 3D Cartesian velocity.
 
     Examples
@@ -255,9 +255,9 @@ def from_(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.CartesianVelocity3D.from_(Quantity([1, 2, 3], "m/s"))
+    >>> vec = cx.CartesianVel3D.from_(Quantity([1, 2, 3], "m/s"))
     >>> vec
-    CartesianVelocity3D(
+    CartesianVel3D(
       d_x=Quantity[...]( value=f32[], unit=Unit("m / s") ),
       d_y=Quantity[...]( value=f32[], unit=Unit("m / s") ),
       d_z=Quantity[...]( value=f32[], unit=Unit("m / s") )
@@ -273,15 +273,13 @@ def from_(
 
 
 @register(jax.lax.add_p)  # type: ignore[misc]
-def _add_pp(
-    lhs: CartesianVelocity3D, rhs: CartesianVelocity3D, /
-) -> CartesianVelocity3D:
+def _add_pp(lhs: CartesianVel3D, rhs: CartesianVel3D, /) -> CartesianVel3D:
     """Add two Cartesian velocities.
 
     Examples
     --------
     >>> import coordinax as cx
-    >>> q = cx.CartesianVelocity3D.from_([1, 2, 3], "km/s")
+    >>> q = cx.CartesianVel3D.from_([1, 2, 3], "km/s")
     >>> q2 = q + q
     >>> q2.d_y
     Quantity['speed'](Array(4., dtype=float32), unit='km / s')
@@ -291,16 +289,13 @@ def _add_pp(
 
 
 @register(jax.lax.sub_p)  # type: ignore[misc]
-def _sub_v3_v3(
-    lhs: CartesianVelocity3D, other: CartesianVelocity3D, /
-) -> CartesianVelocity3D:
+def _sub_v3_v3(lhs: CartesianVel3D, other: CartesianVel3D, /) -> CartesianVel3D:
     """Subtract two differentials.
 
     Examples
     --------
-    >>> from unxt import Quantity
-    >>> from coordinax import CartesianPos3D, CartesianVelocity3D
-    >>> q = CartesianVelocity3D.from_(Quantity([1, 2, 3], "km/s"))
+    >>> from coordinax import CartesianPos3D, CartesianVel3D
+    >>> q = CartesianVel3D.from_([1, 2, 3], "km/s")
     >>> q2 = q - q
     >>> q2.d_y
     Quantity['speed'](Array(0., dtype=float32), unit='km / s')
@@ -334,15 +329,15 @@ class CartesianAcceleration3D(AvalMixin, AbstractAcceleration3D):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[CartesianVelocity3D]:
-        return CartesianVelocity3D
+    def integral_cls(cls) -> type[CartesianVel3D]:
+        return CartesianVel3D
 
     # -----------------------------------------------------
     # Methods
 
     @override
     @partial(eqx.filter_jit, inline=True)
-    def norm(self, _: AbstractVelocity3D | None = None, /) -> ct.BatchableAcc:
+    def norm(self, _: AbstractVel3D | None = None, /) -> ct.BatchableAcc:
         """Return the norm of the vector.
 
         Examples

--- a/src/coordinax/_src/d3/cartesian.py
+++ b/src/coordinax/_src/d3/cartesian.py
@@ -3,7 +3,7 @@
 __all__ = [
     "CartesianPos3D",
     "CartesianVel3D",
-    "CartesianAcceleration3D",
+    "CartesianAcc3D",
 ]
 
 from dataclasses import fields, replace
@@ -23,7 +23,7 @@ from dataclassish import field_items
 from unxt import AbstractQuantity, Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVel3D
+from .base import AbstractAcc3D, AbstractPos3D, AbstractVel3D
 from .generic import CartesianGeneric3D
 from coordinax._src.base import AbstractPos
 from coordinax._src.base.mixins import AvalMixin
@@ -220,8 +220,8 @@ class CartesianVel3D(AvalMixin, AbstractVel3D):
     @override
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["CartesianAcceleration3D"]:
-        return CartesianAcceleration3D
+    def differential_cls(cls) -> type["CartesianAcc3D"]:
+        return CartesianAcc3D
 
     @partial(eqx.filter_jit, inline=True)
     def norm(self, _: AbstractPos3D | None = None, /) -> ct.BatchableSpeed:
@@ -305,11 +305,11 @@ def _sub_v3_v3(lhs: CartesianVel3D, other: CartesianVel3D, /) -> CartesianVel3D:
 
 
 #####################################################################
-# Acceleration
+# Acc
 
 
 @final
-class CartesianAcceleration3D(AvalMixin, AbstractAcceleration3D):
+class CartesianAcc3D(AvalMixin, AbstractAcc3D):
     """Cartesian differential representation."""
 
     d2_x: ct.BatchableSpeed = eqx.field(
@@ -344,7 +344,7 @@ class CartesianAcceleration3D(AvalMixin, AbstractAcceleration3D):
         --------
         >>> from unxt import Quantity
         >>> import coordinax as cx
-        >>> c = cx.CartesianAcceleration3D.from_([1, 2, 3], "km/s2")
+        >>> c = cx.CartesianAcc3D.from_([1, 2, 3], "km/s2")
         >>> c.norm()
         Quantity['acceleration'](Array(3.7416575, dtype=float32), unit='km / s2')
 
@@ -355,10 +355,10 @@ class CartesianAcceleration3D(AvalMixin, AbstractAcceleration3D):
 # -----------------------------------------------------
 
 
-@CartesianAcceleration3D.from_._f.dispatch  # type: ignore[attr-defined, misc]  # noqa: SLF001
+@CartesianAcc3D.from_._f.dispatch  # type: ignore[attr-defined, misc]  # noqa: SLF001
 def from_(
-    cls: type[CartesianAcceleration3D], obj: Shaped[AbstractQuantity, "*batch 3"], /
-) -> CartesianAcceleration3D:
+    cls: type[CartesianAcc3D], obj: Shaped[AbstractQuantity, "*batch 3"], /
+) -> CartesianAcc3D:
     """Construct a 3D Cartesian acceleration.
 
     Examples
@@ -366,9 +366,9 @@ def from_(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.CartesianAcceleration3D.from_(Quantity([1, 2, 3], "m/s2"))
+    >>> vec = cx.CartesianAcc3D.from_(Quantity([1, 2, 3], "m/s2"))
     >>> vec
-    CartesianAcceleration3D(
+    CartesianAcc3D(
       d2_x=Quantity[...](value=f32[], unit=Unit("m / s2")),
       d2_y=Quantity[...](value=f32[], unit=Unit("m / s2")),
       d2_z=Quantity[...](value=f32[], unit=Unit("m / s2"))
@@ -384,9 +384,7 @@ def from_(
 
 
 @register(jax.lax.add_p)  # type: ignore[misc]
-def _add_aa(
-    lhs: CartesianAcceleration3D, rhs: CartesianAcceleration3D, /
-) -> CartesianAcceleration3D:
+def _add_aa(lhs: CartesianAcc3D, rhs: CartesianAcc3D, /) -> CartesianAcc3D:
     """Add two Cartesian accelerations."""
     return jax.tree.map(qlax.add, lhs, rhs)
 
@@ -416,8 +414,6 @@ def _mul_ac3(lhs: ArrayLike, rhs: CartesianPos3D, /) -> CartesianPos3D:
 
 
 @register(jax.lax.sub_p)  # type: ignore[misc]
-def _sub_a3_a3(
-    lhs: CartesianAcceleration3D, rhs: CartesianAcceleration3D, /
-) -> CartesianAcceleration3D:
+def _sub_a3_a3(lhs: CartesianAcc3D, rhs: CartesianAcc3D, /) -> CartesianAcc3D:
     """Subtract two accelerations."""
     return jax.tree.map(qlax.sub, lhs, rhs)

--- a/src/coordinax/_src/d3/compat.py
+++ b/src/coordinax/_src/d3/compat.py
@@ -10,7 +10,7 @@ from plum import convert
 
 from unxt import Quantity
 
-from .cartesian import CartesianPosition3D
+from .cartesian import CartesianPos3D
 from coordinax._src.operators.base import AbstractOperator, op_call_dispatch
 from coordinax._src.typing import TimeBatchOrScalar
 
@@ -26,7 +26,7 @@ def call(self: AbstractOperator, q: Q3, /) -> Q3:
     r"""Operate on a 3D Quantity.
 
     `q` is the position vector. This is interpreted as a 3D CartesianVector.
-    See :class:`coordinax.CartesianPosition3D` for more details.
+    See :class:`coordinax.CartesianPos3D` for more details.
 
     Returns
     -------
@@ -53,9 +53,9 @@ def call(self: AbstractOperator, q: Q3, /) -> Q3:
     Quantity['length'](Array([1., 2., 3.], dtype=float32), unit='kpc')
 
     """
-    cart = CartesianPosition3D.from_(q)
+    cart = CartesianPos3D.from_(q)
     result = self(cart)
-    return convert(result.represent_as(CartesianPosition3D), Quantity)
+    return convert(result.represent_as(CartesianPos3D), Quantity)
 
 
 @op_call_dispatch
@@ -73,7 +73,7 @@ def call(
 
     >>> op = cx.operators.GalileanSpatialTranslationOperator(Quantity([1, 2, 3], "kpc"))
     >>> op
-    GalileanSpatialTranslationOperator( translation=CartesianPosition3D( ... ) )
+    GalileanSpatialTranslationOperator( translation=CartesianPos3D( ... ) )
 
     We can then apply the operator to a position:
 
@@ -92,5 +92,5 @@ def call(
         Quantity['time'](Array(0., dtype=float32, ...), unit='Gyr'))
 
     """
-    vec, t = self(CartesianPosition3D.from_(x), t)
+    vec, t = self(CartesianPos3D.from_(x), t)
     return convert(vec, Quantity), t

--- a/src/coordinax/_src/d3/constructor.py
+++ b/src/coordinax/_src/d3/constructor.py
@@ -5,14 +5,14 @@ __all__: list[str] = []
 
 from typing import Any
 
-from .base import AbstractAcceleration3D, AbstractPosition3D, AbstractVelocity3D
-from .cartesian import CartesianAcceleration3D, CartesianPosition3D, CartesianVelocity3D
+from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVelocity3D
+from .cartesian import CartesianAcceleration3D, CartesianPos3D, CartesianVelocity3D
 
 #####################################################################
 
 
-@AbstractPosition3D.from_._f.dispatch(precedence=-1)  # noqa: SLF001
-def from_(cls: type[AbstractPosition3D], obj: Any, /) -> CartesianPosition3D:
+@AbstractPos3D.from_._f.dispatch(precedence=-1)  # noqa: SLF001
+def from_(cls: type[AbstractPos3D], obj: Any, /) -> CartesianPos3D:
     """Try to construct a 3D Cartesian position from an object.
 
     Examples
@@ -21,39 +21,35 @@ def from_(cls: type[AbstractPosition3D], obj: Any, /) -> CartesianPosition3D:
     >>> import coordinax as cx
 
     >>> x = Quantity([1, 2, 3], "km")
-    >>> cx.AbstractPosition3D.from_(x)
-    CartesianPosition3D(
+    >>> cx.AbstractPos3D.from_(x)
+    CartesianPos3D(
       x=Quantity[...](value=f32[], unit=Unit("km")),
       y=Quantity[...](value=f32[], unit=Unit("km")),
       z=Quantity[...](value=f32[], unit=Unit("km"))
     )
 
     """
-    return (
-        obj if isinstance(obj, CartesianPosition3D) else CartesianPosition3D.from_(obj)
-    )
+    return obj if isinstance(obj, CartesianPos3D) else CartesianPos3D.from_(obj)
 
 
-@AbstractPosition3D.from_._f.dispatch(precedence=1)  # noqa: SLF001
-def from_(
-    cls: type[AbstractPosition3D], obj: AbstractPosition3D, /
-) -> AbstractPosition3D:
+@AbstractPos3D.from_._f.dispatch(precedence=1)  # noqa: SLF001
+def from_(cls: type[AbstractPos3D], obj: AbstractPos3D, /) -> AbstractPos3D:
     """Construct from a 3D position.
 
     Examples
     --------
     >>> import coordinax as cx
 
-    >>> cart = cx.CartesianPosition3D.from_([1, 2, 3], "km")
-    >>> cx.AbstractPosition3D.from_(cart) is cart
+    >>> cart = cx.CartesianPos3D.from_([1, 2, 3], "km")
+    >>> cx.AbstractPos3D.from_(cart) is cart
     True
 
-    >>> sph = cart.represent_as(cx.SphericalPosition)
-    >>> cx.AbstractPosition3D.from_(sph) is sph
+    >>> sph = cart.represent_as(cx.SphericalPos)
+    >>> cx.AbstractPos3D.from_(sph) is sph
     True
 
-    >>> cyl = cart.represent_as(cx.CylindricalPosition)
-    >>> cx.AbstractPosition3D.from_(cyl) is cyl
+    >>> cyl = cart.represent_as(cx.CylindricalPos)
+    >>> cx.AbstractPos3D.from_(cyl) is cyl
     True
 
     """
@@ -96,7 +92,7 @@ def from_(
     --------
     >>> import coordinax as cx
 
-    >>> q = cx.CartesianPosition3D.from_([1, 1, 1], "km")
+    >>> q = cx.CartesianPos3D.from_([1, 1, 1], "km")
 
     >>> cart = cx.CartesianVelocity3D.from_([1, 2, 3], "km/s")
     >>> cx.AbstractVelocity3D.from_(cart) is cart
@@ -152,7 +148,7 @@ def from_(
     --------
     >>> import coordinax as cx
 
-    >>> q = cx.CartesianPosition3D.from_([1, 1, 1], "km")
+    >>> q = cx.CartesianPos3D.from_([1, 1, 1], "km")
     >>> p = cx.CartesianVelocity3D.from_([1, 1, 1], "km/s")
 
     >>> cart = cx.CartesianAcceleration3D.from_([1, 2, 3], "km/s2")

--- a/src/coordinax/_src/d3/constructor.py
+++ b/src/coordinax/_src/d3/constructor.py
@@ -5,8 +5,8 @@ __all__: list[str] = []
 
 from typing import Any
 
-from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVelocity3D
-from .cartesian import CartesianAcceleration3D, CartesianPos3D, CartesianVelocity3D
+from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVel3D
+from .cartesian import CartesianAcceleration3D, CartesianPos3D, CartesianVel3D
 
 #####################################################################
 
@@ -59,8 +59,8 @@ def from_(cls: type[AbstractPos3D], obj: AbstractPos3D, /) -> AbstractPos3D:
 #####################################################################
 
 
-@AbstractVelocity3D.from_._f.dispatch(precedence=-1)  # noqa: SLF001
-def from_(cls: type[AbstractVelocity3D], obj: Any, /) -> CartesianVelocity3D:
+@AbstractVel3D.from_._f.dispatch(precedence=-1)  # noqa: SLF001
+def from_(cls: type[AbstractVel3D], obj: Any, /) -> CartesianVel3D:
     """Try to construct a 3D Cartesian velocity from an object.
 
     Examples
@@ -69,23 +69,19 @@ def from_(cls: type[AbstractVelocity3D], obj: Any, /) -> CartesianVelocity3D:
     >>> import coordinax as cx
 
     >>> x = Quantity([1, 2, 3], "km / s")
-    >>> cx.AbstractVelocity3D.from_(x)
-    CartesianVelocity3D(
+    >>> cx.AbstractVel3D.from_(x)
+    CartesianVel3D(
       d_x=Quantity[...]( value=f32[], unit=Unit("km / s") ),
       d_y=Quantity[...]( value=f32[], unit=Unit("km / s") ),
       d_z=Quantity[...]( value=f32[], unit=Unit("km / s") )
     )
 
     """
-    return (
-        obj if isinstance(obj, CartesianVelocity3D) else CartesianVelocity3D.from_(obj)
-    )
+    return obj if isinstance(obj, CartesianVel3D) else CartesianVel3D.from_(obj)
 
 
-@AbstractVelocity3D.from_._f.dispatch(precedence=1)  # noqa: SLF001
-def from_(
-    cls: type[AbstractVelocity3D], obj: AbstractVelocity3D, /
-) -> AbstractVelocity3D:
+@AbstractVel3D.from_._f.dispatch(precedence=1)  # noqa: SLF001
+def from_(cls: type[AbstractVel3D], obj: AbstractVel3D, /) -> AbstractVel3D:
     """Construct from a 3D velocity.
 
     Examples
@@ -94,16 +90,16 @@ def from_(
 
     >>> q = cx.CartesianPos3D.from_([1, 1, 1], "km")
 
-    >>> cart = cx.CartesianVelocity3D.from_([1, 2, 3], "km/s")
-    >>> cx.AbstractVelocity3D.from_(cart) is cart
+    >>> cart = cx.CartesianVel3D.from_([1, 2, 3], "km/s")
+    >>> cx.AbstractVel3D.from_(cart) is cart
     True
 
-    >>> sph = cart.represent_as(cx.SphericalVelocity, q)
-    >>> cx.AbstractVelocity3D.from_(sph) is sph
+    >>> sph = cart.represent_as(cx.SphericalVel, q)
+    >>> cx.AbstractVel3D.from_(sph) is sph
     True
 
-    >>> cyl = cart.represent_as(cx.CylindricalVelocity, q)
-    >>> cx.AbstractVelocity3D.from_(cyl) is cyl
+    >>> cyl = cart.represent_as(cx.CylindricalVel, q)
+    >>> cx.AbstractVel3D.from_(cyl) is cyl
     True
 
     """
@@ -149,7 +145,7 @@ def from_(
     >>> import coordinax as cx
 
     >>> q = cx.CartesianPos3D.from_([1, 1, 1], "km")
-    >>> p = cx.CartesianVelocity3D.from_([1, 1, 1], "km/s")
+    >>> p = cx.CartesianVel3D.from_([1, 1, 1], "km/s")
 
     >>> cart = cx.CartesianAcceleration3D.from_([1, 2, 3], "km/s2")
     >>> cx.AbstractAcceleration3D.from_(cart) is cart

--- a/src/coordinax/_src/d3/constructor.py
+++ b/src/coordinax/_src/d3/constructor.py
@@ -5,8 +5,8 @@ __all__: list[str] = []
 
 from typing import Any
 
-from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVel3D
-from .cartesian import CartesianAcceleration3D, CartesianPos3D, CartesianVel3D
+from .base import AbstractAcc3D, AbstractPos3D, AbstractVel3D
+from .cartesian import CartesianAcc3D, CartesianPos3D, CartesianVel3D
 
 #####################################################################
 
@@ -109,8 +109,8 @@ def from_(cls: type[AbstractVel3D], obj: AbstractVel3D, /) -> AbstractVel3D:
 #####################################################################
 
 
-@AbstractAcceleration3D.from_._f.dispatch(precedence=-1)  # noqa: SLF001
-def from_(cls: type[AbstractAcceleration3D], obj: Any, /) -> CartesianAcceleration3D:
+@AbstractAcc3D.from_._f.dispatch(precedence=-1)  # noqa: SLF001
+def from_(cls: type[AbstractAcc3D], obj: Any, /) -> CartesianAcc3D:
     """Try to construct a 3D Cartesian velocity from an object.
 
     Examples
@@ -119,25 +119,19 @@ def from_(cls: type[AbstractAcceleration3D], obj: Any, /) -> CartesianAccelerati
     >>> import coordinax as cx
 
     >>> x = Quantity([1, 2, 3], "km / s2")
-    >>> cx.AbstractAcceleration3D.from_(x)
-    CartesianAcceleration3D(
+    >>> cx.AbstractAcc3D.from_(x)
+    CartesianAcc3D(
       d2_x=Quantity[...](value=f32[], unit=Unit("km / s2")),
       d2_y=Quantity[...](value=f32[], unit=Unit("km / s2")),
       d2_z=Quantity[...](value=f32[], unit=Unit("km / s2"))
     )
 
     """
-    return (
-        obj
-        if isinstance(obj, CartesianAcceleration3D)
-        else CartesianAcceleration3D.from_(obj)
-    )
+    return obj if isinstance(obj, CartesianAcc3D) else CartesianAcc3D.from_(obj)
 
 
-@AbstractAcceleration3D.from_._f.dispatch(precedence=1)  # noqa: SLF001
-def from_(
-    cls: type[AbstractAcceleration3D], obj: AbstractAcceleration3D, /
-) -> AbstractAcceleration3D:
+@AbstractAcc3D.from_._f.dispatch(precedence=1)  # noqa: SLF001
+def from_(cls: type[AbstractAcc3D], obj: AbstractAcc3D, /) -> AbstractAcc3D:
     """Construct from a 3D velocity.
 
     Examples
@@ -147,16 +141,16 @@ def from_(
     >>> q = cx.CartesianPos3D.from_([1, 1, 1], "km")
     >>> p = cx.CartesianVel3D.from_([1, 1, 1], "km/s")
 
-    >>> cart = cx.CartesianAcceleration3D.from_([1, 2, 3], "km/s2")
-    >>> cx.AbstractAcceleration3D.from_(cart) is cart
+    >>> cart = cx.CartesianAcc3D.from_([1, 2, 3], "km/s2")
+    >>> cx.AbstractAcc3D.from_(cart) is cart
     True
 
-    >>> sph = cart.represent_as(cx.SphericalAcceleration, p, q)
-    >>> cx.AbstractAcceleration3D.from_(sph) is sph
+    >>> sph = cart.represent_as(cx.SphericalAcc, p, q)
+    >>> cx.AbstractAcc3D.from_(sph) is sph
     True
 
-    >>> cyl = cart.represent_as(cx.CylindricalAcceleration, p, q)
-    >>> cx.AbstractAcceleration3D.from_(cyl) is cyl
+    >>> cyl = cart.represent_as(cx.CylindricalAcc, p, q)
+    >>> cx.AbstractAcc3D.from_(cyl) is cyl
     True
 
     """

--- a/src/coordinax/_src/d3/cylindrical.py
+++ b/src/coordinax/_src/d3/cylindrical.py
@@ -2,7 +2,7 @@
 
 __all__ = [
     "CylindricalPos",
-    "CylindricalVelocity",
+    "CylindricalVel",
     "CylindricalAcceleration",
 ]
 
@@ -16,7 +16,7 @@ import quaxed.numpy as xp
 from unxt import Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVelocity3D
+from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVel3D
 from coordinax._src.checks import check_azimuth_range, check_r_non_negative
 from coordinax._src.converters import converter_azimuth_to_range
 from coordinax._src.utils import classproperty
@@ -55,8 +55,8 @@ class CylindricalPos(AbstractPos3D):
     @override
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["CylindricalVelocity"]:
-        return CylindricalVelocity
+    def differential_cls(cls) -> type["CylindricalVel"]:
+        return CylindricalVel
 
     @override
     @partial(eqx.filter_jit, inline=True)
@@ -77,7 +77,7 @@ class CylindricalPos(AbstractPos3D):
 
 
 @final
-class CylindricalVelocity(AbstractVelocity3D):
+class CylindricalVel(AbstractVel3D):
     """Cylindrical differential representation."""
 
     d_rho: ct.BatchableSpeed = eqx.field(
@@ -127,5 +127,5 @@ class CylindricalAcceleration(AbstractAcceleration3D):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[CylindricalVelocity]:
-        return CylindricalVelocity
+    def integral_cls(cls) -> type[CylindricalVel]:
+        return CylindricalVel

--- a/src/coordinax/_src/d3/cylindrical.py
+++ b/src/coordinax/_src/d3/cylindrical.py
@@ -3,7 +3,7 @@
 __all__ = [
     "CylindricalPos",
     "CylindricalVel",
-    "CylindricalAcceleration",
+    "CylindricalAcc",
 ]
 
 from functools import partial
@@ -16,7 +16,7 @@ import quaxed.numpy as xp
 from unxt import Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVel3D
+from .base import AbstractAcc3D, AbstractPos3D, AbstractVel3D
 from coordinax._src.checks import check_azimuth_range, check_r_non_negative
 from coordinax._src.converters import converter_azimuth_to_range
 from coordinax._src.utils import classproperty
@@ -102,12 +102,12 @@ class CylindricalVel(AbstractVel3D):
 
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["CylindricalAcceleration"]:
-        return CylindricalAcceleration
+    def differential_cls(cls) -> type["CylindricalAcc"]:
+        return CylindricalAcc
 
 
 @final
-class CylindricalAcceleration(AbstractAcceleration3D):
+class CylindricalAcc(AbstractAcc3D):
     """Cylindrical acceleration representation."""
 
     d2_rho: ct.BatchableSpeed = eqx.field(

--- a/src/coordinax/_src/d3/cylindrical.py
+++ b/src/coordinax/_src/d3/cylindrical.py
@@ -1,7 +1,7 @@
 """Built-in vector classes."""
 
 __all__ = [
-    "CylindricalPosition",
+    "CylindricalPos",
     "CylindricalVelocity",
     "CylindricalAcceleration",
 ]
@@ -16,14 +16,14 @@ import quaxed.numpy as xp
 from unxt import Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAcceleration3D, AbstractPosition3D, AbstractVelocity3D
+from .base import AbstractAcceleration3D, AbstractPos3D, AbstractVelocity3D
 from coordinax._src.checks import check_azimuth_range, check_r_non_negative
 from coordinax._src.converters import converter_azimuth_to_range
 from coordinax._src.utils import classproperty
 
 
 @final
-class CylindricalPosition(AbstractPosition3D):
+class CylindricalPos(AbstractPos3D):
     """Cylindrical vector representation.
 
     This adheres to ISO standard 31-11.
@@ -67,7 +67,7 @@ class CylindricalPosition(AbstractPosition3D):
         --------
         >>> from unxt import Quantity
         >>> import coordinax as cx
-        >>> c = cx.CylindricalPosition(rho=Quantity(3, "kpc"), phi=Quantity(0, "deg"),
+        >>> c = cx.CylindricalPos(rho=Quantity(3, "kpc"), phi=Quantity(0, "deg"),
         ...                       z=Quantity(4, "kpc"))
         >>> c.norm()
         Quantity['length'](Array(5., dtype=float32), unit='kpc')
@@ -97,8 +97,8 @@ class CylindricalVelocity(AbstractVelocity3D):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[CylindricalPosition]:
-        return CylindricalPosition
+    def integral_cls(cls) -> type[CylindricalPos]:
+        return CylindricalPos
 
     @classproperty
     @classmethod

--- a/src/coordinax/_src/d3/lonlatspherical.py
+++ b/src/coordinax/_src/d3/lonlatspherical.py
@@ -2,9 +2,9 @@
 
 __all__ = [
     "LonLatSphericalPos",
-    "LonLatSphericalVelocity",
+    "LonLatSphericalVel",
     "LonLatSphericalAcceleration",
-    "LonCosLatSphericalVelocity",
+    "LonCosLatSphericalVel",
 ]
 
 from functools import partial
@@ -22,7 +22,7 @@ import coordinax._src.typing as ct
 from .base_spherical import (
     AbstractSphericalAcceleration,
     AbstractSphericalPos,
-    AbstractSphericalVelocity,
+    AbstractSphericalVel,
     _90d,
     _180d,
 )
@@ -125,8 +125,8 @@ class LonLatSphericalPos(AbstractSphericalPos):
     @override
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["LonLatSphericalVelocity"]:
-        return LonLatSphericalVelocity
+    def differential_cls(cls) -> type["LonLatSphericalVel"]:
+        return LonLatSphericalVel
 
     @override
     @partial(eqx.filter_jit, inline=True)
@@ -248,7 +248,7 @@ def from_(
 
 
 @final
-class LonLatSphericalVelocity(AbstractSphericalVelocity):
+class LonLatSphericalVel(AbstractSphericalVel):
     """Spherical differential representation."""
 
     d_lon: ct.BatchableAngularSpeed = eqx.field(
@@ -278,7 +278,7 @@ class LonLatSphericalVelocity(AbstractSphericalVelocity):
 
 
 @final
-class LonCosLatSphericalVelocity(AbstractSphericalVelocity):
+class LonCosLatSphericalVel(AbstractSphericalVel):
     """Spherical differential representation."""
 
     d_lon_coslat: ct.BatchableAngularSpeed = eqx.field(
@@ -331,5 +331,5 @@ class LonLatSphericalAcceleration(AbstractSphericalAcceleration):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[LonLatSphericalVelocity]:
-        return LonLatSphericalVelocity
+    def integral_cls(cls) -> type[LonLatSphericalVel]:
+        return LonLatSphericalVel

--- a/src/coordinax/_src/d3/lonlatspherical.py
+++ b/src/coordinax/_src/d3/lonlatspherical.py
@@ -1,7 +1,7 @@
 """Built-in vector classes."""
 
 __all__ = [
-    "LonLatSphericalPosition",
+    "LonLatSphericalPos",
     "LonLatSphericalVelocity",
     "LonLatSphericalAcceleration",
     "LonCosLatSphericalVelocity",
@@ -21,7 +21,7 @@ from unxt import AbstractDistance, Distance, Quantity
 import coordinax._src.typing as ct
 from .base_spherical import (
     AbstractSphericalAcceleration,
-    AbstractSphericalPosition,
+    AbstractSphericalPos,
     AbstractSphericalVelocity,
     _90d,
     _180d,
@@ -36,7 +36,7 @@ from coordinax._src.utils import classproperty
 
 
 @final
-class LonLatSphericalPosition(AbstractSphericalPosition):
+class LonLatSphericalPos(AbstractSphericalPos):
     """Spherical vector representation.
 
     .. note::
@@ -57,9 +57,9 @@ class LonLatSphericalPosition(AbstractSphericalPosition):
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> cx.LonLatSphericalPosition(lon=Quantity(0, "deg"), lat=Quantity(0, "deg"),
-    ...                          distance=Quantity(3, "kpc"))
-    LonLatSphericalPosition(
+    >>> cx.LonLatSphericalPos(lon=Quantity(0, "deg"), lat=Quantity(0, "deg"),
+    ...                       distance=Quantity(3, "kpc"))
+    LonLatSphericalPos(
       lon=Quantity[PhysicalType('angle')](value=f32[], unit=Unit("deg")),
       lat=Quantity[PhysicalType('angle')](value=f32[], unit=Unit("deg")),
       distance=Distance(value=f32[], unit=Unit("kpc"))
@@ -69,9 +69,9 @@ class LonLatSphericalPosition(AbstractSphericalPosition):
     and the radial distance is non-negative.
     When initializing, the longitude is wrapped to the [0, 360) degrees range.
 
-    >>> vec = cx.LonLatSphericalPosition(lon=Quantity(365, "deg"),
-    ...                                lat=Quantity(90, "deg"),
-    ...                                distance=Quantity(3, "kpc"))
+    >>> vec = cx.LonLatSphericalPos(lon=Quantity(365, "deg"),
+    ...                             lat=Quantity(90, "deg"),
+    ...                             distance=Quantity(3, "kpc"))
     >>> vec.lon
     Quantity['angle'](Array(5., dtype=float32), unit='deg')
 
@@ -80,8 +80,8 @@ class LonLatSphericalPosition(AbstractSphericalPosition):
     .. skip: next
 
     >>> try:
-    ...     cx.LonLatSphericalPosition(lon=Quantity(0, "deg"), lat=Quantity(100, "deg"),
-    ...                              distance=Quantity(3, "kpc"))
+    ...     cx.LonLatSphericalPos(lon=Quantity(0, "deg"), lat=Quantity(100, "deg"),
+    ...                           distance=Quantity(3, "kpc"))
     ... except Exception as e:
     ...     print(e)
     The inclination angle must be in the range [0, pi]...
@@ -91,8 +91,8 @@ class LonLatSphericalPosition(AbstractSphericalPosition):
     .. skip: next
 
     >>> try:
-    ...     cx.LonLatSphericalPosition(lon=Quantity(0, "deg"), lat=Quantity(0, "deg"),
-    ...                              distance=Quantity(-3, "kpc"))
+    ...     cx.LonLatSphericalPos(lon=Quantity(0, "deg"), lat=Quantity(0, "deg"),
+    ...                           distance=Quantity(-3, "kpc"))
     ... except Exception as e:
     ...     print(e)
     The radial distance must be non-negative...
@@ -137,9 +137,9 @@ class LonLatSphericalPosition(AbstractSphericalPosition):
         --------
         >>> from unxt import Quantity
         >>> import coordinax as cx
-        >>> s = cx.LonLatSphericalPosition(lon=Quantity(0, "deg"),
-        ...                                lat=Quantity(90, "deg"),
-        ...                                distance=Quantity(3, "kpc"))
+        >>> s = cx.LonLatSphericalPos(lon=Quantity(0, "deg"),
+        ...                           lat=Quantity(90, "deg"),
+        ...                            distance=Quantity(3, "kpc"))
         >>> s.norm()
         Distance(Array(3., dtype=float32), unit='kpc')
 
@@ -147,15 +147,15 @@ class LonLatSphericalPosition(AbstractSphericalPosition):
         return self.distance
 
 
-@LonLatSphericalPosition.from_._f.register  # type: ignore[attr-defined, misc]  # noqa: SLF001
+@LonLatSphericalPos.from_._f.register  # type: ignore[attr-defined, misc]  # noqa: SLF001
 def from_(
-    cls: type[LonLatSphericalPosition],
+    cls: type[LonLatSphericalPos],
     *,
     lon: Quantity["angle"],
     lat: Quantity["angle"],
     distance: Distance,
-) -> LonLatSphericalPosition:
-    """Construct LonLatSphericalPosition, allowing for out-of-range values.
+) -> LonLatSphericalPos:
+    """Construct LonLatSphericalPos, allowing for out-of-range values.
 
     Examples
     --------
@@ -163,10 +163,10 @@ def from_(
 
     Let's start with a valid input:
 
-    >>> cx.LonLatSphericalPosition.from_(lon=Quantity(0, "deg"),
-    ...                                      lat=Quantity(0, "deg"),
-    ...                                      distance=Quantity(3, "kpc"))
-    LonLatSphericalPosition(
+    >>> cx.LonLatSphericalPos.from_(lon=Quantity(0, "deg"),
+    ...                             lat=Quantity(0, "deg"),
+    ...                             distance=Quantity(3, "kpc"))
+    LonLatSphericalPos(
       lon=Quantity[PhysicalType('angle')](value=f32[], unit=Unit("deg")),
       lat=Quantity[PhysicalType('angle')](value=f32[], unit=Unit("deg")),
       distance=Distance(value=f32[], unit=Unit("kpc"))
@@ -175,9 +175,9 @@ def from_(
     The distance can be negative, which wraps the longitude by 180 degrees and
     flips the latitude:
 
-    >>> vec = cx.LonLatSphericalPosition.from_(lon=Quantity(0, "deg"),
-    ...                                              lat=Quantity(45, "deg"),
-    ...                                              distance=Quantity(-3, "kpc"))
+    >>> vec = cx.LonLatSphericalPos.from_(lon=Quantity(0, "deg"),
+    ...                                   lat=Quantity(45, "deg"),
+    ...                                   distance=Quantity(-3, "kpc"))
     >>> vec.lon
     Quantity['angle'](Array(180., dtype=float32), unit='deg')
     >>> vec.lat
@@ -188,9 +188,9 @@ def from_(
     The latitude can be outside the [-90, 90] deg range, causing the longitude
     to be shifted by 180 degrees:
 
-    >>> vec = cx.LonLatSphericalPosition.from_(lon=Quantity(0, "deg"),
-    ...                                              lat=Quantity(-100, "deg"),
-    ...                                              distance=Quantity(3, "kpc"))
+    >>> vec = cx.LonLatSphericalPos.from_(lon=Quantity(0, "deg"),
+    ...                                   lat=Quantity(-100, "deg"),
+    ...                                   distance=Quantity(3, "kpc"))
     >>> vec.lon
     Quantity['angle'](Array(180., dtype=float32), unit='deg')
     >>> vec.lat
@@ -198,9 +198,9 @@ def from_(
     >>> vec.distance
     Distance(Array(3., dtype=float32), unit='kpc')
 
-    >>> vec = cx.LonLatSphericalPosition.from_(lon=Quantity(0, "deg"),
-    ...                                              lat=Quantity(100, "deg"),
-    ...                                              distance=Quantity(3, "kpc"))
+    >>> vec = cx.LonLatSphericalPos.from_(lon=Quantity(0, "deg"),
+    ...                                   lat=Quantity(100, "deg"),
+    ...                                   distance=Quantity(3, "kpc"))
     >>> vec.lon
     Quantity['angle'](Array(180., dtype=float32), unit='deg')
     >>> vec.lat
@@ -211,15 +211,15 @@ def from_(
     The longitude can be outside the [0, 360) deg range. This is wrapped to the
     [0, 360) deg range (actually the base constructor does this):
 
-    >>> vec = cx.LonLatSphericalPosition.from_(lon=Quantity(365, "deg"),
-    ...                                              lat=Quantity(0, "deg"),
-    ...                                              distance=Quantity(3, "kpc"))
+    >>> vec = cx.LonLatSphericalPos.from_(lon=Quantity(365, "deg"),
+    ...                                   lat=Quantity(0, "deg"),
+    ...                                   distance=Quantity(3, "kpc"))
     >>> vec.lon
     Quantity['angle'](Array(5., dtype=float32), unit='deg')
 
     """
     # 1) Convert the inputs
-    fields = LonLatSphericalPosition.__dataclass_fields__
+    fields = LonLatSphericalPos.__dataclass_fields__
     lon = fields["lon"].metadata["converter"](lon)
     lat = fields["lat"].metadata["converter"](lat)
     distance = fields["distance"].metadata["converter"](distance)
@@ -268,8 +268,8 @@ class LonLatSphericalVelocity(AbstractSphericalVelocity):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[LonLatSphericalPosition]:
-        return LonLatSphericalPosition
+    def integral_cls(cls) -> type[LonLatSphericalPos]:
+        return LonLatSphericalPos
 
     @classproperty
     @classmethod
@@ -298,8 +298,8 @@ class LonCosLatSphericalVelocity(AbstractSphericalVelocity):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[LonLatSphericalPosition]:
-        return LonLatSphericalPosition
+    def integral_cls(cls) -> type[LonLatSphericalPos]:
+        return LonLatSphericalPos
 
     @classproperty
     @classmethod

--- a/src/coordinax/_src/d3/lonlatspherical.py
+++ b/src/coordinax/_src/d3/lonlatspherical.py
@@ -3,7 +3,7 @@
 __all__ = [
     "LonLatSphericalPos",
     "LonLatSphericalVel",
-    "LonLatSphericalAcceleration",
+    "LonLatSphericalAcc",
     "LonCosLatSphericalVel",
 ]
 
@@ -20,7 +20,7 @@ from unxt import AbstractDistance, Distance, Quantity
 
 import coordinax._src.typing as ct
 from .base_spherical import (
-    AbstractSphericalAcceleration,
+    AbstractSphericalAcc,
     AbstractSphericalPos,
     AbstractSphericalVel,
     _90d,
@@ -273,8 +273,8 @@ class LonLatSphericalVel(AbstractSphericalVel):
 
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["LonLatSphericalAcceleration"]:
-        return LonLatSphericalAcceleration
+    def differential_cls(cls) -> type["LonLatSphericalAcc"]:
+        return LonLatSphericalAcc
 
 
 @final
@@ -303,15 +303,15 @@ class LonCosLatSphericalVel(AbstractSphericalVel):
 
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["LonLatSphericalAcceleration"]:
-        return LonLatSphericalAcceleration
+    def differential_cls(cls) -> type["LonLatSphericalAcc"]:
+        return LonLatSphericalAcc
 
 
 ##############################################################################
 
 
 @final
-class LonLatSphericalAcceleration(AbstractSphericalAcceleration):
+class LonLatSphericalAcc(AbstractSphericalAcc):
     """Spherical acceleration representation."""
 
     d2_lon: ct.BatchableAngularAcc = eqx.field(

--- a/src/coordinax/_src/d3/mathspherical.py
+++ b/src/coordinax/_src/d3/mathspherical.py
@@ -3,7 +3,7 @@
 __all__ = [
     "MathSphericalPos",
     "MathSphericalVel",
-    "MathSphericalAcceleration",
+    "MathSphericalAcc",
 ]
 
 from functools import partial
@@ -23,7 +23,7 @@ from unxt import AbstractDistance, AbstractQuantity, Distance, Quantity
 
 import coordinax._src.typing as ct
 from .base_spherical import (
-    AbstractSphericalAcceleration,
+    AbstractSphericalAcc,
     AbstractSphericalPos,
     AbstractSphericalVel,
     _180d,
@@ -255,15 +255,15 @@ class MathSphericalVel(AbstractSphericalVel):
     @override
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["MathSphericalAcceleration"]:
-        return MathSphericalAcceleration
+    def differential_cls(cls) -> type["MathSphericalAcc"]:
+        return MathSphericalAcc
 
 
 ##############################################################################
 
 
 @final
-class MathSphericalAcceleration(AbstractSphericalAcceleration):
+class MathSphericalAcc(AbstractSphericalAcc):
     """Spherical acceleration representation."""
 
     d2_r: ct.BatchableAcc = eqx.field(

--- a/src/coordinax/_src/d3/mathspherical.py
+++ b/src/coordinax/_src/d3/mathspherical.py
@@ -2,7 +2,7 @@
 
 __all__ = [
     "MathSphericalPos",
-    "MathSphericalVelocity",
+    "MathSphericalVel",
     "MathSphericalAcceleration",
 ]
 
@@ -25,7 +25,7 @@ import coordinax._src.typing as ct
 from .base_spherical import (
     AbstractSphericalAcceleration,
     AbstractSphericalPos,
-    AbstractSphericalVelocity,
+    AbstractSphericalVel,
     _180d,
     _360d,
 )
@@ -83,8 +83,8 @@ class MathSphericalPos(AbstractSphericalPos):
     @override
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["MathSphericalVelocity"]:
-        return MathSphericalVelocity
+    def differential_cls(cls) -> type["MathSphericalVel"]:
+        return MathSphericalVel
 
     @partial(eqx.filter_jit, inline=True)
     def norm(self) -> ct.BatchableDistance:
@@ -228,7 +228,7 @@ def _mul_p_vmsph(lhs: ArrayLike, rhs: MathSphericalPos, /) -> MathSphericalPos:
 
 
 @final
-class MathSphericalVelocity(AbstractSphericalVelocity):
+class MathSphericalVel(AbstractSphericalVel):
     """Spherical differential representation."""
 
     d_r: ct.BatchableSpeed = eqx.field(
@@ -284,5 +284,5 @@ class MathSphericalAcceleration(AbstractSphericalAcceleration):
     @override
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[MathSphericalVelocity]:
-        return MathSphericalVelocity
+    def integral_cls(cls) -> type[MathSphericalVel]:
+        return MathSphericalVel

--- a/src/coordinax/_src/d3/mathspherical.py
+++ b/src/coordinax/_src/d3/mathspherical.py
@@ -1,7 +1,7 @@
 """Built-in vector classes."""
 
 __all__ = [
-    "MathSphericalPosition",
+    "MathSphericalPos",
     "MathSphericalVelocity",
     "MathSphericalAcceleration",
 ]
@@ -24,7 +24,7 @@ from unxt import AbstractDistance, AbstractQuantity, Distance, Quantity
 import coordinax._src.typing as ct
 from .base_spherical import (
     AbstractSphericalAcceleration,
-    AbstractSphericalPosition,
+    AbstractSphericalPos,
     AbstractSphericalVelocity,
     _180d,
     _360d,
@@ -39,7 +39,7 @@ from coordinax._src.utils import classproperty
 
 
 @final
-class MathSphericalPosition(AbstractSphericalPosition):
+class MathSphericalPos(AbstractSphericalPos):
     """Spherical vector representation.
 
     .. note::
@@ -94,7 +94,7 @@ class MathSphericalPosition(AbstractSphericalPosition):
         --------
         >>> from unxt import Quantity
         >>> import coordinax as cx
-        >>> s = cx.MathSphericalPosition(r=Quantity(3, "kpc"),
+        >>> s = cx.MathSphericalPos(r=Quantity(3, "kpc"),
         ...                              theta=Quantity(90, "deg"),
         ...                              phi=Quantity(0, "deg"))
         >>> s.norm()
@@ -104,15 +104,15 @@ class MathSphericalPosition(AbstractSphericalPosition):
         return self.r
 
 
-@MathSphericalPosition.from_._f.register  # type: ignore[attr-defined, misc]  # noqa: SLF001
+@MathSphericalPos.from_._f.register  # type: ignore[attr-defined, misc]  # noqa: SLF001
 def from_(
-    cls: type[MathSphericalPosition],
+    cls: type[MathSphericalPos],
     *,
     r: AbstractQuantity,
     theta: AbstractQuantity,
     phi: AbstractQuantity,
-) -> MathSphericalPosition:
-    """Construct MathSphericalPosition, allowing for out-of-range values.
+) -> MathSphericalPos:
+    """Construct MathSphericalPos, allowing for out-of-range values.
 
     Examples
     --------
@@ -121,10 +121,10 @@ def from_(
 
     Let's start with a valid input:
 
-    >>> cx.MathSphericalPosition.from_(r=Quantity(3, "kpc"),
-    ...                                      theta=Quantity(90, "deg"),
-    ...                                      phi=Quantity(0, "deg"))
-    MathSphericalPosition(
+    >>> cx.MathSphericalPos.from_(r=Quantity(3, "kpc"),
+    ...                           theta=Quantity(90, "deg"),
+    ...                           phi=Quantity(0, "deg"))
+    MathSphericalPos(
       r=Distance(value=f32[], unit=Unit("kpc")),
       theta=Quantity[...](value=f32[], unit=Unit("deg")),
       phi=Quantity[...](value=f32[], unit=Unit("deg"))
@@ -133,9 +133,9 @@ def from_(
     The radial distance can be negative, which wraps the azimuthal angle by 180
     degrees and flips the polar angle:
 
-    >>> vec = cx.MathSphericalPosition.from_(r=Quantity(-3, "kpc"),
-    ...                                            theta=Quantity(100, "deg"),
-    ...                                            phi=Quantity(45, "deg"))
+    >>> vec = cx.MathSphericalPos.from_(r=Quantity(-3, "kpc"),
+    ...                                 theta=Quantity(100, "deg"),
+    ...                                 phi=Quantity(45, "deg"))
     >>> vec.r
     Distance(Array(3., dtype=float32), unit='kpc')
     >>> vec.theta
@@ -146,9 +146,9 @@ def from_(
     The polar angle can be outside the [0, 180] deg range, causing the azimuthal
     angle to be shifted by 180 degrees:
 
-    >>> vec = cx.MathSphericalPosition.from_(r=Quantity(3, "kpc"),
-    ...                                            theta=Quantity(0, "deg"),
-    ...                                            phi=Quantity(190, "deg"))
+    >>> vec = cx.MathSphericalPos.from_(r=Quantity(3, "kpc"),
+    ...                                 theta=Quantity(0, "deg"),
+    ...                                 phi=Quantity(190, "deg"))
     >>> vec.r
     Distance(Array(3., dtype=float32), unit='kpc')
     >>> vec.theta
@@ -159,15 +159,15 @@ def from_(
     The azimuth can be outside the [0, 360) deg range. This is wrapped to the
     [0, 360) deg range (actually the base constructor does this):
 
-    >>> vec = cx.MathSphericalPosition.from_(r=Quantity(3, "kpc"),
-    ...                                            theta=Quantity(365, "deg"),
-    ...                                            phi=Quantity(90, "deg"))
+    >>> vec = cx.MathSphericalPos.from_(r=Quantity(3, "kpc"),
+    ...                                 theta=Quantity(365, "deg"),
+    ...                                 phi=Quantity(90, "deg"))
     >>> vec.theta
     Quantity['angle'](Array(5., dtype=float32), unit='deg')
 
     """
     # 1) Convert the inputs
-    fields = MathSphericalPosition.__dataclass_fields__
+    fields = MathSphericalPos.__dataclass_fields__
     r = fields["r"].metadata["converter"](r)
     theta = fields["theta"].metadata["converter"](theta)
     phi = fields["phi"].metadata["converter"](phi)
@@ -189,9 +189,7 @@ def from_(
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_p_vmsph(
-    lhs: ArrayLike, rhs: MathSphericalPosition, /
-) -> MathSphericalPosition:
+def _mul_p_vmsph(lhs: ArrayLike, rhs: MathSphericalPos, /) -> MathSphericalPos:
     """Scale the polar position by a scalar.
 
     Examples
@@ -200,16 +198,16 @@ def _mul_p_vmsph(
     >>> import coordinax as cx
     >>> import quaxed.numpy as jnp
 
-    >>> v = cx.MathSphericalPosition(r=Quantity(3, "kpc"),
-    ...                              theta=Quantity(90, "deg"),
-    ...                              phi=Quantity(0, "deg"))
+    >>> v = cx.MathSphericalPos(r=Quantity(3, "kpc"),
+    ...                         theta=Quantity(90, "deg"),
+    ...                         phi=Quantity(0, "deg"))
 
     >>> jnp.linalg.vector_norm(v, axis=-1)
     Quantity['length'](Array(3., dtype=float32), unit='kpc')
 
     >>> nv = jnp.multiply(2, v)
     >>> nv
-    MathSphericalPosition(
+    MathSphericalPos(
       r=Distance(value=f32[], unit=Unit("kpc")),
       theta=Quantity[...](value=f32[], unit=Unit("deg")),
       phi=Quantity[...](value=f32[], unit=Unit("deg"))
@@ -251,8 +249,8 @@ class MathSphericalVelocity(AbstractSphericalVelocity):
     @override
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[MathSphericalPosition]:
-        return MathSphericalPosition
+    def integral_cls(cls) -> type[MathSphericalPos]:
+        return MathSphericalPos
 
     @override
     @classproperty

--- a/src/coordinax/_src/d3/spherical.py
+++ b/src/coordinax/_src/d3/spherical.py
@@ -1,11 +1,6 @@
 """Built-in vector classes."""
 
-__all__ = [
-    # Physics conventions
-    "SphericalPosition",
-    "SphericalVelocity",
-    "SphericalAcceleration",
-]
+__all__ = ["SphericalPos", "SphericalVelocity", "SphericalAcceleration"]
 
 from functools import partial
 from typing import final
@@ -20,7 +15,7 @@ from unxt import AbstractDistance, AbstractQuantity, Distance, Quantity
 import coordinax._src.typing as ct
 from .base_spherical import (
     AbstractSphericalAcceleration,
-    AbstractSphericalPosition,
+    AbstractSphericalPos,
     AbstractSphericalVelocity,
     _180d,
     _360d,
@@ -34,12 +29,12 @@ from coordinax._src.converters import converter_azimuth_to_range
 from coordinax._src.utils import classproperty
 
 ##############################################################################
-# Position
+# Pos
 
 
-# TODO: make this an alias for SphericalPolarPosition, the more correct description?
+# TODO: make this an alias for SphericalPolarPos, the more correct description?
 @final
-class SphericalPosition(AbstractSphericalPosition):
+class SphericalPos(AbstractSphericalPos):
     """Spherical-Polar coordinates.
 
     .. note::
@@ -86,15 +81,15 @@ class SphericalPosition(AbstractSphericalPosition):
         return SphericalVelocity
 
 
-@SphericalPosition.from_._f.register  # type: ignore[attr-defined, misc]  # noqa: SLF001
+@SphericalPos.from_._f.register  # type: ignore[attr-defined, misc]  # noqa: SLF001
 def from_(
-    cls: type[SphericalPosition],
+    cls: type[SphericalPos],
     *,
     r: AbstractQuantity,
     theta: AbstractQuantity,
     phi: AbstractQuantity,
-) -> SphericalPosition:
-    """Construct SphericalPosition, allowing for out-of-range values.
+) -> SphericalPos:
+    """Construct SphericalPos, allowing for out-of-range values.
 
     Examples
     --------
@@ -103,10 +98,10 @@ def from_(
 
     Let's start with a valid input:
 
-    >>> cx.SphericalPosition.from_(r=Quantity(3, "kpc"),
-    ...                                 theta=Quantity(90, "deg"),
-    ...                                 phi=Quantity(0, "deg"))
-    SphericalPosition(
+    >>> cx.SphericalPos.from_(r=Quantity(3, "kpc"),
+    ...                       theta=Quantity(90, "deg"),
+    ...                       phi=Quantity(0, "deg"))
+    SphericalPos(
       r=Distance(value=f32[], unit=Unit("kpc")),
       theta=Quantity[...](value=f32[], unit=Unit("deg")),
       phi=Quantity[...](value=f32[], unit=Unit("deg"))
@@ -115,9 +110,9 @@ def from_(
     The radial distance can be negative, which wraps the azimuthal angle by 180
     degrees and flips the polar angle:
 
-    >>> vec = cx.SphericalPosition.from_(r=Quantity(-3, "kpc"),
-    ...                                        theta=Quantity(45, "deg"),
-    ...                                        phi=Quantity(0, "deg"))
+    >>> vec = cx.SphericalPos.from_(r=Quantity(-3, "kpc"),
+    ...                             theta=Quantity(45, "deg"),
+    ...                             phi=Quantity(0, "deg"))
     >>> vec.r
     Distance(Array(3., dtype=float32), unit='kpc')
     >>> vec.theta
@@ -128,9 +123,9 @@ def from_(
     The polar angle can be outside the [0, 180] deg range, causing the azimuthal
     angle to be shifted by 180 degrees:
 
-    >>> vec = cx.SphericalPosition.from_(r=Quantity(3, "kpc"),
-    ...                                        theta=Quantity(190, "deg"),
-    ...                                        phi=Quantity(0, "deg"))
+    >>> vec = cx.SphericalPos.from_(r=Quantity(3, "kpc"),
+    ...                             theta=Quantity(190, "deg"),
+    ...                             phi=Quantity(0, "deg"))
     >>> vec.r
     Distance(Array(3., dtype=float32), unit='kpc')
     >>> vec.theta
@@ -141,15 +136,15 @@ def from_(
     The azimuth can be outside the [0, 360) deg range. This is wrapped to the
     [0, 360) deg range (actually the base from_ does this):
 
-    >>> vec = cx.SphericalPosition.from_(r=Quantity(3, "kpc"),
-    ...                                        theta=Quantity(90, "deg"),
-    ...                                        phi=Quantity(365, "deg"))
+    >>> vec = cx.SphericalPos.from_(r=Quantity(3, "kpc"),
+    ...                             theta=Quantity(90, "deg"),
+    ...                             phi=Quantity(365, "deg"))
     >>> vec.phi
     Quantity['angle'](Array(5., dtype=float32), unit='deg')
 
     """
     # 1) Convert the inputs
-    fields = SphericalPosition.__dataclass_fields__
+    fields = SphericalPos.__dataclass_fields__
     r = fields["r"].metadata["converter"](r)
     theta = fields["theta"].metadata["converter"](theta)
     phi = fields["phi"].metadata["converter"](phi)
@@ -194,8 +189,8 @@ class SphericalVelocity(AbstractSphericalVelocity):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[SphericalPosition]:
-        return SphericalPosition
+    def integral_cls(cls) -> type[SphericalPos]:
+        return SphericalPos
 
     @classproperty
     @classmethod

--- a/src/coordinax/_src/d3/spherical.py
+++ b/src/coordinax/_src/d3/spherical.py
@@ -1,6 +1,6 @@
 """Built-in vector classes."""
 
-__all__ = ["SphericalPos", "SphericalVelocity", "SphericalAcceleration"]
+__all__ = ["SphericalPos", "SphericalVel", "SphericalAcceleration"]
 
 from functools import partial
 from typing import final
@@ -16,7 +16,7 @@ import coordinax._src.typing as ct
 from .base_spherical import (
     AbstractSphericalAcceleration,
     AbstractSphericalPos,
-    AbstractSphericalVelocity,
+    AbstractSphericalVel,
     _180d,
     _360d,
 )
@@ -77,8 +77,8 @@ class SphericalPos(AbstractSphericalPos):
 
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["SphericalVelocity"]:
-        return SphericalVelocity
+    def differential_cls(cls) -> type["SphericalVel"]:
+        return SphericalVel
 
 
 @SphericalPos.from_._f.register  # type: ignore[attr-defined, misc]  # noqa: SLF001
@@ -169,7 +169,7 @@ def from_(
 
 
 @final
-class SphericalVelocity(AbstractSphericalVelocity):
+class SphericalVel(AbstractSphericalVel):
     """Spherical differential representation."""
 
     d_r: ct.BatchableSpeed = eqx.field(
@@ -222,5 +222,5 @@ class SphericalAcceleration(AbstractSphericalAcceleration):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[SphericalVelocity]:
-        return SphericalVelocity
+    def integral_cls(cls) -> type[SphericalVel]:
+        return SphericalVel

--- a/src/coordinax/_src/d3/spherical.py
+++ b/src/coordinax/_src/d3/spherical.py
@@ -29,7 +29,7 @@ from coordinax._src.converters import converter_azimuth_to_range
 from coordinax._src.utils import classproperty
 
 ##############################################################################
-# Pos
+# Position
 
 
 # TODO: make this an alias for SphericalPolarPos, the more correct description?

--- a/src/coordinax/_src/d3/spherical.py
+++ b/src/coordinax/_src/d3/spherical.py
@@ -1,6 +1,6 @@
 """Built-in vector classes."""
 
-__all__ = ["SphericalPos", "SphericalVel", "SphericalAcceleration"]
+__all__ = ["SphericalPos", "SphericalVel", "SphericalAcc"]
 
 from functools import partial
 from typing import final
@@ -14,7 +14,7 @@ from unxt import AbstractDistance, AbstractQuantity, Distance, Quantity
 
 import coordinax._src.typing as ct
 from .base_spherical import (
-    AbstractSphericalAcceleration,
+    AbstractSphericalAcc,
     AbstractSphericalPos,
     AbstractSphericalVel,
     _180d,
@@ -194,15 +194,15 @@ class SphericalVel(AbstractSphericalVel):
 
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["SphericalAcceleration"]:
-        return SphericalAcceleration
+    def differential_cls(cls) -> type["SphericalAcc"]:
+        return SphericalAcc
 
 
 ##############################################################################
 
 
 @final
-class SphericalAcceleration(AbstractSphericalAcceleration):
+class SphericalAcc(AbstractSphericalAcc):
     """Spherical differential representation."""
 
     d2_r: ct.BatchableAcc = eqx.field(

--- a/src/coordinax/_src/d3/transform.py
+++ b/src/coordinax/_src/d3/transform.py
@@ -11,7 +11,7 @@ from unxt import Quantity
 
 from .base import AbstractPos3D, AbstractVel3D
 from .base_spherical import AbstractSphericalPos
-from .cartesian import CartesianAcceleration3D, CartesianPos3D, CartesianVel3D
+from .cartesian import CartesianAcc3D, CartesianPos3D, CartesianVel3D
 from .cylindrical import CylindricalPos, CylindricalVel
 from .lonlatspherical import (
     LonCosLatSphericalVel,
@@ -717,14 +717,14 @@ def represent_as(
 
 
 # =============================================================================
-# CartesianAcceleration3D
+# CartesianAcc3D
 
 
 @dispatch
 def represent_as(
-    current: CartesianAcceleration3D, target: type[CartesianAcceleration3D], /
-) -> CartesianAcceleration3D:
-    """CartesianAcceleration3D -> CartesianAcceleration3D with no position.
+    current: CartesianAcc3D, target: type[CartesianAcc3D], /
+) -> CartesianAcc3D:
+    """CartesianAcc3D -> CartesianAcc3D with no position.
 
     Cartesian coordinates are an affine coordinate system and so the
     transformation of an n-th order derivative vector in this system do not
@@ -736,8 +736,8 @@ def represent_as(
     Examples
     --------
     >>> import coordinax as cx
-    >>> a = cx.CartesianAcceleration3D.from_([1, 1, 1], "m/s2")
-    >>> cx.represent_as(a, cx.CartesianAcceleration3D) is a
+    >>> a = cx.CartesianAcc3D.from_([1, 1, 1], "m/s2")
+    >>> cx.represent_as(a, cx.CartesianAcc3D) is a
     True
 
     """

--- a/src/coordinax/_src/d3/transform.py
+++ b/src/coordinax/_src/d3/transform.py
@@ -9,17 +9,17 @@ from plum import dispatch
 import quaxed.numpy as xp
 from unxt import Quantity
 
-from .base import AbstractPos3D, AbstractVelocity3D
+from .base import AbstractPos3D, AbstractVel3D
 from .base_spherical import AbstractSphericalPos
-from .cartesian import CartesianAcceleration3D, CartesianPos3D, CartesianVelocity3D
-from .cylindrical import CylindricalPos, CylindricalVelocity
+from .cartesian import CartesianAcceleration3D, CartesianPos3D, CartesianVel3D
+from .cylindrical import CylindricalPos, CylindricalVel
 from .lonlatspherical import (
-    LonCosLatSphericalVelocity,
+    LonCosLatSphericalVel,
     LonLatSphericalPos,
-    LonLatSphericalVelocity,
+    LonLatSphericalVel,
 )
-from .mathspherical import MathSphericalPos, MathSphericalVelocity
-from .spherical import SphericalPos, SphericalVelocity
+from .mathspherical import MathSphericalPos, MathSphericalVel
+from .spherical import SphericalPos, SphericalVel
 from coordinax._src.base import AbstractPos
 
 ###############################################################################
@@ -90,24 +90,24 @@ def represent_as(
 
 
 @dispatch.multi(
-    (CartesianVelocity3D, type[CartesianVelocity3D], AbstractPos),
-    (CylindricalVelocity, type[CylindricalVelocity], AbstractPos),
-    (SphericalVelocity, type[SphericalVelocity], AbstractPos),
-    (LonLatSphericalVelocity, type[LonLatSphericalVelocity], AbstractPos),
+    (CartesianVel3D, type[CartesianVel3D], AbstractPos),
+    (CylindricalVel, type[CylindricalVel], AbstractPos),
+    (SphericalVel, type[SphericalVel], AbstractPos),
+    (LonLatSphericalVel, type[LonLatSphericalVel], AbstractPos),
     (
-        LonCosLatSphericalVelocity,
-        type[LonCosLatSphericalVelocity],
+        LonCosLatSphericalVel,
+        type[LonCosLatSphericalVel],
         AbstractPos,
     ),
-    (MathSphericalVelocity, type[MathSphericalVelocity], AbstractPos),
+    (MathSphericalVel, type[MathSphericalVel], AbstractPos),
 )
 def represent_as(
-    current: AbstractVelocity3D,
-    target: type[AbstractVelocity3D],
+    current: AbstractVel3D,
+    target: type[AbstractVel3D],
     position: AbstractPos,
     /,
     **kwargs: Any,
-) -> AbstractVelocity3D:
+) -> AbstractVel3D:
     """Self transforms for 3D velocity.
 
     Examples
@@ -122,48 +122,48 @@ def represent_as(
 
     Cartesian to Cartesian velocity:
 
-    >>> dif = cx.CartesianVelocity3D.from_([1, 2, 3], "km/s")
-    >>> cx.represent_as(dif, cx.CartesianVelocity3D, vec) is dif
+    >>> dif = cx.CartesianVel3D.from_([1, 2, 3], "km/s")
+    >>> cx.represent_as(dif, cx.CartesianVel3D, vec) is dif
     True
 
     Cylindrical to Cylindrical velocity:
 
-    >>> dif = cx.CylindricalVelocity(d_rho=Quantity(1, "km/s"),
-    ...                              d_phi=Quantity(2, "mas/yr"),
-    ...                              d_z=Quantity(3, "km/s"))
-    >>> cx.represent_as(dif, cx.CylindricalVelocity, vec) is dif
+    >>> dif = cx.CylindricalVel(d_rho=Quantity(1, "km/s"),
+    ...                         d_phi=Quantity(2, "mas/yr"),
+    ...                         d_z=Quantity(3, "km/s"))
+    >>> cx.represent_as(dif, cx.CylindricalVel, vec) is dif
     True
 
     Spherical to Spherical velocity:
 
-    >>> dif = cx.SphericalVelocity(d_r=Quantity(1, "km/s"),
-    ...                            d_theta=Quantity(2, "mas/yr"),
-    ...                            d_phi=Quantity(3, "mas/yr"))
-    >>> cx.represent_as(dif, cx.SphericalVelocity, vec) is dif
+    >>> dif = cx.SphericalVel(d_r=Quantity(1, "km/s"),
+    ...                       d_theta=Quantity(2, "mas/yr"),
+    ...                       d_phi=Quantity(3, "mas/yr"))
+    >>> cx.represent_as(dif, cx.SphericalVel, vec) is dif
     True
 
     LonLatSpherical to LonLatSpherical velocity:
 
-    >>> dif = cx.LonLatSphericalVelocity(d_lon=Quantity(1, "mas/yr"),
-    ...                                  d_lat=Quantity(2, "mas/yr"),
-    ...                                  d_distance=Quantity(3, "km/s"))
-    >>> cx.represent_as(dif, cx.LonLatSphericalVelocity, vec) is dif
+    >>> dif = cx.LonLatSphericalVel(d_lon=Quantity(1, "mas/yr"),
+    ...                             d_lat=Quantity(2, "mas/yr"),
+    ...                             d_distance=Quantity(3, "km/s"))
+    >>> cx.represent_as(dif, cx.LonLatSphericalVel, vec) is dif
     True
 
     LonCosLatSpherical to LonCosLatSpherical velocity:
 
-    >>> dif = cx.LonCosLatSphericalVelocity(d_lon_coslat=Quantity(1, "mas/yr"),
-    ...                                     d_lat=Quantity(2, "mas/yr"),
-    ...                                     d_distance=Quantity(3, "km/s"))
-    >>> cx.represent_as(dif, cx.LonCosLatSphericalVelocity, vec) is dif
+    >>> dif = cx.LonCosLatSphericalVel(d_lon_coslat=Quantity(1, "mas/yr"),
+    ...                                d_lat=Quantity(2, "mas/yr"),
+    ...                                d_distance=Quantity(3, "km/s"))
+    >>> cx.represent_as(dif, cx.LonCosLatSphericalVel, vec) is dif
     True
 
     MathSpherical to MathSpherical velocity:
 
-    >>> dif = cx.MathSphericalVelocity(d_r=Quantity(1, "km/s"),
-    ...                                d_theta=Quantity(2, "mas/yr"),
-    ...                                d_phi=Quantity(3, "mas/yr"))
-    >>> cx.represent_as(dif, cx.MathSphericalVelocity, vec) is dif
+    >>> dif = cx.MathSphericalVel(d_r=Quantity(1, "km/s"),
+    ...                           d_theta=Quantity(2, "mas/yr"),
+    ...                           d_phi=Quantity(3, "mas/yr"))
+    >>> cx.represent_as(dif, cx.MathSphericalVel, vec) is dif
     True
 
     """
@@ -579,18 +579,18 @@ def represent_as(
 
 
 # =============================================================================
-# LonLatSphericalVelocity
+# LonLatSphericalVel
 
 
 @dispatch
 def represent_as(
-    current: AbstractVelocity3D,
-    target: type[LonCosLatSphericalVelocity],
+    current: AbstractVel3D,
+    target: type[LonCosLatSphericalVel],
     position: AbstractPos | Quantity["length"],
     /,
     **kwargs: Any,
-) -> LonCosLatSphericalVelocity:
-    """AbstractVelocity3D -> LonCosLatSphericalVelocity.
+) -> LonCosLatSphericalVel:
+    """AbstractVel3D -> LonCosLatSphericalVel.
 
     Examples
     --------
@@ -601,12 +601,12 @@ def represent_as(
     >>> vec = cx.LonLatSphericalPos(lon=Quantity(15, "deg"),
     ...                             lat=Quantity(10, "deg"),
     ...                             distance=Quantity(1.5, "kpc"))
-    >>> dif = cx.LonLatSphericalVelocity(d_lon=Quantity(7, "mas/yr"),
-    ...                                  d_lat=Quantity(0, "deg/Gyr"),
-    ...                                  d_distance=Quantity(-5, "km/s"))
-    >>> newdif = cx.represent_as(dif, cx.LonCosLatSphericalVelocity, vec)
+    >>> dif = cx.LonLatSphericalVel(d_lon=Quantity(7, "mas/yr"),
+    ...                             d_lat=Quantity(0, "deg/Gyr"),
+    ...                             d_distance=Quantity(-5, "km/s"))
+    >>> newdif = cx.represent_as(dif, cx.LonCosLatSphericalVel, vec)
     >>> newdif
-    LonCosLatSphericalVelocity(
+    LonCosLatSphericalVel(
       d_lon_coslat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
       d_lat=Quantity[...]( value=f32[], unit=Unit("deg / Gyr") ),
       d_distance=Quantity[...]( value=f32[], unit=Unit("km / s") )
@@ -624,8 +624,8 @@ def represent_as(
             position
         )
 
-    # Transform the differential to LonLatSphericalVelocity
-    current = represent_as(current, LonLatSphericalVelocity, posvec)
+    # Transform the differential to LonLatSphericalVel
+    current = represent_as(current, LonLatSphericalVel, posvec)
 
     # Transform the position to the required type
     posvec = represent_as(posvec, current.integral_cls)
@@ -640,13 +640,13 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: LonCosLatSphericalVelocity,
-    target: type[LonLatSphericalVelocity],
+    current: LonCosLatSphericalVel,
+    target: type[LonLatSphericalVel],
     position: AbstractPos | Quantity["length"],
     /,
     **kwargs: Any,
-) -> LonLatSphericalVelocity:
-    """LonCosLatSphericalVelocity -> LonLatSphericalVelocity."""
+) -> LonLatSphericalVel:
+    """LonCosLatSphericalVel -> LonLatSphericalVel."""
     # Parse the position to an AbstractPos
     if isinstance(position, AbstractPos):
         posvec = position
@@ -668,13 +668,13 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: LonCosLatSphericalVelocity,
-    target: type[AbstractVelocity3D],
+    current: LonCosLatSphericalVel,
+    target: type[AbstractVel3D],
     position: AbstractPos | Quantity["length"],
     /,
     **kwargs: Any,
-) -> AbstractVelocity3D:
-    """LonCosLatSphericalVelocity -> AbstractVelocity3D."""
+) -> AbstractVel3D:
+    """LonCosLatSphericalVel -> AbstractVel3D."""
     # Parse the position to an AbstractPos
     if isinstance(position, AbstractPos):
         posvec = position
@@ -682,21 +682,21 @@ def represent_as(
         posvec = current.integral_cls._cartesian_cls.from_(  # noqa: SLF001
             position
         )
-    # Transform the differential to LonLatSphericalVelocity
-    current = represent_as(current, LonLatSphericalVelocity, posvec)
+    # Transform the differential to LonLatSphericalVel
+    current = represent_as(current, LonLatSphericalVel, posvec)
     # Transform the position to the required type
     return represent_as(current, target, posvec)
 
 
 # =============================================================================
-# CartesianVelocity3D
+# CartesianVel3D
 
 
 @dispatch
 def represent_as(
-    current: CartesianVelocity3D, target: type[CartesianVelocity3D], /
-) -> CartesianVelocity3D:
-    """CartesianVelocity3D -> CartesianVelocity3D with no position.
+    current: CartesianVel3D, target: type[CartesianVel3D], /
+) -> CartesianVel3D:
+    """CartesianVel3D -> CartesianVel3D with no position.
 
     Cartesian coordinates are an affine coordinate system and so the
     transformation of an n-th order derivative vector in this system do not
@@ -708,8 +708,8 @@ def represent_as(
     Examples
     --------
     >>> import coordinax as cx
-    >>> v = cx.CartesianVelocity3D.from_([1, 1, 1], "m/s")
-    >>> cx.represent_as(v, cx.CartesianVelocity3D) is v
+    >>> v = cx.CartesianVel3D.from_([1, 1, 1], "m/s")
+    >>> cx.represent_as(v, cx.CartesianVel3D) is v
     True
 
     """

--- a/src/coordinax/_src/d3/transform.py
+++ b/src/coordinax/_src/d3/transform.py
@@ -9,18 +9,18 @@ from plum import dispatch
 import quaxed.numpy as xp
 from unxt import Quantity
 
-from .base import AbstractPosition3D, AbstractVelocity3D
-from .base_spherical import AbstractSphericalPosition
-from .cartesian import CartesianAcceleration3D, CartesianPosition3D, CartesianVelocity3D
-from .cylindrical import CylindricalPosition, CylindricalVelocity
+from .base import AbstractPos3D, AbstractVelocity3D
+from .base_spherical import AbstractSphericalPos
+from .cartesian import CartesianAcceleration3D, CartesianPos3D, CartesianVelocity3D
+from .cylindrical import CylindricalPos, CylindricalVelocity
 from .lonlatspherical import (
     LonCosLatSphericalVelocity,
-    LonLatSphericalPosition,
+    LonLatSphericalPos,
     LonLatSphericalVelocity,
 )
-from .mathspherical import MathSphericalPosition, MathSphericalVelocity
-from .spherical import SphericalPosition, SphericalVelocity
-from coordinax._src.base import AbstractPosition
+from .mathspherical import MathSphericalPos, MathSphericalVelocity
+from .spherical import SphericalPos, SphericalVelocity
+from coordinax._src.base import AbstractPos
 
 ###############################################################################
 # 3D
@@ -28,22 +28,22 @@ from coordinax._src.base import AbstractPosition
 
 @dispatch
 def represent_as(
-    current: AbstractPosition3D, target: type[AbstractPosition3D], /, **kwargs: Any
-) -> AbstractPosition3D:
-    """AbstractPosition3D -> Cartesian3D -> AbstractPosition3D."""
-    return represent_as(represent_as(current, CartesianPosition3D), target)
+    current: AbstractPos3D, target: type[AbstractPos3D], /, **kwargs: Any
+) -> AbstractPos3D:
+    """AbstractPos3D -> Cartesian3D -> AbstractPos3D."""
+    return represent_as(represent_as(current, CartesianPos3D), target)
 
 
 @dispatch.multi(
-    (CartesianPosition3D, type[CartesianPosition3D]),
-    (CylindricalPosition, type[CylindricalPosition]),
-    (SphericalPosition, type[SphericalPosition]),
-    (LonLatSphericalPosition, type[LonLatSphericalPosition]),
-    (MathSphericalPosition, type[MathSphericalPosition]),
+    (CartesianPos3D, type[CartesianPos3D]),
+    (CylindricalPos, type[CylindricalPos]),
+    (SphericalPos, type[SphericalPos]),
+    (LonLatSphericalPos, type[LonLatSphericalPos]),
+    (MathSphericalPos, type[MathSphericalPos]),
 )
 def represent_as(
-    current: AbstractPosition3D, target: type[AbstractPosition3D], /, **kwargs: Any
-) -> AbstractPosition3D:
+    current: AbstractPos3D, target: type[AbstractPos3D], /, **kwargs: Any
+) -> AbstractPos3D:
     """Self transforms for 3D vectors.
 
     Examples
@@ -53,36 +53,36 @@ def represent_as(
 
     Cartesian to Cartesian:
 
-    >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "kpc")
-    >>> cx.represent_as(vec, cx.CartesianPosition3D) is vec
+    >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
+    >>> cx.represent_as(vec, cx.CartesianPos3D) is vec
     True
 
     Cylindrical to Cylindrical:
 
-    >>> vec = cx.CylindricalPosition(rho=Quantity(1, "kpc"), phi=Quantity(2, "deg"),
-    ...                            z=Quantity(3, "kpc"))
-    >>> cx.represent_as(vec, cx.CylindricalPosition) is vec
+    >>> vec = cx.CylindricalPos(rho=Quantity(1, "kpc"), phi=Quantity(2, "deg"),
+    ...                         z=Quantity(3, "kpc"))
+    >>> cx.represent_as(vec, cx.CylindricalPos) is vec
     True
 
     Spherical to Spherical:
 
-    >>> vec = cx.SphericalPosition(r=Quantity(1, "kpc"), theta=Quantity(2, "deg"),
-    ...                          phi=Quantity(3, "deg"))
-    >>> cx.represent_as(vec, cx.SphericalPosition) is vec
+    >>> vec = cx.SphericalPos(r=Quantity(1, "kpc"), theta=Quantity(2, "deg"),
+    ...                       phi=Quantity(3, "deg"))
+    >>> cx.represent_as(vec, cx.SphericalPos) is vec
     True
 
     LonLatSpherical to LonLatSpherical:
 
-    >>> vec = cx.LonLatSphericalPosition(lon=Quantity(1, "deg"), lat=Quantity(2, "deg"),
-    ...                                distance=Quantity(3, "kpc"))
-    >>> cx.represent_as(vec, cx.LonLatSphericalPosition) is vec
+    >>> vec = cx.LonLatSphericalPos(lon=Quantity(1, "deg"), lat=Quantity(2, "deg"),
+    ...                             distance=Quantity(3, "kpc"))
+    >>> cx.represent_as(vec, cx.LonLatSphericalPos) is vec
     True
 
     MathSpherical to MathSpherical:
 
-    >>> vec = cx.MathSphericalPosition(r=Quantity(1, "kpc"), theta=Quantity(2, "deg"),
-    ...                              phi=Quantity(3, "deg"))
-    >>> cx.represent_as(vec, cx.MathSphericalPosition) is vec
+    >>> vec = cx.MathSphericalPos(r=Quantity(1, "kpc"), theta=Quantity(2, "deg"),
+    ...                           phi=Quantity(3, "deg"))
+    >>> cx.represent_as(vec, cx.MathSphericalPos) is vec
     True
 
     """
@@ -90,21 +90,21 @@ def represent_as(
 
 
 @dispatch.multi(
-    (CartesianVelocity3D, type[CartesianVelocity3D], AbstractPosition),
-    (CylindricalVelocity, type[CylindricalVelocity], AbstractPosition),
-    (SphericalVelocity, type[SphericalVelocity], AbstractPosition),
-    (LonLatSphericalVelocity, type[LonLatSphericalVelocity], AbstractPosition),
+    (CartesianVelocity3D, type[CartesianVelocity3D], AbstractPos),
+    (CylindricalVelocity, type[CylindricalVelocity], AbstractPos),
+    (SphericalVelocity, type[SphericalVelocity], AbstractPos),
+    (LonLatSphericalVelocity, type[LonLatSphericalVelocity], AbstractPos),
     (
         LonCosLatSphericalVelocity,
         type[LonCosLatSphericalVelocity],
-        AbstractPosition,
+        AbstractPos,
     ),
-    (MathSphericalVelocity, type[MathSphericalVelocity], AbstractPosition),
+    (MathSphericalVelocity, type[MathSphericalVelocity], AbstractPos),
 )
 def represent_as(
     current: AbstractVelocity3D,
     target: type[AbstractVelocity3D],
-    position: AbstractPosition,
+    position: AbstractPos,
     /,
     **kwargs: Any,
 ) -> AbstractVelocity3D:
@@ -118,7 +118,7 @@ def represent_as(
     For these transformations the position does not matter since the
     self-transform returns the velocity unchanged.
 
-    >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "kpc")
+    >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
 
     Cartesian to Cartesian velocity:
 
@@ -129,40 +129,40 @@ def represent_as(
     Cylindrical to Cylindrical velocity:
 
     >>> dif = cx.CylindricalVelocity(d_rho=Quantity(1, "km/s"),
-    ...                                  d_phi=Quantity(2, "mas/yr"),
-    ...                                  d_z=Quantity(3, "km/s"))
+    ...                              d_phi=Quantity(2, "mas/yr"),
+    ...                              d_z=Quantity(3, "km/s"))
     >>> cx.represent_as(dif, cx.CylindricalVelocity, vec) is dif
     True
 
     Spherical to Spherical velocity:
 
     >>> dif = cx.SphericalVelocity(d_r=Quantity(1, "km/s"),
-    ...                                d_theta=Quantity(2, "mas/yr"),
-    ...                                d_phi=Quantity(3, "mas/yr"))
+    ...                            d_theta=Quantity(2, "mas/yr"),
+    ...                            d_phi=Quantity(3, "mas/yr"))
     >>> cx.represent_as(dif, cx.SphericalVelocity, vec) is dif
     True
 
     LonLatSpherical to LonLatSpherical velocity:
 
     >>> dif = cx.LonLatSphericalVelocity(d_lon=Quantity(1, "mas/yr"),
-    ...                                      d_lat=Quantity(2, "mas/yr"),
-    ...                                      d_distance=Quantity(3, "km/s"))
+    ...                                  d_lat=Quantity(2, "mas/yr"),
+    ...                                  d_distance=Quantity(3, "km/s"))
     >>> cx.represent_as(dif, cx.LonLatSphericalVelocity, vec) is dif
     True
 
     LonCosLatSpherical to LonCosLatSpherical velocity:
 
     >>> dif = cx.LonCosLatSphericalVelocity(d_lon_coslat=Quantity(1, "mas/yr"),
-    ...                                         d_lat=Quantity(2, "mas/yr"),
-    ...                                         d_distance=Quantity(3, "km/s"))
+    ...                                     d_lat=Quantity(2, "mas/yr"),
+    ...                                     d_distance=Quantity(3, "km/s"))
     >>> cx.represent_as(dif, cx.LonCosLatSphericalVelocity, vec) is dif
     True
 
     MathSpherical to MathSpherical velocity:
 
     >>> dif = cx.MathSphericalVelocity(d_r=Quantity(1, "km/s"),
-    ...                                    d_theta=Quantity(2, "mas/yr"),
-    ...                                    d_phi=Quantity(3, "mas/yr"))
+    ...                                d_theta=Quantity(2, "mas/yr"),
+    ...                                d_phi=Quantity(3, "mas/yr"))
     >>> cx.represent_as(dif, cx.MathSphericalVelocity, vec) is dif
     True
 
@@ -171,23 +171,23 @@ def represent_as(
 
 
 # =============================================================================
-# CartesianPosition3D
+# CartesianPos3D
 
 
 @dispatch
 def represent_as(
-    current: CartesianPosition3D, target: type[CylindricalPosition], /, **kwargs: Any
-) -> CylindricalPosition:
-    """CartesianPosition3D -> CylindricalPosition.
+    current: CartesianPos3D, target: type[CylindricalPos], /, **kwargs: Any
+) -> CylindricalPos:
+    """CartesianPos3D -> CylindricalPos.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "km")
-    >>> print(cx.represent_as(vec, cx.CylindricalPosition))
-    <CylindricalPosition (rho[km], phi[rad], z[km])
+    >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "km")
+    >>> print(cx.represent_as(vec, cx.CylindricalPos))
+    <CylindricalPos (rho[km], phi[rad], z[km])
         [2.236 1.107 3.   ]>
 
     """
@@ -198,18 +198,18 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CartesianPosition3D, target: type[SphericalPosition], /, **kwargs: Any
-) -> SphericalPosition:
-    """CartesianPosition3D -> SphericalPosition.
+    current: CartesianPos3D, target: type[SphericalPos], /, **kwargs: Any
+) -> SphericalPos:
+    """CartesianPos3D -> SphericalPos.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "km")
-    >>> print(cx.represent_as(vec, cx.SphericalPosition))
-    <SphericalPosition (r[km], theta[rad], phi[rad])
+    >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "km")
+    >>> print(cx.represent_as(vec, cx.SphericalPos))
+    <SphericalPos (r[km], theta[rad], phi[rad])
         [3.742 0.641 1.107]>
 
     """
@@ -220,55 +220,55 @@ def represent_as(
 
 
 @dispatch.multi(
-    (CartesianPosition3D, type[LonLatSphericalPosition]),
-    (CartesianPosition3D, type[MathSphericalPosition]),
+    (CartesianPos3D, type[LonLatSphericalPos]),
+    (CartesianPos3D, type[MathSphericalPos]),
 )
 def represent_as(
-    current: CartesianPosition3D,
-    target: type[AbstractSphericalPosition],
+    current: CartesianPos3D,
+    target: type[AbstractSphericalPos],
     /,
     **kwargs: Any,
-) -> AbstractSphericalPosition:
-    """CartesianPosition3D -> AbstractSphericalPosition.
+) -> AbstractSphericalPos:
+    """CartesianPos3D -> AbstractSphericalPos.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "km")
+    >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "km")
 
-    >>> print(cx.represent_as(vec, cx.LonLatSphericalPosition))
-    <LonLatSphericalPosition (lon[rad], lat[deg], distance[km])
+    >>> print(cx.represent_as(vec, cx.LonLatSphericalPos))
+    <LonLatSphericalPos (lon[rad], lat[deg], distance[km])
         [ 1.107 53.301  3.742]>
 
-    >>> print(cx.represent_as(vec, cx.MathSphericalPosition))
-    <MathSphericalPosition (r[km], theta[rad], phi[rad])
+    >>> print(cx.represent_as(vec, cx.MathSphericalPos))
+    <MathSphericalPos (r[km], theta[rad], phi[rad])
         [3.742 1.107 0.641]>
 
     """
-    return represent_as(represent_as(current, SphericalPosition), target)
+    return represent_as(represent_as(current, SphericalPos), target)
 
 
 # =============================================================================
-# CylindricalPosition
+# CylindricalPos
 
 
 @dispatch
 def represent_as(
-    current: CylindricalPosition, target: type[CartesianPosition3D], /, **kwargs: Any
-) -> CartesianPosition3D:
-    """CylindricalPosition -> CartesianPosition3D.
+    current: CylindricalPos, target: type[CartesianPos3D], /, **kwargs: Any
+) -> CartesianPos3D:
+    """CylindricalPos -> CartesianPos3D.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.CylindricalPosition(rho=Quantity(1., "kpc"), phi=Quantity(90, "deg"),
-    ...                              z=Quantity(1, "kpc"))
-    >>> print(cx.represent_as(vec, cx.CartesianPosition3D))
-    <CartesianPosition3D (x[kpc], y[kpc], z[kpc])
+    >>> vec = cx.CylindricalPos(rho=Quantity(1., "kpc"), phi=Quantity(90, "deg"),
+    ...                         z=Quantity(1, "kpc"))
+    >>> print(cx.represent_as(vec, cx.CartesianPos3D))
+    <CartesianPos3D (x[kpc], y[kpc], z[kpc])
         [-4.371e-08  1.000e+00  1.000e+00]>
 
     """
@@ -280,19 +280,19 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CylindricalPosition, target: type[SphericalPosition], /, **kwargs: Any
-) -> SphericalPosition:
-    """CylindricalPosition -> SphericalPosition.
+    current: CylindricalPos, target: type[SphericalPos], /, **kwargs: Any
+) -> SphericalPos:
+    """CylindricalPos -> SphericalPos.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.CylindricalPosition(rho=Quantity(1., "kpc"), phi=Quantity(90, "deg"),
-    ...                            z=Quantity(1, "kpc"))
-    >>> print(cx.represent_as(vec, cx.SphericalPosition))
-    <SphericalPosition (r[kpc], theta[rad], phi[deg])
+    >>> vec = cx.CylindricalPos(rho=Quantity(1., "kpc"), phi=Quantity(90, "deg"),
+    ...                         z=Quantity(1, "kpc"))
+    >>> print(cx.represent_as(vec, cx.SphericalPos))
+    <SphericalPos (r[kpc], theta[rad], phi[deg])
         [ 1.414  0.785 90.   ]>
 
     """
@@ -302,56 +302,56 @@ def represent_as(
 
 
 @dispatch.multi(
-    (CylindricalPosition, type[LonLatSphericalPosition]),
-    (CylindricalPosition, type[MathSphericalPosition]),
+    (CylindricalPos, type[LonLatSphericalPos]),
+    (CylindricalPos, type[MathSphericalPos]),
 )
 def represent_as(
-    current: CylindricalPosition,
-    target: type[AbstractSphericalPosition],
+    current: CylindricalPos,
+    target: type[AbstractSphericalPos],
     /,
     **kwargs: Any,
-) -> AbstractSphericalPosition:
-    """CylindricalPosition -> AbstractSphericalPosition.
+) -> AbstractSphericalPos:
+    """CylindricalPos -> AbstractSphericalPos.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.CylindricalPosition(rho=Quantity(1., "kpc"), phi=Quantity(90, "deg"),
-    ...                            z=Quantity(1, "kpc"))
+    >>> vec = cx.CylindricalPos(rho=Quantity(1., "kpc"), phi=Quantity(90, "deg"),
+    ...                         z=Quantity(1, "kpc"))
 
-    >>> print(cx.represent_as(vec, cx.LonLatSphericalPosition))
-    <LonLatSphericalPosition (lon[deg], lat[deg], distance[kpc])
+    >>> print(cx.represent_as(vec, cx.LonLatSphericalPos))
+    <LonLatSphericalPos (lon[deg], lat[deg], distance[kpc])
         [90.    45.     1.414]>
 
-    >>> print(cx.represent_as(vec, cx.MathSphericalPosition))
-    <MathSphericalPosition (r[kpc], theta[deg], phi[rad])
+    >>> print(cx.represent_as(vec, cx.MathSphericalPos))
+    <MathSphericalPos (r[kpc], theta[deg], phi[rad])
         [ 1.414 90.     0.785]>
 
     """
-    return represent_as(represent_as(current, SphericalPosition), target)
+    return represent_as(represent_as(current, SphericalPos), target)
 
 
 # =============================================================================
-# SphericalPosition
+# SphericalPos
 
 
 @dispatch
 def represent_as(
-    current: SphericalPosition, target: type[CartesianPosition3D], /, **kwargs: Any
-) -> CartesianPosition3D:
-    """SphericalPosition -> CartesianPosition3D.
+    current: SphericalPos, target: type[CartesianPos3D], /, **kwargs: Any
+) -> CartesianPos3D:
+    """SphericalPos -> CartesianPos3D.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.SphericalPosition(r=Quantity(1., "kpc"), theta=Quantity(90, "deg"),
-    ...                          phi=Quantity(90, "deg"))
-    >>> print(cx.represent_as(vec, cx.CartesianPosition3D))
-    <CartesianPosition3D (x[kpc], y[kpc], z[kpc])
+    >>> vec = cx.SphericalPos(r=Quantity(1., "kpc"), theta=Quantity(90, "deg"),
+    ...                       phi=Quantity(90, "deg"))
+    >>> print(cx.represent_as(vec, cx.CartesianPos3D))
+    <CartesianPos3D (x[kpc], y[kpc], z[kpc])
         [-4.371e-08  1.000e+00 -4.371e-08]>
 
     """
@@ -363,19 +363,19 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: SphericalPosition, target: type[CylindricalPosition], /, **kwargs: Any
-) -> CylindricalPosition:
-    """SphericalPosition -> CylindricalPosition.
+    current: SphericalPos, target: type[CylindricalPos], /, **kwargs: Any
+) -> CylindricalPos:
+    """SphericalPos -> CylindricalPos.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.SphericalPosition(r=Quantity(1., "kpc"), theta=Quantity(90, "deg"),
-    ...                          phi=Quantity(90, "deg"))
-    >>> print(cx.represent_as(vec, cx.CylindricalPosition))
-    <CylindricalPosition (rho[kpc], phi[deg], z[kpc])
+    >>> vec = cx.SphericalPos(r=Quantity(1., "kpc"), theta=Quantity(90, "deg"),
+    ...                       phi=Quantity(90, "deg"))
+    >>> print(cx.represent_as(vec, cx.CylindricalPos))
+    <CylindricalPos (rho[kpc], phi[deg], z[kpc])
         [ 1.000e+00  9.000e+01 -4.371e-08]>
 
     """
@@ -386,19 +386,19 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: SphericalPosition, target: type[LonLatSphericalPosition], /, **kwargs: Any
-) -> LonLatSphericalPosition:
-    """SphericalPosition -> LonLatSphericalPosition.
+    current: SphericalPos, target: type[LonLatSphericalPos], /, **kwargs: Any
+) -> LonLatSphericalPos:
+    """SphericalPos -> LonLatSphericalPos.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.SphericalPosition(r=Quantity(1., "kpc"), theta=Quantity(90, "deg"),
-    ...                          phi=Quantity(90, "deg"))
-    >>> print(cx.represent_as(vec, cx.LonLatSphericalPosition))
-    <LonLatSphericalPosition (lon[deg], lat[deg], distance[kpc])
+    >>> vec = cx.SphericalPos(r=Quantity(1., "kpc"), theta=Quantity(90, "deg"),
+    ...                       phi=Quantity(90, "deg"))
+    >>> print(cx.represent_as(vec, cx.LonLatSphericalPos))
+    <LonLatSphericalPos (lon[deg], lat[deg], distance[kpc])
         [90.  0.  1.]>
 
     """
@@ -409,19 +409,19 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: SphericalPosition, target: type[MathSphericalPosition], /, **kwargs: Any
-) -> MathSphericalPosition:
-    """SphericalPosition -> MathSphericalPosition.
+    current: SphericalPos, target: type[MathSphericalPos], /, **kwargs: Any
+) -> MathSphericalPos:
+    """SphericalPos -> MathSphericalPos.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.SphericalPosition(r=Quantity(1., "kpc"), theta=Quantity(90, "deg"),
-    ...                          phi=Quantity(90, "deg"))
-    >>> print(cx.represent_as(vec, cx.MathSphericalPosition))
-    <MathSphericalPosition (r[kpc], theta[deg], phi[deg])
+    >>> vec = cx.SphericalPos(r=Quantity(1., "kpc"), theta=Quantity(90, "deg"),
+    ...                       phi=Quantity(90, "deg"))
+    >>> print(cx.represent_as(vec, cx.MathSphericalPos))
+    <MathSphericalPos (r[kpc], theta[deg], phi[deg])
         [ 1. 90. 90.]>
 
     """
@@ -429,75 +429,75 @@ def represent_as(
 
 
 # =============================================================================
-# LonLatSphericalPosition
+# LonLatSphericalPos
 
 
 @dispatch
 def represent_as(
-    current: LonLatSphericalPosition,
-    target: type[CartesianPosition3D],
+    current: LonLatSphericalPos,
+    target: type[CartesianPos3D],
     /,
     **kwargs: Any,
-) -> CartesianPosition3D:
-    """LonLatSphericalPosition -> CartesianPosition3D.
+) -> CartesianPos3D:
+    """LonLatSphericalPos -> CartesianPos3D.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.LonLatSphericalPosition(lon=Quantity(90, "deg"),
-    ...                                  lat=Quantity(0, "deg"),
-    ...                                  distance=Quantity(1., "kpc"))
-    >>> print(cx.represent_as(vec, cx.CartesianPosition3D))
-    <CartesianPosition3D (x[kpc], y[kpc], z[kpc])
+    >>> vec = cx.LonLatSphericalPos(lon=Quantity(90, "deg"),
+    ...                             lat=Quantity(0, "deg"),
+    ...                             distance=Quantity(1., "kpc"))
+    >>> print(cx.represent_as(vec, cx.CartesianPos3D))
+    <CartesianPos3D (x[kpc], y[kpc], z[kpc])
         [-4.371e-08  1.000e+00 -4.371e-08]>
 
     """
-    return represent_as(represent_as(current, SphericalPosition), CartesianPosition3D)
+    return represent_as(represent_as(current, SphericalPos), CartesianPos3D)
 
 
 @dispatch
 def represent_as(
-    current: LonLatSphericalPosition,
-    target: type[CylindricalPosition],
+    current: LonLatSphericalPos,
+    target: type[CylindricalPos],
     /,
     **kwargs: Any,
-) -> CylindricalPosition:
-    """LonLatSphericalPosition -> CylindricalPosition.
+) -> CylindricalPos:
+    """LonLatSphericalPos -> CylindricalPos.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.LonLatSphericalPosition(lon=Quantity(90, "deg"),
-    ...                                  lat=Quantity(0, "deg"),
-    ...                                  distance=Quantity(1., "kpc"))
-    >>> print(cx.represent_as(vec, cx.CylindricalPosition))
-    <CylindricalPosition (rho[kpc], phi[deg], z[kpc])
+    >>> vec = cx.LonLatSphericalPos(lon=Quantity(90, "deg"),
+    ...                             lat=Quantity(0, "deg"),
+    ...                             distance=Quantity(1., "kpc"))
+    >>> print(cx.represent_as(vec, cx.CylindricalPos))
+    <CylindricalPos (rho[kpc], phi[deg], z[kpc])
         [ 1.000e+00  9.000e+01 -4.371e-08]>
 
     """
-    return represent_as(represent_as(current, SphericalPosition), target)
+    return represent_as(represent_as(current, SphericalPos), target)
 
 
 @dispatch
 def represent_as(
-    current: LonLatSphericalPosition, target: type[SphericalPosition], /, **kwargs: Any
-) -> SphericalPosition:
-    """LonLatSphericalPosition -> SphericalPosition.
+    current: LonLatSphericalPos, target: type[SphericalPos], /, **kwargs: Any
+) -> SphericalPos:
+    """LonLatSphericalPos -> SphericalPos.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.LonLatSphericalPosition(lon=Quantity(90, "deg"),
-    ...                                  lat=Quantity(0, "deg"),
-    ...                                  distance=Quantity(1., "kpc"))
-    >>> print(cx.represent_as(vec, cx.SphericalPosition))
-    <SphericalPosition (r[kpc], theta[deg], phi[deg])
+    >>> vec = cx.LonLatSphericalPos(lon=Quantity(90, "deg"),
+    ...                             lat=Quantity(0, "deg"),
+    ...                             distance=Quantity(1., "kpc"))
+    >>> print(cx.represent_as(vec, cx.SphericalPos))
+    <SphericalPos (r[kpc], theta[deg], phi[deg])
         [ 1. 90. 90.]>
 
     """
@@ -507,24 +507,24 @@ def represent_as(
 
 
 # =============================================================================
-# MathSphericalPosition
+# MathSphericalPos
 
 
 @dispatch
 def represent_as(
-    current: MathSphericalPosition, target: type[CartesianPosition3D], /, **kwargs: Any
-) -> CartesianPosition3D:
-    """MathSphericalPosition -> CartesianPosition3D.
+    current: MathSphericalPos, target: type[CartesianPos3D], /, **kwargs: Any
+) -> CartesianPos3D:
+    """MathSphericalPos -> CartesianPos3D.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.MathSphericalPosition(r=Quantity(1., "kpc"), theta=Quantity(90, "deg"),
-    ...                              phi=Quantity(90, "deg"))
-    >>> print(cx.represent_as(vec, cx.CartesianPosition3D))
-    <CartesianPosition3D (x[kpc], y[kpc], z[kpc])
+    >>> vec = cx.MathSphericalPos(r=Quantity(1., "kpc"), theta=Quantity(90, "deg"),
+    ...                           phi=Quantity(90, "deg"))
+    >>> print(cx.represent_as(vec, cx.CartesianPos3D))
+    <CartesianPos3D (x[kpc], y[kpc], z[kpc])
         [-4.371e-08  1.000e+00 -4.371e-08]>
 
     """
@@ -536,19 +536,19 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: MathSphericalPosition, target: type[CylindricalPosition], /, **kwargs: Any
-) -> CylindricalPosition:
-    """MathSphericalPosition -> CylindricalPosition.
+    current: MathSphericalPos, target: type[CylindricalPos], /, **kwargs: Any
+) -> CylindricalPos:
+    """MathSphericalPos -> CylindricalPos.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.MathSphericalPosition(r=Quantity(1., "kpc"), theta=Quantity(90, "deg"),
-    ...                              phi=Quantity(90, "deg"))
-    >>> print(cx.represent_as(vec, cx.CylindricalPosition))
-    <CylindricalPosition (rho[kpc], phi[deg], z[kpc])
+    >>> vec = cx.MathSphericalPos(r=Quantity(1., "kpc"), theta=Quantity(90, "deg"),
+    ...                           phi=Quantity(90, "deg"))
+    >>> print(cx.represent_as(vec, cx.CylindricalPos))
+    <CylindricalPos (rho[kpc], phi[deg], z[kpc])
         [ 1.000e+00  9.000e+01 -4.371e-08]>
 
     """
@@ -559,19 +559,19 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: MathSphericalPosition, target: type[SphericalPosition], /, **kwargs: Any
-) -> SphericalPosition:
-    """MathSphericalPosition -> SphericalPosition.
+    current: MathSphericalPos, target: type[SphericalPos], /, **kwargs: Any
+) -> SphericalPos:
+    """MathSphericalPos -> SphericalPos.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.MathSphericalPosition(r=Quantity(1., "kpc"), theta=Quantity(90, "deg"),
-    ...                              phi=Quantity(90, "deg"))
-    >>> print(cx.represent_as(vec, cx.SphericalPosition))
-    <SphericalPosition (r[kpc], theta[deg], phi[deg])
+    >>> vec = cx.MathSphericalPos(r=Quantity(1., "kpc"), theta=Quantity(90, "deg"),
+    ...                           phi=Quantity(90, "deg"))
+    >>> print(cx.represent_as(vec, cx.SphericalPos))
+    <SphericalPos (r[kpc], theta[deg], phi[deg])
         [ 1. 90. 90.]>
 
     """
@@ -586,7 +586,7 @@ def represent_as(
 def represent_as(
     current: AbstractVelocity3D,
     target: type[LonCosLatSphericalVelocity],
-    position: AbstractPosition | Quantity["length"],
+    position: AbstractPos | Quantity["length"],
     /,
     **kwargs: Any,
 ) -> LonCosLatSphericalVelocity:
@@ -598,12 +598,12 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> vec = cx.LonLatSphericalPosition(lon=Quantity(15, "deg"),
-    ...                                  lat=Quantity(10, "deg"),
-    ...                                  distance=Quantity(1.5, "kpc"))
+    >>> vec = cx.LonLatSphericalPos(lon=Quantity(15, "deg"),
+    ...                             lat=Quantity(10, "deg"),
+    ...                             distance=Quantity(1.5, "kpc"))
     >>> dif = cx.LonLatSphericalVelocity(d_lon=Quantity(7, "mas/yr"),
-    ...                                      d_lat=Quantity(0, "deg/Gyr"),
-    ...                                      d_distance=Quantity(-5, "km/s"))
+    ...                                  d_lat=Quantity(0, "deg/Gyr"),
+    ...                                  d_distance=Quantity(-5, "km/s"))
     >>> newdif = cx.represent_as(dif, cx.LonCosLatSphericalVelocity, vec)
     >>> newdif
     LonCosLatSphericalVelocity(
@@ -616,8 +616,8 @@ def represent_as(
     Quantity['angular frequency'](Array(6.9999995, dtype=float32), unit='mas / yr')
 
     """
-    # Parse the position to an AbstractPosition
-    if isinstance(position, AbstractPosition):
+    # Parse the position to an AbstractPos
+    if isinstance(position, AbstractPos):
         posvec = position
     else:  # Q -> Cart<X>D
         posvec = current.integral_cls._cartesian_cls.from_(  # noqa: SLF001
@@ -642,13 +642,13 @@ def represent_as(
 def represent_as(
     current: LonCosLatSphericalVelocity,
     target: type[LonLatSphericalVelocity],
-    position: AbstractPosition | Quantity["length"],
+    position: AbstractPos | Quantity["length"],
     /,
     **kwargs: Any,
 ) -> LonLatSphericalVelocity:
     """LonCosLatSphericalVelocity -> LonLatSphericalVelocity."""
-    # Parse the position to an AbstractPosition
-    if isinstance(position, AbstractPosition):
+    # Parse the position to an AbstractPos
+    if isinstance(position, AbstractPos):
         posvec = position
     else:  # Q -> Cart<X>D
         posvec = current.integral_cls._cartesian_cls.from_(  # noqa: SLF001
@@ -670,13 +670,13 @@ def represent_as(
 def represent_as(
     current: LonCosLatSphericalVelocity,
     target: type[AbstractVelocity3D],
-    position: AbstractPosition | Quantity["length"],
+    position: AbstractPos | Quantity["length"],
     /,
     **kwargs: Any,
 ) -> AbstractVelocity3D:
     """LonCosLatSphericalVelocity -> AbstractVelocity3D."""
-    # Parse the position to an AbstractPosition
-    if isinstance(position, AbstractPosition):
+    # Parse the position to an AbstractPos
+    if isinstance(position, AbstractPos):
         posvec = position
     else:  # Q -> Cart<X>D
         posvec = current.integral_cls._cartesian_cls.from_(  # noqa: SLF001

--- a/src/coordinax/_src/d4/base.py
+++ b/src/coordinax/_src/d4/base.py
@@ -1,19 +1,19 @@
 """Representation of coordinates in different systems."""
 
-__all__ = ["AbstractPosition4D"]
+__all__ = ["AbstractPos4D"]
 
 
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 
-from coordinax._src.base import AbstractPosition, AbstractVector
+from coordinax._src.base import AbstractPos, AbstractVector
 from coordinax._src.utils import classproperty
 
 if TYPE_CHECKING:
     from typing_extensions import Never
 
 
-class AbstractPosition4D(AbstractPosition):
+class AbstractPos4D(AbstractPos):
     """Abstract representation of 4D coordinates in different systems."""
 
     @classproperty

--- a/src/coordinax/_src/d4/compat.py
+++ b/src/coordinax/_src/d4/compat.py
@@ -18,7 +18,7 @@ from coordinax._src.operators.base import AbstractOperator, op_call_dispatch
 
 @conversion_method(type_from=FourVector, type_to=Quantity)  # type: ignore[misc]
 def vec_to_q(obj: FourVector, /) -> Shaped[Quantity["length"], "*batch 4"]:
-    """`coordinax.AbstractPosition3D` -> `unxt.Quantity`."""
+    """`coordinax.AbstractPos3D` -> `unxt.Quantity`."""
     cart = convert(obj.q, Quantity)
     return jnp.concat([obj.c * obj.t[..., None], cart], axis=-1)
 
@@ -40,17 +40,17 @@ def call(self: AbstractOperator, v4: FourVector, /) -> FourVector:
 
     >>> op = cx.operators.GalileanSpatialTranslationOperator(Quantity([1, 2, 3], "kpc"))
     >>> op
-    GalileanSpatialTranslationOperator( translation=CartesianPosition3D( ... ) )
+    GalileanSpatialTranslationOperator( translation=CartesianPos3D( ... ) )
 
     We can then apply the operator to a position:
 
     >>> pos = cx.FourVector.from_([0, 1.0, 2.0, 3.0], "kpc")
     >>> pos
-    FourVector( t=Quantity[PhysicalType('time')](...), q=CartesianPosition3D( ... ) )
+    FourVector( t=Quantity[PhysicalType('time')](...), q=CartesianPos3D( ... ) )
 
     >>> newpos = op(pos)
     >>> newpos
-    FourVector( t=Quantity[PhysicalType('time')](...), q=CartesianPosition3D( ... ) )
+    FourVector( t=Quantity[PhysicalType('time')](...), q=CartesianPos3D( ... ) )
     >>> newpos.q.x
     Quantity['length'](Array(2., dtype=float32), unit='kpc')
 
@@ -74,7 +74,7 @@ def call(
 
     >>> op = cx.operators.GalileanSpatialTranslationOperator(Quantity([1, 2, 3], "kpc"))
     >>> op
-    GalileanSpatialTranslationOperator( translation=CartesianPosition3D( ... ) )
+    GalileanSpatialTranslationOperator( translation=CartesianPos3D( ... ) )
 
     We can then apply the operator to a position:
 

--- a/src/coordinax/_src/d4/spacetime.py
+++ b/src/coordinax/_src/d4/spacetime.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from typing_extensions import Never
 
 ##############################################################################
-# Pos
+# Position
 
 
 @final

--- a/src/coordinax/_src/d4/spacetime.py
+++ b/src/coordinax/_src/d4/spacetime.py
@@ -17,10 +17,10 @@ import quaxed.numpy as jnp
 from dataclassish.converters import Unless
 from unxt import AbstractQuantity, Quantity
 
-from .base import AbstractPosition4D
+from .base import AbstractPos4D
 from coordinax._src.base import AbstractVector
-from coordinax._src.d3.base import AbstractPosition3D
-from coordinax._src.d3.cartesian import CartesianPosition3D
+from coordinax._src.d3.base import AbstractPos3D
+from coordinax._src.d3.cartesian import CartesianPos3D
 from coordinax._src.typing import BatchableLength, BatchableTime, ScalarTime
 from coordinax._src.utils import classproperty
 
@@ -28,11 +28,11 @@ if TYPE_CHECKING:
     from typing_extensions import Never
 
 ##############################################################################
-# Position
+# Pos
 
 
 @final
-class FourVector(AbstractPosition4D):
+class FourVector(AbstractPos4D):
     """3+1 vector representation.
 
     The 3+1 vector representation is a 4-vector with 3 spatial coordinates and 1
@@ -42,7 +42,7 @@ class FourVector(AbstractPosition4D):
     ----------
     t : Quantity[float, (*batch,), "time"]
         Time coordinate.
-    q : AbstractPosition3D[float, (*batch, 3)]
+    q : AbstractPos3D[float, (*batch, 3)]
         Spatial coordinates.
     c : Quantity[float, (), "speed"], optional
         Speed of light, by default ``Quantity(299_792.458, "km/s")``.
@@ -58,17 +58,17 @@ class FourVector(AbstractPosition4D):
     >>> w
     FourVector(
       t=Quantity[PhysicalType('time')](value=f32[], unit=Unit("s")),
-      q=CartesianPosition3D( ... )
+      q=CartesianPos3D( ... )
     )
 
     Note that we used a shortcut to create the 3D vector by passing a ``(*batch,
     3)`` array to the `q` argument. This assumes that `q` is a
-    :class:`coordinax.CartesianPosition3D` and uses the
-    :meth:`coordinax.CartesianPosition3D.from_` method to create the 3D vector.
+    :class:`coordinax.CartesianPos3D` and uses the
+    :meth:`coordinax.CartesianPos3D.from_` method to create the 3D vector.
 
     We can also create the 3D vector explicitly:
 
-    >>> q = cx.CartesianPosition3D(x=Quantity(1, "m"), y=Quantity(2, "m"),
+    >>> q = cx.CartesianPos3D(x=Quantity(1, "m"), y=Quantity(2, "m"),
     ...                            z=Quantity(3, "m"))
     >>> w = cx.FourVector(t=Quantity(1, "s"), q=q)
 
@@ -79,9 +79,7 @@ class FourVector(AbstractPosition4D):
     )
     """Time coordinate."""
 
-    q: AbstractPosition3D = eqx.field(
-        converter=Unless(AbstractPosition3D, CartesianPosition3D.from_)
-    )
+    q: AbstractPos3D = eqx.field(converter=Unless(AbstractPos3D, CartesianPos3D.from_))
     """Spatial coordinates."""
 
     _: KW_ONLY
@@ -102,7 +100,7 @@ class FourVector(AbstractPosition4D):
     # Constructors
 
     @classmethod
-    @AbstractPosition4D.from_._f.dispatch  # type: ignore[attr-defined, misc]  # noqa: SLF001
+    @AbstractPos4D.from_._f.dispatch  # type: ignore[attr-defined, misc]  # noqa: SLF001
     def from_(
         cls: "type[FourVector]", obj: Shaped[Quantity, "*batch 4"], /
     ) -> "FourVector":
@@ -127,7 +125,7 @@ class FourVector(AbstractPosition4D):
         >>> vec
         FourVector(
             t=Quantity[PhysicalType('time')](value=f32[], unit=Unit("m s / km")),
-            q=CartesianPosition3D( ... )
+            q=CartesianPos3D( ... )
         )
 
         >>> xs = Quantity(jnp.array([[0, 1, 2, 3], [10, 4, 5, 6]]), "meter")
@@ -135,7 +133,7 @@ class FourVector(AbstractPosition4D):
         >>> vec
         FourVector(
             t=Quantity[PhysicalType('time')](value=f32[2], unit=Unit("m s / km")),
-            q=CartesianPosition3D( ... )
+            q=CartesianPos3D( ... )
         )
 
         >>> vec.x
@@ -199,7 +197,7 @@ class FourVector(AbstractPosition4D):
         >>> -w
         FourVector(
             t=Quantity[PhysicalType('time')](value=f32[], unit=Unit("s")),
-            q=CartesianPosition3D( ... )
+            q=CartesianPos3D( ... )
         )
 
         """
@@ -260,7 +258,7 @@ def from_(
     >>> vec
     FourVector(
       t=Quantity[...](value=f32[], unit=Unit("s")),
-      q=CartesianPosition3D(
+      q=CartesianPos3D(
         x=Quantity[...](value=f32[], unit=Unit("km")),
         y=Quantity[...](value=f32[], unit=Unit("km")),
         z=Quantity[...](value=f32[], unit=Unit("km"))
@@ -287,7 +285,7 @@ def _add_4v4v(self: FourVector, other: FourVector) -> FourVector:
     >>> w3
     FourVector(
         t=Quantity[PhysicalType('time')](value=f32[], unit=Unit("s")),
-        q=CartesianPosition3D( ... )
+        q=CartesianPos3D( ... )
     )
 
     >>> w3.t
@@ -315,7 +313,7 @@ def _sub_4v_4v(lhs: FourVector, rhs: FourVector) -> FourVector:
     >>> w3
     FourVector(
         t=Quantity[PhysicalType('time')](value=f32[], unit=Unit("s")),
-        q=CartesianPosition3D( ... )
+        q=CartesianPos3D( ... )
     )
 
     >>> w3.t

--- a/src/coordinax/_src/dn/base.py
+++ b/src/coordinax/_src/dn/base.py
@@ -1,6 +1,6 @@
 """Representation of coordinates in different systems."""
 
-__all__ = ["AbstractPositionND", "AbstractVelocityND", "AbstractAccelerationND"]
+__all__ = ["AbstractPosND", "AbstractVelocityND", "AbstractAccelerationND"]
 
 
 from abc import abstractmethod
@@ -14,7 +14,7 @@ import quaxed.numpy as jnp
 
 from coordinax._src.base import (
     AbstractAcceleration,
-    AbstractPosition,
+    AbstractPos,
     AbstractVector,
     AbstractVelocity,
 )
@@ -24,15 +24,15 @@ if TYPE_CHECKING:
     from typing_extensions import Never
 
 
-class AbstractPositionND(AbstractPosition):
+class AbstractPosND(AbstractPos):
     """Abstract representation of N-D coordinates in different systems."""
 
     @classproperty
     @classmethod
     def _cartesian_cls(cls) -> type[AbstractVector]:
-        from .cartesian import CartesianPositionND
+        from .cartesian import CartesianPosND
 
-        return CartesianPositionND
+        return CartesianPosND
 
     @classproperty
     @classmethod
@@ -55,8 +55,8 @@ class AbstractPositionND(AbstractPosition):
         --------
         >>> from unxt import Quantity
         >>> import coordinax as cx
-        >>> vec = cx.CartesianPositionND(Quantity([[[1, 2, 3]],
-        ...                                        [[4, 5, 6]]], "m"))
+        >>> vec = cx.CartesianPosND(Quantity([[[1, 2, 3]],
+        ...                                   [[4, 5, 6]]], "m"))
         >>> vec.shape
         (2, 1)
 
@@ -84,7 +84,7 @@ class AbstractPositionND(AbstractPosition):
         --------
         >>> import coordinax as cx
 
-        >>> vec = cx.CartesianPositionND.from_([[[1, 2]], [[3, 4]]], "m")
+        >>> vec = cx.CartesianPosND.from_([[[1, 2]], [[3, 4]]], "m")
         >>> vec.shape
         (2, 1)
 
@@ -99,7 +99,7 @@ class AbstractPositionND(AbstractPosition):
         --------
         >>> import coordinax as cx
 
-        >>> vec = cx.CartesianPositionND.from_([[[1, 2]], [[3, 4]]], "m")
+        >>> vec = cx.CartesianPosND.from_([[[1, 2]], [[3, 4]]], "m")
         >>> vec.shape
         (2, 1)
 
@@ -121,7 +121,7 @@ class AbstractPositionND(AbstractPosition):
         --------
         >>> import coordinax as cx
 
-        >>> vec = cx.CartesianPositionND.from_([[[1, 2]], [[3, 4]]], "m")
+        >>> vec = cx.CartesianPosND.from_([[[1, 2]], [[3, 4]]], "m")
         >>> vec.shape
         (2, 1)
 
@@ -138,7 +138,7 @@ class AbstractPositionND(AbstractPosition):
         --------
         >>> import coordinax as cx
 
-        >>> vec = cx.CartesianPositionND.from_([[1, 2], [3, 4]], "m")
+        >>> vec = cx.CartesianPosND.from_([[1, 2], [3, 4]], "m")
         >>> vec.shape
         (2,)
 
@@ -174,7 +174,7 @@ class AbstractVelocityND(AbstractVelocity):
     @classproperty
     @classmethod
     @abstractmethod
-    def integral_cls(cls) -> type[AbstractPositionND]:
+    def integral_cls(cls) -> type[AbstractPosND]:
         """Get the integral class."""
         raise NotImplementedError
 

--- a/src/coordinax/_src/dn/base.py
+++ b/src/coordinax/_src/dn/base.py
@@ -1,6 +1,6 @@
 """Representation of coordinates in different systems."""
 
-__all__ = ["AbstractPosND", "AbstractVelocityND", "AbstractAccelerationND"]
+__all__ = ["AbstractPosND", "AbstractVelND", "AbstractAccelerationND"]
 
 
 from abc import abstractmethod
@@ -16,7 +16,7 @@ from coordinax._src.base import (
     AbstractAcceleration,
     AbstractPos,
     AbstractVector,
-    AbstractVelocity,
+    AbstractVel,
 )
 from coordinax._src.utils import classproperty
 
@@ -152,7 +152,7 @@ class AbstractPosND(AbstractPos):
 #####################################################################
 
 
-class AbstractVelocityND(AbstractVelocity):
+class AbstractVelND(AbstractVel):
     """Abstract representation of N-D vector differentials."""
 
     @classproperty
@@ -163,13 +163,13 @@ class AbstractVelocityND(AbstractVelocity):
         Examples
         --------
         >>> import coordinax as cx
-        >>> cx.CartesianVelocityND._cartesian_cls
-        <class 'coordinax...CartesianVelocityND'>
+        >>> cx.CartesianVelND._cartesian_cls
+        <class 'coordinax...CartesianVelND'>
 
         """
-        from .cartesian import CartesianVelocityND
+        from .cartesian import CartesianVelND
 
-        return CartesianVelocityND
+        return CartesianVelND
 
     @classproperty
     @classmethod
@@ -192,7 +192,7 @@ class AbstractVelocityND(AbstractVelocity):
         --------
         >>> import coordinax as cx
 
-        >>> vec = cx.CartesianVelocityND.from_([[[1, 2]], [[3, 4]]], "m/s")
+        >>> vec = cx.CartesianVelND.from_([[[1, 2]], [[3, 4]]], "m/s")
         >>> vec.shape
         (2, 1)
 
@@ -220,7 +220,7 @@ class AbstractVelocityND(AbstractVelocity):
         --------
         >>> import coordinax as cx
 
-        >>> vec = cx.CartesianVelocityND.from_([[1, 2], [3, 4]], "m/s")
+        >>> vec = cx.CartesianVelND.from_([[1, 2], [3, 4]], "m/s")
         >>> vec.shape
         (2,)
 
@@ -235,7 +235,7 @@ class AbstractVelocityND(AbstractVelocity):
         --------
         >>> import coordinax as cx
 
-        >>> vec = cx.CartesianVelocityND.from_([[[1, 2]], [[3, 4]]], "m/s")
+        >>> vec = cx.CartesianVelND.from_([[[1, 2]], [[3, 4]]], "m/s")
         >>> vec.shape
         (2, 1)
 
@@ -257,9 +257,9 @@ class AbstractVelocityND(AbstractVelocity):
         --------
         >>> import coordinax as cx
 
-        >>> vec = cx.CartesianVelocityND.from_([[1, 2], [3, 4]], "m/s")
+        >>> vec = cx.CartesianVelND.from_([[1, 2], [3, 4]], "m/s")
         >>> vec.flatten()
-        CartesianVelocityND(
+        CartesianVelND(
             d_q=Quantity[...]( value=f32[2,2], unit=Unit("m / s") )
         )
 
@@ -275,7 +275,7 @@ class AbstractVelocityND(AbstractVelocity):
         --------
         >>> from unxt import Quantity
         >>> import coordinax as cx
-        >>> vec = cx.CartesianVelocityND(Quantity([1, 2, 3], "m/s"))
+        >>> vec = cx.CartesianVelND(Quantity([1, 2, 3], "m/s"))
         >>> vec.shape
         ()
 
@@ -313,7 +313,7 @@ class AbstractAccelerationND(AbstractAcceleration):
     @classproperty
     @classmethod
     @abstractmethod
-    def integral_cls(cls) -> type[AbstractVelocityND]:
+    def integral_cls(cls) -> type[AbstractVelND]:
         raise NotImplementedError  # pragma: no cover
 
     # ===============================================================

--- a/src/coordinax/_src/dn/base.py
+++ b/src/coordinax/_src/dn/base.py
@@ -1,6 +1,6 @@
 """Representation of coordinates in different systems."""
 
-__all__ = ["AbstractPosND", "AbstractVelND", "AbstractAccelerationND"]
+__all__ = ["AbstractPosND", "AbstractVelND", "AbstractAccND"]
 
 
 from abc import abstractmethod
@@ -13,7 +13,7 @@ import quaxed.lax as qlax
 import quaxed.numpy as jnp
 
 from coordinax._src.base import (
-    AbstractAcceleration,
+    AbstractAcc,
     AbstractPos,
     AbstractVector,
     AbstractVel,
@@ -291,7 +291,7 @@ class AbstractVelND(AbstractVel):
 #####################################################################
 
 
-class AbstractAccelerationND(AbstractAcceleration):
+class AbstractAccND(AbstractAcc):
     """Abstract representation of N-D vector differentials."""
 
     @classproperty
@@ -302,13 +302,13 @@ class AbstractAccelerationND(AbstractAcceleration):
         Examples
         --------
         >>> import coordinax as cx
-        >>> cx.CartesianAccelerationND._cartesian_cls
-        <class 'coordinax...CartesianAccelerationND'>
+        >>> cx.CartesianAccND._cartesian_cls
+        <class 'coordinax...CartesianAccND'>
 
         """
-        from .cartesian import CartesianAccelerationND
+        from .cartesian import CartesianAccND
 
-        return CartesianAccelerationND
+        return CartesianAccND
 
     @classproperty
     @classmethod
@@ -330,7 +330,7 @@ class AbstractAccelerationND(AbstractAcceleration):
         --------
         >>> from unxt import Quantity
         >>> import coordinax as cx
-        >>> vec = cx.CartesianAccelerationND(Quantity([[[1, 2, 3]],
+        >>> vec = cx.CartesianAccND(Quantity([[[1, 2, 3]],
         ...                                            [[4, 5, 6]]], "m/s2"))
         >>> vec.shape
         (2, 1)
@@ -359,7 +359,7 @@ class AbstractAccelerationND(AbstractAcceleration):
         --------
         >>> from unxt import Quantity
         >>> import coordinax as cx
-        >>> vec = cx.CartesianAccelerationND(Quantity([[[1, 2, 3]],
+        >>> vec = cx.CartesianAccND(Quantity([[[1, 2, 3]],
         ...                                            [[4, 5, 6]]], "m/s2"))
         >>> vec.shape
         (2, 1)
@@ -375,7 +375,7 @@ class AbstractAccelerationND(AbstractAcceleration):
         --------
         >>> from unxt import Quantity
         >>> import coordinax as cx
-        >>> vec = cx.CartesianAccelerationND(Quantity([[[1, 2, 3]],
+        >>> vec = cx.CartesianAccND(Quantity([[[1, 2, 3]],
         ...                                            [[4, 5, 6]]], "m/s2"))
         >>> vec.shape
         (2, 1)
@@ -398,7 +398,7 @@ class AbstractAccelerationND(AbstractAcceleration):
         --------
         >>> from unxt import Quantity
         >>> import coordinax as cx
-        >>> vec = cx.CartesianAccelerationND(Quantity([[[1, 2, 3]],
+        >>> vec = cx.CartesianAccND(Quantity([[[1, 2, 3]],
         ...                                            [[4, 5, 6]]], "m/s2"))
         >>> vec.shape
         (2, 1)
@@ -418,7 +418,7 @@ class AbstractAccelerationND(AbstractAcceleration):
         --------
         >>> from unxt import Quantity
         >>> import coordinax as cx
-        >>> vec = cx.CartesianAccelerationND(Quantity([1, 2, 3], "m/s2"))
+        >>> vec = cx.CartesianAccND(Quantity([1, 2, 3], "m/s2"))
         >>> vec.shape
         ()
 

--- a/src/coordinax/_src/dn/cartesian.py
+++ b/src/coordinax/_src/dn/cartesian.py
@@ -24,7 +24,7 @@ from coordinax._src.base.mixins import AvalMixin
 from coordinax._src.utils import classproperty
 
 ##############################################################################
-# Pos
+# Position
 
 
 @final
@@ -276,7 +276,7 @@ def _sub_cnd_pos(lhs: CartesianPosND, rhs: AbstractPos, /) -> CartesianPosND:
 
 
 ##############################################################################
-# Vel
+# Velocity
 
 
 @final
@@ -424,7 +424,7 @@ def from_(
 
 
 ##############################################################################
-# Acc
+# Acceleration
 
 
 @final

--- a/src/coordinax/_src/dn/cartesian.py
+++ b/src/coordinax/_src/dn/cartesian.py
@@ -1,6 +1,6 @@
 """Built-in vector classes."""
 
-__all__ = ["CartesianPositionND", "CartesianVelocityND", "CartesianAccelerationND"]
+__all__ = ["CartesianPosND", "CartesianVelocityND", "CartesianAccelerationND"]
 
 from dataclasses import replace
 from functools import partial
@@ -18,17 +18,17 @@ import quaxed.numpy as jnp
 from unxt import Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAccelerationND, AbstractPositionND, AbstractVelocityND
-from coordinax._src.base import AbstractPosition
+from .base import AbstractAccelerationND, AbstractPosND, AbstractVelocityND
+from coordinax._src.base import AbstractPos
 from coordinax._src.base.mixins import AvalMixin
 from coordinax._src.utils import classproperty
 
 ##############################################################################
-# Position
+# Pos
 
 
 @final
-class CartesianPositionND(AbstractPositionND):
+class CartesianPosND(AbstractPosND):
     """N-dimensional Cartesian vector representation.
 
     Examples
@@ -38,7 +38,7 @@ class CartesianPositionND(AbstractPositionND):
 
     A 1D vector:
 
-    >>> q = cx.CartesianPositionND(Quantity([[1]], "kpc"))
+    >>> q = cx.CartesianPosND(Quantity([[1]], "kpc"))
     >>> q.q
     Quantity['length'](Array([[1.]], dtype=float32), unit='kpc')
     >>> q.shape
@@ -46,7 +46,7 @@ class CartesianPositionND(AbstractPositionND):
 
     A 2D vector:
 
-    >>> q = cx.CartesianPositionND(Quantity([1, 2], "kpc"))
+    >>> q = cx.CartesianPosND(Quantity([1, 2], "kpc"))
     >>> q.q
     Quantity['length'](Array([1., 2.], dtype=float32), unit='kpc')
     >>> q.shape
@@ -54,7 +54,7 @@ class CartesianPositionND(AbstractPositionND):
 
     A 3D vector:
 
-    >>> q = cx.CartesianPositionND(Quantity([1, 2, 3], "kpc"))
+    >>> q = cx.CartesianPosND(Quantity([1, 2, 3], "kpc"))
     >>> q.q
     Quantity['length'](Array([1., 2., 3.], dtype=float32), unit='kpc')
     >>> q.shape
@@ -62,7 +62,7 @@ class CartesianPositionND(AbstractPositionND):
 
     A 4D vector:
 
-    >>> q = cx.CartesianPositionND(Quantity([1, 2, 3, 4], "kpc"))
+    >>> q = cx.CartesianPosND(Quantity([1, 2, 3, 4], "kpc"))
     >>> q.q
     Quantity['length'](Array([1., 2., 3., 4.], dtype=float32), unit='kpc')
     >>> q.shape
@@ -70,7 +70,7 @@ class CartesianPositionND(AbstractPositionND):
 
     A 5D vector:
 
-    >>> q = cx.CartesianPositionND(Quantity([1, 2, 3, 4, 5], "kpc"))
+    >>> q = cx.CartesianPosND(Quantity([1, 2, 3, 4, 5], "kpc"))
     >>> q.q
     Quantity['length'](Array([1., 2., 3., 4., 5.], dtype=float32), unit='kpc')
     >>> q.shape
@@ -111,7 +111,7 @@ class CartesianPositionND(AbstractPositionND):
 
         A 3D vector:
 
-        >>> q = cx.CartesianPositionND(Quantity([1, 2, 3], "kpc"))
+        >>> q = cx.CartesianPosND(Quantity([1, 2, 3], "kpc"))
         >>> q.norm()
         Quantity['length'](Array(3.7416575, dtype=float32), unit='kpc')
 
@@ -123,12 +123,12 @@ class CartesianPositionND(AbstractPositionND):
 
 
 # TODO: move to the class in py3.11+
-@CartesianPositionND.from_._f.dispatch  # type: ignore[attr-defined,misc]  # noqa: SLF001
+@CartesianPosND.from_._f.dispatch  # type: ignore[attr-defined,misc]  # noqa: SLF001
 def from_(
-    cls: type[CartesianPositionND],
+    cls: type[CartesianPosND],
     x: Shaped[Quantity["length"], ""] | Shaped[Quantity["length"], "*batch N"],
     /,
-) -> CartesianPositionND:
+) -> CartesianPosND:
     """Construct an N-dimensional position.
 
     Examples
@@ -138,34 +138,34 @@ def from_(
 
     1D vector:
 
-    >>> cx.CartesianPositionND.from_(Quantity(1, "kpc"))
-    CartesianPositionND(
+    >>> cx.CartesianPosND.from_(Quantity(1, "kpc"))
+    CartesianPosND(
       q=Quantity[...](value=f32[1], unit=Unit("kpc"))
     )
 
-    >>> cx.CartesianPositionND.from_(Quantity([1], "kpc"))
-    CartesianPositionND(
+    >>> cx.CartesianPosND.from_(Quantity([1], "kpc"))
+    CartesianPosND(
       q=Quantity[...](value=f32[1], unit=Unit("kpc"))
     )
 
     2D vector:
 
-    >>> cx.CartesianPositionND.from_(Quantity([1, 2], "kpc"))
-    CartesianPositionND(
+    >>> cx.CartesianPosND.from_(Quantity([1, 2], "kpc"))
+    CartesianPosND(
       q=Quantity[...](value=f32[2], unit=Unit("kpc"))
     )
 
     3D vector:
 
-    >>> cx.CartesianPositionND.from_(Quantity([1, 2, 3], "kpc"))
-    CartesianPositionND(
+    >>> cx.CartesianPosND.from_(Quantity([1, 2, 3], "kpc"))
+    CartesianPosND(
       q=Quantity[...](value=f32[3], unit=Unit("kpc"))
     )
 
     4D vector:
 
-    >>> cx.CartesianPositionND.from_(Quantity([1, 2, 3, 4], "kpc"))
-    CartesianPositionND(
+    >>> cx.CartesianPosND.from_(Quantity([1, 2, 3, 4], "kpc"))
+    CartesianPosND(
       q=Quantity[...](value=f32[4], unit=Unit("kpc"))
     )
 
@@ -173,9 +173,9 @@ def from_(
     return cls(jnp.atleast_1d(x))
 
 
-@conversion_method(CartesianPositionND, Quantity)  # type: ignore[misc]
-def _vec_to_q(obj: CartesianPositionND, /) -> Shaped[Quantity["length"], "*batch N"]:
-    """`coordinax.AbstractPosition3D` -> `unxt.Quantity`.
+@conversion_method(CartesianPosND, Quantity)  # type: ignore[misc]
+def _vec_to_q(obj: CartesianPosND, /) -> Shaped[Quantity["length"], "*batch N"]:
+    """`coordinax.AbstractPos3D` -> `unxt.Quantity`.
 
     Examples
     --------
@@ -183,7 +183,7 @@ def _vec_to_q(obj: CartesianPositionND, /) -> Shaped[Quantity["length"], "*batch
     >>> from plum import convert
     >>> from unxt import Quantity
 
-    >>> vec = cx.CartesianPositionND(Quantity([1, 2, 3, 4, 5], unit="kpc"))
+    >>> vec = cx.CartesianPosND(Quantity([1, 2, 3, 4, 5], unit="kpc"))
     >>> convert(vec, Quantity)
     Quantity['length'](Array([1., 2., 3., 4., 5.], dtype=float32), unit='kpc')
 
@@ -192,9 +192,7 @@ def _vec_to_q(obj: CartesianPositionND, /) -> Shaped[Quantity["length"], "*batch
 
 
 @register(jax.lax.add_p)  # type: ignore[misc]
-def _add_vcnd(
-    lhs: CartesianPositionND, rhs: AbstractPosition, /
-) -> CartesianPositionND:
+def _add_vcnd(lhs: CartesianPosND, rhs: AbstractPos, /) -> CartesianPosND:
     """Add two vectors.
 
     Examples
@@ -203,18 +201,18 @@ def _add_vcnd(
 
     A 3D vector:
 
-    >>> q1 = cx.CartesianPositionND.from_([1, 2, 3], "kpc")
-    >>> q2 = cx.CartesianPositionND.from_([2, 3, 4], "kpc")
+    >>> q1 = cx.CartesianPosND.from_([1, 2, 3], "kpc")
+    >>> q2 = cx.CartesianPosND.from_([2, 3, 4], "kpc")
     >>> (q1 + q2).q
     Quantity['length'](Array([3., 5., 7.], dtype=float32), unit='kpc')
 
     """
-    cart = rhs.represent_as(CartesianPositionND)
+    cart = rhs.represent_as(CartesianPosND)
     return replace(lhs, q=lhs.q + cart.q)
 
 
 @register(jax.lax.mul_p)  # type: ignore[misc]
-def _mul_vcnd(lhs: ArrayLike, rhs: CartesianPositionND, /) -> CartesianPositionND:
+def _mul_vcnd(lhs: ArrayLike, rhs: CartesianPosND, /) -> CartesianPosND:
     """Scale a position by a scalar.
 
     Examples
@@ -223,7 +221,7 @@ def _mul_vcnd(lhs: ArrayLike, rhs: CartesianPositionND, /) -> CartesianPositionN
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> v = cx.CartesianPositionND(Quantity([1, 2, 3, 4, 5], "kpc"))
+    >>> v = cx.CartesianPosND(Quantity([1, 2, 3, 4, 5], "kpc"))
     >>> jnp.multiply(2, v).q
     Quantity['length'](Array([ 2.,  4.,  6.,  8., 10.], dtype=float32), unit='kpc')
 
@@ -238,8 +236,8 @@ def _mul_vcnd(lhs: ArrayLike, rhs: CartesianPositionND, /) -> CartesianPositionN
 
 
 @register(jax.lax.neg_p)  # type: ignore[misc]
-def _neg_p_cartnd_pos(obj: CartesianPositionND, /) -> CartesianPositionND:
-    """Negate the `coordinax.CartesianPositionND`.
+def _neg_p_cartnd_pos(obj: CartesianPosND, /) -> CartesianPosND:
+    """Negate the `coordinax.CartesianPosND`.
 
     Examples
     --------
@@ -248,7 +246,7 @@ def _neg_p_cartnd_pos(obj: CartesianPositionND, /) -> CartesianPositionND:
 
     A 3D vector:
 
-    >>> vec = cx.CartesianPositionND(Quantity([1, 2, 3], "kpc"))
+    >>> vec = cx.CartesianPosND(Quantity([1, 2, 3], "kpc"))
     >>> (-vec).q
     Quantity['length'](Array([-1., -2., -3.], dtype=float32), unit='kpc')
 
@@ -257,25 +255,23 @@ def _neg_p_cartnd_pos(obj: CartesianPositionND, /) -> CartesianPositionND:
 
 
 @register(jax.lax.sub_p)  # type: ignore[misc]
-def _sub_cnd_pos(
-    lhs: CartesianPositionND, rhs: AbstractPosition, /
-) -> CartesianPositionND:
+def _sub_cnd_pos(lhs: CartesianPosND, rhs: AbstractPos, /) -> CartesianPosND:
     """Subtract two vectors.
 
     Examples
     --------
     >>> from unxt import Quantity
-    >>> from coordinax import CartesianPositionND
+    >>> from coordinax import CartesianPosND
 
     A 3D vector:
 
-    >>> q1 = CartesianPositionND(Quantity([1, 2, 3], "kpc"))
-    >>> q2 = CartesianPositionND(Quantity([2, 3, 4], "kpc"))
+    >>> q1 = CartesianPosND(Quantity([1, 2, 3], "kpc"))
+    >>> q2 = CartesianPosND(Quantity([2, 3, 4], "kpc"))
     >>> (q1 - q2).q
     Quantity['length'](Array([-1., -1., -1.], dtype=float32), unit='kpc')
 
     """
-    cart = rhs.represent_as(CartesianPositionND)
+    cart = rhs.represent_as(CartesianPosND)
     return replace(lhs, q=lhs.q - cart.q)
 
 
@@ -345,8 +341,8 @@ class CartesianVelocityND(AvalMixin, AbstractVelocityND):
 
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[CartesianPositionND]:
-        return CartesianPositionND
+    def integral_cls(cls) -> type[CartesianPosND]:
+        return CartesianPosND
 
     @override
     @classproperty
@@ -355,7 +351,7 @@ class CartesianVelocityND(AvalMixin, AbstractVelocityND):
         return CartesianAccelerationND
 
     @partial(eqx.filter_jit, inline=True)
-    def norm(self, _: AbstractPositionND | None = None, /) -> ct.BatchableSpeed:
+    def norm(self, _: AbstractPosND | None = None, /) -> ct.BatchableSpeed:
         """Return the norm of the vector.
 
         Examples
@@ -527,7 +523,7 @@ class CartesianAccelerationND(AvalMixin, AbstractAccelerationND):
     def norm(
         self,
         velocity: AbstractVelocityND | None = None,
-        position: AbstractPositionND | None = None,
+        position: AbstractPosND | None = None,
         /,
     ) -> ct.BatchableSpeed:
         """Return the norm of the vector.

--- a/src/coordinax/_src/dn/cartesian.py
+++ b/src/coordinax/_src/dn/cartesian.py
@@ -1,6 +1,6 @@
 """Built-in vector classes."""
 
-__all__ = ["CartesianPosND", "CartesianVelND", "CartesianAccelerationND"]
+__all__ = ["CartesianPosND", "CartesianVelND", "CartesianAccND"]
 
 from dataclasses import replace
 from functools import partial
@@ -18,7 +18,7 @@ import quaxed.numpy as jnp
 from unxt import Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAccelerationND, AbstractPosND, AbstractVelND
+from .base import AbstractAccND, AbstractPosND, AbstractVelND
 from coordinax._src.base import AbstractPos
 from coordinax._src.base.mixins import AvalMixin
 from coordinax._src.utils import classproperty
@@ -347,8 +347,8 @@ class CartesianVelND(AvalMixin, AbstractVelND):
     @override
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["CartesianAccelerationND"]:
-        return CartesianAccelerationND
+    def differential_cls(cls) -> type["CartesianAccND"]:
+        return CartesianAccND
 
     @partial(eqx.filter_jit, inline=True)
     def norm(self, _: AbstractPosND | None = None, /) -> ct.BatchableSpeed:
@@ -424,11 +424,11 @@ def from_(
 
 
 ##############################################################################
-# Acceleration
+# Acc
 
 
 @final
-class CartesianAccelerationND(AvalMixin, AbstractAccelerationND):
+class CartesianAccND(AvalMixin, AbstractAccND):
     """Cartesian N-dimensional acceleration representation.
 
     Examples
@@ -438,7 +438,7 @@ class CartesianAccelerationND(AvalMixin, AbstractAccelerationND):
 
     A 1D vector:
 
-    >>> q = cx.CartesianAccelerationND(Quantity([[1]], "km/s2"))
+    >>> q = cx.CartesianAccND(Quantity([[1]], "km/s2"))
     >>> q.d2_q
     Quantity['acceleration'](Array([[1.]], dtype=float32), unit='km / s2')
     >>> q.shape
@@ -446,7 +446,7 @@ class CartesianAccelerationND(AvalMixin, AbstractAccelerationND):
 
     A 2D vector:
 
-    >>> q = cx.CartesianAccelerationND(Quantity([1, 2], "km/s2"))
+    >>> q = cx.CartesianAccND(Quantity([1, 2], "km/s2"))
     >>> q.d2_q
     Quantity['acceleration'](Array([1., 2.], dtype=float32), unit='km / s2')
     >>> q.shape
@@ -454,7 +454,7 @@ class CartesianAccelerationND(AvalMixin, AbstractAccelerationND):
 
     A 3D vector:
 
-    >>> q = cx.CartesianAccelerationND(Quantity([1, 2, 3], "km/s2"))
+    >>> q = cx.CartesianAccND(Quantity([1, 2, 3], "km/s2"))
     >>> q.d2_q
     Quantity['acceleration'](Array([1., 2., 3.], dtype=float32), unit='km / s2')
     >>> q.shape
@@ -462,7 +462,7 @@ class CartesianAccelerationND(AvalMixin, AbstractAccelerationND):
 
     A 4D vector:
 
-    >>> q = cx.CartesianAccelerationND(Quantity([1, 2, 3, 4], "km/s2"))
+    >>> q = cx.CartesianAccND(Quantity([1, 2, 3, 4], "km/s2"))
     >>> q.d2_q
     Quantity['acceleration'](Array([1., 2., 3., 4.], dtype=float32), unit='km / s2')
     >>> q.shape
@@ -470,7 +470,7 @@ class CartesianAccelerationND(AvalMixin, AbstractAccelerationND):
 
     A 5D vector:
 
-    >>> q = cx.CartesianAccelerationND(Quantity([1, 2, 3, 4, 5], "km/s2"))
+    >>> q = cx.CartesianAccND(Quantity([1, 2, 3, 4, 5], "km/s2"))
     >>> q.d2_q
     Quantity['acceleration'](Array([1., 2., 3., 4., 5.], dtype=float32), unit='km / s2')
     >>> q.shape
@@ -496,7 +496,7 @@ class CartesianAccelerationND(AvalMixin, AbstractAccelerationND):
         Examples
         --------
         >>> import coordinax as cx
-        >>> cx.CartesianAccelerationND.integral_cls.__name__
+        >>> cx.CartesianAccND.integral_cls.__name__
         'CartesianVelND'
 
         """
@@ -510,7 +510,7 @@ class CartesianAccelerationND(AvalMixin, AbstractAccelerationND):
         Examples
         --------
         >>> import coordinax as cx
-        >>> try: cx.CartesianAccelerationND.differential_cls
+        >>> try: cx.CartesianAccND.differential_cls
         ... except NotImplementedError as e: print(e)
         Not yet supported
 
@@ -535,7 +535,7 @@ class CartesianAccelerationND(AvalMixin, AbstractAccelerationND):
 
         A 3D vector:
 
-        >>> c = cx.CartesianAccelerationND(Quantity([1, 2, 3], "km/s2"))
+        >>> c = cx.CartesianAccND(Quantity([1, 2, 3], "km/s2"))
         >>> c.norm()
         Quantity['acceleration'](Array(3.7416575, dtype=float32), unit='km / s2')
 
@@ -547,13 +547,13 @@ class CartesianAccelerationND(AvalMixin, AbstractAccelerationND):
 
 
 # TODO: move to the class in py3.11+
-@CartesianAccelerationND.from_._f.dispatch  # type: ignore[attr-defined,misc]  # noqa: SLF001
+@CartesianAccND.from_._f.dispatch  # type: ignore[attr-defined,misc]  # noqa: SLF001
 def from_(
-    cls: type[CartesianAccelerationND],
+    cls: type[CartesianAccND],
     x: Shaped[Quantity["acceleration"], ""]
     | Shaped[Quantity["acceleration"], "*batch N"],
     /,
-) -> CartesianAccelerationND:
+) -> CartesianAccND:
     """Construct an N-dimensional acceleration.
 
     Examples
@@ -563,34 +563,34 @@ def from_(
 
     1D vector:
 
-    >>> cx.CartesianAccelerationND.from_(Quantity(1, "km/s2"))
-    CartesianAccelerationND(
+    >>> cx.CartesianAccND.from_(Quantity(1, "km/s2"))
+    CartesianAccND(
       d2_q=Quantity[...]( value=f32[1], unit=Unit("km / s2") )
     )
 
-    >>> cx.CartesianAccelerationND.from_(Quantity([1], "km/s2"))
-    CartesianAccelerationND(
+    >>> cx.CartesianAccND.from_(Quantity([1], "km/s2"))
+    CartesianAccND(
       d2_q=Quantity[...]( value=f32[1], unit=Unit("km / s2") )
     )
 
     2D vector:
 
-    >>> cx.CartesianAccelerationND.from_(Quantity([1, 2], "km/s2"))
-    CartesianAccelerationND(
+    >>> cx.CartesianAccND.from_(Quantity([1, 2], "km/s2"))
+    CartesianAccND(
       d2_q=Quantity[...]( value=f32[2], unit=Unit("km / s2") )
     )
 
     3D vector:
 
-    >>> cx.CartesianAccelerationND.from_(Quantity([1, 2, 3], "km/s2"))
-    CartesianAccelerationND(
+    >>> cx.CartesianAccND.from_(Quantity([1, 2, 3], "km/s2"))
+    CartesianAccND(
       d2_q=Quantity[...]( value=f32[3], unit=Unit("km / s2") )
     )
 
     4D vector:
 
-    >>> cx.CartesianAccelerationND.from_(Quantity([1, 2, 3, 4], "km/s2"))
-    CartesianAccelerationND(
+    >>> cx.CartesianAccND.from_(Quantity([1, 2, 3, 4], "km/s2"))
+    CartesianAccND(
       d2_q=Quantity[...]( value=f32[4], unit=Unit("km / s2") )
     )
 

--- a/src/coordinax/_src/dn/cartesian.py
+++ b/src/coordinax/_src/dn/cartesian.py
@@ -1,6 +1,6 @@
 """Built-in vector classes."""
 
-__all__ = ["CartesianPosND", "CartesianVelocityND", "CartesianAccelerationND"]
+__all__ = ["CartesianPosND", "CartesianVelND", "CartesianAccelerationND"]
 
 from dataclasses import replace
 from functools import partial
@@ -18,7 +18,7 @@ import quaxed.numpy as jnp
 from unxt import Quantity
 
 import coordinax._src.typing as ct
-from .base import AbstractAccelerationND, AbstractPosND, AbstractVelocityND
+from .base import AbstractAccelerationND, AbstractPosND, AbstractVelND
 from coordinax._src.base import AbstractPos
 from coordinax._src.base.mixins import AvalMixin
 from coordinax._src.utils import classproperty
@@ -90,8 +90,8 @@ class CartesianPosND(AbstractPosND):
     @override
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type["CartesianVelocityND"]:  # type: ignore[override]
-        return CartesianVelocityND
+    def differential_cls(cls) -> type["CartesianVelND"]:  # type: ignore[override]
+        return CartesianVelND
 
     # -----------------------------------------------------
     # Unary operations
@@ -276,11 +276,11 @@ def _sub_cnd_pos(lhs: CartesianPosND, rhs: AbstractPos, /) -> CartesianPosND:
 
 
 ##############################################################################
-# Velocity
+# Vel
 
 
 @final
-class CartesianVelocityND(AvalMixin, AbstractVelocityND):
+class CartesianVelND(AvalMixin, AbstractVelND):
     """Cartesian differential representation.
 
     Examples
@@ -290,7 +290,7 @@ class CartesianVelocityND(AvalMixin, AbstractVelocityND):
 
     A 1D vector:
 
-    >>> q = cx.CartesianVelocityND(Quantity([[1]], "km/s"))
+    >>> q = cx.CartesianVelND(Quantity([[1]], "km/s"))
     >>> q.d_q
     Quantity['speed'](Array([[1.]], dtype=float32), unit='km / s')
     >>> q.shape
@@ -298,7 +298,7 @@ class CartesianVelocityND(AvalMixin, AbstractVelocityND):
 
     A 2D vector:
 
-    >>> q = cx.CartesianVelocityND(Quantity([1, 2], "km/s"))
+    >>> q = cx.CartesianVelND(Quantity([1, 2], "km/s"))
     >>> q.d_q
     Quantity['speed'](Array([1., 2.], dtype=float32), unit='km / s')
     >>> q.shape
@@ -306,7 +306,7 @@ class CartesianVelocityND(AvalMixin, AbstractVelocityND):
 
     A 3D vector:
 
-    >>> q = cx.CartesianVelocityND(Quantity([1, 2, 3], "km/s"))
+    >>> q = cx.CartesianVelND(Quantity([1, 2, 3], "km/s"))
     >>> q.d_q
     Quantity['speed'](Array([1., 2., 3.], dtype=float32), unit='km / s')
     >>> q.shape
@@ -314,7 +314,7 @@ class CartesianVelocityND(AvalMixin, AbstractVelocityND):
 
     A 4D vector:
 
-    >>> q = cx.CartesianVelocityND(Quantity([1, 2, 3, 4], "km/s"))
+    >>> q = cx.CartesianVelND(Quantity([1, 2, 3, 4], "km/s"))
     >>> q.d_q
     Quantity['speed'](Array([1., 2., 3., 4.], dtype=float32), unit='km / s')
     >>> q.shape
@@ -322,7 +322,7 @@ class CartesianVelocityND(AvalMixin, AbstractVelocityND):
 
     A 5D vector:
 
-    >>> q = cx.CartesianVelocityND(Quantity([1, 2, 3, 4, 5], "km/s"))
+    >>> q = cx.CartesianVelND(Quantity([1, 2, 3, 4, 5], "km/s"))
     >>> q.d_q
     Quantity['speed'](Array([1., 2., 3., 4., 5.], dtype=float32), unit='km / s')
     >>> q.shape
@@ -361,7 +361,7 @@ class CartesianVelocityND(AvalMixin, AbstractVelocityND):
 
         A 3D vector:
 
-        >>> c = cx.CartesianVelocityND(Quantity([1, 2, 3], "km/s"))
+        >>> c = cx.CartesianVelND(Quantity([1, 2, 3], "km/s"))
         >>> c.norm()
         Quantity['speed'](Array(3.7416575, dtype=float32), unit='km / s')
 
@@ -373,12 +373,12 @@ class CartesianVelocityND(AvalMixin, AbstractVelocityND):
 
 
 # TODO: move to the class in py3.11+
-@CartesianVelocityND.from_._f.dispatch  # type: ignore[attr-defined,misc]  # noqa: SLF001
+@CartesianVelND.from_._f.dispatch  # type: ignore[attr-defined,misc]  # noqa: SLF001
 def from_(
-    cls: type[CartesianVelocityND],
+    cls: type[CartesianVelND],
     x: Shaped[Quantity["speed"], ""] | Shaped[Quantity["speed"], "*batch N"],
     /,
-) -> CartesianVelocityND:
+) -> CartesianVelND:
     """Construct an N-dimensional velocity.
 
     Examples
@@ -388,34 +388,34 @@ def from_(
 
     1D vector:
 
-    >>> cx.CartesianVelocityND.from_(Quantity(1, "km/s"))
-    CartesianVelocityND(
+    >>> cx.CartesianVelND.from_(Quantity(1, "km/s"))
+    CartesianVelND(
       d_q=Quantity[...]( value=f32[1], unit=Unit("km / s") )
     )
 
-    >>> cx.CartesianVelocityND.from_(Quantity([1], "km/s"))
-    CartesianVelocityND(
+    >>> cx.CartesianVelND.from_(Quantity([1], "km/s"))
+    CartesianVelND(
       d_q=Quantity[...]( value=f32[1], unit=Unit("km / s") )
     )
 
     2D vector:
 
-    >>> cx.CartesianVelocityND.from_(Quantity([1, 2], "km/s"))
-    CartesianVelocityND(
+    >>> cx.CartesianVelND.from_(Quantity([1, 2], "km/s"))
+    CartesianVelND(
       d_q=Quantity[...]( value=f32[2], unit=Unit("km / s") )
     )
 
     3D vector:
 
-    >>> cx.CartesianVelocityND.from_(Quantity([1, 2, 3], "km/s"))
-    CartesianVelocityND(
+    >>> cx.CartesianVelND.from_(Quantity([1, 2, 3], "km/s"))
+    CartesianVelND(
       d_q=Quantity[...]( value=f32[3], unit=Unit("km / s") )
     )
 
     4D vector:
 
-    >>> cx.CartesianVelocityND.from_(Quantity([1, 2, 3, 4], "km/s"))
-    CartesianVelocityND(
+    >>> cx.CartesianVelND.from_(Quantity([1, 2, 3, 4], "km/s"))
+    CartesianVelND(
       d_q=Quantity[...]( value=f32[4], unit=Unit("km / s") )
     )
 
@@ -490,17 +490,17 @@ class CartesianAccelerationND(AvalMixin, AbstractAccelerationND):
     @override
     @classproperty
     @classmethod
-    def integral_cls(cls) -> type[CartesianVelocityND]:
+    def integral_cls(cls) -> type[CartesianVelND]:
         """Return the integral class.
 
         Examples
         --------
         >>> import coordinax as cx
         >>> cx.CartesianAccelerationND.integral_cls.__name__
-        'CartesianVelocityND'
+        'CartesianVelND'
 
         """
-        return CartesianVelocityND
+        return CartesianVelND
 
     @classproperty
     @classmethod
@@ -522,7 +522,7 @@ class CartesianAccelerationND(AvalMixin, AbstractAccelerationND):
     @partial(eqx.filter_jit, inline=True)
     def norm(
         self,
-        velocity: AbstractVelocityND | None = None,
+        velocity: AbstractVelND | None = None,
         position: AbstractPosND | None = None,
         /,
     ) -> ct.BatchableSpeed:

--- a/src/coordinax/_src/dn/poincare.py
+++ b/src/coordinax/_src/dn/poincare.py
@@ -11,7 +11,7 @@ from jaxtyping import Shaped
 from unxt import Quantity
 
 import coordinax._src.typing as ct
-from coordinax._src.base import AbstractPos, AbstractVelocity
+from coordinax._src.base import AbstractPos, AbstractVel
 from coordinax._src.utils import classproperty
 
 
@@ -53,6 +53,6 @@ class PoincarePolarVector(AbstractPos):  # TODO: better name
 
     @classproperty
     @classmethod
-    def differential_cls(cls) -> type[AbstractVelocity]:
+    def differential_cls(cls) -> type[AbstractVel]:
         """Return the corresponding differential vector class."""
         raise NotImplementedError

--- a/src/coordinax/_src/dn/poincare.py
+++ b/src/coordinax/_src/dn/poincare.py
@@ -11,12 +11,12 @@ from jaxtyping import Shaped
 from unxt import Quantity
 
 import coordinax._src.typing as ct
-from coordinax._src.base import AbstractPosition, AbstractVelocity
+from coordinax._src.base import AbstractPos, AbstractVelocity
 from coordinax._src.utils import classproperty
 
 
 @final
-class PoincarePolarVector(AbstractPosition):  # TODO: better name
+class PoincarePolarVector(AbstractPos):  # TODO: better name
     """Poincare vector + differential."""
 
     rho: ct.BatchableLength = eqx.field(
@@ -47,7 +47,7 @@ class PoincarePolarVector(AbstractPosition):  # TODO: better name
 
     @classproperty
     @classmethod
-    def _cartesian_cls(cls) -> type[AbstractPosition]:
+    def _cartesian_cls(cls) -> type[AbstractPos]:
         """Return the corresponding Cartesian vector class."""
         raise NotImplementedError
 

--- a/src/coordinax/_src/dn/transform.py
+++ b/src/coordinax/_src/dn/transform.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from plum import dispatch
 
-from .cartesian import CartesianAccelerationND, CartesianPosND, CartesianVelND
+from .cartesian import CartesianAccND, CartesianPosND, CartesianVelND
 from .poincare import PoincarePolarVector
 
 ###############################################################################
@@ -87,14 +87,14 @@ def represent_as(
 
 
 # =============================================================================
-# CartesianAccelerationND
+# CartesianAccND
 
 
 @dispatch
 def represent_as(
-    current: CartesianAccelerationND, target: type[CartesianAccelerationND], /
-) -> CartesianAccelerationND:
-    """CartesianAccelerationND -> CartesianAccelerationND with no position.
+    current: CartesianAccND, target: type[CartesianAccND], /
+) -> CartesianAccND:
+    """CartesianAccND -> CartesianAccND with no position.
 
     Cartesian coordinates are an affine coordinate system and so the
     transformation of an n-th order derivative vector in this system do not
@@ -106,8 +106,8 @@ def represent_as(
     Examples
     --------
     >>> import coordinax as cx
-    >>> a = cx.CartesianAccelerationND.from_([1, 1, 1], "m/s2")
-    >>> cx.represent_as(a, cx.CartesianAccelerationND) is a
+    >>> a = cx.CartesianAccND.from_([1, 1, 1], "m/s2")
+    >>> cx.represent_as(a, cx.CartesianAccND) is a
     True
 
     """

--- a/src/coordinax/_src/dn/transform.py
+++ b/src/coordinax/_src/dn/transform.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from plum import dispatch
 
-from .cartesian import CartesianAccelerationND, CartesianPosND, CartesianVelocityND
+from .cartesian import CartesianAccelerationND, CartesianPosND, CartesianVelND
 from .poincare import PoincarePolarVector
 
 ###############################################################################
@@ -35,13 +35,13 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CartesianVelocityND,
-    target: type[CartesianVelocityND],
+    current: CartesianVelND,
+    target: type[CartesianVelND],
     position: CartesianPosND,
     /,
     **kwargs: Any,
-) -> CartesianVelocityND:
-    """CartesianVelocityND -> CartesianVelocityND.
+) -> CartesianVelND:
+    """CartesianVelND -> CartesianVelND.
 
     Examples
     --------
@@ -49,9 +49,9 @@ def represent_as(
     >>> from unxt import Quantity
 
     >>> x = cx.CartesianPosND(Quantity([1, 2, 3, 4], "km"))
-    >>> v = cx.CartesianVelocityND(Quantity([1, 2, 3, 4], "km/s"))
+    >>> v = cx.CartesianVelND(Quantity([1, 2, 3, 4], "km/s"))
 
-    >>> cx.represent_as(v, cx.CartesianVelocityND, x) is v
+    >>> cx.represent_as(v, cx.CartesianVelND, x) is v
     True
 
     """
@@ -59,14 +59,14 @@ def represent_as(
 
 
 # =============================================================================
-# CartesianVelocityND
+# CartesianVelND
 
 
 @dispatch
 def represent_as(
-    current: CartesianVelocityND, target: type[CartesianVelocityND], /
-) -> CartesianVelocityND:
-    """CartesianVelocityND -> CartesianVelocityND with no position.
+    current: CartesianVelND, target: type[CartesianVelND], /
+) -> CartesianVelND:
+    """CartesianVelND -> CartesianVelND with no position.
 
     Cartesian coordinates are an affine coordinate system and so the
     transformation of an n-th order derivative vector in this system do not
@@ -78,8 +78,8 @@ def represent_as(
     Examples
     --------
     >>> import coordinax as cx
-    >>> v = cx.CartesianVelocityND.from_([1, 1, 1], "m/s")
-    >>> cx.represent_as(v, cx.CartesianVelocityND) is v
+    >>> v = cx.CartesianVelND.from_([1, 1, 1], "m/s")
+    >>> cx.represent_as(v, cx.CartesianVelND) is v
     True
 
     """

--- a/src/coordinax/_src/dn/transform.py
+++ b/src/coordinax/_src/dn/transform.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from plum import dispatch
 
-from .cartesian import CartesianAccelerationND, CartesianPositionND, CartesianVelocityND
+from .cartesian import CartesianAccelerationND, CartesianPosND, CartesianVelocityND
 from .poincare import PoincarePolarVector
 
 ###############################################################################
@@ -15,18 +15,18 @@ from .poincare import PoincarePolarVector
 
 @dispatch
 def represent_as(
-    current: CartesianPositionND, target: type[CartesianPositionND], /, **kwargs: Any
-) -> CartesianPositionND:
-    """CartesianPositionND -> CartesianPositionND.
+    current: CartesianPosND, target: type[CartesianPosND], /, **kwargs: Any
+) -> CartesianPosND:
+    """CartesianPosND -> CartesianPosND.
 
     Examples
     --------
     >>> import coordinax as cx
     >>> from unxt import Quantity
 
-    >>> q = cx.CartesianPositionND(Quantity([1, 2, 3, 4], "kpc"))
+    >>> q = cx.CartesianPosND(Quantity([1, 2, 3, 4], "kpc"))
 
-    >>> cx.represent_as(q, cx.CartesianPositionND) is q
+    >>> cx.represent_as(q, cx.CartesianPosND) is q
     True
 
     """
@@ -37,7 +37,7 @@ def represent_as(
 def represent_as(
     current: CartesianVelocityND,
     target: type[CartesianVelocityND],
-    position: CartesianPositionND,
+    position: CartesianPosND,
     /,
     **kwargs: Any,
 ) -> CartesianVelocityND:
@@ -48,7 +48,7 @@ def represent_as(
     >>> import coordinax as cx
     >>> from unxt import Quantity
 
-    >>> x = cx.CartesianPositionND(Quantity([1, 2, 3, 4], "km"))
+    >>> x = cx.CartesianPosND(Quantity([1, 2, 3, 4], "km"))
     >>> v = cx.CartesianVelocityND(Quantity([1, 2, 3, 4], "km/s"))
 
     >>> cx.represent_as(v, cx.CartesianVelocityND, x) is v

--- a/src/coordinax/_src/exceptions.py
+++ b/src/coordinax/_src/exceptions.py
@@ -15,10 +15,10 @@ class IrreversibleDimensionChange(UserWarning):
     >>> import warnings
     >>> import coordinax as cx
 
-    >>> vec = cx.CartesianPosition3D.from_([1, 2, 3], "m")
+    >>> vec = cx.CartesianPos3D.from_([1, 2, 3], "m")
     >>> with warnings.catch_warnings(record=True) as w:
     ...     warnings.simplefilter("always")
-    ...     _ = vec.represent_as(cx.CartesianPosition2D)
+    ...     _ = vec.represent_as(cx.CartesianPos2D)
     >>> print(w[0].message)
     irreversible dimension change
 

--- a/src/coordinax/_src/operators/base.py
+++ b/src/coordinax/_src/operators/base.py
@@ -12,7 +12,7 @@ from plum import dispatch
 from dataclassish import field_items
 from unxt import Quantity
 
-from coordinax._src.base import AbstractPosition
+from coordinax._src.base import AbstractPos
 
 if TYPE_CHECKING:
     from coordinax.operators import OperatorSequence
@@ -56,9 +56,9 @@ class AbstractOperator(eqx.Module):  # type: ignore[misc]
     @dispatch.abstract
     def __call__(
         self: "AbstractOperator",
-        x: AbstractPosition,  # noqa: ARG002
+        x: AbstractPos,  # noqa: ARG002
         /,
-    ) -> AbstractPosition:
+    ) -> AbstractPos:
         """Apply the operator to the coordinates `x`."""
         msg = "implement this method in the subclass"
         raise TypeError(msg)
@@ -66,10 +66,10 @@ class AbstractOperator(eqx.Module):  # type: ignore[misc]
     @dispatch.abstract
     def __call__(
         self: "AbstractOperator",
-        x: AbstractPosition,  # noqa: ARG002
+        x: AbstractPos,  # noqa: ARG002
         t: Quantity["time"],  # noqa: ARG002
         /,
-    ) -> AbstractPosition:
+    ) -> AbstractPos:
         """Apply the operator to the coordinates `x` at a time `t`."""
         msg = "implement this method in the subclass"
         raise TypeError(msg)

--- a/src/coordinax/_src/operators/composite.py
+++ b/src/coordinax/_src/operators/composite.py
@@ -10,7 +10,7 @@ from dataclassish import DataclassInstance
 from unxt import Quantity
 
 from .base import AbstractOperator, op_call_dispatch
-from coordinax._src.base import AbstractPosition
+from coordinax._src.base import AbstractPos
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -42,9 +42,7 @@ class AbstractCompositeOperator(AbstractOperator):
     # writeable (in the from_) and read-only (as a property) subclasses.
 
     @op_call_dispatch(precedence=1)
-    def __call__(
-        self: "AbstractCompositeOperator", x: AbstractPosition, /
-    ) -> AbstractPosition:
+    def __call__(self: "AbstractCompositeOperator", x: AbstractPos, /) -> AbstractPos:
         """Apply the operator to the coordinates.
 
         This is the default implementation, which applies the operators in
@@ -57,8 +55,8 @@ class AbstractCompositeOperator(AbstractOperator):
 
     @op_call_dispatch(precedence=1)
     def __call__(
-        self: "AbstractCompositeOperator", x: AbstractPosition, t: Quantity["time"], /
-    ) -> tuple[AbstractPosition, Quantity["time"]]:
+        self: "AbstractCompositeOperator", x: AbstractPos, t: Quantity["time"], /
+    ) -> tuple[AbstractPos, Quantity["time"]]:
         """Apply the operator to the coordinates."""
         # TODO: with lax.scan?
         for op in self.operators:

--- a/src/coordinax/_src/operators/funcs.py
+++ b/src/coordinax/_src/operators/funcs.py
@@ -22,7 +22,7 @@ def simplify_op(op: AbstractOperator, /) -> AbstractOperator:
     >>> op = co.GalileanSpatialTranslationOperator(shift)
     >>> co.simplify_op(op)
     GalileanSpatialTranslationOperator(
-      translation=CartesianPosition3D( ... )
+      translation=CartesianPos3D( ... )
     )
 
     An operator with no effect can be simplified:

--- a/src/coordinax/_src/operators/galilean/boost.py
+++ b/src/coordinax/_src/operators/galilean/boost.py
@@ -15,7 +15,7 @@ import quaxed.numpy as jnp
 from unxt import Quantity
 
 from .base import AbstractGalileanOperator
-from coordinax._src.d3.base import AbstractPosition3D
+from coordinax._src.d3.base import AbstractPos3D
 from coordinax._src.d3.cartesian import CartesianVelocity3D
 from coordinax._src.d4.spacetime import FourVector
 from coordinax._src.operators.base import AbstractOperator, op_call_dispatch
@@ -118,8 +118,8 @@ class GalileanBoostOperator(AbstractGalileanOperator):
 
     @op_call_dispatch(precedence=1)
     def __call__(
-        self: "GalileanBoostOperator", q: AbstractPosition3D, t: Quantity["time"], /
-    ) -> tuple[AbstractPosition3D, Quantity["time"]]:
+        self: "GalileanBoostOperator", q: AbstractPos3D, t: Quantity["time"], /
+    ) -> tuple[AbstractPos3D, Quantity["time"]]:
         """Apply the boost to the coordinates.
 
         Examples
@@ -129,7 +129,7 @@ class GalileanBoostOperator(AbstractGalileanOperator):
 
         >>> op = GalileanBoostOperator(Quantity([1, 2, 3], "m/s"))
 
-        >>> q = cx.CartesianPosition3D.from_([0, 0, 0], "m")
+        >>> q = cx.CartesianPos3D.from_([0, 0, 0], "m")
         >>> t = Quantity(1, "s")
         >>> newq, newt = op(q, t)
         >>> newt

--- a/src/coordinax/_src/operators/galilean/boost.py
+++ b/src/coordinax/_src/operators/galilean/boost.py
@@ -16,7 +16,7 @@ from unxt import Quantity
 
 from .base import AbstractGalileanOperator
 from coordinax._src.d3.base import AbstractPos3D
-from coordinax._src.d3.cartesian import CartesianVelocity3D
+from coordinax._src.d3.cartesian import CartesianVel3D
 from coordinax._src.d4.spacetime import FourVector
 from coordinax._src.operators.base import AbstractOperator, op_call_dispatch
 from coordinax._src.operators.funcs import simplify_op
@@ -37,11 +37,10 @@ class GalileanBoostOperator(AbstractGalileanOperator):
 
     Parameters
     ----------
-    velocity : :class:`vector.CartesianVelocity3D`
+    velocity : :class:`vector.CartesianVel3D`
         The boost velocity. This parameters uses
-        :meth:`vector.CartesianVelocity3D.from_` to enable a variety
-        of more convenient input types. See
-        :class:`vector.CartesianVelocity3D` for details.
+        :meth:`vector.CartesianVel3D.from_` to enable a variety of more
+        convenient input types. See :class:`vector.CartesianVel3D` for details.
 
     Examples
     --------
@@ -55,26 +54,25 @@ class GalileanBoostOperator(AbstractGalileanOperator):
 
     >>> op = co.GalileanBoostOperator(Quantity([1.0, 2.0, 3.0], "m/s"))
     >>> op
-    GalileanBoostOperator( velocity=CartesianVelocity3D( ... ) )
+    GalileanBoostOperator( velocity=CartesianVel3D( ... ) )
 
-    Note that the velocity is a :class:`vector.CartesianVelocity3D`, which
-    was constructed from a 1D array, using
-    :meth:`vector.CartesianVelocity3D.from_`. We can also construct it
-    directly:
+    Note that the velocity is a :class:`vector.CartesianVel3D`, which was
+    constructed from a 1D array, using :meth:`vector.CartesianVel3D.from_`. We
+    can also construct it directly:
 
-    >>> boost = cx.CartesianVelocity3D.from_([1, 2, 3], "m/s")
+    >>> boost = cx.CartesianVel3D.from_([1, 2, 3], "m/s")
     >>> op = co.GalileanBoostOperator(boost)
     >>> op
-    GalileanBoostOperator( velocity=CartesianVelocity3D( ... ) )
+    GalileanBoostOperator( velocity=CartesianVel3D( ... ) )
 
     """
 
-    velocity: CartesianVelocity3D = eqx.field(converter=CartesianVelocity3D.from_)
+    velocity: CartesianVel3D = eqx.field(converter=CartesianVel3D.from_)
     """The boost velocity.
 
-    This parameters uses :meth:`vector.CartesianVelocity3D.from_` to
-    enable a variety of more convenient input types. See
-    :class:`vector.CartesianVelocity3D` for details.
+    This parameters uses :meth:`vector.CartesianVel3D.from_` to enable a variety
+    of more convenient input types. See :class:`vector.CartesianVel3D` for
+    details.
     """
 
     # -----------------------------------------------------
@@ -106,7 +104,7 @@ class GalileanBoostOperator(AbstractGalileanOperator):
 
         >>> op = GalileanBoostOperator(Quantity([1, 2, 3], "m/s"))
         >>> op.inverse
-        GalileanBoostOperator( velocity=CartesianVelocity3D( ... ) )
+        GalileanBoostOperator( velocity=CartesianVel3D( ... ) )
 
         >>> op.inverse.velocity.d_x
         Quantity['speed'](Array(-1., dtype=float32), unit='m / s')

--- a/src/coordinax/_src/operators/galilean/composite.py
+++ b/src/coordinax/_src/operators/galilean/composite.py
@@ -70,7 +70,7 @@ class GalileanOperator(AbstractCompositeOperator, AbstractGalileanOperator):
       translation=GalileanTranslationOperator(
         translation=FourVector(
           t=Quantity[PhysicalType('time')](value=f32[], unit=Unit("kpc s / km")),
-          q=CartesianPosition3D( ... ) )
+          q=CartesianPos3D( ... ) )
       ),
       velocity=GalileanBoostOperator( velocity=CartesianVelocity3D( ... ) )
     )
@@ -85,13 +85,11 @@ class GalileanOperator(AbstractCompositeOperator, AbstractGalileanOperator):
     >>> op = cx.operators.GalileanOperator(
     ...     translation=cx.operators.GalileanTranslationOperator(
     ...         cx.FourVector(t=Quantity(2.5, "Gyr"),
-    ...                    q=cx.SphericalPosition(r=Quantity(1, "kpc"),
-    ...                                         theta=Quantity(90, "deg"),
-    ...                                         phi=Quantity(0, "rad") ) ) ),
+    ...                    q=cx.SphericalPos(r=Quantity(1, "kpc"),
+    ...                                      theta=Quantity(90, "deg"),
+    ...                                      phi=Quantity(0, "rad") ) ) ),
     ...     velocity=cx.operators.GalileanBoostOperator(
-    ...         cx.CartesianVelocity3D(d_x=Quantity(1, "km/s"),
-    ...                                    d_y=Quantity(2, "km/s"),
-    ...                                    d_z=Quantity(3, "km/s")))
+    ...         cx.CartesianVelocity3D.from_([1, 2, 3], "km/s") )
     ... )
     >>> op
     GalileanOperator(
@@ -99,7 +97,7 @@ class GalileanOperator(AbstractCompositeOperator, AbstractGalileanOperator):
       translation=GalileanTranslationOperator(
         translation=FourVector(
           t=Quantity[PhysicalType('time')](value=f32[], unit=Unit("Gyr")),
-          q=SphericalPosition( ... )
+          q=SphericalPos( ... )
         )
       ),
       velocity=GalileanBoostOperator( velocity=CartesianVelocity3D( ... ) )
@@ -112,7 +110,7 @@ class GalileanOperator(AbstractCompositeOperator, AbstractGalileanOperator):
     >>> new
     FourVector(
       t=Quantity[PhysicalType('time')](value=f32[], unit=Unit("kpc s / km")),
-      q=CartesianPosition3D( ... )
+      q=CartesianPos3D( ... )
     )
     >>> new.t.to_units("Gyr").value.round(2)
     Array(2.5, dtype=float32)
@@ -120,9 +118,9 @@ class GalileanOperator(AbstractCompositeOperator, AbstractGalileanOperator):
     Quantity['length'](Array(3.5567803, dtype=float32), unit='kpc')
 
     Also the Galilean operators can also be applied to
-    :class:`vector.AbstractPosition3D` and :class:`unxt.Quantity`:
+    :class:`vector.AbstractPos3D` and :class:`unxt.Quantity`:
 
-    >>> q = cx.CartesianPosition3D.from_([0, 0, 0], "kpc")
+    >>> q = cx.CartesianPos3D.from_([0, 0, 0], "kpc")
     >>> t = Quantity(0, "Gyr")
     >>> newq, newt = op(q, t)
     >>> newq.x

--- a/src/coordinax/_src/operators/galilean/composite.py
+++ b/src/coordinax/_src/operators/galilean/composite.py
@@ -45,12 +45,12 @@ class GalileanOperator(AbstractCompositeOperator, AbstractGalileanOperator):
     ----------
     translation : `coordinax.operators.GalileanTranslationOperator`
         The spatial translation of the frame. See
-        :class:`coordinax.operators.GalileanTranslationOperator` for
-        alternative inputs to construct this parameter.
+        :class:`coordinax.operators.GalileanTranslationOperator` for alternative
+        inputs to construct this parameter.
     velocity : :class:`coordinax.operators.GalileanBoostOperator`
         The boost to the frame. See
-        :class:`coordinax.operators.GalileanBoostOperator` for
-        alternative inputs to construct this parameter.
+        :class:`coordinax.operators.GalileanBoostOperator` for alternative
+        inputs to construct this parameter.
 
     Examples
     --------
@@ -72,14 +72,14 @@ class GalileanOperator(AbstractCompositeOperator, AbstractGalileanOperator):
           t=Quantity[PhysicalType('time')](value=f32[], unit=Unit("kpc s / km")),
           q=CartesianPos3D( ... ) )
       ),
-      velocity=GalileanBoostOperator( velocity=CartesianVelocity3D( ... ) )
+      velocity=GalileanBoostOperator( velocity=CartesianVel3D( ... ) )
     )
 
     Note that the translation is a
     :class:`coordinax.operators.GalileanTranslationOperator` with a
     :class:`vector.FourVector` translation, and the velocity is a
     :class:`coordinax.operators.GalileanBoostOperator` with a
-    :class:`vector.CartesianVelocity3D` velocity. We can also construct them
+    :class:`vector.CartesianVel3D` velocity. We can also construct them
     directly, which allows for other vector types.
 
     >>> op = cx.operators.GalileanOperator(
@@ -89,7 +89,7 @@ class GalileanOperator(AbstractCompositeOperator, AbstractGalileanOperator):
     ...                                      theta=Quantity(90, "deg"),
     ...                                      phi=Quantity(0, "rad") ) ) ),
     ...     velocity=cx.operators.GalileanBoostOperator(
-    ...         cx.CartesianVelocity3D.from_([1, 2, 3], "km/s") )
+    ...         cx.CartesianVel3D.from_([1, 2, 3], "km/s") )
     ... )
     >>> op
     GalileanOperator(
@@ -100,7 +100,7 @@ class GalileanOperator(AbstractCompositeOperator, AbstractGalileanOperator):
           q=SphericalPos( ... )
         )
       ),
-      velocity=GalileanBoostOperator( velocity=CartesianVelocity3D( ... ) )
+      velocity=GalileanBoostOperator( velocity=CartesianVel3D( ... ) )
     )
 
     Galilean operators can be applied to :class:`vector.FourVector`:
@@ -158,11 +158,10 @@ class GalileanOperator(AbstractCompositeOperator, AbstractGalileanOperator):
     """The boost to the frame.
 
     This parameters accepts either a
-    :class:`coordinax.operators.GalileanBoostOperator` instance or any
-    input that can be used to construct a
-    :class:`vector.CartesianVelocity3D`, using
-    :meth:`vector.CartesianVelocity3D.from_`. See
-    :class:`vector.CartesianVelocity3D` for details.
+    :class:`coordinax.operators.GalileanBoostOperator` instance or any input
+    that can be used to construct a :class:`vector.CartesianVel3D`, using
+    :meth:`vector.CartesianVel3D.from_`. See :class:`vector.CartesianVel3D` for
+    details.
     """
 
     @property

--- a/src/coordinax/_src/operators/galilean/rotation.py
+++ b/src/coordinax/_src/operators/galilean/rotation.py
@@ -19,8 +19,8 @@ from unxt import Quantity, ustrip
 
 from .base import AbstractGalileanOperator
 from coordinax._src.base import ToUnitsOptions
-from coordinax._src.d3.base import AbstractPosition3D
-from coordinax._src.d3.cartesian import CartesianPosition3D
+from coordinax._src.d3.base import AbstractPos3D
+from coordinax._src.d3.cartesian import CartesianPos3D
 from coordinax._src.operators.base import AbstractOperator, op_call_dispatch
 from coordinax._src.operators.funcs import simplify_op
 from coordinax._src.operators.identity import IdentityOperator
@@ -110,9 +110,9 @@ class GalileanRotationOperator(AbstractGalileanOperator):
                               [-0.70710677,  0.70710677,  0.        ]], dtype=float32),
                        unit='m')
 
-    Translation operators can be applied to :class:`vector.AbstractPosition3D`:
+    Translation operators can be applied to :class:`vector.AbstractPos3D`:
 
-    >>> q = cx.CartesianPosition3D.from_(q)  # from the previous example
+    >>> q = cx.CartesianPos3D.from_(q)  # from the previous example
     >>> newq, newt = op(q, t)
     >>> newq.x
     Quantity['length'](Array([ 0.70710677, -0.70710677], dtype=float32), unit='m')
@@ -221,8 +221,8 @@ class GalileanRotationOperator(AbstractGalileanOperator):
 
     @op_call_dispatch(precedence=1)
     def __call__(
-        self: "GalileanRotationOperator", q: AbstractPosition3D, /
-    ) -> AbstractPosition3D:
+        self: "GalileanRotationOperator", q: AbstractPos3D, /
+    ) -> AbstractPos3D:
         """Apply the boost to the coordinates.
 
         Examples
@@ -238,7 +238,7 @@ class GalileanRotationOperator(AbstractGalileanOperator):
         ...                  [0,             0,              1]])
         >>> op = GalileanRotationOperator(Rz)
 
-        >>> q = cx.CartesianPosition3D.from_([1, 0, 0], "m")
+        >>> q = cx.CartesianPos3D.from_([1, 0, 0], "m")
         >>> t = Quantity(1, "s")
         >>> newq, newt = op(q, t)
         >>> newq.x
@@ -250,28 +250,22 @@ class GalileanRotationOperator(AbstractGalileanOperator):
 
         """
         vec = convert(  # Array[float, (N, 3)]
-            q.represent_as(CartesianPosition3D).to_units(ToUnitsOptions.consistent),
+            q.represent_as(CartesianPos3D).to_units(ToUnitsOptions.consistent),
             Quantity,
         )
-        rcart = CartesianPosition3D.from_(vec_matmul(self.rotation, vec))
+        rcart = CartesianPos3D.from_(vec_matmul(self.rotation, vec))
         return rcart.represent_as(type(q))
 
     @op_call_dispatch(precedence=1)
     def __call__(
-        self: "GalileanRotationOperator",
-        q: AbstractPosition3D,
-        t: Quantity["time"],
-        /,
-    ) -> tuple[AbstractPosition3D, Quantity["time"]]:
+        self: "GalileanRotationOperator", q: AbstractPos3D, t: Quantity["time"], /
+    ) -> tuple[AbstractPos3D, Quantity["time"]]:
         return self(q), t
 
     @op_call_dispatch(precedence=1)
     def __call__(
-        self: "GalileanRotationOperator",
-        q: AbstractPosition3D,
-        t: Quantity["time"],
-        /,
-    ) -> tuple[AbstractPosition3D, Quantity["time"]]:
+        self: "GalileanRotationOperator", q: AbstractPos3D, t: Quantity["time"], /
+    ) -> tuple[AbstractPos3D, Quantity["time"]]:
         return self(q), t
 
 

--- a/src/coordinax/_src/operators/galilean/translation.py
+++ b/src/coordinax/_src/operators/galilean/translation.py
@@ -16,11 +16,11 @@ import quaxed.numpy as jnp
 from unxt import Quantity
 
 from .base import AbstractGalileanOperator
-from coordinax._src.base import AbstractPosition
-from coordinax._src.d1.cartesian import CartesianPosition1D
-from coordinax._src.d2.cartesian import CartesianPosition2D
-from coordinax._src.d3.base import AbstractPosition3D
-from coordinax._src.d3.cartesian import CartesianPosition3D
+from coordinax._src.base import AbstractPos
+from coordinax._src.d1.cartesian import CartesianPos1D
+from coordinax._src.d2.cartesian import CartesianPos2D
+from coordinax._src.d3.base import AbstractPos3D
+from coordinax._src.d3.cartesian import CartesianPos3D
 from coordinax._src.d4.spacetime import FourVector
 from coordinax._src.operators.base import AbstractOperator, op_call_dispatch
 from coordinax._src.operators.funcs import simplify_op
@@ -30,22 +30,22 @@ from coordinax._src.operators.identity import IdentityOperator
 # Spatial Translations
 
 
-def _converter_spatialtranslation(x: Any) -> AbstractPosition:
+def _converter_spatialtranslation(x: Any) -> AbstractPos:
     """Convert to a spatial translation vector."""
-    out: AbstractPosition | None = None
+    out: AbstractPos | None = None
     if isinstance(x, GalileanSpatialTranslationOperator):
         out = x.translation
-    elif isinstance(x, AbstractPosition):
+    elif isinstance(x, AbstractPos):
         out = x
     elif isinstance(x, Quantity):
         shape: tuple[int, ...] = x.shape
         match shape:
             case (1,):
-                out = CartesianPosition1D.from_(x)
+                out = CartesianPos1D.from_(x)
             case (2,):
-                out = CartesianPosition2D.from_(x)
+                out = CartesianPos2D.from_(x)
             case (3,):
-                out = CartesianPosition3D.from_(x)
+                out = CartesianPos3D.from_(x)
             case _:
                 msg = f"Cannot convert {x} to a spatial translation vector."
                 raise TypeError(msg)
@@ -69,12 +69,12 @@ class GalileanSpatialTranslationOperator(AbstractGalileanOperator):
 
     Parameters
     ----------
-    translation : :class:`vector.AbstractPosition3D`
+    translation : :class:`vector.AbstractPos3D`
         The spatial translation vector. This parameters accepts either a
-        :class:`vector.AbstractPosition3D` instance or uses
-        :meth:`vector.CartesianPosition3D.from_` to enable a variety of more
+        :class:`vector.AbstractPos3D` instance or uses
+        :meth:`vector.CartesianPos3D.from_` to enable a variety of more
         convenient input types to create a Cartesian vector. See
-        :class:`vector.CartesianPosition3D` for details.
+        :class:`vector.CartesianPos3D` for details.
 
     Examples
     --------
@@ -89,25 +89,24 @@ class GalileanSpatialTranslationOperator(AbstractGalileanOperator):
     >>> shift = Quantity([1.0, 2.0, 3.0], "kpc")
     >>> op = cx.operators.GalileanSpatialTranslationOperator(shift)
     >>> op
-    GalileanSpatialTranslationOperator( translation=CartesianPosition3D( ... ) )
+    GalileanSpatialTranslationOperator( translation=CartesianPos3D( ... ) )
 
-    Note that the translation is a :class:`vector.CartesianPosition3D`, which was
-    constructed from a 1D array, using
-    :meth:`vector.CartesianPosition3D.from_`. We can also construct it
-    directly, which allows for other vector types.
+    Note that the translation is a :class:`vector.CartesianPos3D`, which was
+    constructed from a 1D array, using :meth:`vector.CartesianPos3D.from_`. We
+    can also construct it directly, which allows for other vector types.
 
-    >>> shift = cx.SphericalPosition(r=Quantity(1.0, "kpc"),
+    >>> shift = cx.SphericalPos(r=Quantity(1.0, "kpc"),
     ...                              theta=Quantity(jnp.pi/2, "rad"),
     ...                              phi=Quantity(0, "rad"))
     >>> op = cx.operators.GalileanSpatialTranslationOperator(shift)
     >>> op
-    GalileanSpatialTranslationOperator( translation=SphericalPosition( ... ) )
+    GalileanSpatialTranslationOperator( translation=SphericalPos( ... ) )
 
-    Translation operators can be applied to :class:`vector.AbstractPosition`:
+    Translation operators can be applied to :class:`vector.AbstractPos`:
 
-    >>> q = cx.CartesianPosition3D.from_([0, 0, 0], "kpc")
+    >>> q = cx.CartesianPos3D.from_([0, 0, 0], "kpc")
     >>> op(q)
-    CartesianPosition3D( ... )
+    CartesianPos3D( ... )
 
     And to :class:`~unxt.Quantity`:
 
@@ -126,9 +125,9 @@ class GalileanSpatialTranslationOperator(AbstractGalileanOperator):
     >>> op(q)
     Quantity['length'](Array([1.], dtype=float32), unit='kpc')
 
-    >>> vec = cx.CartesianPosition1D.from_(q).represent_as(cx.RadialPosition)
+    >>> vec = cx.CartesianPos1D.from_(q).represent_as(cx.RadialPos)
     >>> op(vec)
-    RadialPosition(r=Distance(value=f32[], unit=Unit("kpc")))
+    RadialPos(r=Distance(value=f32[], unit=Unit("kpc")))
 
     - 2D:
 
@@ -138,9 +137,9 @@ class GalileanSpatialTranslationOperator(AbstractGalileanOperator):
     >>> op(q)
     Quantity['length'](Array([1., 2.], dtype=float32), unit='kpc')
 
-    >>> vec = cx.CartesianPosition2D.from_(q).represent_as(cx.PolarPosition)
+    >>> vec = cx.CartesianPos2D.from_(q).represent_as(cx.PolarPos)
     >>> op(vec)
-    PolarPosition( r=Distance(value=f32[], unit=Unit("kpc")),
+    PolarPos( r=Distance(value=f32[], unit=Unit("kpc")),
                  phi=Quantity[...](value=f32[], unit=Unit("rad")) )
 
     - 3D:
@@ -151,9 +150,9 @@ class GalileanSpatialTranslationOperator(AbstractGalileanOperator):
     >>> op(q)
     Quantity['length'](Array([1., 2., 3.], dtype=float32), unit='kpc')
 
-    >>> vec = cx.CartesianPosition3D.from_(q).represent_as(cx.SphericalPosition)
+    >>> vec = cx.CartesianPos3D.from_(q).represent_as(cx.SphericalPos)
     >>> op(vec)
-    SphericalPosition( r=Distance(value=f32[], unit=Unit("kpc")),
+    SphericalPos( r=Distance(value=f32[], unit=Unit("kpc")),
                      theta=Quantity[...](value=f32[], unit=Unit("rad")),
                      phi=Quantity[...](value=f32[], unit=Unit("rad")) )
 
@@ -166,13 +165,13 @@ class GalileanSpatialTranslationOperator(AbstractGalileanOperator):
 
     """
 
-    translation: AbstractPosition = eqx.field(converter=_converter_spatialtranslation)
+    translation: AbstractPos = eqx.field(converter=_converter_spatialtranslation)
     """The spatial translation.
 
     This parameters accepts either a :class:`vector.AbstracVector` instance or
     uses a Cartesian vector from_ to enable a variety of more convenient
     input types to create a Cartesian vector. See
-    :class:`vector.CartesianPosition3D.from_` for an example when doing a 3D
+    :class:`vector.CartesianPos3D.from_` for an example when doing a 3D
     translation.
     """
 
@@ -236,7 +235,7 @@ class GalileanSpatialTranslationOperator(AbstractGalileanOperator):
         >>> import coordinax as cx
         >>> from coordinax.operators import GalileanSpatialTranslationOperator
 
-        >>> shift = cx.CartesianPosition3D.from_([1, 1, 1], "kpc")
+        >>> shift = cx.CartesianPos3D.from_([1, 1, 1], "kpc")
         >>> op = GalileanSpatialTranslationOperator(shift)
 
         >>> op.is_inertial
@@ -255,11 +254,11 @@ class GalileanSpatialTranslationOperator(AbstractGalileanOperator):
         >>> import coordinax as cx
         >>> from coordinax.operators import GalileanSpatialTranslationOperator
 
-        >>> shift = cx.CartesianPosition3D.from_([1, 1, 1], "kpc")
+        >>> shift = cx.CartesianPos3D.from_([1, 1, 1], "kpc")
         >>> op = GalileanSpatialTranslationOperator(shift)
 
         >>> op.inverse
-        GalileanSpatialTranslationOperator( translation=CartesianPosition3D( ... ) )
+        GalileanSpatialTranslationOperator( translation=CartesianPos3D( ... ) )
 
         >>> op.inverse.translation.x
         Quantity['length'](Array(-1., dtype=float32), unit='kpc')
@@ -271,8 +270,8 @@ class GalileanSpatialTranslationOperator(AbstractGalileanOperator):
 
     @op_call_dispatch(precedence=1)
     def __call__(
-        self: "GalileanSpatialTranslationOperator", q: AbstractPosition, /
-    ) -> AbstractPosition:
+        self: "GalileanSpatialTranslationOperator", q: AbstractPos, /
+    ) -> AbstractPos:
         """Apply the translation to the coordinates.
 
         Examples
@@ -281,10 +280,10 @@ class GalileanSpatialTranslationOperator(AbstractGalileanOperator):
         >>> import coordinax as cx
         >>> from coordinax.operators import GalileanSpatialTranslationOperator
 
-        >>> shift = cx.CartesianPosition3D.from_([1, 1, 1], "kpc")
+        >>> shift = cx.CartesianPos3D.from_([1, 1, 1], "kpc")
         >>> op = GalileanSpatialTranslationOperator(shift)
 
-        >>> q = cx.CartesianPosition3D.from_([1, 2, 3], "kpc")
+        >>> q = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
         >>> t = Quantity(0, "Gyr")
         >>> newq = op(q)
         >>> newq.x
@@ -296,10 +295,10 @@ class GalileanSpatialTranslationOperator(AbstractGalileanOperator):
     @op_call_dispatch(precedence=1)
     def __call__(
         self: "GalileanSpatialTranslationOperator",
-        q: AbstractPosition,
+        q: AbstractPos,
         t: Quantity["time"],
         /,
-    ) -> tuple[AbstractPosition, Quantity["time"]]:
+    ) -> tuple[AbstractPos, Quantity["time"]]:
         """Apply the translation to the coordinates.
 
         Examples
@@ -308,10 +307,10 @@ class GalileanSpatialTranslationOperator(AbstractGalileanOperator):
         >>> import coordinax as cx
         >>> from coordinax.operators import GalileanSpatialTranslationOperator
 
-        >>> shift = cx.CartesianPosition3D.from_([1, 1, 1], "kpc")
+        >>> shift = cx.CartesianPos3D.from_([1, 1, 1], "kpc")
         >>> op = GalileanSpatialTranslationOperator(shift)
 
-        >>> q = cx.CartesianPosition3D.from_([1, 2, 3], "kpc")
+        >>> q = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
         >>> t = Quantity(0, "Gyr")
         >>> newq, newt = op(q, t)
         >>> newq.x
@@ -328,7 +327,7 @@ class GalileanSpatialTranslationOperator(AbstractGalileanOperator):
     @op_call_dispatch(precedence=1)
     def __call__(
         self: "GalileanSpatialTranslationOperator", v4: FourVector, /
-    ) -> AbstractPosition:
+    ) -> AbstractPos:
         """Apply the translation to the coordinates."""  # TODO: docstring
         return replace(v4, q=v4.q + self.translation)
 
@@ -384,14 +383,14 @@ class GalileanTranslationOperator(AbstractGalileanOperator):
     GalileanTranslationOperator(
       translation=FourVector(
         t=Quantity[PhysicalType('time')](value=f32[], unit=Unit("kpc s / km")),
-        q=CartesianPosition3D( ... ) )
+        q=CartesianPos3D( ... ) )
     )
 
     Note that the translation is a :class:`vector.FourVector`, which was
     constructed from a 1D array, using :meth:`vector.FourVector.from_`. We
     can also construct it directly, which allows for other vector types.
 
-    >>> qshift = cx.SphericalPosition(r=Quantity(1.0, "kpc"),
+    >>> qshift = cx.SphericalPos(r=Quantity(1.0, "kpc"),
     ...                               theta=Quantity(jnp.pi/2, "rad"),
     ...                               phi=Quantity(0, "rad"))
     >>> op = GalileanTranslationOperator(FourVector(t=Quantity(1.0, "Gyr"), q=qshift))
@@ -399,7 +398,7 @@ class GalileanTranslationOperator(AbstractGalileanOperator):
     GalileanTranslationOperator(
       translation=FourVector(
         t=Quantity[PhysicalType('time')](value=f32[], unit=Unit("Gyr")),
-        q=SphericalPosition( ... ) )
+        q=SphericalPos( ... ) )
     )
 
     Translation operators can be applied to :class:`vector.FourVector`:
@@ -408,12 +407,12 @@ class GalileanTranslationOperator(AbstractGalileanOperator):
     >>> op(w)
     FourVector(
       t=Quantity[PhysicalType('time')](value=f32[], unit=Unit("kpc s / km")),
-      q=CartesianPosition3D( ... )
+      q=CartesianPos3D( ... )
     )
 
-    Also to :class:`vector.AbstractPosition3D` and :class:`unxt.Quantity`:
+    Also to :class:`vector.AbstractPos3D` and :class:`unxt.Quantity`:
 
-    >>> q = cx.CartesianPosition3D.from_([0, 0, 0], "kpc")
+    >>> q = cx.CartesianPos3D.from_([0, 0, 0], "kpc")
     >>> t = Quantity(0, "Gyr")
     >>> newq, newt = op(q, t)
     >>> newq.x
@@ -462,7 +461,7 @@ class GalileanTranslationOperator(AbstractGalileanOperator):
         >>> import coordinax as cx
         >>> from coordinax.operators import GalileanSpatialTranslationOperator
 
-        >>> qshift = cx.CartesianPosition3D.from_([1, 1, 1], "kpc")
+        >>> qshift = cx.CartesianPos3D.from_([1, 1, 1], "kpc")
         >>> tshift = Quantity(1, "Gyr")
         >>> shift = FourVector(tshift, qshift)
         >>> op = GalileanTranslationOperator(shift)
@@ -490,7 +489,7 @@ class GalileanTranslationOperator(AbstractGalileanOperator):
 
         Explicitly construct the translation operator:
 
-        >>> qshift = cx.CartesianPosition3D.from_([1, 1, 1], "kpc")
+        >>> qshift = cx.CartesianPos3D.from_([1, 1, 1], "kpc")
         >>> tshift = Quantity(1, "Gyr")
         >>> shift = FourVector(tshift, qshift)
         >>> op = GalileanTranslationOperator(shift)
@@ -517,10 +516,10 @@ class GalileanTranslationOperator(AbstractGalileanOperator):
     @op_call_dispatch(precedence=1)
     def __call__(
         self: "GalileanTranslationOperator",
-        x: AbstractPosition3D,
+        x: AbstractPos3D,
         t: Quantity["time"],
         /,
-    ) -> tuple[AbstractPosition3D, Quantity["time"]]:
+    ) -> tuple[AbstractPos3D, Quantity["time"]]:
         """Apply the translation to the coordinates.
 
         Examples
@@ -531,14 +530,14 @@ class GalileanTranslationOperator(AbstractGalileanOperator):
 
         Explicitly construct the translation operator:
 
-        >>> qshift = cx.CartesianPosition3D.from_([1, 1, 1], "kpc")
+        >>> qshift = cx.CartesianPos3D.from_([1, 1, 1], "kpc")
         >>> tshift = Quantity(1, "Gyr")
         >>> shift = cx.FourVector(tshift, qshift)
         >>> op = GalileanTranslationOperator(shift)
 
         Construct a vector to translate
 
-        >>> q = cx.CartesianPosition3D.from_([1, 2, 3], "kpc")
+        >>> q = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
         >>> t = Quantity(1, "Gyr")
         >>> newq, newt = op(q, t)
 

--- a/src/coordinax/_src/operators/identity.py
+++ b/src/coordinax/_src/operators/identity.py
@@ -9,7 +9,7 @@ from jaxtyping import Shaped
 from unxt import Quantity
 
 from .base import AbstractOperator, op_call_dispatch
-from coordinax._src.base import AbstractPosition
+from coordinax._src.base import AbstractPos
 
 
 @final
@@ -35,7 +35,7 @@ class IdentityOperator(AbstractOperator):
     And the common objects we will use:
 
     >>> q = Quantity([1, 2, 3], "kpc")
-    >>> vec = cx.CartesianPosition3D.from_(q)
+    >>> vec = cx.CartesianPos3D.from_(q)
 
     The first call signature is for the case where the input is a vector:
 
@@ -52,21 +52,21 @@ class IdentityOperator(AbstractOperator):
     - 1D:
 
     >>> q = Quantity([1], "kpc")
-    >>> vec = cx.CartesianPosition1D.from_(q)
+    >>> vec = cx.CartesianPos1D.from_(q)
     >>> op(vec) is vec and op(q) is q
     True
 
     - 2D:
 
     >>> q = Quantity([1, 2], "kpc")
-    >>> vec = cx.CartesianPosition2D.from_(q)
+    >>> vec = cx.CartesianPos2D.from_(q)
     >>> op(vec) is vec and op(q) is q
     True
 
-    - 3D (not using a `~coordinax.CartesianPosition3D` instance):
+    - 3D (not using a `~coordinax.CartesianPos3D` instance):
 
     >>> q = Quantity([1, 2, 3], "kpc")
-    >>> vec = cx.CartesianPosition3D.from_(q).represent_as(cx.SphericalPosition)
+    >>> vec = cx.CartesianPos3D.from_(q).represent_as(cx.SphericalPos)
     >>> op(vec) is vec and op(q) is q
     True
 
@@ -100,7 +100,7 @@ class IdentityOperator(AbstractOperator):
         >>> import coordinax as cx
         >>> from coordinax.operators import IdentityOperator
 
-        >>> q = cx.CartesianPosition3D.from_([1, 2, 3], "kpc")
+        >>> q = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
         >>> t = Quantity(0, "Gyr")
         >>> op = IdentityOperator()
         >>> op.is_inertial
@@ -132,7 +132,7 @@ class IdentityOperator(AbstractOperator):
     # More call signatures are registered in the `coordinax._d<X>.operate` modules.
 
     @op_call_dispatch(precedence=1)
-    def __call__(self: "IdentityOperator", x: AbstractPosition, /) -> AbstractPosition:
+    def __call__(self: "IdentityOperator", x: AbstractPos, /) -> AbstractPos:
         """Apply the Identity operation.
 
         This is the identity operation, which does nothing to the input.
@@ -143,7 +143,7 @@ class IdentityOperator(AbstractOperator):
         >>> import coordinax as cx
         >>> from coordinax.operators import IdentityOperator
 
-        >>> q = cx.CartesianPosition3D.from_([1, 2, 3], "kpc")
+        >>> q = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
         >>> op = IdentityOperator()
         >>> op(q) is q
         True
@@ -174,8 +174,8 @@ class IdentityOperator(AbstractOperator):
 
     @op_call_dispatch(precedence=1)
     def __call__(
-        self: "IdentityOperator", x: AbstractPosition, t: Quantity["time"], /
-    ) -> tuple[AbstractPosition, Quantity["time"]]:
+        self: "IdentityOperator", x: AbstractPos, t: Quantity["time"], /
+    ) -> tuple[AbstractPos, Quantity["time"]]:
         """Apply the Identity operation."""  # TODO: docstring
         return x, t
 

--- a/src/coordinax/_src/space.py
+++ b/src/coordinax/_src/space.py
@@ -19,12 +19,7 @@ import quaxed.numpy as jnp
 from unxt import Quantity, dimensions
 from xmmutablemap import ImmutableMap
 
-from .base import (
-    AbstractAcceleration,
-    AbstractPos,
-    AbstractVector,
-    AbstractVelocity,
-)
+from .base import AbstractAcceleration, AbstractPos, AbstractVector, AbstractVel
 from .typing import Unit
 from .utils import classproperty
 from coordinax._src.funcs import represent_as
@@ -70,14 +65,14 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
     >>> from unxt import Quantity
 
     >>> x = cx.CartesianPos3D.from_([1, 2, 3], "km")
-    >>> v = cx.CartesianVelocity3D.from_([4, 5, 6], "km/s")
+    >>> v = cx.CartesianVel3D.from_([4, 5, 6], "km/s")
     >>> a = cx.CartesianAcceleration3D.from_([7, 8, 9], "km/s^2")
 
     >>> space = cx.Space(length=x, speed=v, acceleration=a)
     >>> space
     Space({
         'length': CartesianPos3D( ... ),
-        'speed': CartesianVelocity3D( ... ),
+        'speed': CartesianVel3D( ... ),
         'acceleration': CartesianAcceleration3D( ... )}
     )
 
@@ -87,14 +82,14 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
     >>> space.represent_as(cx.SphericalPos)
     Space({
         'length': SphericalPos( ... ),
-        'speed': SphericalVelocity( ... ),
+        'speed': SphericalVel( ... ),
         'acceleration': SphericalAcceleration( ... )}
     )
 
     >>> cx.represent_as(space, cx.SphericalPos)
     Space({
         'length': SphericalPos( ... ),
-        'speed': SphericalVelocity( ... ),
+        'speed': SphericalVel( ... ),
         'acceleration': SphericalAcceleration( ... )}
     )
 
@@ -140,7 +135,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         --------
         >>> import coordinax as cx
         >>> w = cx.Space(length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
-        ...              speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s"))
+        ...              speed=cx.CartesianVel3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s"))
 
         By number:
 
@@ -150,7 +145,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
                 x=Quantity[...](value=f32[2], unit=Unit("m")),
                 y=Quantity[...](value=f32[2], unit=Unit("m")),
                 z=Quantity[...](value=f32[2], unit=Unit("m")) ),
-            'speed': CartesianVelocity3D(
+            'speed': CartesianVel3D(
                 d_x=Quantity[...]( value=f32[2], unit=Unit("m / s") ),
                 d_y=Quantity[...]( value=f32[2], unit=Unit("m / s") ),
                 d_z=Quantity[...]( value=f32[2], unit=Unit("m / s") ) )}
@@ -164,7 +159,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
                 x=Quantity[...](value=f32[0,2], unit=Unit("m")),
                 y=Quantity[...](value=f32[0,2], unit=Unit("m")),
                 z=Quantity[...](value=f32[0,2], unit=Unit("m")) ),
-            'speed': CartesianVelocity3D(
+            'speed': CartesianVel3D(
                 d_x=Quantity[...]( value=f32[0,2], unit=Unit("m / s") ),
                 d_y=Quantity[...]( value=f32[0,2], unit=Unit("m / s") ),
                 d_z=Quantity[...]( value=f32[0,2], unit=Unit("m / s") ) )}
@@ -178,7 +173,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
                 x=Quantity[...](value=f32[1,2], unit=Unit("m")),
                 y=Quantity[...](value=f32[1,2], unit=Unit("m")),
                 z=Quantity[...](value=f32[1,2], unit=Unit("m")) ),
-            'speed': CartesianVelocity3D(
+            'speed': CartesianVel3D(
                 d_x=Quantity[...]( value=f32[1,2], unit=Unit("m / s") ),
                 d_y=Quantity[...]( value=f32[1,2], unit=Unit("m / s") ),
                 d_z=Quantity[...]( value=f32[1,2], unit=Unit("m / s") ) )}
@@ -192,7 +187,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
                 x=Quantity[...](value=f32[], unit=Unit("m")),
                 y=Quantity[...](value=f32[], unit=Unit("m")),
                 z=Quantity[...](value=f32[], unit=Unit("m")) ),
-            'speed': CartesianVelocity3D(
+            'speed': CartesianVel3D(
                 d_x=Quantity[...]( value=f32[], unit=Unit("m / s") ),
                 d_y=Quantity[...]( value=f32[], unit=Unit("m / s") ),
                 d_z=Quantity[...]( value=f32[], unit=Unit("m / s") ) )}
@@ -212,7 +207,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         --------
         >>> import coordinax as cx
         >>> w = cx.Space(length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
-        ...              speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s"))
+        ...              speed=cx.CartesianVel3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s"))
 
         By string key:
 
@@ -262,7 +257,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> w = cx.Space(
         ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
-        ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
+        ...     speed=cx.CartesianVel3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
         >>> w.mT
         Space({
@@ -270,7 +265,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
                 x=Quantity[...](value=f32[2,1], unit=Unit("m")),
                 y=Quantity[...](value=f32[2,1], unit=Unit("m")),
                 z=Quantity[...](value=f32[2,1], unit=Unit("m"))
-            ), 'speed': CartesianVelocity3D(
+            ), 'speed': CartesianVel3D(
                 d_x=Quantity[...]( value=f32[2,1], unit=Unit("m / s") ),
                 d_y=Quantity[...]( value=f32[2,1], unit=Unit("m / s") ),
                 d_z=Quantity[...]( value=f32[2,1], unit=Unit("m / s") )
@@ -289,7 +284,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> w = cx.Space(
         ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
-        ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s") )
+        ...     speed=cx.CartesianVel3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s") )
 
         >>> w.ndim
         2
@@ -308,7 +303,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> w = cx.Space(
         ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
-        ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
+        ...     speed=cx.CartesianVel3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
 
         >>> w.shape
@@ -328,7 +323,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> w = cx.Space(
         ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
-        ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s") )
+        ...     speed=cx.CartesianVel3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s") )
 
         >>> w.size
         2
@@ -347,7 +342,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> w = cx.Space(
         ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
-        ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
+        ...     speed=cx.CartesianVel3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
 
         >>> w.T
@@ -357,7 +352,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
                 y=Quantity[...](value=f32[2,1], unit=Unit("m")),
                 z=Quantity[...](value=f32[2,1], unit=Unit("m"))
             ),
-            'speed': CartesianVelocity3D(
+            'speed': CartesianVel3D(
                 d_x=Quantity[...]( value=f32[2,1], unit=Unit("m / s") ),
                 d_y=Quantity[...]( value=f32[2,1], unit=Unit("m / s") ),
                 d_z=Quantity[...]( value=f32[2,1], unit=Unit("m / s") )
@@ -379,7 +374,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> w = cx.Space(
         ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
-        ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
+        ...     speed=cx.CartesianVel3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
 
         >>> (-w)["length"].x
@@ -397,7 +392,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         >>> from unxt import Quantity
 
         >>> q = cx.CartesianPos3D.from_([1, 2, 3], "m")
-        >>> p = cx.CartesianVelocity3D.from_([1, 2, 3], "m/s")
+        >>> p = cx.CartesianVel3D.from_([1, 2, 3], "m/s")
         >>> w = cx.Space(length=q, speed=p)
         >>> w
         Space({
@@ -406,7 +401,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
                 y=Quantity[...](value=f32[], unit=Unit("m")),
                 z=Quantity[...](value=f32[], unit=Unit("m"))
             ),
-            'speed': CartesianVelocity3D(
+            'speed': CartesianVel3D(
                 d_x=Quantity[...]( value=f32[], unit=Unit("m / s") ),
                 d_y=Quantity[...]( value=f32[], unit=Unit("m / s") ),
                 d_z=Quantity[...]( value=f32[], unit=Unit("m / s") )
@@ -473,7 +468,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> w = cx.Space(
         ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
-        ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
+        ...     speed=cx.CartesianVel3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
 
         >>> w.dtypes
@@ -495,7 +490,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> w = cx.Space(
         ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
-        ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
+        ...     speed=cx.CartesianVel3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
 
         >>> w.devices
@@ -517,7 +512,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> w = cx.Space(
         ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
-        ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
+        ...     speed=cx.CartesianVel3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
 
         >>> w.shapes
@@ -537,7 +532,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> w = cx.Space(
         ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
-        ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
+        ...     speed=cx.CartesianVel3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
 
         >>> w.sizes
@@ -609,8 +604,8 @@ def temp_represent_as(
 # TODO: should this be moved to a different file?
 @dispatch
 def temp_represent_as(
-    current: AbstractVelocity, target: type[AbstractPos], space: Space, /
-) -> AbstractVelocity:
+    current: AbstractVel, target: type[AbstractPos], space: Space, /
+) -> AbstractVel:
     """Transform of Velocities."""
     return represent_as(current, target.differential_cls, space["length"])
 

--- a/src/coordinax/_src/space.py
+++ b/src/coordinax/_src/space.py
@@ -19,7 +19,7 @@ import quaxed.numpy as jnp
 from unxt import Quantity, dimensions
 from xmmutablemap import ImmutableMap
 
-from .base import AbstractAcceleration, AbstractPos, AbstractVector, AbstractVel
+from .base import AbstractAcc, AbstractPos, AbstractVector, AbstractVel
 from .typing import Unit
 from .utils import classproperty
 from coordinax._src.funcs import represent_as
@@ -66,14 +66,14 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
     >>> x = cx.CartesianPos3D.from_([1, 2, 3], "km")
     >>> v = cx.CartesianVel3D.from_([4, 5, 6], "km/s")
-    >>> a = cx.CartesianAcceleration3D.from_([7, 8, 9], "km/s^2")
+    >>> a = cx.CartesianAcc3D.from_([7, 8, 9], "km/s^2")
 
     >>> space = cx.Space(length=x, speed=v, acceleration=a)
     >>> space
     Space({
         'length': CartesianPos3D( ... ),
         'speed': CartesianVel3D( ... ),
-        'acceleration': CartesianAcceleration3D( ... )}
+        'acceleration': CartesianAcc3D( ... )}
     )
 
     >>> space["length"]
@@ -83,14 +83,14 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
     Space({
         'length': SphericalPos( ... ),
         'speed': SphericalVel( ... ),
-        'acceleration': SphericalAcceleration( ... )}
+        'acceleration': SphericalAcc( ... )}
     )
 
     >>> cx.represent_as(space, cx.SphericalPos)
     Space({
         'length': SphericalPos( ... ),
         'speed': SphericalVel( ... ),
-        'acceleration': SphericalAcceleration( ... )}
+        'acceleration': SphericalAcc( ... )}
     )
 
     """  # noqa: E501
@@ -613,9 +613,9 @@ def temp_represent_as(
 # TODO: should this be moved to a different file?
 @dispatch
 def temp_represent_as(
-    current: AbstractAcceleration, target: type[AbstractPos], space: Space, /
-) -> AbstractAcceleration:
-    """Transform of Accelerations."""
+    current: AbstractAcc, target: type[AbstractPos], space: Space, /
+) -> AbstractAcc:
+    """Transform of Accs."""
     return represent_as(
         current,
         target.differential_cls.differential_cls,

--- a/src/coordinax/_src/space.py
+++ b/src/coordinax/_src/space.py
@@ -21,7 +21,7 @@ from xmmutablemap import ImmutableMap
 
 from .base import (
     AbstractAcceleration,
-    AbstractPosition,
+    AbstractPos,
     AbstractVector,
     AbstractVelocity,
 )
@@ -69,31 +69,31 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
     >>> import coordinax as cx
     >>> from unxt import Quantity
 
-    >>> x = cx.CartesianPosition3D.from_([1, 2, 3], "km")
+    >>> x = cx.CartesianPos3D.from_([1, 2, 3], "km")
     >>> v = cx.CartesianVelocity3D.from_([4, 5, 6], "km/s")
     >>> a = cx.CartesianAcceleration3D.from_([7, 8, 9], "km/s^2")
 
     >>> space = cx.Space(length=x, speed=v, acceleration=a)
     >>> space
     Space({
-        'length': CartesianPosition3D( ... ),
+        'length': CartesianPos3D( ... ),
         'speed': CartesianVelocity3D( ... ),
         'acceleration': CartesianAcceleration3D( ... )}
     )
 
     >>> space["length"]
-    CartesianPosition3D( ... )
+    CartesianPos3D( ... )
 
-    >>> space.represent_as(cx.SphericalPosition)
+    >>> space.represent_as(cx.SphericalPos)
     Space({
-        'length': SphericalPosition( ... ),
+        'length': SphericalPos( ... ),
         'speed': SphericalVelocity( ... ),
         'acceleration': SphericalAcceleration( ... )}
     )
 
-    >>> cx.represent_as(space, cx.SphericalPosition)
+    >>> cx.represent_as(space, cx.SphericalPos)
     Space({
-        'length': SphericalPosition( ... ),
+        'length': SphericalPos( ... ),
         'speed': SphericalVelocity( ... ),
         'acceleration': SphericalAcceleration( ... )}
     )
@@ -139,14 +139,14 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         Examples
         --------
         >>> import coordinax as cx
-        >>> w = cx.Space(length=cx.CartesianPosition3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
+        >>> w = cx.Space(length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
         ...              speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s"))
 
         By number:
 
         >>> w[0]
         Space({
-            'length': CartesianPosition3D(
+            'length': CartesianPos3D(
                 x=Quantity[...](value=f32[2], unit=Unit("m")),
                 y=Quantity[...](value=f32[2], unit=Unit("m")),
                 z=Quantity[...](value=f32[2], unit=Unit("m")) ),
@@ -160,7 +160,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> w[1:]
         Space({
-            'length': CartesianPosition3D(
+            'length': CartesianPos3D(
                 x=Quantity[...](value=f32[0,2], unit=Unit("m")),
                 y=Quantity[...](value=f32[0,2], unit=Unit("m")),
                 z=Quantity[...](value=f32[0,2], unit=Unit("m")) ),
@@ -174,7 +174,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> w[...]
         Space({
-            'length': CartesianPosition3D(
+            'length': CartesianPos3D(
                 x=Quantity[...](value=f32[1,2], unit=Unit("m")),
                 y=Quantity[...](value=f32[1,2], unit=Unit("m")),
                 z=Quantity[...](value=f32[1,2], unit=Unit("m")) ),
@@ -188,7 +188,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> w[(0, 1)]
         Space({
-            'length': CartesianPosition3D(
+            'length': CartesianPos3D(
                 x=Quantity[...](value=f32[], unit=Unit("m")),
                 y=Quantity[...](value=f32[], unit=Unit("m")),
                 z=Quantity[...](value=f32[], unit=Unit("m")) ),
@@ -211,13 +211,13 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         Examples
         --------
         >>> import coordinax as cx
-        >>> w = cx.Space(length=cx.CartesianPosition3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
+        >>> w = cx.Space(length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
         ...              speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s"))
 
         By string key:
 
         >>> w["length"]
-        CartesianPosition3D(
+        CartesianPos3D(
             x=Quantity[...](value=f32[1,2], unit=Unit("m")),
             y=Quantity[...](value=f32[1,2], unit=Unit("m")),
             z=Quantity[...](value=f32[1,2], unit=Unit("m"))
@@ -227,7 +227,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> import astropy.units as u
         >>> w[u.get_physical_type("length")]
-        CartesianPosition3D(
+        CartesianPos3D(
             x=Quantity[...](value=f32[1,2], unit=Unit("m")),
             y=Quantity[...](value=f32[1,2], unit=Unit("m")),
             z=Quantity[...](value=f32[1,2], unit=Unit("m"))
@@ -259,15 +259,14 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         Examples
         --------
         >>> import coordinax as cx
-        >>> from unxt import Quantity
 
         >>> w = cx.Space(
-        ...     length=cx.CartesianPosition3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
+        ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
         ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
         >>> w.mT
         Space({
-            'length': CartesianPosition3D(
+            'length': CartesianPos3D(
                 x=Quantity[...](value=f32[2,1], unit=Unit("m")),
                 y=Quantity[...](value=f32[2,1], unit=Unit("m")),
                 z=Quantity[...](value=f32[2,1], unit=Unit("m"))
@@ -287,10 +286,9 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         Examples
         --------
         >>> import coordinax as cx
-        >>> from unxt import Quantity
 
         >>> w = cx.Space(
-        ...     length=cx.CartesianPosition3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
+        ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
         ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s") )
 
         >>> w.ndim
@@ -309,7 +307,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         >>> from unxt import Quantity
 
         >>> w = cx.Space(
-        ...     length=cx.CartesianPosition3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
+        ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
         ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
 
@@ -329,7 +327,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         >>> from unxt import Quantity
 
         >>> w = cx.Space(
-        ...     length=cx.CartesianPosition3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
+        ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
         ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s") )
 
         >>> w.size
@@ -348,13 +346,13 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         >>> from unxt import Quantity
 
         >>> w = cx.Space(
-        ...     length=cx.CartesianPosition3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
+        ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
         ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
 
         >>> w.T
         Space({
-            'length': CartesianPosition3D(
+            'length': CartesianPos3D(
                 x=Quantity[...](value=f32[2,1], unit=Unit("m")),
                 y=Quantity[...](value=f32[2,1], unit=Unit("m")),
                 z=Quantity[...](value=f32[2,1], unit=Unit("m"))
@@ -380,7 +378,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         >>> from unxt import Quantity
 
         >>> w = cx.Space(
-        ...     length=cx.CartesianPosition3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
+        ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
         ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
 
@@ -398,12 +396,12 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         >>> import coordinax as cx
         >>> from unxt import Quantity
 
-        >>> q = cx.CartesianPosition3D.from_([1, 2, 3], "m")
+        >>> q = cx.CartesianPos3D.from_([1, 2, 3], "m")
         >>> p = cx.CartesianVelocity3D.from_([1, 2, 3], "m/s")
         >>> w = cx.Space(length=q, speed=p)
         >>> w
         Space({
-            'length': CartesianPosition3D(
+            'length': CartesianPos3D(
                 x=Quantity[...](value=f32[], unit=Unit("m")),
                 y=Quantity[...](value=f32[], unit=Unit("m")),
                 z=Quantity[...](value=f32[], unit=Unit("m"))
@@ -474,7 +472,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         >>> from unxt import Quantity
 
         >>> w = cx.Space(
-        ...     length=cx.CartesianPosition3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
+        ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
         ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
 
@@ -496,7 +494,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         >>> from unxt import Quantity
 
         >>> w = cx.Space(
-        ...     length=cx.CartesianPosition3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
+        ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
         ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
 
@@ -518,7 +516,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         >>> from unxt import Quantity
 
         >>> w = cx.Space(
-        ...     length=cx.CartesianPosition3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
+        ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
         ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
 
@@ -538,7 +536,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         >>> from unxt import Quantity
 
         >>> w = cx.Space(
-        ...     length=cx.CartesianPosition3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
+        ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
         ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
         ... )
 
@@ -602,16 +600,16 @@ def field_items(obj: Space, /) -> ItemsView[str, AbstractVector]:
 # TODO: should this be moved to a different file?
 @dispatch
 def temp_represent_as(
-    current: AbstractPosition, target: type[AbstractPosition], space: Space, /
-) -> AbstractPosition:
-    """Transform of Positions."""
+    current: AbstractPos, target: type[AbstractPos], space: Space, /
+) -> AbstractPos:
+    """Transform of Poss."""
     return represent_as(current, target)  # space is unnecessary
 
 
 # TODO: should this be moved to a different file?
 @dispatch
 def temp_represent_as(
-    current: AbstractVelocity, target: type[AbstractPosition], space: Space, /
+    current: AbstractVelocity, target: type[AbstractPos], space: Space, /
 ) -> AbstractVelocity:
     """Transform of Velocities."""
     return represent_as(current, target.differential_cls, space["length"])
@@ -620,7 +618,7 @@ def temp_represent_as(
 # TODO: should this be moved to a different file?
 @dispatch
 def temp_represent_as(
-    current: AbstractAcceleration, target: type[AbstractPosition], space: Space, /
+    current: AbstractAcceleration, target: type[AbstractPos], space: Space, /
 ) -> AbstractAcceleration:
     """Transform of Accelerations."""
     return represent_as(

--- a/src/coordinax/_src/space.py
+++ b/src/coordinax/_src/space.py
@@ -196,7 +196,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         This also supports numpy index arrays. But this example section
         highlights core python indexing.
 
-        """  # noqa: E501
+        """
         return Space(**{k: v[key] for k, v in self.items()})
 
     @dispatch
@@ -228,7 +228,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
             z=Quantity[...](value=f32[1,2], unit=Unit("m"))
         )
 
-        """  # noqa: E501
+        """
         if isinstance(key, Dimension):
             key = _get_dimension_name(key)
 

--- a/src/coordinax/_src/transform/accelerations.py
+++ b/src/coordinax/_src/transform/accelerations.py
@@ -14,51 +14,51 @@ import quaxed.numpy as jnp
 from dataclassish import field_items
 from unxt import AbstractDistance, Quantity
 
-from coordinax._src.base import AbstractAcceleration, AbstractPos, AbstractVel
-from coordinax._src.d1.base import AbstractAcceleration1D
-from coordinax._src.d2.base import AbstractAcceleration2D
-from coordinax._src.d3.base import AbstractAcceleration3D
+from coordinax._src.base import AbstractAcc, AbstractPos, AbstractVel
+from coordinax._src.d1.base import AbstractAcc1D
+from coordinax._src.d2.base import AbstractAcc2D
+from coordinax._src.d3.base import AbstractAcc3D
 
 
 # TODO: implement for cross-representations
 @dispatch.multi(  # type: ignore[misc]
     # N-D -> N-D
     (
-        AbstractAcceleration1D,
-        type[AbstractAcceleration1D],
+        AbstractAcc1D,
+        type[AbstractAcc1D],
         AbstractVel | Quantity["speed"],
         AbstractPos | Quantity["length"],
     ),
     (
-        AbstractAcceleration2D,
-        type[AbstractAcceleration2D],
+        AbstractAcc2D,
+        type[AbstractAcc2D],
         AbstractVel | Quantity["speed"],
         AbstractPos | Quantity["length"],
     ),
     (
-        AbstractAcceleration3D,
-        type[AbstractAcceleration3D],
+        AbstractAcc3D,
+        type[AbstractAcc3D],
         AbstractVel | Quantity["speed"],
         AbstractPos | Quantity["length"],
     ),
 )
 def represent_as(
-    current: AbstractAcceleration,
-    target: type[AbstractAcceleration],
+    current: AbstractAcc,
+    target: type[AbstractAcc],
     velocity: AbstractVel | Quantity["speed"],
     position: AbstractPos | Quantity["length"],
     /,
     **kwargs: Any,
-) -> AbstractAcceleration:
-    """AbstractAcceleration -> Cartesian -> AbstractAcceleration.
+) -> AbstractAcc:
+    """AbstractAcc -> Cartesian -> AbstractAcc.
 
     This is the base case for the transformation of accelerations.
 
     Parameters
     ----------
-    current : AbstractAcceleration
+    current : AbstractAcc
         The vector acceleration to transform.
-    target : type[AbstractAcceleration]
+    target : type[AbstractAcc]
         The target type of the vector acceleration.
     velocity : AbstractVel
         The velocity vector used to transform the acceleration.
@@ -76,17 +76,17 @@ def represent_as(
 
     >>> q = cx.CartesianPos1D(x=Quantity(1.0, "km"))
     >>> p = cx.CartesianVel1D(d_x=Quantity(1.0, "km/s"))
-    >>> a = cx.CartesianAcceleration1D(d2_x=Quantity(1.0, "km/s2"))
-    >>> cx.represent_as(a, cx.RadialAcceleration, p, q)
-    RadialAcceleration( d2_r=Quantity[...](value=f32[], unit=Unit("km / s2")) )
+    >>> a = cx.CartesianAcc1D(d2_x=Quantity(1.0, "km/s2"))
+    >>> cx.represent_as(a, cx.RadialAcc, p, q)
+    RadialAcc( d2_r=Quantity[...](value=f32[], unit=Unit("km / s2")) )
 
     Now in 2D:
 
     >>> q = cx.CartesianPos2D.from_([1.0, 2.0], "km")
     >>> p = cx.CartesianVel2D.from_([1.0, 2.0], "km/s")
-    >>> a = cx.CartesianAcceleration2D.from_([1.0, 2.0], "km/s2")
-    >>> cx.represent_as(a, cx.PolarAcceleration, p, q)
-    PolarAcceleration(
+    >>> a = cx.CartesianAcc2D.from_([1.0, 2.0], "km/s2")
+    >>> cx.represent_as(a, cx.PolarAcc, p, q)
+    PolarAcc(
       d2_r=Quantity[...](value=f32[], unit=Unit("km / s2")),
       d2_phi=Quantity[...]( value=f32[], unit=Unit("rad / s2") )
     )
@@ -95,9 +95,9 @@ def represent_as(
 
     >>> q = cx.CartesianPos3D.from_([1.0, 2.0, 3.0], "km")
     >>> p = cx.CartesianVel3D.from_([1.0, 2.0, 3.0], "km/s")
-    >>> a = cx.CartesianAcceleration3D.from_([1.0, 2.0, 3.0], "km/s2")
-    >>> cx.represent_as(a, cx.SphericalAcceleration, p, q)
-    SphericalAcceleration(
+    >>> a = cx.CartesianAcc3D.from_([1.0, 2.0, 3.0], "km/s2")
+    >>> cx.represent_as(a, cx.SphericalAcc, p, q)
+    SphericalAcc(
       d2_r=Quantity[...](value=f32[], unit=Unit("km / s2")),
       d2_theta=Quantity[...]( value=f32[], unit=Unit("rad / s2") ),
       d2_phi=Quantity[...]( value=f32[], unit=Unit("rad / s2") )
@@ -106,10 +106,10 @@ def represent_as(
     If given a position as a Quantity, it will be converted to the appropriate
     Cartesian vector:
 
-    >>> cx.represent_as(a, cx.SphericalAcceleration,
+    >>> cx.represent_as(a, cx.SphericalAcc,
     ...                 Quantity([1.0, 2.0, 3.0], "km/s"),
     ...                 Quantity([1.0, 2.0, 3.0], "km"))
-    SphericalAcceleration(
+    SphericalAcc(
       d2_r=Quantity[...](value=f32[], unit=Unit("km / s2")),
       d2_theta=Quantity[...]( value=f32[], unit=Unit("rad / s2") ),
       d2_phi=Quantity[...]( value=f32[], unit=Unit("rad / s2") )

--- a/src/coordinax/_src/transform/accelerations.py
+++ b/src/coordinax/_src/transform/accelerations.py
@@ -14,7 +14,7 @@ import quaxed.numpy as jnp
 from dataclassish import field_items
 from unxt import AbstractDistance, Quantity
 
-from coordinax._src.base import AbstractAcceleration, AbstractPosition, AbstractVelocity
+from coordinax._src.base import AbstractAcceleration, AbstractPos, AbstractVelocity
 from coordinax._src.d1.base import AbstractAcceleration1D
 from coordinax._src.d2.base import AbstractAcceleration2D
 from coordinax._src.d3.base import AbstractAcceleration3D
@@ -27,26 +27,26 @@ from coordinax._src.d3.base import AbstractAcceleration3D
         AbstractAcceleration1D,
         type[AbstractAcceleration1D],
         AbstractVelocity | Quantity["speed"],
-        AbstractPosition | Quantity["length"],
+        AbstractPos | Quantity["length"],
     ),
     (
         AbstractAcceleration2D,
         type[AbstractAcceleration2D],
         AbstractVelocity | Quantity["speed"],
-        AbstractPosition | Quantity["length"],
+        AbstractPos | Quantity["length"],
     ),
     (
         AbstractAcceleration3D,
         type[AbstractAcceleration3D],
         AbstractVelocity | Quantity["speed"],
-        AbstractPosition | Quantity["length"],
+        AbstractPos | Quantity["length"],
     ),
 )
 def represent_as(
     current: AbstractAcceleration,
     target: type[AbstractAcceleration],
     velocity: AbstractVelocity | Quantity["speed"],
-    position: AbstractPosition | Quantity["length"],
+    position: AbstractPos | Quantity["length"],
     /,
     **kwargs: Any,
 ) -> AbstractAcceleration:
@@ -62,7 +62,7 @@ def represent_as(
         The target type of the vector acceleration.
     velocity : AbstractVelocity
         The velocity vector used to transform the acceleration.
-    position : AbstractPosition
+    position : AbstractPos
         The position vector used to transform the acceleration.
     **kwargs : Any
         Additional keyword arguments.
@@ -74,7 +74,7 @@ def represent_as(
 
     Let's start in 1D:
 
-    >>> q = cx.CartesianPosition1D(x=Quantity(1.0, "km"))
+    >>> q = cx.CartesianPos1D(x=Quantity(1.0, "km"))
     >>> p = cx.CartesianVelocity1D(d_x=Quantity(1.0, "km/s"))
     >>> a = cx.CartesianAcceleration1D(d2_x=Quantity(1.0, "km/s2"))
     >>> cx.represent_as(a, cx.RadialAcceleration, p, q)
@@ -82,7 +82,7 @@ def represent_as(
 
     Now in 2D:
 
-    >>> q = cx.CartesianPosition2D.from_([1.0, 2.0], "km")
+    >>> q = cx.CartesianPos2D.from_([1.0, 2.0], "km")
     >>> p = cx.CartesianVelocity2D.from_([1.0, 2.0], "km/s")
     >>> a = cx.CartesianAcceleration2D.from_([1.0, 2.0], "km/s2")
     >>> cx.represent_as(a, cx.PolarAcceleration, p, q)
@@ -93,7 +93,7 @@ def represent_as(
 
     And in 3D:
 
-    >>> q = cx.CartesianPosition3D.from_([1.0, 2.0, 3.0], "km")
+    >>> q = cx.CartesianPos3D.from_([1.0, 2.0, 3.0], "km")
     >>> p = cx.CartesianVelocity3D.from_([1.0, 2.0, 3.0], "km/s")
     >>> a = cx.CartesianAcceleration3D.from_([1.0, 2.0, 3.0], "km/s2")
     >>> cx.represent_as(a, cx.SphericalAcceleration, p, q)
@@ -120,8 +120,8 @@ def represent_as(
     shape = current.shape
     flat_shape = prod(shape)
 
-    # Parse the position to an AbstractPosition
-    if isinstance(position, AbstractPosition):
+    # Parse the position to an AbstractPos
+    if isinstance(position, AbstractPos):
         posvec = position
     else:  # Q -> Cart<X>D
         posvec = current.integral_cls.integral_cls._cartesian_cls.from_(  # noqa: SLF001

--- a/src/coordinax/_src/transform/accelerations.py
+++ b/src/coordinax/_src/transform/accelerations.py
@@ -14,7 +14,7 @@ import quaxed.numpy as jnp
 from dataclassish import field_items
 from unxt import AbstractDistance, Quantity
 
-from coordinax._src.base import AbstractAcceleration, AbstractPos, AbstractVelocity
+from coordinax._src.base import AbstractAcceleration, AbstractPos, AbstractVel
 from coordinax._src.d1.base import AbstractAcceleration1D
 from coordinax._src.d2.base import AbstractAcceleration2D
 from coordinax._src.d3.base import AbstractAcceleration3D
@@ -26,26 +26,26 @@ from coordinax._src.d3.base import AbstractAcceleration3D
     (
         AbstractAcceleration1D,
         type[AbstractAcceleration1D],
-        AbstractVelocity | Quantity["speed"],
+        AbstractVel | Quantity["speed"],
         AbstractPos | Quantity["length"],
     ),
     (
         AbstractAcceleration2D,
         type[AbstractAcceleration2D],
-        AbstractVelocity | Quantity["speed"],
+        AbstractVel | Quantity["speed"],
         AbstractPos | Quantity["length"],
     ),
     (
         AbstractAcceleration3D,
         type[AbstractAcceleration3D],
-        AbstractVelocity | Quantity["speed"],
+        AbstractVel | Quantity["speed"],
         AbstractPos | Quantity["length"],
     ),
 )
 def represent_as(
     current: AbstractAcceleration,
     target: type[AbstractAcceleration],
-    velocity: AbstractVelocity | Quantity["speed"],
+    velocity: AbstractVel | Quantity["speed"],
     position: AbstractPos | Quantity["length"],
     /,
     **kwargs: Any,
@@ -60,7 +60,7 @@ def represent_as(
         The vector acceleration to transform.
     target : type[AbstractAcceleration]
         The target type of the vector acceleration.
-    velocity : AbstractVelocity
+    velocity : AbstractVel
         The velocity vector used to transform the acceleration.
     position : AbstractPos
         The position vector used to transform the acceleration.
@@ -75,7 +75,7 @@ def represent_as(
     Let's start in 1D:
 
     >>> q = cx.CartesianPos1D(x=Quantity(1.0, "km"))
-    >>> p = cx.CartesianVelocity1D(d_x=Quantity(1.0, "km/s"))
+    >>> p = cx.CartesianVel1D(d_x=Quantity(1.0, "km/s"))
     >>> a = cx.CartesianAcceleration1D(d2_x=Quantity(1.0, "km/s2"))
     >>> cx.represent_as(a, cx.RadialAcceleration, p, q)
     RadialAcceleration( d2_r=Quantity[...](value=f32[], unit=Unit("km / s2")) )
@@ -83,7 +83,7 @@ def represent_as(
     Now in 2D:
 
     >>> q = cx.CartesianPos2D.from_([1.0, 2.0], "km")
-    >>> p = cx.CartesianVelocity2D.from_([1.0, 2.0], "km/s")
+    >>> p = cx.CartesianVel2D.from_([1.0, 2.0], "km/s")
     >>> a = cx.CartesianAcceleration2D.from_([1.0, 2.0], "km/s2")
     >>> cx.represent_as(a, cx.PolarAcceleration, p, q)
     PolarAcceleration(
@@ -94,7 +94,7 @@ def represent_as(
     And in 3D:
 
     >>> q = cx.CartesianPos3D.from_([1.0, 2.0, 3.0], "km")
-    >>> p = cx.CartesianVelocity3D.from_([1.0, 2.0, 3.0], "km/s")
+    >>> p = cx.CartesianVel3D.from_([1.0, 2.0, 3.0], "km/s")
     >>> a = cx.CartesianAcceleration3D.from_([1.0, 2.0, 3.0], "km/s2")
     >>> cx.represent_as(a, cx.SphericalAcceleration, p, q)
     SphericalAcceleration(
@@ -128,8 +128,8 @@ def represent_as(
             position
         )
 
-    # Parse the velocity to an AbstractVelocity
-    if isinstance(velocity, AbstractVelocity):
+    # Parse the velocity to an AbstractVel
+    if isinstance(velocity, AbstractVel):
         velvec = velocity
     else:  # Q -> Cart<X>D
         velvec = current.integral_cls._cartesian_cls.from_(  # noqa: SLF001

--- a/src/coordinax/_src/transform/d1.py
+++ b/src/coordinax/_src/transform/d1.py
@@ -9,17 +9,17 @@ from plum import dispatch
 import quaxed.numpy as jnp
 from unxt import Quantity
 
-from coordinax._src.d1.cartesian import CartesianPosition1D
-from coordinax._src.d1.radial import RadialPosition
-from coordinax._src.d2.cartesian import CartesianPosition2D
-from coordinax._src.d2.polar import PolarPosition
-from coordinax._src.d3.cartesian import CartesianPosition3D
-from coordinax._src.d3.cylindrical import CylindricalPosition
-from coordinax._src.d3.mathspherical import MathSphericalPosition
-from coordinax._src.d3.spherical import SphericalPosition
+from coordinax._src.d1.cartesian import CartesianPos1D
+from coordinax._src.d1.radial import RadialPos
+from coordinax._src.d2.cartesian import CartesianPos2D
+from coordinax._src.d2.polar import PolarPos
+from coordinax._src.d3.cartesian import CartesianPos3D
+from coordinax._src.d3.cylindrical import CylindricalPos
+from coordinax._src.d3.mathspherical import MathSphericalPos
+from coordinax._src.d3.spherical import SphericalPos
 
 # =============================================================================
-# CartesianPosition1D
+# CartesianPos1D
 
 
 # -----------------------------------------------
@@ -28,14 +28,14 @@ from coordinax._src.d3.spherical import SphericalPosition
 
 @dispatch
 def represent_as(
-    current: CartesianPosition1D,
-    target: type[CartesianPosition2D],
+    current: CartesianPos1D,
+    target: type[CartesianPos2D],
     /,
     *,
     y: Quantity = Quantity(0.0, "m"),
     **kwargs: Any,
-) -> CartesianPosition2D:
-    """CartesianPosition1D -> CartesianPosition2D.
+) -> CartesianPos2D:
+    """CartesianPos1D -> CartesianPos2D.
 
     The `x` coordinate is converted to the `x` coordinate of the 2D system.
     The `y` coordinate is a keyword argument and defaults to 0.
@@ -45,15 +45,15 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CartesianPosition1D(x=Quantity(1.0, "km"))
-    >>> x2 = cx.represent_as(x, cx.CartesianPosition2D)
+    >>> x = cx.CartesianPos1D(x=Quantity(1.0, "km"))
+    >>> x2 = cx.represent_as(x, cx.CartesianPos2D)
     >>> x2
-    CartesianPosition2D( x=Quantity[...](value=f32[], unit=Unit("km")),
+    CartesianPos2D( x=Quantity[...](value=f32[], unit=Unit("km")),
                        y=Quantity[...](value=f32[], unit=Unit("m")) )
     >>> x2.y
     Quantity['length'](Array(0., dtype=float32), unit='m')
 
-    >>> x3 = cx.represent_as(x, cx.CartesianPosition3D, y=Quantity(14, "km"))
+    >>> x3 = cx.represent_as(x, cx.CartesianPos3D, y=Quantity(14, "km"))
     >>> x3.y
     Quantity['length'](Array(14., dtype=float32), unit='km')
 
@@ -63,14 +63,14 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CartesianPosition1D,
-    target: type[PolarPosition],
+    current: CartesianPos1D,
+    target: type[PolarPos],
     /,
     *,
     phi: Quantity = Quantity(0.0, "radian"),
     **kwargs: Any,
-) -> PolarPosition:
-    """CartesianPosition1D -> PolarPosition.
+) -> PolarPos:
+    """CartesianPos1D -> PolarPos.
 
     The `x` coordinate is converted to the radial coordinate `r`.
     The `phi` coordinate is a keyword argument and defaults to 0.
@@ -80,15 +80,15 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CartesianPosition1D(x=Quantity(1.0, "km"))
-    >>> x2 = cx.represent_as(x, cx.PolarPosition)
+    >>> x = cx.CartesianPos1D(x=Quantity(1.0, "km"))
+    >>> x2 = cx.represent_as(x, cx.PolarPos)
     >>> x2
-    PolarPosition( r=Distance(value=f32[], unit=Unit("km")),
+    PolarPos( r=Distance(value=f32[], unit=Unit("km")),
                  phi=Quantity[...](value=f32[], unit=Unit("rad")) )
     >>> x2.phi
     Quantity['angle'](Array(0., dtype=float32), unit='rad')
 
-    >>> x3 = cx.represent_as(x, cx.PolarPosition, phi=Quantity(14, "deg"))
+    >>> x3 = cx.represent_as(x, cx.PolarPos, phi=Quantity(14, "deg"))
     >>> x3.phi
     Quantity['angle'](Array(14., dtype=float32), unit='deg')
 
@@ -102,15 +102,15 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CartesianPosition1D,
-    target: type[CartesianPosition3D],
+    current: CartesianPos1D,
+    target: type[CartesianPos3D],
     /,
     *,
     y: Quantity = Quantity(0.0, "m"),
     z: Quantity = Quantity(0.0, "m"),
     **kwargs: Any,
-) -> CartesianPosition3D:
-    """CartesianPosition1D -> CartesianPosition3D.
+) -> CartesianPos3D:
+    """CartesianPos1D -> CartesianPos3D.
 
     The `x` coordinate is converted to the `x` coordinate of the 3D system.
     The `y` and `z` coordinates are keyword arguments and default to 0.
@@ -120,10 +120,10 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CartesianPosition1D(x=Quantity(1.0, "km"))
-    >>> x2 = cx.represent_as(x, cx.CartesianPosition3D)
+    >>> x = cx.CartesianPos1D(x=Quantity(1.0, "km"))
+    >>> x2 = cx.represent_as(x, cx.CartesianPos3D)
     >>> x2
-    CartesianPosition3D( x=Quantity[...](value=f32[], unit=Unit("km")),
+    CartesianPos3D( x=Quantity[...](value=f32[], unit=Unit("km")),
                        y=Quantity[...](value=f32[], unit=Unit("m")),
                        z=Quantity[...](value=f32[], unit=Unit("m")) )
     >>> x2.y
@@ -131,7 +131,7 @@ def represent_as(
     >>> x2.z
     Quantity['length'](Array(0., dtype=float32), unit='m')
 
-    >>> x3 = cx.represent_as(x, cx.CartesianPosition3D, y=Quantity(14, "km"))
+    >>> x3 = cx.represent_as(x, cx.CartesianPos3D, y=Quantity(14, "km"))
     >>> x3.y
     Quantity['length'](Array(14., dtype=float32), unit='km')
     >>> x3.z
@@ -143,15 +143,15 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CartesianPosition1D,
-    target: type[SphericalPosition] | type[MathSphericalPosition],
+    current: CartesianPos1D,
+    target: type[SphericalPos] | type[MathSphericalPos],
     /,
     *,
     theta: Quantity = Quantity(0.0, "radian"),
     phi: Quantity = Quantity(0.0, "radian"),
     **kwargs: Any,
-) -> SphericalPosition | MathSphericalPosition:
-    """CartesianPosition1D -> SphericalPosition | MathSphericalPosition.
+) -> SphericalPos | MathSphericalPos:
+    """CartesianPos1D -> SphericalPos | MathSphericalPos.
 
     The `x` coordinate is converted to the radial coordinate `r`.
     The `theta` and `phi` coordinates are keyword arguments and default to 0.
@@ -161,12 +161,12 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    SphericalPosition:
+    SphericalPos:
 
-    >>> x = cx.CartesianPosition1D(x=Quantity(1.0, "km"))
-    >>> x2 = cx.represent_as(x, cx.SphericalPosition)
+    >>> x = cx.CartesianPos1D(x=Quantity(1.0, "km"))
+    >>> x2 = cx.represent_as(x, cx.SphericalPos)
     >>> x2
-    SphericalPosition( r=Distance(value=f32[], unit=Unit("km")),
+    SphericalPos( r=Distance(value=f32[], unit=Unit("km")),
                        theta=Quantity[...](value=f32[], unit=Unit("deg")),
                        phi=Quantity[...](value=f32[], unit=Unit("rad")) )
     >>> x2.phi
@@ -174,18 +174,18 @@ def represent_as(
     >>> x2.theta
     Quantity['angle'](Array(0., dtype=float32), unit='deg')
 
-    >>> x3 = cx.represent_as(x, cx.SphericalPosition, phi=Quantity(14, "deg"))
+    >>> x3 = cx.represent_as(x, cx.SphericalPos, phi=Quantity(14, "deg"))
     >>> x3.phi
     Quantity['angle'](Array(14., dtype=float32), unit='deg')
     >>> x2.theta
     Quantity['angle'](Array(0., dtype=float32), unit='deg')
 
-    MathSphericalPosition:
+    MathSphericalPos:
     Note that ``theta`` and ``phi`` have different meanings in this context.
 
-    >>> x2 = cx.represent_as(x, cx.MathSphericalPosition)
+    >>> x2 = cx.represent_as(x, cx.MathSphericalPos)
     >>> x2
-    MathSphericalPosition( r=Distance(value=f32[], unit=Unit("km")),
+    MathSphericalPos( r=Distance(value=f32[], unit=Unit("km")),
                          theta=Quantity[...](value=f32[], unit=Unit("rad")),
                          phi=Quantity[...](value=f32[], unit=Unit("deg")) )
     >>> x2.theta
@@ -193,7 +193,7 @@ def represent_as(
     >>> x2.phi
     Quantity['angle'](Array(0., dtype=float32), unit='deg')
 
-    >>> x3 = cx.represent_as(x, cx.MathSphericalPosition, phi=Quantity(14, "deg"))
+    >>> x3 = cx.represent_as(x, cx.MathSphericalPos, phi=Quantity(14, "deg"))
     >>> x3.theta
     Quantity['angle'](Array(0., dtype=float32), unit='rad')
     >>> x3.phi
@@ -206,15 +206,15 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CartesianPosition1D,
-    target: type[CylindricalPosition],
+    current: CartesianPos1D,
+    target: type[CylindricalPos],
     /,
     *,
     phi: Quantity = Quantity(0.0, "radian"),
     z: Quantity = Quantity(0.0, "m"),
     **kwargs: Any,
-) -> CylindricalPosition:
-    """CartesianPosition1D -> CylindricalPosition.
+) -> CylindricalPos:
+    """CartesianPos1D -> CylindricalPos.
 
     The `x` coordinate is converted to the radial coordinate `rho`.
     The `phi` and `z` coordinates are keyword arguments and default to 0.
@@ -224,10 +224,10 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CartesianPosition1D(x=Quantity(1.0, "km"))
-    >>> x2 = cx.represent_as(x, cx.CylindricalPosition)
+    >>> x = cx.CartesianPos1D(x=Quantity(1.0, "km"))
+    >>> x2 = cx.represent_as(x, cx.CylindricalPos)
     >>> x2
-    CylindricalPosition( rho=Quantity[...](value=f32[], unit=Unit("km")),
+    CylindricalPos( rho=Quantity[...](value=f32[], unit=Unit("km")),
                        phi=Quantity[...](value=f32[], unit=Unit("rad")),
                        z=Quantity[...](value=f32[], unit=Unit("m")) )
     >>> x2.phi
@@ -235,7 +235,7 @@ def represent_as(
     >>> x2.z
     Quantity['length'](Array(0., dtype=float32), unit='m')
 
-    >>> x3 = cx.represent_as(x, cx.CylindricalPosition, phi=Quantity(14, "deg"))
+    >>> x3 = cx.represent_as(x, cx.CylindricalPos, phi=Quantity(14, "deg"))
     >>> x3.phi
     Quantity['angle'](Array(14., dtype=float32), unit='deg')
     >>> x3.z
@@ -246,7 +246,7 @@ def represent_as(
 
 
 # =============================================================================
-# RadialPosition
+# RadialPos
 
 # -----------------------------------------------
 # 2D
@@ -254,14 +254,14 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: RadialPosition,
-    target: type[CartesianPosition2D],
+    current: RadialPos,
+    target: type[CartesianPos2D],
     /,
     *,
     y: Quantity = Quantity(0.0, "m"),
     **kwargs: Any,
-) -> CartesianPosition2D:
-    """RadialPosition -> CartesianPosition2D.
+) -> CartesianPos2D:
+    """RadialPos -> CartesianPos2D.
 
     The `r` coordinate is converted to the cartesian coordinate `x`.
     The `y` coordinate is a keyword argument and defaults to 0.
@@ -271,15 +271,15 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.RadialPosition(r=Quantity(1.0, "km"))
-    >>> x2 = cx.represent_as(x, cx.CartesianPosition2D)
+    >>> x = cx.RadialPos(r=Quantity(1.0, "km"))
+    >>> x2 = cx.represent_as(x, cx.CartesianPos2D)
     >>> x2
-    CartesianPosition2D( x=Quantity[...](value=f32[], unit=Unit("km")),
+    CartesianPos2D( x=Quantity[...](value=f32[], unit=Unit("km")),
                        y=Quantity[...](value=f32[], unit=Unit("m")) )
     >>> x2.y
     Quantity['length'](Array(0., dtype=float32), unit='m')
 
-    >>> x3 = cx.represent_as(x, cx.CartesianPosition2D, y=Quantity(14, "km"))
+    >>> x3 = cx.represent_as(x, cx.CartesianPos2D, y=Quantity(14, "km"))
     >>> x3.y
     Quantity['length'](Array(14., dtype=float32), unit='km')
 
@@ -289,14 +289,14 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: RadialPosition,
-    target: type[PolarPosition],
+    current: RadialPos,
+    target: type[PolarPos],
     /,
     *,
     phi: Quantity = Quantity(0.0, "radian"),
     **kwargs: Any,
-) -> PolarPosition:
-    """RadialPosition -> PolarPosition.
+) -> PolarPos:
+    """RadialPos -> PolarPos.
 
     The `r` coordinate is converted to the radial coordinate `r`.
     The `phi` coordinate is a keyword argument and defaults to 0.
@@ -306,15 +306,15 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.RadialPosition(r=Quantity(1.0, "km"))
-    >>> x2 = cx.represent_as(x, cx.PolarPosition)
+    >>> x = cx.RadialPos(r=Quantity(1.0, "km"))
+    >>> x2 = cx.represent_as(x, cx.PolarPos)
     >>> x2
-    PolarPosition( r=Distance(value=f32[], unit=Unit("km")),
+    PolarPos( r=Distance(value=f32[], unit=Unit("km")),
                  phi=Quantity[...](value=f32[], unit=Unit("rad")) )
     >>> x2.phi
     Quantity['angle'](Array(0., dtype=float32), unit='rad')
 
-    >>> x3 = cx.represent_as(x, cx.PolarPosition, phi=Quantity(14, "deg"))
+    >>> x3 = cx.represent_as(x, cx.PolarPos, phi=Quantity(14, "deg"))
     >>> x3.phi
     Quantity['angle'](Array(14., dtype=float32), unit='deg')
 
@@ -328,15 +328,15 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: RadialPosition,
-    target: type[CartesianPosition3D],
+    current: RadialPos,
+    target: type[CartesianPos3D],
     /,
     *,
     y: Quantity = Quantity(0.0, "m"),
     z: Quantity = Quantity(0.0, "m"),
     **kwargs: Any,
-) -> CartesianPosition3D:
-    """RadialPosition -> CartesianPosition3D.
+) -> CartesianPos3D:
+    """RadialPos -> CartesianPos3D.
 
     The `r` coordinate is converted to the `x` coordinate of the 3D system.
     The `y` and `z` coordinates are keyword arguments and default to 0.
@@ -346,10 +346,10 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.RadialPosition(r=Quantity(1.0, "km"))
-    >>> x2 = cx.represent_as(x, cx.CartesianPosition3D)
+    >>> x = cx.RadialPos(r=Quantity(1.0, "km"))
+    >>> x2 = cx.represent_as(x, cx.CartesianPos3D)
     >>> x2
-    CartesianPosition3D( x=Quantity[...](value=f32[], unit=Unit("km")),
+    CartesianPos3D( x=Quantity[...](value=f32[], unit=Unit("km")),
                        y=Quantity[...](value=f32[], unit=Unit("m")),
                        z=Quantity[...](value=f32[], unit=Unit("m")) )
     >>> x2.y
@@ -357,7 +357,7 @@ def represent_as(
     >>> x2.z
     Quantity['length'](Array(0., dtype=float32), unit='m')
 
-    >>> x3 = cx.represent_as(x, cx.CartesianPosition3D, y=Quantity(14, "km"))
+    >>> x3 = cx.represent_as(x, cx.CartesianPos3D, y=Quantity(14, "km"))
     >>> x3.y
     Quantity['length'](Array(14., dtype=float32), unit='km')
     >>> x3.z
@@ -369,15 +369,15 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: RadialPosition,
-    target: type[SphericalPosition] | type[MathSphericalPosition],
+    current: RadialPos,
+    target: type[SphericalPos] | type[MathSphericalPos],
     /,
     *,
     theta: Quantity = Quantity(0.0, "radian"),
     phi: Quantity = Quantity(0.0, "radian"),
     **kwargs: Any,
-) -> SphericalPosition | MathSphericalPosition:
-    """RadialPosition -> SphericalPosition | MathSphericalPosition.
+) -> SphericalPos | MathSphericalPos:
+    """RadialPos -> SphericalPos | MathSphericalPos.
 
     The `r` coordinate is converted to the radial coordinate `r`.
     The `theta` and `phi` coordinates are keyword arguments and default to 0.
@@ -387,13 +387,13 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.RadialPosition(r=Quantity(1.0, "km"))
+    >>> x = cx.RadialPos(r=Quantity(1.0, "km"))
 
-    SphericalPosition:
+    SphericalPos:
 
-    >>> x2 = cx.represent_as(x, cx.SphericalPosition)
+    >>> x2 = cx.represent_as(x, cx.SphericalPos)
     >>> x2
-    SphericalPosition( r=Distance(value=f32[], unit=Unit("km")),
+    SphericalPos( r=Distance(value=f32[], unit=Unit("km")),
                        theta=Quantity[...](value=f32[], unit=Unit("deg")),
                        phi=Quantity[...](value=f32[], unit=Unit("rad")) )
     >>> x2.phi
@@ -401,17 +401,17 @@ def represent_as(
     >>> x2.theta
     Quantity['angle'](Array(0., dtype=float32), unit='deg')
 
-    >>> x3 = cx.represent_as(x, cx.SphericalPosition, phi=Quantity(14, "deg"))
+    >>> x3 = cx.represent_as(x, cx.SphericalPos, phi=Quantity(14, "deg"))
     >>> x3.phi
     Quantity['angle'](Array(14., dtype=float32), unit='deg')
     >>> x3.theta
     Quantity['angle'](Array(0., dtype=float32), unit='deg')
 
-    MathSphericalPosition:
+    MathSphericalPos:
 
-    >>> x2 = cx.represent_as(x, cx.MathSphericalPosition)
+    >>> x2 = cx.represent_as(x, cx.MathSphericalPos)
     >>> x2
-    MathSphericalPosition( r=Distance(value=f32[], unit=Unit("km")),
+    MathSphericalPos( r=Distance(value=f32[], unit=Unit("km")),
                            theta=Quantity[...](value=f32[], unit=Unit("rad")),
                            phi=Quantity[...](value=f32[], unit=Unit("deg")) )
     >>> x2.theta
@@ -419,7 +419,7 @@ def represent_as(
     >>> x2.phi
     Quantity['angle'](Array(0., dtype=float32), unit='deg')
 
-    >>> x3 = cx.represent_as(x, cx.MathSphericalPosition, phi=Quantity(14, "deg"))
+    >>> x3 = cx.represent_as(x, cx.MathSphericalPos, phi=Quantity(14, "deg"))
     >>> x3.theta
     Quantity['angle'](Array(0., dtype=float32), unit='rad')
     >>> x3.phi
@@ -432,15 +432,15 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: RadialPosition,
-    target: type[CylindricalPosition],
+    current: RadialPos,
+    target: type[CylindricalPos],
     /,
     *,
     phi: Quantity = Quantity(0.0, "radian"),
     z: Quantity = Quantity(0.0, "m"),
     **kwargs: Any,
-) -> CylindricalPosition:
-    """RadialPosition -> CylindricalPosition.
+) -> CylindricalPos:
+    """RadialPos -> CylindricalPos.
 
     The `r` coordinate is converted to the radial coordinate `rho`.
     The `phi` and `z` coordinates are keyword arguments and default to 0.
@@ -450,10 +450,10 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.RadialPosition(r=Quantity(1.0, "km"))
-    >>> x2 = cx.represent_as(x, cx.CylindricalPosition)
+    >>> x = cx.RadialPos(r=Quantity(1.0, "km"))
+    >>> x2 = cx.represent_as(x, cx.CylindricalPos)
     >>> x2
-    CylindricalPosition( rho=Quantity[...](value=f32[], unit=Unit("km")),
+    CylindricalPos( rho=Quantity[...](value=f32[], unit=Unit("km")),
                        phi=Quantity[...](value=f32[], unit=Unit("rad")),
                        z=Quantity[...](value=f32[], unit=Unit("m")) )
     >>> x2.phi
@@ -461,7 +461,7 @@ def represent_as(
     >>> x2.z
     Quantity['length'](Array(0., dtype=float32), unit='m')
 
-    >>> x3 = cx.represent_as(x, cx.CylindricalPosition, phi=Quantity(14, "deg"))
+    >>> x3 = cx.represent_as(x, cx.CylindricalPos, phi=Quantity(14, "deg"))
     >>> x3.phi
     Quantity['angle'](Array(14., dtype=float32), unit='deg')
     >>> x3.z

--- a/src/coordinax/_src/transform/d2.py
+++ b/src/coordinax/_src/transform/d2.py
@@ -11,32 +11,32 @@ from plum import dispatch
 import quaxed.numpy as jnp
 from unxt import Quantity
 
-from coordinax._src.d1.cartesian import CartesianPosition1D
-from coordinax._src.d1.radial import RadialPosition
-from coordinax._src.d2.base import AbstractPosition2D
-from coordinax._src.d2.cartesian import CartesianPosition2D
-from coordinax._src.d2.polar import PolarPosition
-from coordinax._src.d3.base import AbstractPosition3D
-from coordinax._src.d3.cartesian import CartesianPosition3D
-from coordinax._src.d3.cylindrical import CylindricalPosition
-from coordinax._src.d3.mathspherical import MathSphericalPosition
-from coordinax._src.d3.spherical import SphericalPosition
+from coordinax._src.d1.cartesian import CartesianPos1D
+from coordinax._src.d1.radial import RadialPos
+from coordinax._src.d2.base import AbstractPos2D
+from coordinax._src.d2.cartesian import CartesianPos2D
+from coordinax._src.d2.polar import PolarPos
+from coordinax._src.d3.base import AbstractPos3D
+from coordinax._src.d3.cartesian import CartesianPos3D
+from coordinax._src.d3.cylindrical import CylindricalPos
+from coordinax._src.d3.mathspherical import MathSphericalPos
+from coordinax._src.d3.spherical import SphericalPos
 from coordinax._src.exceptions import IrreversibleDimensionChange
 
 
 @dispatch.multi(
-    (CartesianPosition2D, type[CylindricalPosition]),
-    (CartesianPosition2D, type[SphericalPosition]),
-    (CartesianPosition2D, type[MathSphericalPosition]),
+    (CartesianPos2D, type[CylindricalPos]),
+    (CartesianPos2D, type[SphericalPos]),
+    (CartesianPos2D, type[MathSphericalPos]),
 )
 def represent_as(
-    current: AbstractPosition2D,
-    target: type[AbstractPosition3D],
+    current: AbstractPos2D,
+    target: type[AbstractPos3D],
     /,
     z: Quantity = Quantity(0.0, u.m),
     **kwargs: Any,
-) -> AbstractPosition3D:
-    """AbstractPosition2D -> Cartesian2D -> Cartesian3D -> AbstractPosition3D.
+) -> AbstractPos3D:
+    """AbstractPos2D -> Cartesian2D -> Cartesian3D -> AbstractPos3D.
 
     The 2D vector is in the xy plane. The `z` coordinate is a keyword argument and
     defaults to 0.
@@ -46,49 +46,49 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CartesianPosition2D.from_([1.0, 2.0], "km")
+    >>> x = cx.CartesianPos2D.from_([1.0, 2.0], "km")
 
-    >>> x2 = cx.represent_as(x, cx.CylindricalPosition, z=Quantity(14, "km"))
+    >>> x2 = cx.represent_as(x, cx.CylindricalPos, z=Quantity(14, "km"))
     >>> x2
-    CylindricalPosition( rho=Quantity[...](value=f32[], unit=Unit("km")),
+    CylindricalPos( rho=Quantity[...](value=f32[], unit=Unit("km")),
                        phi=Quantity[...](value=f32[], unit=Unit("rad")),
                        z=Quantity[...](value=f32[], unit=Unit("km")) )
     >>> x2.z
     Quantity['length'](Array(14., dtype=float32), unit='km')
 
-    >>> x3 = cx.represent_as(x, cx.SphericalPosition, z=Quantity(14, "km"))
+    >>> x3 = cx.represent_as(x, cx.SphericalPos, z=Quantity(14, "km"))
     >>> x3
-    SphericalPosition( r=Distance(value=f32[], unit=Unit("km")),
+    SphericalPos( r=Distance(value=f32[], unit=Unit("km")),
                      theta=Quantity[...](value=f32[], unit=Unit("rad")),
                      phi=Quantity[...](value=f32[], unit=Unit("rad")) )
     >>> x3.r
     Distance(Array(14.177447, dtype=float32), unit='km')
 
-    >>> x3 = cx.represent_as(x, cx.MathSphericalPosition, z=Quantity(14, "km"))
+    >>> x3 = cx.represent_as(x, cx.MathSphericalPos, z=Quantity(14, "km"))
     >>> x3
-    MathSphericalPosition( r=Distance(value=f32[], unit=Unit("km")),
+    MathSphericalPos( r=Distance(value=f32[], unit=Unit("km")),
                          theta=Quantity[...](value=f32[], unit=Unit("rad")),
                          phi=Quantity[...](value=f32[], unit=Unit("rad")) )
     >>> x3.r
     Distance(Array(14.177447, dtype=float32), unit='km')
 
     """
-    cart2 = represent_as(current, CartesianPosition2D)
-    cart3 = represent_as(cart2, CartesianPosition3D, z=z)
+    cart2 = represent_as(current, CartesianPos2D)
+    cart3 = represent_as(cart2, CartesianPos3D, z=z)
     return represent_as(cart3, target)
 
 
 @dispatch.multi(
-    (PolarPosition, type[CartesianPosition3D]),
+    (PolarPos, type[CartesianPos3D]),
 )
 def represent_as(
-    current: AbstractPosition2D,
-    target: type[AbstractPosition3D],
+    current: AbstractPos2D,
+    target: type[AbstractPos3D],
     /,
     z: Quantity = Quantity(0.0, u.m),
     **kwargs: Any,
-) -> AbstractPosition3D:
-    """AbstractPosition2D -> PolarPosition -> Cylindrical -> AbstractPosition3D.
+) -> AbstractPos3D:
+    """AbstractPos2D -> PolarPos -> Cylindrical -> AbstractPos3D.
 
     The 2D vector is in the xy plane. The `z` coordinate is a keyword argument and
     defaults to 0.
@@ -98,24 +98,24 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.PolarPosition(r=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"))
+    >>> x = cx.PolarPos(r=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"))
 
-    >>> x2 = cx.represent_as(x, cx.CartesianPosition3D, z=Quantity(14, "km"))
+    >>> x2 = cx.represent_as(x, cx.CartesianPos3D, z=Quantity(14, "km"))
     >>> x2
-    CartesianPosition3D( x=Quantity[...](value=f32[], unit=Unit("km")),
+    CartesianPos3D( x=Quantity[...](value=f32[], unit=Unit("km")),
                        y=Quantity[...](value=f32[], unit=Unit("km")),
                        z=Quantity[...](value=f32[], unit=Unit("km")) )
     >>> x2.z
     Quantity['length'](Array(14., dtype=float32), unit='km')
 
     """
-    polar = represent_as(current, PolarPosition)
-    cyl = represent_as(polar, CylindricalPosition, z=z)
+    polar = represent_as(current, PolarPos)
+    cyl = represent_as(polar, CylindricalPos, z=z)
     return represent_as(cyl, target)
 
 
 # =============================================================================
-# CartesianPosition2D
+# CartesianPos2D
 
 
 # -----------------------------------------------
@@ -124,9 +124,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CartesianPosition2D, target: type[CartesianPosition1D], /, **kwargs: Any
-) -> CartesianPosition1D:
-    """CartesianPosition2D -> CartesianPosition1D.
+    current: CartesianPos2D, target: type[CartesianPos1D], /, **kwargs: Any
+) -> CartesianPos1D:
+    """CartesianPos2D -> CartesianPos1D.
 
     The `y` coordinate is dropped.
 
@@ -136,13 +136,13 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CartesianPosition2D.from_([1.0, 2.0], "km")
+    >>> x = cx.CartesianPos2D.from_([1.0, 2.0], "km")
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.CartesianPosition1D, z=Quantity(14, "km"))
+    ...     x2 = cx.represent_as(x, cx.CartesianPos1D, z=Quantity(14, "km"))
     >>> x2
-    CartesianPosition1D( x=Quantity[...](value=f32[], unit=Unit("km")) )
+    CartesianPos1D(x=Quantity[...](value=f32[], unit=Unit("km")))
     >>> x2.x
     Quantity['length'](Array(1., dtype=float32), unit='km')
 
@@ -153,9 +153,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CartesianPosition2D, target: type[RadialPosition], /, **kwargs: Any
-) -> RadialPosition:
-    """CartesianPosition2D -> RadialPosition.
+    current: CartesianPos2D, target: type[RadialPos], /, **kwargs: Any
+) -> RadialPos:
+    """CartesianPos2D -> RadialPos.
 
     The `x` and `y` coordinates are converted to the radial coordinate `r`.
 
@@ -164,13 +164,13 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CartesianPosition2D.from_([1.0, 2.0], "km")
+    >>> x = cx.CartesianPos2D.from_([1.0, 2.0], "km")
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.RadialPosition, z=Quantity(14, "km"))
+    ...     x2 = cx.represent_as(x, cx.RadialPos, z=Quantity(14, "km"))
     >>> x2
-    RadialPosition(r=Distance(value=f32[], unit=Unit("km")))
+    RadialPos(r=Distance(value=f32[], unit=Unit("km")))
     >>> x2.r
     Distance(Array(2.236068, dtype=float32), unit='km')
 
@@ -185,14 +185,14 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CartesianPosition2D,
-    target: type[CartesianPosition3D],
+    current: CartesianPos2D,
+    target: type[CartesianPos3D],
     /,
     *,
     z: Quantity = Quantity(0.0, u.m),
     **kwargs: Any,
-) -> CartesianPosition3D:
-    """CartesianPosition2D -> CartesianPosition3D.
+) -> CartesianPos3D:
+    """CartesianPos2D -> CartesianPos3D.
 
     The `x` and `y` coordinates are converted to the `x` and `y` coordinates of
     the 3D system.  The `z` coordinate is a keyword argument and defaults to 0.
@@ -202,11 +202,11 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CartesianPosition2D.from_([1.0, 2.0], "km")
+    >>> x = cx.CartesianPos2D.from_([1.0, 2.0], "km")
 
-    >>> x2 = cx.represent_as(x, cx.CartesianPosition3D, z=Quantity(14, "km"))
+    >>> x2 = cx.represent_as(x, cx.CartesianPos3D, z=Quantity(14, "km"))
     >>> x2
-    CartesianPosition3D( x=Quantity[...](value=f32[], unit=Unit("km")),
+    CartesianPos3D( x=Quantity[...](value=f32[], unit=Unit("km")),
                        y=Quantity[...](value=f32[], unit=Unit("km")),
                        z=Quantity[...](value=f32[], unit=Unit("km")) )
     >>> x2.z
@@ -217,7 +217,7 @@ def represent_as(
 
 
 # =============================================================================
-# PolarPosition
+# PolarPos
 
 # -----------------------------------------------
 # 1D
@@ -225,9 +225,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: PolarPosition, target: type[CartesianPosition1D], /, **kwargs: Any
-) -> CartesianPosition1D:
-    """PolarPosition -> CartesianPosition1D.
+    current: PolarPos, target: type[CartesianPos1D], /, **kwargs: Any
+) -> CartesianPos1D:
+    """PolarPos -> CartesianPos1D.
 
     Examples
     --------
@@ -235,13 +235,13 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.PolarPosition(r=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"))
+    >>> x = cx.PolarPos(r=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"))
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.CartesianPosition1D)
+    ...     x2 = cx.represent_as(x, cx.CartesianPos1D)
     >>> x2
-    CartesianPosition1D( x=Quantity[...](value=f32[], unit=Unit("km")) )
+    CartesianPos1D(x=Quantity[...](value=f32[], unit=Unit("km")))
     >>> x2.x
     Quantity['length'](Array(0.9848077, dtype=float32), unit='km')
 
@@ -252,9 +252,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: PolarPosition, target: type[RadialPosition], /, **kwargs: Any
-) -> RadialPosition:
-    """PolarPosition -> RadialPosition.
+    current: PolarPos, target: type[RadialPos], /, **kwargs: Any
+) -> RadialPos:
+    """PolarPos -> RadialPos.
 
     Examples
     --------
@@ -262,13 +262,13 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.PolarPosition(r=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"))
+    >>> x = cx.PolarPos(r=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"))
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.RadialPosition)
+    ...     x2 = cx.represent_as(x, cx.RadialPos)
     >>> x2
-    RadialPosition(r=Distance(value=f32[], unit=Unit("km")))
+    RadialPos(r=Distance(value=f32[], unit=Unit("km")))
     >>> x2.r
     Distance(Array(1., dtype=float32), unit='km')
 
@@ -283,24 +283,24 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: PolarPosition,
-    target: type[SphericalPosition],
+    current: PolarPos,
+    target: type[SphericalPos],
     /,
     theta: Quantity["angle"] = Quantity(0.0, u.radian),  # type: ignore[name-defined]
     **kwargs: Any,
-) -> SphericalPosition:
-    """PolarPosition -> SphericalPosition.
+) -> SphericalPos:
+    """PolarPos -> SphericalPos.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.PolarPosition(r=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"))
+    >>> x = cx.PolarPos(r=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"))
 
-    >>> x2 = cx.represent_as(x, cx.SphericalPosition, theta=Quantity(14, "deg"))
+    >>> x2 = cx.represent_as(x, cx.SphericalPos, theta=Quantity(14, "deg"))
     >>> x2
-    SphericalPosition( r=Distance(value=f32[], unit=Unit("km")),
+    SphericalPos( r=Distance(value=f32[], unit=Unit("km")),
                      theta=Quantity[...](value=f32[], unit=Unit("deg")),
                      phi=Quantity[...](value=f32[], unit=Unit("deg")) )
     >>> x2.theta
@@ -312,24 +312,24 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: PolarPosition,
-    target: type[MathSphericalPosition],
+    current: PolarPos,
+    target: type[MathSphericalPos],
     /,
     phi: Quantity["angle"] = Quantity(0.0, u.radian),  # type: ignore[name-defined]
     **kwargs: Any,
-) -> MathSphericalPosition:
-    """PolarPosition -> MathSphericalPosition.
+) -> MathSphericalPos:
+    """PolarPos -> MathSphericalPos.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.PolarPosition(r=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"))
+    >>> x = cx.PolarPos(r=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"))
 
-    >>> x2 = cx.represent_as(x, cx.MathSphericalPosition, phi=Quantity(14, "deg"))
+    >>> x2 = cx.represent_as(x, cx.MathSphericalPos, phi=Quantity(14, "deg"))
     >>> x2
-    MathSphericalPosition( r=Distance(value=f32[], unit=Unit("km")),
+    MathSphericalPos( r=Distance(value=f32[], unit=Unit("km")),
                          theta=Quantity[...](value=f32[], unit=Unit("deg")),
                          phi=Quantity[...](value=f32[], unit=Unit("deg")) )
     >>> x2.phi
@@ -341,25 +341,25 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: PolarPosition,
-    target: type[CylindricalPosition],
+    current: PolarPos,
+    target: type[CylindricalPos],
     /,
     *,
     z: Quantity["length"] = Quantity(0.0, u.m),  # type: ignore[name-defined]
     **kwargs: Any,
-) -> CylindricalPosition:
-    """PolarPosition -> CylindricalPosition.
+) -> CylindricalPos:
+    """PolarPos -> CylindricalPos.
 
     Examples
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.PolarPosition(r=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"))
+    >>> x = cx.PolarPos(r=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"))
 
-    >>> x2 = cx.represent_as(x, cx.CylindricalPosition, z=Quantity(14, "km"))
+    >>> x2 = cx.represent_as(x, cx.CylindricalPos, z=Quantity(14, "km"))
     >>> x2
-    CylindricalPosition( rho=Quantity[...](value=f32[], unit=Unit("km")),
+    CylindricalPos( rho=Quantity[...](value=f32[], unit=Unit("km")),
                        phi=Quantity[...](value=f32[], unit=Unit("deg")),
                        z=Quantity[...](value=f32[], unit=Unit("km")) )
     >>> x2.z

--- a/src/coordinax/_src/transform/d3.py
+++ b/src/coordinax/_src/transform/d3.py
@@ -9,19 +9,19 @@ from plum import dispatch
 
 import quaxed.numpy as jnp
 
-from coordinax._src.d1.cartesian import CartesianPosition1D
-from coordinax._src.d1.radial import RadialPosition
-from coordinax._src.d2.base import AbstractPosition2D
-from coordinax._src.d2.cartesian import CartesianPosition2D
-from coordinax._src.d2.polar import PolarPosition
-from coordinax._src.d3.cartesian import CartesianPosition3D
-from coordinax._src.d3.cylindrical import CylindricalPosition
-from coordinax._src.d3.mathspherical import MathSphericalPosition
-from coordinax._src.d3.spherical import SphericalPosition
+from coordinax._src.d1.cartesian import CartesianPos1D
+from coordinax._src.d1.radial import RadialPos
+from coordinax._src.d2.base import AbstractPos2D
+from coordinax._src.d2.cartesian import CartesianPos2D
+from coordinax._src.d2.polar import PolarPos
+from coordinax._src.d3.cartesian import CartesianPos3D
+from coordinax._src.d3.cylindrical import CylindricalPos
+from coordinax._src.d3.mathspherical import MathSphericalPos
+from coordinax._src.d3.spherical import SphericalPos
 from coordinax._src.exceptions import IrreversibleDimensionChange
 
 # =============================================================================
-# CartesianPosition3D
+# CartesianPos3D
 
 
 # -----------------------------------------------
@@ -30,9 +30,9 @@ from coordinax._src.exceptions import IrreversibleDimensionChange
 
 @dispatch
 def represent_as(
-    current: CartesianPosition3D, target: type[CartesianPosition1D], /, **kwargs: Any
-) -> CartesianPosition1D:
-    """CartesianPosition3D -> CartesianPosition1D.
+    current: CartesianPos3D, target: type[CartesianPos1D], /, **kwargs: Any
+) -> CartesianPos1D:
+    """CartesianPos3D -> CartesianPos1D.
 
     The `y` and `z` coordinates are dropped.
 
@@ -42,15 +42,13 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CartesianPosition3D.from_([1.0, 2.0, 3.0], "km")
+    >>> x = cx.CartesianPos3D.from_([1.0, 2.0, 3.0], "km")
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.CartesianPosition1D)
+    ...     x2 = cx.represent_as(x, cx.CartesianPos1D)
     >>> x2
-    CartesianPosition1D(
-      x=Quantity[PhysicalType('length')](value=f32[], unit=Unit("km"))
-    )
+    CartesianPos1D(x=Quantity[...](value=f32[], unit=Unit("km")))
 
     """
     warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
@@ -59,9 +57,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CartesianPosition3D, target: type[RadialPosition], /, **kwargs: Any
-) -> RadialPosition:
-    """CartesianPosition3D -> RadialPosition.
+    current: CartesianPos3D, target: type[RadialPos], /, **kwargs: Any
+) -> RadialPos:
+    """CartesianPos3D -> RadialPos.
 
     Examples
     --------
@@ -69,13 +67,13 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CartesianPosition3D.from_([1.0, 2.0, 3.0], "km")
+    >>> x = cx.CartesianPos3D.from_([1.0, 2.0, 3.0], "km")
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.RadialPosition)
+    ...     x2 = cx.represent_as(x, cx.RadialPos)
     >>> x2
-    RadialPosition(r=Distance(value=f32[], unit=Unit("km")))
+    RadialPos(r=Distance(value=f32[], unit=Unit("km")))
 
     """
     warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
@@ -88,9 +86,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CartesianPosition3D, target: type[CartesianPosition2D], /, **kwargs: Any
-) -> CartesianPosition2D:
-    """CartesianPosition3D -> CartesianPosition2D.
+    current: CartesianPos3D, target: type[CartesianPos2D], /, **kwargs: Any
+) -> CartesianPos2D:
+    """CartesianPos3D -> CartesianPos2D.
 
     Examples
     --------
@@ -98,13 +96,13 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CartesianPosition3D.from_([1.0, 2.0, 3.0], "km")
+    >>> x = cx.CartesianPos3D.from_([1.0, 2.0, 3.0], "km")
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.CartesianPosition2D)
+    ...     x2 = cx.represent_as(x, cx.CartesianPos2D)
     >>> x2
-    CartesianPosition2D( x=Quantity[...](value=f32[], unit=Unit("km")),
+    CartesianPos2D( x=Quantity[...](value=f32[], unit=Unit("km")),
                        y=Quantity[...](value=f32[], unit=Unit("km")) )
 
     """
@@ -113,12 +111,12 @@ def represent_as(
 
 
 @dispatch.multi(
-    (CartesianPosition3D, type[PolarPosition]),
+    (CartesianPos3D, type[PolarPos]),
 )
 def represent_as(
-    current: CartesianPosition3D, target: type[AbstractPosition2D], /, **kwargs: Any
-) -> AbstractPosition2D:
-    """CartesianPosition3D -> Cartesian2D -> AbstractPosition2D.
+    current: CartesianPos3D, target: type[AbstractPos2D], /, **kwargs: Any
+) -> AbstractPos2D:
+    """CartesianPos3D -> Cartesian2D -> AbstractPos2D.
 
     Examples
     --------
@@ -126,23 +124,23 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CartesianPosition3D.from_([1.0, 2.0, 3.0], "km")
+    >>> x = cx.CartesianPos3D.from_([1.0, 2.0, 3.0], "km")
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.PolarPosition)
+    ...     x2 = cx.represent_as(x, cx.PolarPos)
     >>> x2
-    PolarPosition( r=Distance(value=f32[], unit=Unit("km")),
+    PolarPos( r=Distance(value=f32[], unit=Unit("km")),
                  phi=Quantity[...](value=f32[], unit=Unit("rad")) )
 
     """
     warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
-    cart2 = represent_as(current, CartesianPosition2D)
+    cart2 = represent_as(current, CartesianPos2D)
     return represent_as(cart2, target)
 
 
 # =============================================================================
-# CylindricalPosition
+# CylindricalPos
 
 
 # -----------------------------------------------
@@ -151,9 +149,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CylindricalPosition, target: type[CartesianPosition1D], /, **kwargs: Any
-) -> CartesianPosition1D:
-    """CylindricalPosition -> CartesianPosition1D.
+    current: CylindricalPos, target: type[CartesianPos1D], /, **kwargs: Any
+) -> CartesianPos1D:
+    """CylindricalPos -> CartesianPos1D.
 
     Examples
     --------
@@ -161,14 +159,14 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CylindricalPosition(rho=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"),
+    >>> x = cx.CylindricalPos(rho=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"),
     ...                          z=Quantity(14, "km"))
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.CartesianPosition1D)
+    ...     x2 = cx.represent_as(x, cx.CartesianPos1D)
     >>> x2
-    CartesianPosition1D( x=Quantity[...](value=f32[], unit=Unit("km")) )
+    CartesianPos1D(x=Quantity[...](value=f32[], unit=Unit("km")))
 
     """
     warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
@@ -177,9 +175,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CylindricalPosition, target: type[RadialPosition], /, **kwargs: Any
-) -> RadialPosition:
-    """CylindricalPosition -> RadialPosition.
+    current: CylindricalPos, target: type[RadialPos], /, **kwargs: Any
+) -> RadialPos:
+    """CylindricalPos -> RadialPos.
 
     Examples
     --------
@@ -187,14 +185,14 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CylindricalPosition(rho=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"),
+    >>> x = cx.CylindricalPos(rho=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"),
     ...                          z=Quantity(14, "km"))
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.RadialPosition)
+    ...     x2 = cx.represent_as(x, cx.RadialPos)
     >>> x2
-    RadialPosition(r=Distance(value=f32[], unit=Unit("km")))
+    RadialPos(r=Distance(value=f32[], unit=Unit("km")))
 
     """
     warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
@@ -207,9 +205,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CylindricalPosition, target: type[CartesianPosition2D], /, **kwargs: Any
-) -> CartesianPosition2D:
-    """CylindricalPosition -> CartesianPosition2D.
+    current: CylindricalPos, target: type[CartesianPos2D], /, **kwargs: Any
+) -> CartesianPos2D:
+    """CylindricalPos -> CartesianPos2D.
 
     Examples
     --------
@@ -217,14 +215,14 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CylindricalPosition(rho=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"),
+    >>> x = cx.CylindricalPos(rho=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"),
     ...                          z=Quantity(14, "km"))
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.CartesianPosition2D)
+    ...     x2 = cx.represent_as(x, cx.CartesianPos2D)
     >>> x2
-    CartesianPosition2D( x=Quantity[...](value=f32[], unit=Unit("km")),
+    CartesianPos2D( x=Quantity[...](value=f32[], unit=Unit("km")),
                        y=Quantity[...](value=f32[], unit=Unit("km")) )
 
     """
@@ -236,9 +234,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CylindricalPosition, target: type[PolarPosition], /, **kwargs: Any
-) -> PolarPosition:
-    """CylindricalPosition -> PolarPosition.
+    current: CylindricalPos, target: type[PolarPos], /, **kwargs: Any
+) -> PolarPos:
+    """CylindricalPos -> PolarPos.
 
     Examples
     --------
@@ -246,14 +244,14 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.CylindricalPosition(rho=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"),
+    >>> x = cx.CylindricalPos(rho=Quantity(1.0, "km"), phi=Quantity(10.0, "deg"),
     ...                          z=Quantity(14, "km"))
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.PolarPosition)
+    ...     x2 = cx.represent_as(x, cx.PolarPos)
     >>> x2
-    PolarPosition( r=Distance(value=f32[], unit=Unit("km")),
+    PolarPos( r=Distance(value=f32[], unit=Unit("km")),
                  phi=Quantity[...](value=f32[], unit=Unit("deg")) )
 
     """
@@ -262,7 +260,7 @@ def represent_as(
 
 
 # =============================================================================
-# SphericalPosition
+# SphericalPos
 
 
 # -----------------------------------------------
@@ -271,9 +269,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: SphericalPosition, target: type[CartesianPosition1D], /, **kwargs: Any
-) -> CartesianPosition1D:
-    """SphericalPosition -> CartesianPosition1D.
+    current: SphericalPos, target: type[CartesianPos1D], /, **kwargs: Any
+) -> CartesianPos1D:
+    """SphericalPos -> CartesianPos1D.
 
     Examples
     --------
@@ -281,14 +279,14 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.SphericalPosition(r=Quantity(1.0, "km"), theta=Quantity(14, "deg"),
+    >>> x = cx.SphericalPos(r=Quantity(1.0, "km"), theta=Quantity(14, "deg"),
     ...                        phi=Quantity(10.0, "deg"))
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.CartesianPosition1D)
+    ...     x2 = cx.represent_as(x, cx.CartesianPos1D)
     >>> x2
-    CartesianPosition1D( x=Quantity[...](value=f32[], unit=Unit("km")) )
+    CartesianPos1D(x=Quantity[...](value=f32[], unit=Unit("km")))
 
     """
     warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
@@ -297,9 +295,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: SphericalPosition, target: type[RadialPosition], /, **kwargs: Any
-) -> RadialPosition:
-    """SphericalPosition -> RadialPosition.
+    current: SphericalPos, target: type[RadialPos], /, **kwargs: Any
+) -> RadialPos:
+    """SphericalPos -> RadialPos.
 
     Examples
     --------
@@ -307,14 +305,14 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.SphericalPosition(r=Quantity(1.0, "km"), theta=Quantity(14, "deg"),
+    >>> x = cx.SphericalPos(r=Quantity(1.0, "km"), theta=Quantity(14, "deg"),
     ...                        phi=Quantity(10.0, "deg"))
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.RadialPosition)
+    ...     x2 = cx.represent_as(x, cx.RadialPos)
     >>> x2
-    RadialPosition(r=Distance(value=f32[], unit=Unit("km")))
+    RadialPos(r=Distance(value=f32[], unit=Unit("km")))
 
     """
     warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
@@ -327,9 +325,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: SphericalPosition, target: type[CartesianPosition2D], /, **kwargs: Any
-) -> CartesianPosition2D:
-    """SphericalPosition -> CartesianPosition2D.
+    current: SphericalPos, target: type[CartesianPos2D], /, **kwargs: Any
+) -> CartesianPos2D:
+    """SphericalPos -> CartesianPos2D.
 
     Examples
     --------
@@ -337,14 +335,14 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.SphericalPosition(r=Quantity(1.0, "km"), theta=Quantity(14, "deg"),
+    >>> x = cx.SphericalPos(r=Quantity(1.0, "km"), theta=Quantity(14, "deg"),
     ...                        phi=Quantity(10.0, "deg"))
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.CartesianPosition2D)
+    ...     x2 = cx.represent_as(x, cx.CartesianPos2D)
     >>> x2
-    CartesianPosition2D( x=Quantity[...](value=f32[], unit=Unit("km")),
+    CartesianPos2D( x=Quantity[...](value=f32[], unit=Unit("km")),
                        y=Quantity[...](value=f32[], unit=Unit("km")) )
 
     """
@@ -356,9 +354,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: SphericalPosition, target: type[PolarPosition], /, **kwargs: Any
-) -> PolarPosition:
-    """SphericalPosition -> PolarPosition.
+    current: SphericalPos, target: type[PolarPos], /, **kwargs: Any
+) -> PolarPos:
+    """SphericalPos -> PolarPos.
 
     Examples
     --------
@@ -366,14 +364,14 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.SphericalPosition(r=Quantity(1.0, "km"), theta=Quantity(14, "deg"),
+    >>> x = cx.SphericalPos(r=Quantity(1.0, "km"), theta=Quantity(14, "deg"),
     ...                        phi=Quantity(10.0, "deg"))
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.PolarPosition)
+    ...     x2 = cx.represent_as(x, cx.PolarPos)
     >>> x2
-    PolarPosition( r=Distance(value=f32[], unit=Unit("km")),
+    PolarPos( r=Distance(value=f32[], unit=Unit("km")),
                  phi=Quantity[...](value=f32[], unit=Unit("deg")) )
 
     """
@@ -382,7 +380,7 @@ def represent_as(
 
 
 # =============================================================================
-# MathSphericalPosition
+# MathSphericalPos
 
 
 # -----------------------------------------------
@@ -391,9 +389,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: MathSphericalPosition, target: type[CartesianPosition1D], /, **kwargs: Any
-) -> CartesianPosition1D:
-    """MathSphericalPosition -> CartesianPosition1D.
+    current: MathSphericalPos, target: type[CartesianPos1D], /, **kwargs: Any
+) -> CartesianPos1D:
+    """MathSphericalPos -> CartesianPos1D.
 
     Examples
     --------
@@ -401,14 +399,14 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.MathSphericalPosition(r=Quantity(1.0, "km"), theta=Quantity(10.0, "deg"),
+    >>> x = cx.MathSphericalPos(r=Quantity(1.0, "km"), theta=Quantity(10.0, "deg"),
     ...                            phi=Quantity(14, "deg"))
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.CartesianPosition1D)
+    ...     x2 = cx.represent_as(x, cx.CartesianPos1D)
     >>> x2
-    CartesianPosition1D( x=Quantity[...](value=f32[], unit=Unit("km")) )
+    CartesianPos1D(x=Quantity[...](value=f32[], unit=Unit("km")))
 
     """
     warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
@@ -417,9 +415,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: MathSphericalPosition, target: type[RadialPosition], /, **kwargs: Any
-) -> RadialPosition:
-    """MathSphericalPosition -> RadialPosition.
+    current: MathSphericalPos, target: type[RadialPos], /, **kwargs: Any
+) -> RadialPos:
+    """MathSphericalPos -> RadialPos.
 
     Examples
     --------
@@ -427,14 +425,14 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.MathSphericalPosition(r=Quantity(1.0, "km"), theta=Quantity(10.0, "deg"),
+    >>> x = cx.MathSphericalPos(r=Quantity(1.0, "km"), theta=Quantity(10.0, "deg"),
     ...                            phi=Quantity(14, "deg"))
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.RadialPosition)
+    ...     x2 = cx.represent_as(x, cx.RadialPos)
     >>> x2
-    RadialPosition(r=Distance(value=f32[], unit=Unit("km")))
+    RadialPos(r=Distance(value=f32[], unit=Unit("km")))
 
     """
     warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
@@ -447,9 +445,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: MathSphericalPosition, target: type[CartesianPosition2D], /, **kwargs: Any
-) -> CartesianPosition2D:
-    """MathSphericalPosition -> CartesianPosition2D.
+    current: MathSphericalPos, target: type[CartesianPos2D], /, **kwargs: Any
+) -> CartesianPos2D:
+    """MathSphericalPos -> CartesianPos2D.
 
     Examples
     --------
@@ -457,14 +455,14 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.MathSphericalPosition(r=Quantity(1.0, "km"), theta=Quantity(10.0, "deg"),
+    >>> x = cx.MathSphericalPos(r=Quantity(1.0, "km"), theta=Quantity(10.0, "deg"),
     ...                            phi=Quantity(14, "deg"))
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.CartesianPosition2D)
+    ...     x2 = cx.represent_as(x, cx.CartesianPos2D)
     >>> x2
-    CartesianPosition2D( x=Quantity[...](value=f32[], unit=Unit("km")),
+    CartesianPos2D( x=Quantity[...](value=f32[], unit=Unit("km")),
                        y=Quantity[...](value=f32[], unit=Unit("km")) )
 
     """
@@ -476,9 +474,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: MathSphericalPosition, target: type[PolarPosition], /, **kwargs: Any
-) -> PolarPosition:
-    """MathSphericalPosition -> PolarPosition.
+    current: MathSphericalPos, target: type[PolarPos], /, **kwargs: Any
+) -> PolarPos:
+    """MathSphericalPos -> PolarPos.
 
     Examples
     --------
@@ -486,14 +484,14 @@ def represent_as(
     >>> from unxt import Quantity
     >>> import coordinax as cx
 
-    >>> x = cx.MathSphericalPosition(r=Quantity(1.0, "km"), theta=Quantity(10.0, "deg"),
+    >>> x = cx.MathSphericalPos(r=Quantity(1.0, "km"), theta=Quantity(10.0, "deg"),
     ...                            phi=Quantity(14, "deg"))
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
-    ...     x2 = cx.represent_as(x, cx.PolarPosition)
+    ...     x2 = cx.represent_as(x, cx.PolarPos)
     >>> x2
-    PolarPosition( r=Distance(value=f32[], unit=Unit("km")),
+    PolarPos( r=Distance(value=f32[], unit=Unit("km")),
                  phi=Quantity[...](value=f32[], unit=Unit("deg")) )
 
     """

--- a/src/coordinax/_src/transform/differentials.py
+++ b/src/coordinax/_src/transform/differentials.py
@@ -14,47 +14,35 @@ import quaxed.numpy as jnp
 from dataclassish import field_items
 from unxt import AbstractDistance, Quantity
 
-from coordinax._src.base import AbstractPos, AbstractVelocity
-from coordinax._src.d1.base import AbstractVelocity1D
-from coordinax._src.d2.base import AbstractVelocity2D
-from coordinax._src.d3.base import AbstractVelocity3D
+from coordinax._src.base import AbstractPos, AbstractVel
+from coordinax._src.d1.base import AbstractVel1D
+from coordinax._src.d2.base import AbstractVel2D
+from coordinax._src.d3.base import AbstractVel3D
 
 
 # TODO: implement for cross-representations
 @dispatch.multi(  # type: ignore[misc]
     # N-D -> N-D
-    (
-        AbstractVelocity1D,
-        type[AbstractVelocity1D],
-        AbstractPos | Quantity["length"],
-    ),
-    (
-        AbstractVelocity2D,
-        type[AbstractVelocity2D],
-        AbstractPos | Quantity["length"],
-    ),
-    (
-        AbstractVelocity3D,
-        type[AbstractVelocity3D],
-        AbstractPos | Quantity["length"],
-    ),
+    (AbstractVel1D, type[AbstractVel1D], AbstractPos | Quantity["length"]),
+    (AbstractVel2D, type[AbstractVel2D], AbstractPos | Quantity["length"]),
+    (AbstractVel3D, type[AbstractVel3D], AbstractPos | Quantity["length"]),
 )
 def represent_as(
-    current: AbstractVelocity,
-    target: type[AbstractVelocity],
+    current: AbstractVel,
+    target: type[AbstractVel],
     position: AbstractPos | Quantity["length"],
     /,
     **kwargs: Any,
-) -> AbstractVelocity:
-    """AbstractVelocity -> Cartesian -> AbstractVelocity.
+) -> AbstractVel:
+    """AbstractVel -> Cartesian -> AbstractVel.
 
     This is the base case for the transformation of vector differentials.
 
     Parameters
     ----------
-    current : AbstractVelocity
+    current : AbstractVel
         The vector differential to transform.
-    target : type[AbstractVelocity]
+    target : type[AbstractVel]
         The target type of the vector differential.
     position : AbstractPos
         The position vector used to transform the differential.
@@ -69,16 +57,16 @@ def represent_as(
     Let's start in 1D:
 
     >>> q = cx.CartesianPos1D(x=Quantity(1.0, "km"))
-    >>> p = cx.CartesianVelocity1D(d_x=Quantity(1.0, "km/s"))
-    >>> cx.represent_as(p, cx.RadialVelocity, q)
-    RadialVelocity( d_r=Quantity[...]( value=f32[], unit=Unit("km / s") ) )
+    >>> p = cx.CartesianVel1D(d_x=Quantity(1.0, "km/s"))
+    >>> cx.represent_as(p, cx.RadialVel, q)
+    RadialVel( d_r=Quantity[...]( value=f32[], unit=Unit("km / s") ) )
 
     Now in 2D:
 
     >>> q = cx.CartesianPos2D.from_([1.0, 2.0], "km")
-    >>> p = cx.CartesianVelocity2D.from_([1.0, 2.0], "km/s")
-    >>> cx.represent_as(p, cx.PolarVelocity, q)
-    PolarVelocity(
+    >>> p = cx.CartesianVel2D.from_([1.0, 2.0], "km/s")
+    >>> cx.represent_as(p, cx.PolarVel, q)
+    PolarVel(
       d_r=Quantity[...]( value=f32[], unit=Unit("km / s") ),
       d_phi=Quantity[...]( value=f32[], unit=Unit("rad / s") )
     )
@@ -86,9 +74,9 @@ def represent_as(
     And in 3D:
 
     >>> q = cx.CartesianPos3D.from_([1.0, 2.0, 3.0], "km")
-    >>> p = cx.CartesianVelocity3D.from_([1.0, 2.0, 3.0], "km/s")
-    >>> cx.represent_as(p, cx.SphericalVelocity, q)
-    SphericalVelocity(
+    >>> p = cx.CartesianVel3D.from_([1.0, 2.0, 3.0], "km/s")
+    >>> cx.represent_as(p, cx.SphericalVel, q)
+    SphericalVel(
       d_r=Quantity[...]( value=f32[], unit=Unit("km / s") ),
       d_theta=Quantity[...]( value=f32[], unit=Unit("rad / s") ),
       d_phi=Quantity[...]( value=f32[], unit=Unit("rad / s") )
@@ -97,9 +85,9 @@ def represent_as(
     If given a position as a Quantity, it will be converted to the appropriate
     Cartesian vector:
 
-    >>> p = cx.CartesianVelocity3D.from_([1.0, 2.0, 3.0], "km/s")
-    >>> cx.represent_as(p, cx.SphericalVelocity, Quantity([1.0, 2.0, 3.0], "km"))
-    SphericalVelocity(
+    >>> p = cx.CartesianVel3D.from_([1.0, 2.0, 3.0], "km/s")
+    >>> cx.represent_as(p, cx.SphericalVel, Quantity([1.0, 2.0, 3.0], "km"))
+    SphericalVel(
       d_r=Quantity[...]( value=f32[], unit=Unit("km / s") ),
       d_theta=Quantity[...]( value=f32[], unit=Unit("rad / s") ),
       d_phi=Quantity[...]( value=f32[], unit=Unit("rad / s") )

--- a/src/coordinax/_src/transform/differentials.py
+++ b/src/coordinax/_src/transform/differentials.py
@@ -14,7 +14,7 @@ import quaxed.numpy as jnp
 from dataclassish import field_items
 from unxt import AbstractDistance, Quantity
 
-from coordinax._src.base import AbstractPosition, AbstractVelocity
+from coordinax._src.base import AbstractPos, AbstractVelocity
 from coordinax._src.d1.base import AbstractVelocity1D
 from coordinax._src.d2.base import AbstractVelocity2D
 from coordinax._src.d3.base import AbstractVelocity3D
@@ -26,23 +26,23 @@ from coordinax._src.d3.base import AbstractVelocity3D
     (
         AbstractVelocity1D,
         type[AbstractVelocity1D],
-        AbstractPosition | Quantity["length"],
+        AbstractPos | Quantity["length"],
     ),
     (
         AbstractVelocity2D,
         type[AbstractVelocity2D],
-        AbstractPosition | Quantity["length"],
+        AbstractPos | Quantity["length"],
     ),
     (
         AbstractVelocity3D,
         type[AbstractVelocity3D],
-        AbstractPosition | Quantity["length"],
+        AbstractPos | Quantity["length"],
     ),
 )
 def represent_as(
     current: AbstractVelocity,
     target: type[AbstractVelocity],
-    position: AbstractPosition | Quantity["length"],
+    position: AbstractPos | Quantity["length"],
     /,
     **kwargs: Any,
 ) -> AbstractVelocity:
@@ -56,7 +56,7 @@ def represent_as(
         The vector differential to transform.
     target : type[AbstractVelocity]
         The target type of the vector differential.
-    position : AbstractPosition
+    position : AbstractPos
         The position vector used to transform the differential.
     **kwargs : Any
         Additional keyword arguments.
@@ -68,14 +68,14 @@ def represent_as(
 
     Let's start in 1D:
 
-    >>> q = cx.CartesianPosition1D(x=Quantity(1.0, "km"))
+    >>> q = cx.CartesianPos1D(x=Quantity(1.0, "km"))
     >>> p = cx.CartesianVelocity1D(d_x=Quantity(1.0, "km/s"))
     >>> cx.represent_as(p, cx.RadialVelocity, q)
     RadialVelocity( d_r=Quantity[...]( value=f32[], unit=Unit("km / s") ) )
 
     Now in 2D:
 
-    >>> q = cx.CartesianPosition2D.from_([1.0, 2.0], "km")
+    >>> q = cx.CartesianPos2D.from_([1.0, 2.0], "km")
     >>> p = cx.CartesianVelocity2D.from_([1.0, 2.0], "km/s")
     >>> cx.represent_as(p, cx.PolarVelocity, q)
     PolarVelocity(
@@ -85,7 +85,7 @@ def represent_as(
 
     And in 3D:
 
-    >>> q = cx.CartesianPosition3D.from_([1.0, 2.0, 3.0], "km")
+    >>> q = cx.CartesianPos3D.from_([1.0, 2.0, 3.0], "km")
     >>> p = cx.CartesianVelocity3D.from_([1.0, 2.0, 3.0], "km/s")
     >>> cx.represent_as(p, cx.SphericalVelocity, q)
     SphericalVelocity(
@@ -110,8 +110,8 @@ def represent_as(
     shape = current.shape
     flat_shape = prod(shape)
 
-    # Parse the position to an AbstractPosition
-    if isinstance(position, AbstractPosition):
+    # Parse the position to an AbstractPos
+    if isinstance(position, AbstractPos):
         posvec = position
     else:  # Q -> Cart<X>D
         posvec = current.integral_cls._cartesian_cls.from_(  # noqa: SLF001

--- a/src/coordinax/_src/transform/dn.py
+++ b/src/coordinax/_src/transform/dn.py
@@ -7,7 +7,7 @@ from plum import dispatch
 
 import quaxed.numpy as jnp
 
-from coordinax._src.d3.cylindrical import CylindricalPosition, CylindricalVelocity
+from coordinax._src.d3.cylindrical import CylindricalPos, CylindricalVelocity
 from coordinax._src.dn.poincare import PoincarePolarVector
 from coordinax._src.space import Space
 
@@ -22,7 +22,7 @@ def represent_as(w: PoincarePolarVector, target: type[Space], /) -> Space:
     >>> from unxt import Quantity
 
     >>> w = cx.Space(
-    ...     length=cx.CartesianPosition3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
+    ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
     ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
     ... )
 
@@ -38,7 +38,7 @@ def represent_as(w: PoincarePolarVector, target: type[Space], /) -> Space:
 
     >>> cx.represent_as(w, cx.Space)
     Space({
-        'length': CartesianPosition3D(
+        'length': CartesianPos3D(
             x=Quantity[...](value=f32[1,2], unit=Unit("m")),
             y=Quantity[...](value=f32[1,2], unit=Unit("m")),
             z=Quantity[...](value=f32[1,2], unit=Unit("m"))
@@ -54,6 +54,6 @@ def represent_as(w: PoincarePolarVector, target: type[Space], /) -> Space:
     d_phi = (w.pp_phi**2 + w.d_pp_phi**2) / 2 / w.rho**2  # TODO: note the abs
 
     return Space(
-        length=CylindricalPosition(rho=w.rho, z=w.z, phi=phi),
+        length=CylindricalPos(rho=w.rho, z=w.z, phi=phi),
         speed=CylindricalVelocity(d_rho=w.d_rho, d_z=w.d_z, d_phi=d_phi),
     )

--- a/src/coordinax/_src/transform/dn.py
+++ b/src/coordinax/_src/transform/dn.py
@@ -7,7 +7,7 @@ from plum import dispatch
 
 import quaxed.numpy as jnp
 
-from coordinax._src.d3.cylindrical import CylindricalPos, CylindricalVelocity
+from coordinax._src.d3.cylindrical import CylindricalPos, CylindricalVel
 from coordinax._src.dn.poincare import PoincarePolarVector
 from coordinax._src.space import Space
 
@@ -23,7 +23,7 @@ def represent_as(w: PoincarePolarVector, target: type[Space], /) -> Space:
 
     >>> w = cx.Space(
     ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
-    ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
+    ...     speed=cx.CartesianVel3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
     ... )
 
     >>> cx.represent_as(w, cx.PoincarePolarVector)
@@ -43,7 +43,7 @@ def represent_as(w: PoincarePolarVector, target: type[Space], /) -> Space:
             y=Quantity[...](value=f32[1,2], unit=Unit("m")),
             z=Quantity[...](value=f32[1,2], unit=Unit("m"))
         ),
-        'speed': CartesianVelocity3D(
+        'speed': CartesianVel3D(
             d_x=Quantity[...]( value=f32[1,2], unit=Unit("m / s") ),
             d_y=Quantity[...]( value=f32[1,2], unit=Unit("m / s") ),
             d_z=Quantity[...]( value=f32[1,2], unit=Unit("m / s") )
@@ -55,5 +55,5 @@ def represent_as(w: PoincarePolarVector, target: type[Space], /) -> Space:
 
     return Space(
         length=CylindricalPos(rho=w.rho, z=w.z, phi=phi),
-        speed=CylindricalVelocity(d_rho=w.d_rho, d_z=w.d_z, d_phi=d_phi),
+        speed=CylindricalVel(d_rho=w.d_rho, d_z=w.d_z, d_phi=d_phi),
     )

--- a/src/coordinax/_src/transform/space.py
+++ b/src/coordinax/_src/transform/space.py
@@ -7,7 +7,7 @@ from plum import dispatch
 
 import quaxed.numpy as jnp
 
-from coordinax._src.d3.cylindrical import CylindricalPos, CylindricalVelocity
+from coordinax._src.d3.cylindrical import CylindricalPos, CylindricalVel
 from coordinax._src.dn.poincare import PoincarePolarVector
 from coordinax._src.space import Space
 
@@ -23,13 +23,13 @@ def represent_as(w: Space, target: type[Space]) -> Space:
 
     >>> w = cx.Space(
     ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
-    ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
+    ...     speed=cx.CartesianVel3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
     ... )
 
     >>> cx.represent_as(w, cx.Space)
     Space({
         'length': CartesianPos3D( ... ),
-        'speed': CartesianVelocity3D( ... )} )
+        'speed': CartesianVel3D( ... )} )
 
     """
     return w
@@ -46,7 +46,7 @@ def represent_as(w: Space, target: type[PoincarePolarVector], /) -> PoincarePola
 
     >>> w = cx.Space(
     ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
-    ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
+    ...     speed=cx.CartesianVel3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
     ... )
 
     >>> cx.represent_as(w, cx.PoincarePolarVector)
@@ -61,7 +61,7 @@ def represent_as(w: Space, target: type[PoincarePolarVector], /) -> PoincarePola
 
     """
     q = w["length"].represent_as(CylindricalPos)
-    p = w["speed"].represent_as(CylindricalVelocity, q)
+    p = w["speed"].represent_as(CylindricalVel, q)
 
     # pg. 437, Papaphillipou & Laskar (1996)
     sqrt2theta = jnp.sqrt(jnp.abs(2 * q.rho**2 * p.d_phi))

--- a/src/coordinax/_src/transform/space.py
+++ b/src/coordinax/_src/transform/space.py
@@ -7,7 +7,7 @@ from plum import dispatch
 
 import quaxed.numpy as jnp
 
-from coordinax._src.d3.cylindrical import CylindricalPosition, CylindricalVelocity
+from coordinax._src.d3.cylindrical import CylindricalPos, CylindricalVelocity
 from coordinax._src.dn.poincare import PoincarePolarVector
 from coordinax._src.space import Space
 
@@ -22,13 +22,13 @@ def represent_as(w: Space, target: type[Space]) -> Space:
     >>> from unxt import Quantity
 
     >>> w = cx.Space(
-    ...     length=cx.CartesianPosition3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
+    ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
     ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
     ... )
 
     >>> cx.represent_as(w, cx.Space)
     Space({
-        'length': CartesianPosition3D( ... ),
+        'length': CartesianPos3D( ... ),
         'speed': CartesianVelocity3D( ... )} )
 
     """
@@ -45,7 +45,7 @@ def represent_as(w: Space, target: type[PoincarePolarVector], /) -> PoincarePola
     >>> from unxt import Quantity
 
     >>> w = cx.Space(
-    ...     length=cx.CartesianPosition3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
+    ...     length=cx.CartesianPos3D.from_([[[1, 2, 3], [4, 5, 6]]], "m"),
     ...     speed=cx.CartesianVelocity3D.from_([[[1, 2, 3], [4, 5, 6]]], "m/s")
     ... )
 
@@ -60,7 +60,7 @@ def represent_as(w: Space, target: type[PoincarePolarVector], /) -> PoincarePola
     )
 
     """
-    q = w["length"].represent_as(CylindricalPosition)
+    q = w["length"].represent_as(CylindricalPos)
     p = w["speed"].represent_as(CylindricalVelocity, q)
 
     # pg. 437, Papaphillipou & Laskar (1996)

--- a/src/coordinax/_src/utils.py
+++ b/src/coordinax/_src/utils.py
@@ -21,7 +21,7 @@ def full_shaped(obj: "AbstractVector", /) -> "AbstractVector":
     --------
     >>> from unxt import Quantity
     >>> import coordinax as cx
-    >>> v = cx.CartesianPosition2D(Quantity([1], "m"), Quantity([3, 4], "m"))
+    >>> v = cx.CartesianPos2D(Quantity([1], "m"), Quantity([3, 4], "m"))
     >>> v.x.shape
     (1,)
     >>> v.y.shape

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -13,42 +13,42 @@ from dataclassish import field_items
 from unxt import AbstractQuantity
 
 from coordinax import (
-    AbstractPosition,
-    AbstractPosition1D,
-    AbstractPosition2D,
-    AbstractPosition3D,
+    AbstractPos,
+    AbstractPos1D,
+    AbstractPos2D,
+    AbstractPos3D,
     AbstractVelocity,
     AbstractVelocity1D,
     AbstractVelocity2D,
     AbstractVelocity3D,
-    CartesianPosition1D,
-    CartesianPosition2D,
-    CartesianPosition3D,
+    CartesianPos1D,
+    CartesianPos2D,
+    CartesianPos3D,
     CartesianVelocity1D,
     CartesianVelocity2D,
     CartesianVelocity3D,
-    CylindricalPosition,
+    CylindricalPos,
     CylindricalVelocity,
     IrreversibleDimensionChange,
-    PolarPosition,
+    PolarPos,
     PolarVelocity,
-    RadialPosition,
+    RadialPos,
     RadialVelocity,
-    SphericalPosition,
+    SphericalPos,
     SphericalVelocity,
 )
 
 BUILTIN_VECTORS = [
     # 1D
-    CartesianPosition1D,
-    RadialPosition,
+    CartesianPos1D,
+    RadialPos,
     # 2D
-    CartesianPosition2D,
-    PolarPosition,
+    CartesianPos2D,
+    PolarPos,
     # 3D
-    CartesianPosition3D,
-    SphericalPosition,
-    CylindricalPosition,
+    CartesianPos3D,
+    SphericalPos,
+    CylindricalPos,
 ]
 
 BUILTIN_DIFFERENTIALS = [
@@ -68,16 +68,13 @@ BUILTIN_DIFFERENTIALS = [
 
 
 def context_dimension_reduction(
-    vector: AbstractPosition, target: type[AbstractPosition]
+    vector: AbstractPos, target: type[AbstractPos]
 ) -> AbstractContextManager[Any]:
     """Return a context manager that checks for dimensionality reduction."""
     context: AbstractContextManager[Any]
-    if (
-        isinstance(vector, AbstractPosition2D)
-        and issubclass(target, AbstractPosition1D)
-    ) or (
-        isinstance(vector, AbstractPosition3D)
-        and issubclass(target, AbstractPosition2D | AbstractPosition1D)
+    if (isinstance(vector, AbstractPos2D) and issubclass(target, AbstractPos1D)) or (
+        isinstance(vector, AbstractPos3D)
+        and issubclass(target, AbstractPos2D | AbstractPos1D)
     ):
         context = pytest.warns(IrreversibleDimensionChange)
     else:
@@ -178,17 +175,17 @@ class AbstractVectorTest:
         assert all(v == getattr(vector, k).shape for k, v in shapes.items())
 
 
-class AbstractPositionTest(AbstractVectorTest):
-    """Test :class:`coordinax.AbstractPosition`."""
+class AbstractPosTest(AbstractVectorTest):
+    """Test :class:`coordinax.AbstractPos`."""
 
     @pytest.fixture(scope="class")
-    def vector(self) -> AbstractPosition:
+    def vector(self) -> AbstractPos:
         """Return a vector."""
         raise NotImplementedError
 
     @pytest.mark.parametrize("target", BUILTIN_VECTORS)
     def test_represent_as(self, vector, target):
-        """Test :meth:`AbstractPosition.represent_as`.
+        """Test :meth:`AbstractPos.represent_as`.
 
         This just tests that the machiner works.
         """
@@ -205,7 +202,7 @@ class AbstractVelocityTest(AbstractVectorTest):
     """Test :class:`coordinax.AbstractVelocity`."""
 
     @pytest.fixture(scope="class")
-    def vector(self) -> AbstractPosition:
+    def vector(self) -> AbstractPos:
         """Return a vector."""
         raise NotImplementedError
 
@@ -217,7 +214,7 @@ class AbstractVelocityTest(AbstractVectorTest):
     @pytest.mark.parametrize("target", BUILTIN_DIFFERENTIALS)
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_represent_as(self, difntl, target, vector):
-        """Test :meth:`AbstractPosition.represent_as`.
+        """Test :meth:`AbstractPos.represent_as`.
 
         This just tests that the machiner works.
         """

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -17,25 +17,25 @@ from coordinax import (
     AbstractPos1D,
     AbstractPos2D,
     AbstractPos3D,
-    AbstractVelocity,
-    AbstractVelocity1D,
-    AbstractVelocity2D,
-    AbstractVelocity3D,
+    AbstractVel,
+    AbstractVel1D,
+    AbstractVel2D,
+    AbstractVel3D,
     CartesianPos1D,
     CartesianPos2D,
     CartesianPos3D,
-    CartesianVelocity1D,
-    CartesianVelocity2D,
-    CartesianVelocity3D,
+    CartesianVel1D,
+    CartesianVel2D,
+    CartesianVel3D,
     CylindricalPos,
-    CylindricalVelocity,
+    CylindricalVel,
     IrreversibleDimensionChange,
     PolarPos,
-    PolarVelocity,
+    PolarVel,
     RadialPos,
-    RadialVelocity,
+    RadialVel,
     SphericalPos,
-    SphericalVelocity,
+    SphericalVel,
 )
 
 BUILTIN_VECTORS = [
@@ -53,17 +53,17 @@ BUILTIN_VECTORS = [
 
 BUILTIN_DIFFERENTIALS = [
     # 1D
-    CartesianVelocity1D,
-    RadialVelocity,
+    CartesianVel1D,
+    RadialVel,
     # 2D
-    CartesianVelocity2D,
-    PolarVelocity,
-    # LnPolarVelocity,
-    # Log10PolarVelocity,
+    CartesianVel2D,
+    PolarVel,
+    # LnPolarVel,
+    # Log10PolarVel,
     # 3D
-    CartesianVelocity3D,
-    SphericalVelocity,
-    CylindricalVelocity,
+    CartesianVel3D,
+    SphericalVel,
+    CylindricalVel,
 ]
 
 
@@ -198,8 +198,8 @@ class AbstractPosTest(AbstractVectorTest):
         assert isinstance(newvec, target)
 
 
-class AbstractVelocityTest(AbstractVectorTest):
-    """Test :class:`coordinax.AbstractVelocity`."""
+class AbstractVelTest(AbstractVectorTest):
+    """Test :class:`coordinax.AbstractVel`."""
 
     @pytest.fixture(scope="class")
     def vector(self) -> AbstractPos:
@@ -207,7 +207,7 @@ class AbstractVelocityTest(AbstractVectorTest):
         raise NotImplementedError
 
     @pytest.fixture(scope="class")
-    def difntl(self) -> AbstractVelocity:
+    def difntl(self) -> AbstractVel:
         """Return a vector."""
         raise NotImplementedError
 
@@ -221,16 +221,16 @@ class AbstractVelocityTest(AbstractVectorTest):
         # TODO: have all the conversions
         if (
             (
-                isinstance(difntl, AbstractVelocity1D)
-                and not issubclass(target, AbstractVelocity1D)
+                isinstance(difntl, AbstractVel1D)
+                and not issubclass(target, AbstractVel1D)
             )
             or (
-                isinstance(difntl, AbstractVelocity2D)
-                and not issubclass(target, AbstractVelocity2D)
+                isinstance(difntl, AbstractVel2D)
+                and not issubclass(target, AbstractVel2D)
             )
             or (
-                isinstance(difntl, AbstractVelocity3D)
-                and not issubclass(target, AbstractVelocity3D)
+                isinstance(difntl, AbstractVel3D)
+                and not issubclass(target, AbstractVel3D)
             )
         ):
             pytest.xfail("Not implemented yet")

--- a/tests/test_d1.py
+++ b/tests/test_d1.py
@@ -6,182 +6,178 @@ import quaxed.numpy as jnp
 from unxt import Quantity
 
 import coordinax as cx
-from .test_base import AbstractPositionTest, AbstractVelocityTest
+from .test_base import AbstractPosTest, AbstractVelocityTest
 
 
-class AbstractPosition1DTest(AbstractPositionTest):
-    """Test :class:`coordinax.AbstractPosition1D`."""
+class AbstractPos1DTest(AbstractPosTest):
+    """Test :class:`coordinax.AbstractPos1D`."""
 
     # TODO: Add tests
 
 
-class TestCartesianPosition1D(AbstractPosition1DTest):
-    """Test :class:`coordinax.CartesianPosition1D`."""
+class TestCartesianPos1D(AbstractPos1DTest):
+    """Test :class:`coordinax.CartesianPos1D`."""
 
     @pytest.fixture(scope="class")
-    def vector(self) -> cx.AbstractPosition:
+    def vector(self) -> cx.AbstractPos:
         """Return a vector."""
-        return cx.CartesianPosition1D(x=Quantity([1, 2, 3, 4], "kpc"))
+        return cx.CartesianPos1D(x=Quantity([1, 2, 3, 4], "kpc"))
 
     # ==========================================================================
     # represent_as
 
     def test_cartesian1d_to_cartesian1d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition1D)``."""
+        """Test ``coordinax.represent_as(CartesianPos1D)``."""
         # Jit can copy
-        newvec = vector.represent_as(cx.CartesianPosition1D)
+        newvec = vector.represent_as(cx.CartesianPos1D)
         assert jnp.array_equal(newvec, vector)
 
         # The normal `represent_as` method should return the same object
-        newvec = cx.represent_as(vector, cx.CartesianPosition1D)
+        newvec = cx.represent_as(vector, cx.CartesianPos1D)
         assert newvec is vector
 
     def test_cartesian1d_to_radial(self, vector):
-        """Test ``coordinax.represent_as(RadialPosition)``."""
-        radial = vector.represent_as(cx.RadialPosition)
+        """Test ``coordinax.represent_as(RadialPos)``."""
+        radial = vector.represent_as(cx.RadialPos)
 
-        assert isinstance(radial, cx.RadialPosition)
+        assert isinstance(radial, cx.RadialPos)
         assert jnp.array_equal(radial.r, Quantity([1, 2, 3, 4], "kpc"))
 
     def test_cartesian1d_to_cartesian2d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition2D)``."""
-        cart2d = vector.represent_as(
-            cx.CartesianPosition2D, y=Quantity([5, 6, 7, 8], "km")
-        )
+        """Test ``coordinax.represent_as(CartesianPos2D)``."""
+        cart2d = vector.represent_as(cx.CartesianPos2D, y=Quantity([5, 6, 7, 8], "km"))
 
-        assert isinstance(cart2d, cx.CartesianPosition2D)
+        assert isinstance(cart2d, cx.CartesianPos2D)
         assert jnp.array_equal(cart2d.x, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(cart2d.y, Quantity([5, 6, 7, 8], "km"))
 
     def test_cartesian1d_to_polar(self, vector):
-        """Test ``coordinax.represent_as(PolarPosition)``."""
-        polar = vector.represent_as(cx.PolarPosition, phi=Quantity([0, 1, 2, 3], "rad"))
+        """Test ``coordinax.represent_as(PolarPos)``."""
+        polar = vector.represent_as(cx.PolarPos, phi=Quantity([0, 1, 2, 3], "rad"))
 
-        assert isinstance(polar, cx.PolarPosition)
+        assert isinstance(polar, cx.PolarPos)
         assert jnp.array_equal(polar.r, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(polar.phi, Quantity([0, 1, 2, 3], "rad"))
 
     def test_cartesian1d_to_cartesian3d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition3D)``."""
+        """Test ``coordinax.represent_as(CartesianPos3D)``."""
         cart3d = vector.represent_as(
-            cx.CartesianPosition3D,
+            cx.CartesianPos3D,
             y=Quantity([5, 6, 7, 8], "km"),
             z=Quantity([9, 10, 11, 12], "m"),
         )
 
-        assert isinstance(cart3d, cx.CartesianPosition3D)
+        assert isinstance(cart3d, cx.CartesianPos3D)
         assert jnp.array_equal(cart3d.x, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(cart3d.y, Quantity([5, 6, 7, 8], "km"))
         assert jnp.array_equal(cart3d.z, Quantity([9, 10, 11, 12], "m"))
 
     def test_cartesian1d_to_spherical(self, vector):
-        """Test ``coordinax.represent_as(SphericalPosition)``."""
+        """Test ``coordinax.represent_as(SphericalPos)``."""
         spherical = vector.represent_as(
-            cx.SphericalPosition,
+            cx.SphericalPos,
             theta=Quantity([4, 15, 60, 170], "deg"),
             phi=Quantity([0, 1, 2, 3], "rad"),
         )
 
-        assert isinstance(spherical, cx.SphericalPosition)
+        assert isinstance(spherical, cx.SphericalPos)
         assert jnp.array_equal(spherical.r, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(spherical.theta, Quantity([4, 15, 60, 170], "deg"))
         assert jnp.array_equal(spherical.phi, Quantity([0, 1, 2, 3], "rad"))
 
     def test_cartesian1d_to_cylindrical(self, vector):
-        """Test ``coordinax.represent_as(CylindricalPosition)``."""
+        """Test ``coordinax.represent_as(CylindricalPos)``."""
         cylindrical = vector.represent_as(
-            cx.CylindricalPosition,
+            cx.CylindricalPos,
             phi=Quantity([0, 1, 2, 3], "rad"),
             z=Quantity([4, 5, 6, 7], "m"),
         )
 
-        assert isinstance(cylindrical, cx.CylindricalPosition)
+        assert isinstance(cylindrical, cx.CylindricalPos)
         assert jnp.array_equal(cylindrical.rho, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(cylindrical.phi, Quantity([0, 1, 2, 3], "rad"))
         assert jnp.array_equal(cylindrical.z, Quantity([4, 5, 6, 7], "m"))
 
 
-class TestRadialPosition(AbstractPosition1DTest):
-    """Test :class:`coordinax.RadialPosition`."""
+class TestRadialPos(AbstractPos1DTest):
+    """Test :class:`coordinax.RadialPos`."""
 
     @pytest.fixture(scope="class")
-    def vector(self) -> cx.AbstractPosition:
+    def vector(self) -> cx.AbstractPos:
         """Return a vector."""
-        return cx.RadialPosition(r=Quantity([1, 2, 3, 4], "kpc"))
+        return cx.RadialPos(r=Quantity([1, 2, 3, 4], "kpc"))
 
     # ==========================================================================
     # represent_as
 
     def test_radial_to_cartesian1d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition1D)``."""
-        cart1d = vector.represent_as(cx.CartesianPosition1D)
+        """Test ``coordinax.represent_as(CartesianPos1D)``."""
+        cart1d = vector.represent_as(cx.CartesianPos1D)
 
-        assert isinstance(cart1d, cx.CartesianPosition1D)
+        assert isinstance(cart1d, cx.CartesianPos1D)
         assert jnp.array_equal(cart1d.x, Quantity([1, 2, 3, 4], "kpc"))
 
     def test_radial_to_radial(self, vector):
-        """Test ``coordinax.represent_as(RadialPosition)``."""
+        """Test ``coordinax.represent_as(RadialPos)``."""
         # Jit can copy
-        newvec = vector.represent_as(cx.RadialPosition)
+        newvec = vector.represent_as(cx.RadialPos)
         assert jnp.array_equal(newvec, vector)
 
         # The normal `represent_as` method should return the same object
-        newvec = cx.represent_as(vector, cx.RadialPosition)
+        newvec = cx.represent_as(vector, cx.RadialPos)
         assert newvec is vector
 
     def test_radial_to_cartesian2d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition2D)``."""
-        cart2d = vector.represent_as(
-            cx.CartesianPosition2D, y=Quantity([5, 6, 7, 8], "km")
-        )
+        """Test ``coordinax.represent_as(CartesianPos2D)``."""
+        cart2d = vector.represent_as(cx.CartesianPos2D, y=Quantity([5, 6, 7, 8], "km"))
 
-        assert isinstance(cart2d, cx.CartesianPosition2D)
+        assert isinstance(cart2d, cx.CartesianPos2D)
         assert jnp.array_equal(cart2d.x, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(cart2d.y, Quantity([5, 6, 7, 8], "km"))
 
     def test_radial_to_polar(self, vector):
-        """Test ``coordinax.represent_as(PolarPosition)``."""
-        polar = vector.represent_as(cx.PolarPosition, phi=Quantity([0, 1, 2, 3], "rad"))
+        """Test ``coordinax.represent_as(PolarPos)``."""
+        polar = vector.represent_as(cx.PolarPos, phi=Quantity([0, 1, 2, 3], "rad"))
 
-        assert isinstance(polar, cx.PolarPosition)
+        assert isinstance(polar, cx.PolarPos)
         assert jnp.array_equal(polar.r, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(polar.phi, Quantity([0, 1, 2, 3], "rad"))
 
     def test_radial_to_cartesian3d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition3D)``."""
+        """Test ``coordinax.represent_as(CartesianPos3D)``."""
         cart3d = vector.represent_as(
-            cx.CartesianPosition3D,
+            cx.CartesianPos3D,
             y=Quantity([5, 6, 7, 8], "km"),
             z=Quantity([9, 10, 11, 12], "m"),
         )
 
-        assert isinstance(cart3d, cx.CartesianPosition3D)
+        assert isinstance(cart3d, cx.CartesianPos3D)
         assert jnp.array_equal(cart3d.x, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(cart3d.y, Quantity([5, 6, 7, 8], "km"))
         assert jnp.array_equal(cart3d.z, Quantity([9, 10, 11, 12], "m"))
 
     def test_radial_to_spherical(self, vector):
-        """Test ``coordinax.represent_as(SphericalPosition)``."""
+        """Test ``coordinax.represent_as(SphericalPos)``."""
         spherical = vector.represent_as(
-            cx.SphericalPosition,
+            cx.SphericalPos,
             theta=Quantity([4, 15, 60, 170], "deg"),
             phi=Quantity([0, 1, 2, 3], "rad"),
         )
 
-        assert isinstance(spherical, cx.SphericalPosition)
+        assert isinstance(spherical, cx.SphericalPos)
         assert jnp.array_equal(spherical.r, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(spherical.theta, Quantity([4, 15, 60, 170], "deg"))
         assert jnp.array_equal(spherical.phi, Quantity([0, 1, 2, 3], "rad"))
 
     def test_radial_to_cylindrical(self, vector):
-        """Test ``coordinax.represent_as(CylindricalPosition)``."""
+        """Test ``coordinax.represent_as(CylindricalPos)``."""
         cylindrical = vector.represent_as(
-            cx.CylindricalPosition,
+            cx.CylindricalPos,
             phi=Quantity([0, 1, 2, 3], "rad"),
             z=Quantity([4, 5, 6, 7], "m"),
         )
 
-        assert isinstance(cylindrical, cx.CylindricalPosition)
+        assert isinstance(cylindrical, cx.CylindricalPos)
         assert jnp.array_equal(cylindrical.rho, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(cylindrical.phi, Quantity([0, 1, 2, 3], "rad"))
         assert jnp.array_equal(cylindrical.z, Quantity([4, 5, 6, 7], "m"))
@@ -200,9 +196,9 @@ class TestCartesianVelocity1D(AbstractVelocity1DTest):
         return cx.CartesianVelocity1D(d_x=Quantity([1.0, 2, 3, 4], "km/s"))
 
     @pytest.fixture(scope="class")
-    def vector(self) -> cx.CartesianPosition1D:
+    def vector(self) -> cx.CartesianPos1D:
         """Return a vector."""
-        return cx.CartesianPosition1D(x=Quantity([1.0, 2, 3, 4], "kpc"))
+        return cx.CartesianPos1D(x=Quantity([1.0, 2, 3, 4], "kpc"))
 
     # ==========================================================================
     # represent_as
@@ -308,9 +304,9 @@ class TestRadialVelocity(AbstractVelocity1DTest):
         return cx.RadialVelocity(d_r=Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.fixture(scope="class")
-    def vector(self) -> cx.RadialPosition:
+    def vector(self) -> cx.RadialPos:
         """Return a vector."""
-        return cx.RadialPosition(r=Quantity([1, 2, 3, 4], "kpc"))
+        return cx.RadialPos(r=Quantity([1, 2, 3, 4], "kpc"))
 
     # ==========================================================================
     # represent_as

--- a/tests/test_d1.py
+++ b/tests/test_d1.py
@@ -6,7 +6,7 @@ import quaxed.numpy as jnp
 from unxt import Quantity
 
 import coordinax as cx
-from .test_base import AbstractPosTest, AbstractVelocityTest
+from .test_base import AbstractPosTest, AbstractVelTest
 
 
 class AbstractPos1DTest(AbstractPosTest):
@@ -183,17 +183,17 @@ class TestRadialPos(AbstractPos1DTest):
         assert jnp.array_equal(cylindrical.z, Quantity([4, 5, 6, 7], "m"))
 
 
-class AbstractVelocity1DTest(AbstractVelocityTest):
-    """Test :class:`coordinax.AbstractVelocity1D`."""
+class AbstractVel1DTest(AbstractVelTest):
+    """Test :class:`coordinax.AbstractVel1D`."""
 
 
-class TestCartesianVelocity1D(AbstractVelocity1DTest):
-    """Test :class:`coordinax.CartesianVelocity1D`."""
+class TestCartesianVel1D(AbstractVel1DTest):
+    """Test :class:`coordinax.CartesianVel1D`."""
 
     @pytest.fixture(scope="class")
-    def difntl(self) -> cx.CartesianVelocity1D:
+    def difntl(self) -> cx.CartesianVel1D:
         """Return a vector."""
-        return cx.CartesianVelocity1D(d_x=Quantity([1.0, 2, 3, 4], "km/s"))
+        return cx.CartesianVel1D(d_x=Quantity([1.0, 2, 3, 4], "km/s"))
 
     @pytest.fixture(scope="class")
     def vector(self) -> cx.CartesianPos1D:
@@ -205,59 +205,59 @@ class TestCartesianVelocity1D(AbstractVelocity1DTest):
 
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian1d_to_cartesian1d(self, difntl, vector):
-        """Test ``difntl.represent_as(CartesianVelocity1D)``."""
+        """Test ``difntl.represent_as(CartesianVel1D)``."""
         # Jit can copy
-        newvec = difntl.represent_as(cx.CartesianVelocity1D, vector)
+        newvec = difntl.represent_as(cx.CartesianVel1D, vector)
         assert jnp.array_equal(newvec, difntl)
 
         # The normal `represent_as` method should return the same object
-        newvec = cx.represent_as(difntl, cx.CartesianVelocity1D, vector)
+        newvec = cx.represent_as(difntl, cx.CartesianVel1D, vector)
         assert newvec is difntl
 
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian1d_to_radial(self, difntl, vector):
-        """Test ``difntl.represent_as(RadialVelocity)``."""
-        radial = difntl.represent_as(cx.RadialVelocity, vector)
+        """Test ``difntl.represent_as(RadialVel)``."""
+        radial = difntl.represent_as(cx.RadialVel, vector)
 
-        assert isinstance(radial, cx.RadialVelocity)
+        assert isinstance(radial, cx.RadialVel)
         assert jnp.array_equal(radial.d_r, Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian1d_to_cartesian2d(self, difntl, vector):
-        """Test ``difntl.represent_as(CartesianVelocity2D)``."""
+        """Test ``difntl.represent_as(CartesianVel2D)``."""
         cart2d = difntl.represent_as(
-            cx.CartesianVelocity2D, vector, d_y=Quantity([5, 6, 7, 8], "km")
+            cx.CartesianVel2D, vector, d_y=Quantity([5, 6, 7, 8], "km")
         )
 
-        assert isinstance(cart2d, cx.CartesianVelocity2D)
+        assert isinstance(cart2d, cx.CartesianVel2D)
         assert jnp.array_equal(cart2d.d_x, Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(cart2d.d_y, Quantity([5, 6, 7, 8], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian1d_to_polar(self, difntl, vector):
-        """Test ``difntl.represent_as(PolarVelocity)``."""
+        """Test ``difntl.represent_as(PolarVel)``."""
         polar = difntl.represent_as(
-            cx.PolarVelocity, vector, d_phi=Quantity([0, 1, 2, 3], "rad")
+            cx.PolarVel, vector, d_phi=Quantity([0, 1, 2, 3], "rad")
         )
 
-        assert isinstance(polar, cx.PolarVelocity)
+        assert isinstance(polar, cx.PolarVel)
         assert jnp.array_equal(polar.d_r, Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(polar.d_phi, Quantity([0, 1, 2, 3], "rad/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian1d_to_cartesian3d(self, difntl, vector):
-        """Test ``difntl.represent_as(CartesianVelocity3D)``."""
+        """Test ``difntl.represent_as(CartesianVel3D)``."""
         cart3d = difntl.represent_as(
-            cx.CartesianVelocity3D,
+            cx.CartesianVel3D,
             vector,
             d_y=Quantity([5, 6, 7, 8], "km"),
             d_z=Quantity([9, 10, 11, 12], "m"),
         )
 
-        assert isinstance(cart3d, cx.CartesianVelocity3D)
+        assert isinstance(cart3d, cx.CartesianVel3D)
         assert jnp.array_equal(cart3d.d_x, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(cart3d.d_y, Quantity([5, 6, 7, 8], "km"))
         assert jnp.array_equal(cart3d.d_z, Quantity([9, 10, 11, 12], "m"))
@@ -265,15 +265,15 @@ class TestCartesianVelocity1D(AbstractVelocity1DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian1d_to_spherical(self, difntl, vector):
-        """Test ``difntl.represent_as(SphericalVelocity)``."""
+        """Test ``difntl.represent_as(SphericalVel)``."""
         spherical = difntl.represent_as(
-            cx.SphericalVelocity,
+            cx.SphericalVel,
             vector,
             d_theta=Quantity([4, 5, 6, 7], "rad/s"),
             d_phi=Quantity([0, 1, 2, 3], "rad/s"),
         )
 
-        assert isinstance(spherical, cx.SphericalVelocity)
+        assert isinstance(spherical, cx.SphericalVel)
         assert jnp.array_equal(spherical.d_r, Quantity([1, 2, 3, 4], "kpc"))
         assert spherical.d_theta == Quantity([4, 5, 6, 7], "rad/s")
         assert jnp.array_equal(spherical.d_phi, Quantity([0, 1, 2, 3], "rad/s"))
@@ -281,27 +281,27 @@ class TestCartesianVelocity1D(AbstractVelocity1DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian1d_to_cylindrical(self, difntl, vector):
-        """Test ``difntl.represent_as(CylindricalVelocity)``."""
+        """Test ``difntl.represent_as(CylindricalVel)``."""
         cylindrical = difntl.represent_as(
-            cx.CylindricalVelocity,
+            cx.CylindricalVel,
             vector,
             d_phi=Quantity([0, 1, 2, 3], "rad/s"),
             d_z=Quantity([4, 5, 6, 7], "m/s"),
         )
 
-        assert isinstance(cylindrical, cx.CylindricalVelocity)
+        assert isinstance(cylindrical, cx.CylindricalVel)
         assert jnp.array_equal(cylindrical.d_rho, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(cylindrical.d_phi, Quantity([0, 1, 2, 3], "rad/s"))
         assert jnp.array_equal(cylindrical.d_z, Quantity([4, 5, 6, 7], "m/s"))
 
 
-class TestRadialVelocity(AbstractVelocity1DTest):
-    """Test :class:`coordinax.RadialVelocity`."""
+class TestRadialVel(AbstractVel1DTest):
+    """Test :class:`coordinax.RadialVel`."""
 
     @pytest.fixture(scope="class")
-    def difntl(self) -> cx.RadialVelocity:
+    def difntl(self) -> cx.RadialVel:
         """Return a vector."""
-        return cx.RadialVelocity(d_r=Quantity([1, 2, 3, 4], "km/s"))
+        return cx.RadialVel(d_r=Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.fixture(scope="class")
     def vector(self) -> cx.RadialPos:
@@ -313,59 +313,59 @@ class TestRadialVelocity(AbstractVelocity1DTest):
 
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_radial_to_cartesian1d(self, difntl, vector):
-        """Test ``difntl.represent_as(CartesianVelocity1D)``."""
-        cart1d = difntl.represent_as(cx.CartesianVelocity1D, vector)
+        """Test ``difntl.represent_as(CartesianVel1D)``."""
+        cart1d = difntl.represent_as(cx.CartesianVel1D, vector)
 
-        assert isinstance(cart1d, cx.CartesianVelocity1D)
+        assert isinstance(cart1d, cx.CartesianVel1D)
         assert jnp.array_equal(cart1d.d_x, Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_radial_to_radial(self, difntl, vector):
-        """Test ``difntl.represent_as(RadialVelocity)``."""
+        """Test ``difntl.represent_as(RadialVel)``."""
         # Jit can copy
-        newvec = difntl.represent_as(cx.RadialVelocity, vector)
+        newvec = difntl.represent_as(cx.RadialVel, vector)
         assert jnp.array_equal(newvec, difntl)
 
         # The normal `represent_as` method should return the same object
-        newvec = cx.represent_as(difntl, cx.RadialVelocity, vector)
+        newvec = cx.represent_as(difntl, cx.RadialVel, vector)
         assert newvec is difntl
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_radial_to_cartesian2d(self, difntl, vector):
-        """Test ``difntl.represent_as(CartesianVelocity2D)``."""
+        """Test ``difntl.represent_as(CartesianVel2D)``."""
         cart2d = difntl.represent_as(
-            cx.CartesianVelocity2D, vector, d_y=Quantity([5, 6, 7, 8], "km")
+            cx.CartesianVel2D, vector, d_y=Quantity([5, 6, 7, 8], "km")
         )
 
-        assert isinstance(cart2d, cx.CartesianVelocity2D)
+        assert isinstance(cart2d, cx.CartesianVel2D)
         assert jnp.array_equal(cart2d.d_x, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(cart2d.d_y, Quantity([5, 6, 7, 8], "km"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_radial_to_polar(self, difntl, vector):
-        """Test ``difntl.represent_as(PolarVelocity)``."""
+        """Test ``difntl.represent_as(PolarVel)``."""
         polar = difntl.represent_as(
-            cx.PolarVelocity, vector, d_phi=Quantity([0, 1, 2, 3], "rad")
+            cx.PolarVel, vector, d_phi=Quantity([0, 1, 2, 3], "rad")
         )
 
-        assert isinstance(polar, cx.PolarVelocity)
+        assert isinstance(polar, cx.PolarVel)
         assert jnp.array_equal(polar.d_r, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(polar.d_phi, Quantity([0, 1, 2, 3], "rad"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_radial_to_cartesian3d(self, difntl, vector):
-        """Test ``difntl.represent_as(CartesianVelocity3D)``."""
+        """Test ``difntl.represent_as(CartesianVel3D)``."""
         cart3d = difntl.represent_as(
-            cx.CartesianVelocity3D,
+            cx.CartesianVel3D,
             vector,
             d_y=Quantity([5, 6, 7, 8], "km"),
             d_z=Quantity([9, 10, 11, 12], "m"),
         )
 
-        assert isinstance(cart3d, cx.CartesianVelocity3D)
+        assert isinstance(cart3d, cx.CartesianVel3D)
         assert jnp.array_equal(cart3d.d_x, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(cart3d.d_y, Quantity([5, 6, 7, 8], "km"))
         assert jnp.array_equal(cart3d.d_z, Quantity([9, 10, 11, 12], "m"))
@@ -373,15 +373,15 @@ class TestRadialVelocity(AbstractVelocity1DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_radial_to_spherical(self, difntl, vector):
-        """Test ``difntl.represent_as(SphericalVelocity)``."""
+        """Test ``difntl.represent_as(SphericalVel)``."""
         spherical = difntl.represent_as(
-            cx.SphericalVelocity,
+            cx.SphericalVel,
             vector,
             d_theta=Quantity([4, 5, 6, 7], "rad"),
             d_phi=Quantity([0, 1, 2, 3], "rad"),
         )
 
-        assert isinstance(spherical, cx.SphericalVelocity)
+        assert isinstance(spherical, cx.SphericalVel)
         assert jnp.array_equal(spherical.d_r, Quantity([1, 2, 3, 4], "kpc"))
         assert spherical.d_theta == Quantity([4, 5, 6, 7], "rad")
         assert jnp.array_equal(spherical.d_phi, Quantity([0, 1, 2, 3], "rad"))
@@ -389,15 +389,15 @@ class TestRadialVelocity(AbstractVelocity1DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_radial_to_cylindrical(self, difntl, vector):
-        """Test ``difntl.represent_as(CylindricalVelocity)``."""
+        """Test ``difntl.represent_as(CylindricalVel)``."""
         cylindrical = difntl.represent_as(
-            cx.CylindricalVelocity,
+            cx.CylindricalVel,
             vector,
             d_phi=Quantity([0, 1, 2, 3], "rad"),
             d_z=Quantity([4, 5, 6, 7], "m"),
         )
 
-        assert isinstance(cylindrical, cx.CylindricalVelocity)
+        assert isinstance(cylindrical, cx.CylindricalVel)
         assert jnp.array_equal(cylindrical.d_rho, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(cylindrical.d_phi, Quantity([0, 1, 2, 3], "rad"))
         assert jnp.array_equal(cylindrical.d_z, Quantity([4, 5, 6, 7], "m"))

--- a/tests/test_d2.py
+++ b/tests/test_d2.py
@@ -6,20 +6,20 @@ import quaxed.numpy as jnp
 from unxt import Quantity
 
 import coordinax as cx
-from .test_base import AbstractPositionTest, AbstractVelocityTest
+from .test_base import AbstractPosTest, AbstractVelocityTest
 
 
-class AbstractPosition2DTest(AbstractPositionTest):
-    """Test :class:`coordinax.AbstractPosition2D`."""
+class AbstractPos2DTest(AbstractPosTest):
+    """Test :class:`coordinax.AbstractPos2D`."""
 
 
-class TestCartesianPosition2D:
-    """Test :class:`coordinax.CartesianPosition2D`."""
+class TestCartesianPos2D:
+    """Test :class:`coordinax.CartesianPos2D`."""
 
     @pytest.fixture(scope="class")
-    def vector(self) -> cx.CartesianPosition2D:
+    def vector(self) -> cx.CartesianPos2D:
         """Return a vector."""
-        return cx.CartesianPosition2D(
+        return cx.CartesianPos2D(
             x=Quantity([1, 2, 3, 4], "kpc"), y=Quantity([5, 6, 7, 8], "kpc")
         )
 
@@ -28,40 +28,40 @@ class TestCartesianPosition2D:
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_cartesian2d_to_cartesian1d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition1D)``."""
-        cart1d = vector.represent_as(cx.CartesianPosition1D)
+        """Test ``coordinax.represent_as(CartesianPos1D)``."""
+        cart1d = vector.represent_as(cx.CartesianPos1D)
 
-        assert isinstance(cart1d, cx.CartesianPosition1D)
+        assert isinstance(cart1d, cx.CartesianPos1D)
         assert jnp.array_equal(cart1d.x, Quantity([1, 2, 3, 4], "kpc"))
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_cartesian2d_to_radial(self, vector):
-        """Test ``coordinax.represent_as(RadialPosition)``."""
-        radial = vector.represent_as(cx.RadialPosition)
+        """Test ``coordinax.represent_as(RadialPos)``."""
+        radial = vector.represent_as(cx.RadialPos)
 
-        assert isinstance(radial, cx.RadialPosition)
+        assert isinstance(radial, cx.RadialPos)
         assert jnp.array_equal(radial.r, jnp.hypot(vector.x, vector.y))
 
     def test_cartesian2d_to_cartesian2d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition2D)``."""
-        newvec = vector.represent_as(cx.CartesianPosition2D)
+        """Test ``coordinax.represent_as(CartesianPos2D)``."""
+        newvec = vector.represent_as(cx.CartesianPos2D)
         assert newvec is vector
 
     def test_cartesian2d_to_cartesian2d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition2D)``."""
+        """Test ``coordinax.represent_as(CartesianPos2D)``."""
         # Jit can copy
-        newvec = vector.represent_as(cx.CartesianPosition2D)
+        newvec = vector.represent_as(cx.CartesianPos2D)
         assert jnp.array_equal(newvec, vector)
 
         # The normal `represent_as` method should return the same object
-        newvec = cx.represent_as(vector, cx.CartesianPosition2D)
+        newvec = cx.represent_as(vector, cx.CartesianPos2D)
         assert newvec is vector
 
     def test_cartesian2d_to_polar(self, vector):
-        """Test ``coordinax.represent_as(PolarPosition)``."""
-        polar = vector.represent_as(cx.PolarPosition)
+        """Test ``coordinax.represent_as(PolarPos)``."""
+        polar = vector.represent_as(cx.PolarPos)
 
-        assert isinstance(polar, cx.PolarPosition)
+        assert isinstance(polar, cx.PolarPos)
         assert jnp.array_equal(polar.r, jnp.hypot(vector.x, vector.y))
         assert jnp.allclose(
             polar.phi,
@@ -70,23 +70,23 @@ class TestCartesianPosition2D:
         )
 
     def test_cartesian2d_to_cartesian3d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition3D)``."""
+        """Test ``coordinax.represent_as(CartesianPos3D)``."""
         cart3d = vector.represent_as(
-            cx.CartesianPosition3D, z=Quantity([9, 10, 11, 12], "m")
+            cx.CartesianPos3D, z=Quantity([9, 10, 11, 12], "m")
         )
 
-        assert isinstance(cart3d, cx.CartesianPosition3D)
+        assert isinstance(cart3d, cx.CartesianPos3D)
         assert jnp.array_equal(cart3d.x, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(cart3d.y, Quantity([5, 6, 7, 8], "kpc"))
         assert jnp.array_equal(cart3d.z, Quantity([9, 10, 11, 12], "m"))
 
     def test_cartesian2d_to_spherical(self, vector):
-        """Test ``coordinax.represent_as(SphericalPosition)``."""
+        """Test ``coordinax.represent_as(SphericalPos)``."""
         spherical = vector.represent_as(
-            cx.SphericalPosition, theta=Quantity([4, 5, 6, 7], "rad")
+            cx.SphericalPos, theta=Quantity([4, 5, 6, 7], "rad")
         )
 
-        assert isinstance(spherical, cx.SphericalPosition)
+        assert isinstance(spherical, cx.SphericalPos)
         assert jnp.array_equal(spherical.r, jnp.hypot(vector.x, vector.y))
         assert jnp.allclose(
             spherical.phi,
@@ -98,12 +98,12 @@ class TestCartesianPosition2D:
         )
 
     def test_cartesian2d_to_cylindrical(self, vector):
-        """Test ``coordinax.represent_as(CylindricalPosition)``."""
+        """Test ``coordinax.represent_as(CylindricalPos)``."""
         cylindrical = vector.represent_as(
-            cx.CylindricalPosition, z=Quantity([9, 10, 11, 12], "m")
+            cx.CylindricalPos, z=Quantity([9, 10, 11, 12], "m")
         )
 
-        assert isinstance(cylindrical, cx.CylindricalPosition)
+        assert isinstance(cylindrical, cx.CylindricalPos)
         assert jnp.array_equal(cylindrical.rho, jnp.hypot(vector.x, vector.y))
         assert jnp.array_equal(
             cylindrical.phi,
@@ -112,13 +112,13 @@ class TestCartesianPosition2D:
         assert jnp.array_equal(cylindrical.z, Quantity([9, 10, 11, 12], "m"))
 
 
-class TestPolarPosition:
-    """Test :class:`coordinax.PolarPosition`."""
+class TestPolarPos:
+    """Test :class:`coordinax.PolarPos`."""
 
     @pytest.fixture(scope="class")
-    def vector(self) -> cx.AbstractPosition:
+    def vector(self) -> cx.AbstractPos:
         """Return a vector."""
-        return cx.PolarPosition(
+        return cx.PolarPos(
             r=Quantity([1, 2, 3, 4], "kpc"), phi=Quantity([0, 1, 2, 3], "rad")
         )
 
@@ -127,10 +127,10 @@ class TestPolarPosition:
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_polar_to_cartesian1d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition1D)``."""
-        cart1d = vector.represent_as(cx.CartesianPosition1D)
+        """Test ``coordinax.represent_as(CartesianPos1D)``."""
+        cart1d = vector.represent_as(cx.CartesianPos1D)
 
-        assert isinstance(cart1d, cx.CartesianPosition1D)
+        assert isinstance(cart1d, cx.CartesianPos1D)
         assert jnp.allclose(
             cart1d.x,
             Quantity([1.0, 1.0806047, -1.2484405, -3.95997], "kpc"),
@@ -140,19 +140,17 @@ class TestPolarPosition:
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_polar_to_radial(self, vector):
-        """Test ``coordinax.represent_as(RadialPosition)``."""
-        radial = vector.represent_as(cx.RadialPosition)
+        """Test ``coordinax.represent_as(RadialPos)``."""
+        radial = vector.represent_as(cx.RadialPos)
 
-        assert isinstance(radial, cx.RadialPosition)
+        assert isinstance(radial, cx.RadialPos)
         assert jnp.array_equal(radial.r, Quantity([1, 2, 3, 4], "kpc"))
 
     def test_polar_to_cartesian2d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition2D)``."""
-        cart2d = vector.represent_as(
-            cx.CartesianPosition2D, y=Quantity([5, 6, 7, 8], "km")
-        )
+        """Test ``coordinax.represent_as(CartesianPos2D)``."""
+        cart2d = vector.represent_as(cx.CartesianPos2D, y=Quantity([5, 6, 7, 8], "km"))
 
-        assert isinstance(cart2d, cx.CartesianPosition2D)
+        assert isinstance(cart2d, cx.CartesianPos2D)
         assert jnp.array_equal(
             cart2d.x, Quantity([1.0, 1.0806046, -1.2484405, -3.95997], "kpc")
         )
@@ -167,22 +165,22 @@ class TestPolarPosition:
         )
 
     def test_polar_to_polar(self, vector):
-        """Test ``coordinax.represent_as(PolarPosition)``."""
+        """Test ``coordinax.represent_as(PolarPos)``."""
         # Jit can copy
-        newvec = vector.represent_as(cx.PolarPosition)
+        newvec = vector.represent_as(cx.PolarPos)
         assert jnp.array_equal(newvec, vector)
 
         # The normal `represent_as` method should return the same object
-        newvec = cx.represent_as(vector, cx.PolarPosition)
+        newvec = cx.represent_as(vector, cx.PolarPos)
         assert newvec is vector
 
     def test_polar_to_cartesian3d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition3D)``."""
+        """Test ``coordinax.represent_as(CartesianPos3D)``."""
         cart3d = vector.represent_as(
-            cx.CartesianPosition3D, z=Quantity([9, 10, 11, 12], "m")
+            cx.CartesianPos3D, z=Quantity([9, 10, 11, 12], "m")
         )
 
-        assert isinstance(cart3d, cx.CartesianPosition3D)
+        assert isinstance(cart3d, cx.CartesianPos3D)
         assert jnp.array_equal(
             cart3d.x, Quantity([1.0, 1.0806046, -1.2484405, -3.95997], "kpc")
         )
@@ -192,23 +190,23 @@ class TestPolarPosition:
         assert jnp.array_equal(cart3d.z, Quantity([9, 10, 11, 12], "m"))
 
     def test_polar_to_spherical(self, vector):
-        """Test ``coordinax.represent_as(SphericalPosition)``."""
+        """Test ``coordinax.represent_as(SphericalPos)``."""
         spherical = vector.represent_as(
-            cx.SphericalPosition, theta=Quantity([4, 15, 60, 170], "deg")
+            cx.SphericalPos, theta=Quantity([4, 15, 60, 170], "deg")
         )
 
-        assert isinstance(spherical, cx.SphericalPosition)
+        assert isinstance(spherical, cx.SphericalPos)
         assert jnp.array_equal(spherical.r, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(spherical.theta, Quantity([4, 15, 60, 170], "deg"))
         assert jnp.array_equal(spherical.phi, Quantity([0, 1, 2, 3], "rad"))
 
     def test_polar_to_cylindrical(self, vector):
-        """Test ``coordinax.represent_as(CylindricalPosition)``."""
+        """Test ``coordinax.represent_as(CylindricalPos)``."""
         cylindrical = vector.represent_as(
-            cx.CylindricalPosition, z=Quantity([9, 10, 11, 12], "m")
+            cx.CylindricalPos, z=Quantity([9, 10, 11, 12], "m")
         )
 
-        assert isinstance(cylindrical, cx.CylindricalPosition)
+        assert isinstance(cylindrical, cx.CylindricalPos)
         assert jnp.array_equal(cylindrical.rho, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(cylindrical.phi, Quantity([0, 1, 2, 3], "rad"))
         assert jnp.array_equal(cylindrical.z, Quantity([9, 10, 11, 12], "m"))
@@ -230,9 +228,9 @@ class TestCartesianVelocity2D(AbstractVelocity2DTest):
         )
 
     @pytest.fixture(scope="class")
-    def vector(self) -> cx.CartesianPosition2D:
+    def vector(self) -> cx.CartesianPos2D:
         """Return a vector."""
-        return cx.CartesianPosition2D(
+        return cx.CartesianPos2D(
             x=Quantity([1, 2, 3, 4], "kpc"), y=Quantity([5, 6, 7, 8], "km")
         )
 
@@ -332,9 +330,9 @@ class TestPolarVelocity(AbstractVelocity2DTest):
         )
 
     @pytest.fixture(scope="class")
-    def vector(self) -> cx.PolarPosition:
+    def vector(self) -> cx.PolarPos:
         """Return a vector."""
-        return cx.PolarPosition(
+        return cx.PolarPos(
             r=Quantity([1, 2, 3, 4], "kpc"), phi=Quantity([0, 1, 2, 3], "rad")
         )
 

--- a/tests/test_d2.py
+++ b/tests/test_d2.py
@@ -6,7 +6,7 @@ import quaxed.numpy as jnp
 from unxt import Quantity
 
 import coordinax as cx
-from .test_base import AbstractPosTest, AbstractVelocityTest
+from .test_base import AbstractPosTest, AbstractVelTest
 
 
 class AbstractPos2DTest(AbstractPosTest):
@@ -212,17 +212,17 @@ class TestPolarPos:
         assert jnp.array_equal(cylindrical.z, Quantity([9, 10, 11, 12], "m"))
 
 
-class AbstractVelocity2DTest(AbstractVelocityTest):
-    """Test :class:`coordinax.AbstractVelocity2D`."""
+class AbstractVel2DTest(AbstractVelTest):
+    """Test :class:`coordinax.AbstractVel2D`."""
 
 
-class TestCartesianVelocity2D(AbstractVelocity2DTest):
-    """Test :class:`coordinax.CartesianVelocity2D`."""
+class TestCartesianVel2D(AbstractVel2DTest):
+    """Test :class:`coordinax.CartesianVel2D`."""
 
     @pytest.fixture(scope="class")
-    def difntl(self) -> cx.CartesianVelocity2D:
+    def difntl(self) -> cx.CartesianVel2D:
         """Return a differential."""
-        return cx.CartesianVelocity2D(
+        return cx.CartesianVel2D(
             d_x=Quantity([1, 2, 3, 4], "km/s"),
             d_y=Quantity([5, 6, 7, 8], "km/s"),
         )
@@ -240,38 +240,38 @@ class TestCartesianVelocity2D(AbstractVelocity2DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian2d_to_cartesian1d(self, difntl, vector):
-        """Test ``difntl.represent_as(CartesianVelocity1D, vector)``."""
-        cart1d = difntl.represent_as(cx.CartesianVelocity1D, vector)
+        """Test ``difntl.represent_as(CartesianVel1D, vector)``."""
+        cart1d = difntl.represent_as(cx.CartesianVel1D, vector)
 
-        assert isinstance(cart1d, cx.CartesianVelocity1D)
+        assert isinstance(cart1d, cx.CartesianVel1D)
         assert jnp.array_equal(cart1d.d_x, Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian2d_to_radial(self, difntl, vector):
-        """Test ``difntl.represent_as(RadialVelocity, vector)``."""
-        radial = difntl.represent_as(cx.RadialVelocity, vector)
+        """Test ``difntl.represent_as(RadialVel, vector)``."""
+        radial = difntl.represent_as(cx.RadialVel, vector)
 
-        assert isinstance(radial, cx.RadialVelocity)
+        assert isinstance(radial, cx.RadialVel)
         assert jnp.array_equal(radial.d_r, Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian2d_to_cartesian2d(self, difntl, vector):
-        """Test ``difntl.represent_as(CartesianVelocity2D, vector)``."""
+        """Test ``difntl.represent_as(CartesianVel2D, vector)``."""
         # Jit can copy
-        newvec = difntl.represent_as(cx.CartesianVelocity2D, vector)
+        newvec = difntl.represent_as(cx.CartesianVel2D, vector)
         assert jnp.array_equal(newvec, difntl)
 
         # The normal `represent_as` method should return the same object
-        newvec = cx.represent_as(difntl, cx.CartesianVelocity2D, vector)
+        newvec = cx.represent_as(difntl, cx.CartesianVel2D, vector)
         assert newvec is difntl
 
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian2d_to_polar(self, difntl, vector):
-        """Test ``difntl.represent_as(PolarVelocity, vector)``."""
-        polar = difntl.represent_as(cx.PolarVelocity, vector)
+        """Test ``difntl.represent_as(PolarVel, vector)``."""
+        polar = difntl.represent_as(cx.PolarVel, vector)
 
-        assert isinstance(polar, cx.PolarVelocity)
+        assert isinstance(polar, cx.PolarVel)
         assert jnp.array_equal(polar.d_r, Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(
             polar.d_phi,
@@ -281,12 +281,12 @@ class TestCartesianVelocity2D(AbstractVelocity2DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian2d_to_cartesian3d(self, difntl, vector):
-        """Test ``difntl.represent_as(CartesianVelocity3D, vector)``."""
+        """Test ``difntl.represent_as(CartesianVel3D, vector)``."""
         cart3d = difntl.represent_as(
-            cx.CartesianVelocity3D, vector, d_z=Quantity([9, 10, 11, 12], "m/s")
+            cx.CartesianVel3D, vector, d_z=Quantity([9, 10, 11, 12], "m/s")
         )
 
-        assert isinstance(cart3d, cx.CartesianVelocity3D)
+        assert isinstance(cart3d, cx.CartesianVel3D)
         assert jnp.array_equal(cart3d.d_x, Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(cart3d.d_y, Quantity([5, 6, 7, 8], "km/s"))
         assert jnp.array_equal(cart3d.d_z, Quantity([9, 10, 11, 12], "m/s"))
@@ -294,12 +294,12 @@ class TestCartesianVelocity2D(AbstractVelocity2DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian2d_to_spherical(self, difntl, vector):
-        """Test ``difntl.represent_as(SphericalVelocity, vector)``."""
+        """Test ``difntl.represent_as(SphericalVel, vector)``."""
         spherical = difntl.represent_as(
-            cx.SphericalVelocity, vector, d_theta=Quantity([4, 5, 6, 7], "rad")
+            cx.SphericalVel, vector, d_theta=Quantity([4, 5, 6, 7], "rad")
         )
 
-        assert isinstance(spherical, cx.SphericalVelocity)
+        assert isinstance(spherical, cx.SphericalVel)
         assert jnp.array_equal(spherical.d_r, Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(spherical.d_theta, Quantity([4, 5, 6, 7], "rad"))
         assert jnp.array_equal(spherical.d_phi, Quantity([5, 6, 7, 8], "km/s"))
@@ -307,24 +307,24 @@ class TestCartesianVelocity2D(AbstractVelocity2DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian2d_to_cylindrical(self, difntl, vector):
-        """Test ``difntl.represent_as(CylindricalVelocity, vector)``."""
+        """Test ``difntl.represent_as(CylindricalVel, vector)``."""
         cylindrical = difntl.represent_as(
-            cx.CylindricalVelocity, vector, d_z=Quantity([9, 10, 11, 12], "m/s")
+            cx.CylindricalVel, vector, d_z=Quantity([9, 10, 11, 12], "m/s")
         )
 
-        assert isinstance(cylindrical, cx.CylindricalVelocity)
+        assert isinstance(cylindrical, cx.CylindricalVel)
         assert jnp.array_equal(cylindrical.d_rho, Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(cylindrical.d_phi, Quantity([5, 6, 7, 8], "km/s"))
         assert jnp.array_equal(cylindrical.d_z, Quantity([9, 10, 11, 12], "m/s"))
 
 
-class TestPolarVelocity(AbstractVelocity2DTest):
-    """Test :class:`coordinax.PolarVelocity`."""
+class TestPolarVel(AbstractVel2DTest):
+    """Test :class:`coordinax.PolarVel`."""
 
     @pytest.fixture(scope="class")
-    def difntl(self) -> cx.PolarVelocity:
+    def difntl(self) -> cx.PolarVel:
         """Return a differential."""
-        return cx.PolarVelocity(
+        return cx.PolarVel(
             d_r=Quantity([1, 2, 3, 4], "km/s"),
             d_phi=Quantity([5, 6, 7, 8], "mas/yr"),
         )
@@ -342,27 +342,27 @@ class TestPolarVelocity(AbstractVelocity2DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_polar_to_cartesian1d(self, difntl, vector):
-        """Test ``difntl.represent_as(CartesianVelocity1D, vector)``."""
-        cart1d = difntl.represent_as(cx.CartesianVelocity1D, vector)
+        """Test ``difntl.represent_as(CartesianVel1D, vector)``."""
+        cart1d = difntl.represent_as(cx.CartesianVel1D, vector)
 
-        assert isinstance(cart1d, cx.CartesianVelocity1D)
+        assert isinstance(cart1d, cx.CartesianVel1D)
         assert jnp.array_equal(cart1d.d_x, Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_polar_to_radial(self, difntl, vector):
-        """Test ``difntl.represent_as(RadialVelocity, vector)``."""
-        radial = difntl.represent_as(cx.RadialVelocity, vector)
+        """Test ``difntl.represent_as(RadialVel, vector)``."""
+        radial = difntl.represent_as(cx.RadialVel, vector)
 
-        assert isinstance(radial, cx.RadialVelocity)
+        assert isinstance(radial, cx.RadialVel)
         assert jnp.array_equal(radial.d_r, Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_polar_to_cartesian2d(self, difntl, vector):
-        """Test ``difntl.represent_as(CartesianVelocity2D, vector)``."""
-        cart2d = difntl.represent_as(cx.CartesianVelocity2D, vector)
+        """Test ``difntl.represent_as(CartesianVel2D, vector)``."""
+        cart2d = difntl.represent_as(cx.CartesianVel2D, vector)
 
-        assert isinstance(cart2d, cx.CartesianVelocity2D)
+        assert isinstance(cart2d, cx.CartesianVel2D)
         assert jnp.array_equal(
             cart2d.d_x, Quantity([1.0, -46.787014, -91.76889, -25.367176], "km/s")
         )
@@ -373,24 +373,24 @@ class TestPolarVelocity(AbstractVelocity2DTest):
 
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_polar_to_polar(self, difntl, vector):
-        """Test ``difntl.represent_as(PolarVelocity, vector)``."""
+        """Test ``difntl.represent_as(PolarVel, vector)``."""
         # Jit can copy
-        newvec = difntl.represent_as(cx.PolarVelocity, vector)
+        newvec = difntl.represent_as(cx.PolarVel, vector)
         assert all(newvec == difntl)
 
         # The normal `represent_as` method should return the same object
-        newvec = cx.represent_as(difntl, cx.PolarVelocity, vector)
+        newvec = cx.represent_as(difntl, cx.PolarVel, vector)
         assert newvec is difntl
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_polar_to_cartesian3d(self, difntl, vector):
-        """Test ``difntl.represent_as(CartesianVelocity3D, vector)``."""
+        """Test ``difntl.represent_as(CartesianVel3D, vector)``."""
         cart3d = difntl.represent_as(
-            cx.CartesianVelocity3D, vector, d_z=Quantity([9, 10, 11, 12], "m/s")
+            cx.CartesianVel3D, vector, d_z=Quantity([9, 10, 11, 12], "m/s")
         )
 
-        assert isinstance(cart3d, cx.CartesianVelocity3D)
+        assert isinstance(cart3d, cx.CartesianVel3D)
         assert jnp.array_equal(cart3d.d_x, Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(cart3d.d_y, Quantity([5, 6, 7, 8], "km/s"))
         assert jnp.array_equal(cart3d.d_z, Quantity([9, 10, 11, 12], "m/s"))
@@ -398,12 +398,12 @@ class TestPolarVelocity(AbstractVelocity2DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_polar_to_spherical(self, difntl, vector):
-        """Test ``difntl.represent_as(SphericalVelocity, vector)``."""
+        """Test ``difntl.represent_as(SphericalVel, vector)``."""
         spherical = difntl.represent_as(
-            cx.SphericalVelocity, vector, d_theta=Quantity([4, 5, 6, 7], "rad")
+            cx.SphericalVel, vector, d_theta=Quantity([4, 5, 6, 7], "rad")
         )
 
-        assert isinstance(spherical, cx.SphericalVelocity)
+        assert isinstance(spherical, cx.SphericalVel)
         assert jnp.array_equal(spherical.d_r, Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(spherical.d_theta, Quantity([4, 5, 6, 7], "rad"))
         assert jnp.array_equal(spherical.d_phi, Quantity([5, 6, 7, 8], "km/s"))
@@ -411,12 +411,12 @@ class TestPolarVelocity(AbstractVelocity2DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_polar_to_cylindrical(self, difntl, vector):
-        """Test ``difntl.represent_as(CylindricalVelocity, vector)``."""
+        """Test ``difntl.represent_as(CylindricalVel, vector)``."""
         cylindrical = difntl.represent_as(
-            cx.CylindricalVelocity, vector, d_z=Quantity([9, 10, 11, 12], "m/s")
+            cx.CylindricalVel, vector, d_z=Quantity([9, 10, 11, 12], "m/s")
         )
 
-        assert isinstance(cylindrical, cx.CylindricalVelocity)
+        assert isinstance(cylindrical, cx.CylindricalVel)
         assert jnp.array_equal(cylindrical.d_rho, Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(cylindrical.d_phi, Quantity([5, 6, 7, 8], "km/s"))
         assert jnp.array_equal(cylindrical.d_z, Quantity([9, 10, 11, 12], "m/s"))

--- a/tests/test_d3.py
+++ b/tests/test_d3.py
@@ -11,7 +11,7 @@ import quaxed.numpy as jnp
 from unxt import Quantity
 
 import coordinax as cx
-from .test_base import AbstractPosTest, AbstractVelocityTest
+from .test_base import AbstractPosTest, AbstractVelTest
 
 
 class AbstractPos3DTest(AbstractPosTest):
@@ -475,26 +475,26 @@ class TestSphericalPos(AbstractPos3DTest):
         assert np.allclose(convert(llsph.lat, APYQuantity), apycart3.lat)
 
 
-class AbstractVelocity3DTest(AbstractVelocityTest):
-    """Test :class:`coordinax.AbstractVelocity2D`."""
+class AbstractVel3DTest(AbstractVelTest):
+    """Test :class:`coordinax.AbstractVel2D`."""
 
     # ==========================================================================
     # Unary operations
 
     def test_neg_compare_apy(
-        self, difntl: cx.AbstractVelocity, apydifntl: apyc.BaseDifferential
+        self, difntl: cx.AbstractVel, apydifntl: apyc.BaseDifferential
     ):
         """Test negation."""
         assert all(representation_equal(convert(-difntl, type(apydifntl)), -apydifntl))
 
 
-class TestCartesianVelocity3D(AbstractVelocity3DTest):
-    """Test :class:`coordinax.CartesianVelocity3D`."""
+class TestCartesianVel3D(AbstractVel3DTest):
+    """Test :class:`coordinax.CartesianVel3D`."""
 
     @pytest.fixture(scope="class")
-    def difntl(self) -> cx.CartesianVelocity3D:
+    def difntl(self) -> cx.CartesianVel3D:
         """Return a differential."""
-        return cx.CartesianVelocity3D(
+        return cx.CartesianVel3D(
             d_x=Quantity([5, 6, 7, 8], "km/s"),
             d_y=Quantity([9, 10, 11, 12], "km/s"),
             d_z=Quantity([13, 14, 15, 16], "km/s"),
@@ -510,7 +510,7 @@ class TestCartesianVelocity3D(AbstractVelocity3DTest):
         )
 
     @pytest.fixture(scope="class")
-    def apydifntl(self, difntl: cx.CartesianVelocity3D):
+    def apydifntl(self, difntl: cx.CartesianVel3D):
         """Return an Astropy differential."""
         return convert(difntl, apyc.CartesianDifferential)
 
@@ -525,9 +525,9 @@ class TestCartesianVelocity3D(AbstractVelocity3DTest):
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian3d_to_cartesian1d(self, difntl, vector):
         """Test ``coordinax.represent_as(CartesianPos1D)``."""
-        cart1d = difntl.represent_as(cx.CartesianVelocity1D, vector)
+        cart1d = difntl.represent_as(cx.CartesianVel1D, vector)
 
-        assert isinstance(cart1d, cx.CartesianVelocity1D)
+        assert isinstance(cart1d, cx.CartesianVel1D)
         assert jnp.array_equal(cart1d.d_x, Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
@@ -543,9 +543,9 @@ class TestCartesianVelocity3D(AbstractVelocity3DTest):
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian3d_to_cartesian2d(self, difntl, vector):
         """Test ``coordinax.represent_as(CartesianPos2D)``."""
-        cart2d = difntl.represent_as(cx.CartesianVelocity2D, vector)
+        cart2d = difntl.represent_as(cx.CartesianVel2D, vector)
 
-        assert isinstance(cart2d, cx.CartesianVelocity2D)
+        assert isinstance(cart2d, cx.CartesianVel2D)
         assert jnp.array_equal(cart2d.d_x, Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(cart2d.d_y, Quantity([5, 6, 7, 8], "km/s"))
 
@@ -562,18 +562,18 @@ class TestCartesianVelocity3D(AbstractVelocity3DTest):
     def test_cartesian3d_to_cartesian3d(self, difntl, vector):
         """Test ``coordinax.represent_as(CartesianPos3D)``."""
         # Jit can copy
-        newvec = difntl.represent_as(cx.CartesianVelocity3D, vector)
+        newvec = difntl.represent_as(cx.CartesianVel3D, vector)
         assert jnp.array_equal(newvec, difntl)
 
         # The normal `represent_as` method should return the same object
-        newvec = cx.represent_as(difntl, cx.CartesianVelocity3D, vector)
+        newvec = cx.represent_as(difntl, cx.CartesianVel3D, vector)
         assert newvec is difntl
 
     def test_cartesian3d_to_cartesian3d_astropy(
         self, difntl, vector, apydifntl, apyvector
     ):
         """Test Astropy equivalence."""
-        cart3 = difntl.represent_as(cx.CartesianVelocity3D, vector)
+        cart3 = difntl.represent_as(cx.CartesianVel3D, vector)
 
         apycart3 = apydifntl.represent_as(apyc.CartesianDifferential, apyvector)
         assert np.allclose(convert(cart3.d_x, APYQuantity), apycart3.d_x)
@@ -581,10 +581,10 @@ class TestCartesianVelocity3D(AbstractVelocity3DTest):
         assert np.allclose(convert(cart3.d_z, APYQuantity), apycart3.d_z)
 
     def test_cartesian3d_to_spherical(self, difntl, vector):
-        """Test ``coordinax.represent_as(SphericalVelocity)``."""
-        spherical = difntl.represent_as(cx.SphericalVelocity, vector)
+        """Test ``coordinax.represent_as(SphericalVel)``."""
+        spherical = difntl.represent_as(cx.SphericalVel, vector)
 
-        assert isinstance(spherical, cx.SphericalVelocity)
+        assert isinstance(spherical, cx.SphericalVel)
         assert jnp.allclose(
             spherical.d_r,
             Quantity([16.1445, 17.917269, 19.657543, 21.380898], "km/s"),
@@ -609,7 +609,7 @@ class TestCartesianVelocity3D(AbstractVelocity3DTest):
         self, difntl, vector, apydifntl, apyvector
     ):
         """Test Astropy equivalence."""
-        sph = difntl.represent_as(cx.SphericalVelocity, vector)
+        sph = difntl.represent_as(cx.SphericalVel, vector)
 
         apysph = apydifntl.represent_as(apyc.PhysicsSphericalDifferential, apyvector)
         assert np.allclose(convert(sph.d_r, APYQuantity), apysph.d_r)
@@ -617,10 +617,10 @@ class TestCartesianVelocity3D(AbstractVelocity3DTest):
         assert np.allclose(convert(sph.d_phi, APYQuantity), apysph.d_phi, atol=1e-7)
 
     def test_cartesian3d_to_cylindrical(self, difntl, vector):
-        """Test ``coordinax.represent_as(CylindricalVelocity)``."""
-        cylindrical = difntl.represent_as(cx.CylindricalVelocity, vector)
+        """Test ``coordinax.represent_as(CylindricalVel)``."""
+        cylindrical = difntl.represent_as(cx.CylindricalVel, vector)
 
-        assert isinstance(cylindrical, cx.CylindricalVelocity)
+        assert isinstance(cylindrical, cx.CylindricalVel)
         assert jnp.array_equal(
             cylindrical.d_rho,
             Quantity([9.805806, 11.384199, 12.86803, 14.310835], "km/s"),
@@ -640,20 +640,20 @@ class TestCartesianVelocity3D(AbstractVelocity3DTest):
         self, difntl, vector, apydifntl, apyvector
     ):
         """Test Astropy equivalence."""
-        cyl = difntl.represent_as(cx.CylindricalVelocity, vector)
+        cyl = difntl.represent_as(cx.CylindricalVel, vector)
         apycyl = apydifntl.represent_as(apyc.CylindricalDifferential, apyvector)
         assert np.allclose(convert(cyl.d_rho, APYQuantity), apycyl.d_rho)
         assert np.allclose(convert(cyl.d_phi, APYQuantity), apycyl.d_phi)
         assert np.allclose(convert(cyl.d_z, APYQuantity), apycyl.d_z)
 
 
-class TestCylindricalVelocity(AbstractVelocity3DTest):
-    """Test :class:`coordinax.CylindricalVelocity`."""
+class TestCylindricalVel(AbstractVel3DTest):
+    """Test :class:`coordinax.CylindricalVel`."""
 
     @pytest.fixture(scope="class")
-    def difntl(self) -> cx.CylindricalVelocity:
+    def difntl(self) -> cx.CylindricalVel:
         """Return a differential."""
-        return cx.CylindricalVelocity(
+        return cx.CylindricalVel(
             d_rho=Quantity([5, 6, 7, 8], "km/s"),
             d_phi=Quantity([9, 10, 11, 12], "mas/yr"),
             d_z=Quantity([13, 14, 15, 16], "km/s"),
@@ -669,7 +669,7 @@ class TestCylindricalVelocity(AbstractVelocity3DTest):
         )
 
     @pytest.fixture(scope="class")
-    def apydifntl(self, difntl: cx.CylindricalVelocity):
+    def apydifntl(self, difntl: cx.CylindricalVel):
         """Return an Astropy differential."""
         return convert(difntl, apyc.CylindricalDifferential)
 
@@ -684,9 +684,9 @@ class TestCylindricalVelocity(AbstractVelocity3DTest):
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cylindrical_to_cartesian1d(self, difntl, vector):
         """Test ``coordinax.represent_as(CartesianPos1D)``."""
-        cart1d = difntl.represent_as(cx.CartesianVelocity1D, vector)
+        cart1d = difntl.represent_as(cx.CartesianVel1D, vector)
 
-        assert isinstance(cart1d, cx.CartesianVelocity1D)
+        assert isinstance(cart1d, cx.CartesianVel1D)
         assert jnp.array_equal(cart1d.d_x, Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
@@ -702,9 +702,9 @@ class TestCylindricalVelocity(AbstractVelocity3DTest):
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cylindrical_to_cartesian2d(self, difntl, vector):
         """Test ``coordinax.represent_as(CartesianPos2D)``."""
-        cart2d = difntl.represent_as(cx.CartesianVelocity2D, vector)
+        cart2d = difntl.represent_as(cx.CartesianVel2D, vector)
 
-        assert isinstance(cart2d, cx.CartesianVelocity2D)
+        assert isinstance(cart2d, cx.CartesianVel2D)
         assert jnp.array_equal(cart2d.d_x, Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(cart2d.d_y, Quantity([5, 6, 7, 8], "km/s"))
 
@@ -720,9 +720,9 @@ class TestCylindricalVelocity(AbstractVelocity3DTest):
 
     def test_cylindrical_to_cartesian3d(self, difntl, vector, apydifntl, apyvector):
         """Test ``coordinax.represent_as(CartesianPos3D)``."""
-        cart3d = difntl.represent_as(cx.CartesianVelocity3D, vector)
+        cart3d = difntl.represent_as(cx.CartesianVel3D, vector)
 
-        assert isinstance(cart3d, cx.CartesianVelocity3D)
+        assert isinstance(cart3d, cx.CartesianVel3D)
         assert jnp.array_equal(
             cart3d.d_x, Quantity([5.0, -76.537544, -145.15944, -40.03075], "km/s")
         )
@@ -738,10 +738,10 @@ class TestCylindricalVelocity(AbstractVelocity3DTest):
         assert np.allclose(convert(cart3d.d_z, APYQuantity), apycart3.d_z)
 
     def test_cylindrical_to_spherical(self, difntl, vector):
-        """Test ``coordinax.represent_as(SphericalVelocity)``."""
-        dsph = difntl.represent_as(cx.SphericalVelocity, vector)
+        """Test ``coordinax.represent_as(SphericalVel)``."""
+        dsph = difntl.represent_as(cx.SphericalVel, vector)
 
-        assert isinstance(dsph, cx.SphericalVelocity)
+        assert isinstance(dsph, cx.SphericalVel)
         assert jnp.array_equal(
             dsph.d_r,
             Quantity([13.472646, 14.904826, 16.313278, 17.708754], "km/s"),
@@ -762,38 +762,38 @@ class TestCylindricalVelocity(AbstractVelocity3DTest):
         self, difntl, vector, apydifntl, apyvector
     ):
         """Test Astropy equivalence."""
-        sph = difntl.represent_as(cx.SphericalVelocity, vector)
+        sph = difntl.represent_as(cx.SphericalVel, vector)
         apysph = apydifntl.represent_as(apyc.PhysicsSphericalDifferential, apyvector)
         assert np.allclose(convert(sph.d_r, APYQuantity), apysph.d_r)
         assert np.allclose(convert(sph.d_theta, APYQuantity), apysph.d_theta)
         assert np.allclose(convert(sph.d_phi, APYQuantity), apysph.d_phi)
 
     def test_cylindrical_to_cylindrical(self, difntl, vector):
-        """Test ``coordinax.represent_as(CylindricalVelocity)``."""
+        """Test ``coordinax.represent_as(CylindricalVel)``."""
         # Jit can copy
-        newvec = difntl.represent_as(cx.CylindricalVelocity, vector)
+        newvec = difntl.represent_as(cx.CylindricalVel, vector)
         assert newvec == difntl
 
         # The normal `represent_as` method should return the same object
-        newvec = cx.represent_as(difntl, cx.CylindricalVelocity, vector)
+        newvec = cx.represent_as(difntl, cx.CylindricalVel, vector)
         assert newvec is difntl
 
     def test_cylindrical_to_cylindrical(self, difntl, vector, apydifntl, apyvector):
         """Test Astropy equivalence."""
-        cyl = difntl.represent_as(cx.CylindricalVelocity, vector)
+        cyl = difntl.represent_as(cx.CylindricalVel, vector)
         apycyl = apydifntl.represent_as(apyc.CylindricalDifferential, apyvector)
         assert np.allclose(convert(cyl.d_rho, APYQuantity), apycyl.d_rho)
         assert np.allclose(convert(cyl.d_phi, APYQuantity), apycyl.d_phi)
         assert np.allclose(convert(cyl.d_z, APYQuantity), apycyl.d_z)
 
 
-class TestSphericalVelocity(AbstractVelocity3DTest):
-    """Test :class:`coordinax.SphericalVelocity`."""
+class TestSphericalVel(AbstractVel3DTest):
+    """Test :class:`coordinax.SphericalVel`."""
 
     @pytest.fixture(scope="class")
-    def difntl(self) -> cx.SphericalVelocity:
+    def difntl(self) -> cx.SphericalVel:
         """Return a differential."""
-        return cx.SphericalVelocity(
+        return cx.SphericalVel(
             d_r=Quantity([5, 6, 7, 8], "km/s"),
             d_theta=Quantity([13, 14, 15, 16], "mas/yr"),
             d_phi=Quantity([9, 10, 11, 12], "mas/yr"),
@@ -809,9 +809,7 @@ class TestSphericalVelocity(AbstractVelocity3DTest):
         )
 
     @pytest.fixture(scope="class")
-    def apydifntl(
-        self, difntl: cx.SphericalVelocity
-    ) -> apyc.PhysicsSphericalDifferential:
+    def apydifntl(self, difntl: cx.SphericalVel) -> apyc.PhysicsSphericalDifferential:
         """Return an Astropy differential."""
         return convert(difntl, apyc.PhysicsSphericalDifferential)
 
@@ -826,9 +824,9 @@ class TestSphericalVelocity(AbstractVelocity3DTest):
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_spherical_to_cartesian1d(self, difntl, vector):
         """Test ``coordinax.represent_as(CartesianPos1D)``."""
-        cart1d = difntl.represent_as(cx.CartesianVelocity1D, vector)
+        cart1d = difntl.represent_as(cx.CartesianVel1D, vector)
 
-        assert isinstance(cart1d, cx.CartesianVelocity1D)
+        assert isinstance(cart1d, cx.CartesianVel1D)
         assert jnp.array_equal(cart1d.d_x, Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
@@ -844,9 +842,9 @@ class TestSphericalVelocity(AbstractVelocity3DTest):
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_spherical_to_cartesian2d(self, difntl, vector):
         """Test ``coordinax.represent_as(CartesianPos2D)``."""
-        cart2d = difntl.represent_as(cx.CartesianVelocity2D, vector)
+        cart2d = difntl.represent_as(cx.CartesianVel2D, vector)
 
-        assert isinstance(cart2d, cx.CartesianVelocity2D)
+        assert isinstance(cart2d, cx.CartesianVel2D)
         assert jnp.array_equal(cart2d.d_x, Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(cart2d.d_y, Quantity([5, 6, 7, 8], "km/s"))
 
@@ -862,9 +860,9 @@ class TestSphericalVelocity(AbstractVelocity3DTest):
 
     def test_spherical_to_cartesian3d(self, difntl, vector):
         """Test ``coordinax.represent_as(CartesianPos3D)``."""
-        cart3d = difntl.represent_as(cx.CartesianVelocity3D, vector)
+        cart3d = difntl.represent_as(cx.CartesianVel3D, vector)
 
-        assert isinstance(cart3d, cx.CartesianVelocity3D)
+        assert isinstance(cart3d, cx.CartesianVel3D)
         assert jnp.allclose(
             cart3d.d_x,
             Quantity([61.803337, -7.770853, -60.081947, 1.985678], "km/s"),
@@ -885,7 +883,7 @@ class TestSphericalVelocity(AbstractVelocity3DTest):
         self, difntl, vector, apydifntl, apyvector
     ):
         """Test Astropy equivalence."""
-        cart3d = difntl.represent_as(cx.CartesianVelocity3D, vector)
+        cart3d = difntl.represent_as(cx.CartesianVel3D, vector)
 
         apycart3 = apydifntl.represent_as(apyc.CartesianDifferential, apyvector)
         assert np.allclose(convert(cart3d.d_x, APYQuantity), apycart3.d_x)
@@ -893,10 +891,10 @@ class TestSphericalVelocity(AbstractVelocity3DTest):
         assert np.allclose(convert(cart3d.d_z, APYQuantity), apycart3.d_z)
 
     def test_spherical_to_cylindrical(self, difntl, vector):
-        """Test ``coordinax.represent_as(CylindricalVelocity)``."""
-        cylindrical = difntl.represent_as(cx.CylindricalVelocity, vector)
+        """Test ``coordinax.represent_as(CylindricalVel)``."""
+        cylindrical = difntl.represent_as(cx.CylindricalVel, vector)
 
-        assert isinstance(cylindrical, cx.CylindricalVelocity)
+        assert isinstance(cylindrical, cx.CylindricalVel)
         assert jnp.allclose(
             cylindrical.d_rho,
             Quantity([61.803337, 65.60564, 6.9999905, -303.30875], "km/s"),
@@ -917,35 +915,35 @@ class TestSphericalVelocity(AbstractVelocity3DTest):
         self, difntl, vector, apydifntl, apyvector
     ):
         """Test Astropy equivalence."""
-        cyl = difntl.represent_as(cx.CylindricalVelocity, vector)
+        cyl = difntl.represent_as(cx.CylindricalVel, vector)
         apycyl = apydifntl.represent_as(apyc.CylindricalDifferential, apyvector)
         assert np.allclose(convert(cyl.d_rho, APYQuantity), apycyl.d_rho)
         assert np.allclose(convert(cyl.d_phi, APYQuantity), apycyl.d_phi)
         assert np.allclose(convert(cyl.d_z, APYQuantity), apycyl.d_z)
 
     def test_spherical_to_spherical(self, difntl, vector):
-        """Test ``coordinax.represent_as(SphericalVelocity)``."""
+        """Test ``coordinax.represent_as(SphericalVel)``."""
         # Jit can copy
-        newvec = difntl.represent_as(cx.SphericalVelocity, vector)
+        newvec = difntl.represent_as(cx.SphericalVel, vector)
         assert all(newvec == difntl)
 
         # The normal `represent_as` method should return the same object
-        newvec = cx.represent_as(difntl, cx.SphericalVelocity, vector)
+        newvec = cx.represent_as(difntl, cx.SphericalVel, vector)
         assert newvec is difntl
 
     def test_spherical_to_spherical_astropy(self, difntl, vector, apydifntl, apyvector):
         """Test Astropy equivalence."""
-        sph = difntl.represent_as(cx.SphericalVelocity, vector)
+        sph = difntl.represent_as(cx.SphericalVel, vector)
         apysph = apydifntl.represent_as(apyc.PhysicsSphericalDifferential, apyvector)
         assert np.allclose(convert(sph.d_r, APYQuantity), apysph.d_r)
         assert np.allclose(convert(sph.d_theta, APYQuantity), apysph.d_theta)
         assert np.allclose(convert(sph.d_phi, APYQuantity), apysph.d_phi)
 
     def test_spherical_to_lonlatspherical(self, difntl, vector):
-        """Test ``coordinax.represent_as(LonLatSphericalVelocity)``."""
-        llsph = difntl.represent_as(cx.LonLatSphericalVelocity, vector)
+        """Test ``coordinax.represent_as(LonLatSphericalVel)``."""
+        llsph = difntl.represent_as(cx.LonLatSphericalVel, vector)
 
-        assert isinstance(llsph, cx.LonLatSphericalVelocity)
+        assert isinstance(llsph, cx.LonLatSphericalVel)
         assert jnp.array_equal(llsph.d_distance, difntl.d_r)
         assert jnp.array_equal(llsph.d_lon, difntl.d_phi)
         assert jnp.allclose(
@@ -958,7 +956,7 @@ class TestSphericalVelocity(AbstractVelocity3DTest):
         self, difntl, vector, apydifntl, apyvector
     ):
         """Test Astropy equivalence."""
-        cart3d = difntl.represent_as(cx.LonLatSphericalVelocity, vector)
+        cart3d = difntl.represent_as(cx.LonLatSphericalVel, vector)
 
         apycart3 = apydifntl.represent_as(apyc.SphericalDifferential, apyvector)
         assert np.allclose(convert(cart3d.d_distance, APYQuantity), apycart3.d_distance)
@@ -967,9 +965,9 @@ class TestSphericalVelocity(AbstractVelocity3DTest):
 
     def test_spherical_to_mathspherical(self, difntl, vector):
         """Test ``coordinax.represent_as(MathSpherical)``."""
-        llsph = difntl.represent_as(cx.MathSphericalVelocity, vector)
+        llsph = difntl.represent_as(cx.MathSphericalVel, vector)
 
-        assert isinstance(llsph, cx.MathSphericalVelocity)
+        assert isinstance(llsph, cx.MathSphericalVel)
         assert jnp.array_equal(llsph.d_r, difntl.d_r)
         assert jnp.array_equal(llsph.d_phi, difntl.d_theta)
         assert jnp.array_equal(llsph.d_theta, difntl.d_phi)

--- a/tests/test_d3.py
+++ b/tests/test_d3.py
@@ -11,17 +11,17 @@ import quaxed.numpy as jnp
 from unxt import Quantity
 
 import coordinax as cx
-from .test_base import AbstractPositionTest, AbstractVelocityTest
+from .test_base import AbstractPosTest, AbstractVelocityTest
 
 
-class AbstractPosition3DTest(AbstractPositionTest):
-    """Test :class:`coordinax.AbstractPosition3D`."""
+class AbstractPos3DTest(AbstractPosTest):
+    """Test :class:`coordinax.AbstractPos3D`."""
 
     # ==========================================================================
     # Unary operations
 
     def test_neg_compare_apy(
-        self, vector: cx.AbstractPosition, apyvector: apyc.BaseRepresentation
+        self, vector: cx.AbstractPos, apyvector: apyc.BaseRepresentation
     ):
         """Test negation."""
         # To take the negative, Vector converts to Cartesian coordinates, takes
@@ -54,20 +54,20 @@ class AbstractPosition3DTest(AbstractPositionTest):
         #     )
 
 
-class TestCartesianPosition3D(AbstractPosition3DTest):
-    """Test :class:`coordinax.CartesianPosition3D`."""
+class TestCartesianPos3D(AbstractPos3DTest):
+    """Test :class:`coordinax.CartesianPos3D`."""
 
     @pytest.fixture(scope="class")
-    def vector(self) -> cx.AbstractPosition:
+    def vector(self) -> cx.AbstractPos:
         """Return a vector."""
-        return cx.CartesianPosition3D(
+        return cx.CartesianPos3D(
             x=Quantity([1, 2, 3, 4], "kpc"),
             y=Quantity([5, 6, 7, 8], "kpc"),
             z=Quantity([9, 10, 11, 12], "kpc"),
         )
 
     @pytest.fixture(scope="class")
-    def apyvector(self, vector: cx.AbstractPosition) -> apyc.CartesianRepresentation:
+    def apyvector(self, vector: cx.AbstractPos) -> apyc.CartesianRepresentation:
         """Return an Astropy vector."""
         return convert(vector, apyc.CartesianRepresentation)
 
@@ -76,67 +76,65 @@ class TestCartesianPosition3D(AbstractPosition3DTest):
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_cartesian3d_to_cartesian1d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition1D)``."""
-        cart1d = vector.represent_as(cx.CartesianPosition1D)
+        """Test ``coordinax.represent_as(CartesianPos1D)``."""
+        cart1d = vector.represent_as(cx.CartesianPos1D)
 
-        assert isinstance(cart1d, cx.CartesianPosition1D)
+        assert isinstance(cart1d, cx.CartesianPos1D)
         assert jnp.array_equal(cart1d.x, Quantity([1, 2, 3, 4], "kpc"))
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_cartesian3d_to_radial(self, vector):
-        """Test ``coordinax.represent_as(RadialPosition)``."""
-        radial = vector.represent_as(cx.RadialPosition)
+        """Test ``coordinax.represent_as(RadialPos)``."""
+        radial = vector.represent_as(cx.RadialPos)
 
-        assert isinstance(radial, cx.RadialPosition)
+        assert isinstance(radial, cx.RadialPos)
         assert jnp.array_equal(
             radial.r, Quantity([10.34408, 11.83216, 13.379088, 14.96663], "kpc")
         )
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_cartesian3d_to_cartesian2d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition2D)``."""
-        cart2d = vector.represent_as(
-            cx.CartesianPosition2D, y=Quantity([5, 6, 7, 8], "km")
-        )
+        """Test ``coordinax.represent_as(CartesianPos2D)``."""
+        cart2d = vector.represent_as(cx.CartesianPos2D, y=Quantity([5, 6, 7, 8], "km"))
 
-        assert isinstance(cart2d, cx.CartesianPosition2D)
+        assert isinstance(cart2d, cx.CartesianPos2D)
         assert jnp.array_equal(cart2d.x, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(cart2d.y, Quantity([5, 6, 7, 8], "kpc"))
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_cartesian3d_to_polar(self, vector):
-        """Test ``coordinax.represent_as(PolarPosition)``."""
-        polar = vector.represent_as(cx.PolarPosition, phi=Quantity([0, 1, 2, 3], "rad"))
+        """Test ``coordinax.represent_as(PolarPos)``."""
+        polar = vector.represent_as(cx.PolarPos, phi=Quantity([0, 1, 2, 3], "rad"))
 
-        assert isinstance(polar, cx.PolarPosition)
+        assert isinstance(polar, cx.PolarPos)
         assert jnp.array_equal(polar.r, jnp.hypot(vector.x, vector.y))
         assert jnp.array_equal(
             polar.phi, Quantity([1.3734008, 1.2490457, 1.1659045, 1.1071488], "rad")
         )
 
     def test_cartesian3d_to_cartesian3d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition3D)``."""
+        """Test ``coordinax.represent_as(CartesianPos3D)``."""
         # Jit can copy
-        newvec = vector.represent_as(cx.CartesianPosition3D)
+        newvec = vector.represent_as(cx.CartesianPos3D)
         assert jnp.array_equal(newvec, vector)
 
         # The normal `represent_as` method should return the same object
-        newvec = cx.represent_as(vector, cx.CartesianPosition3D)
+        newvec = cx.represent_as(vector, cx.CartesianPos3D)
         assert newvec is vector
 
     def test_cartesian3d_to_cartesian3d_astropy(self, vector, apyvector):
         """Test Astropy equivalence."""
-        newvec = vector.represent_as(cx.CartesianPosition3D)
+        newvec = vector.represent_as(cx.CartesianPos3D)
 
         assert np.allclose(convert(newvec.x, APYQuantity), apyvector.x)
         assert np.allclose(convert(newvec.y, APYQuantity), apyvector.y)
         assert np.allclose(convert(newvec.z, APYQuantity), apyvector.z)
 
     def test_cartesian3d_to_spherical(self, vector):
-        """Test ``coordinax.represent_as(SphericalPosition)``."""
-        spherical = vector.represent_as(cx.SphericalPosition)
+        """Test ``coordinax.represent_as(SphericalPos)``."""
+        spherical = vector.represent_as(cx.SphericalPos)
 
-        assert isinstance(spherical, cx.SphericalPosition)
+        assert isinstance(spherical, cx.SphericalPos)
         assert jnp.array_equal(
             spherical.r, Quantity([10.34408, 11.83216, 13.379088, 14.96663], "kpc")
         )
@@ -151,7 +149,7 @@ class TestCartesianPosition3D(AbstractPosition3DTest):
 
     def test_cartesian3d_to_spherical_astropy(self, vector, apyvector):
         """Test Astropy equivalence."""
-        sph = vector.represent_as(cx.SphericalPosition)
+        sph = vector.represent_as(cx.SphericalPos)
 
         apysph = apyvector.represent_as(apyc.PhysicsSphericalRepresentation)
         assert np.allclose(convert(sph.r, APYQuantity), apysph.r)
@@ -159,10 +157,10 @@ class TestCartesianPosition3D(AbstractPosition3DTest):
         assert np.allclose(convert(sph.phi, APYQuantity), apysph.phi)
 
     def test_cartesian3d_to_cylindrical(self, vector):
-        """Test ``coordinax.represent_as(CylindricalPosition)``."""
-        cylindrical = vector.represent_as(cx.CylindricalPosition)
+        """Test ``coordinax.represent_as(CylindricalPos)``."""
+        cylindrical = vector.represent_as(cx.CylindricalPos)
 
-        assert isinstance(cylindrical, cx.CylindricalPosition)
+        assert isinstance(cylindrical, cx.CylindricalPos)
         assert jnp.array_equal(cylindrical.rho, jnp.hypot(vector.x, vector.y))
         assert jnp.array_equal(
             cylindrical.phi,
@@ -172,7 +170,7 @@ class TestCartesianPosition3D(AbstractPosition3DTest):
 
     def test_cartesian3d_to_cylindrical_astropy(self, vector, apyvector):
         """Test Astropy equivalence."""
-        cyl = vector.represent_as(cx.CylindricalPosition)
+        cyl = vector.represent_as(cx.CylindricalPos)
 
         apycyl = apyvector.represent_as(apyc.CylindricalRepresentation)
         assert np.allclose(convert(cyl.rho, APYQuantity), apycyl.rho)
@@ -180,20 +178,20 @@ class TestCartesianPosition3D(AbstractPosition3DTest):
         assert np.allclose(convert(cyl.z, APYQuantity), apycyl.z)
 
 
-class TestCylindricalPosition(AbstractPosition3DTest):
-    """Test :class:`coordinax.CylindricalPosition`."""
+class TestCylindricalPos(AbstractPos3DTest):
+    """Test :class:`coordinax.CylindricalPos`."""
 
     @pytest.fixture(scope="class")
-    def vector(self) -> cx.AbstractPosition:
+    def vector(self) -> cx.AbstractPos:
         """Return a vector."""
-        return cx.CylindricalPosition(
+        return cx.CylindricalPos(
             rho=Quantity([1, 2, 3, 4], "kpc"),
             phi=Quantity([0, 1, 2, 3], "rad"),
             z=Quantity([9, 10, 11, 12], "m"),
         )
 
     @pytest.fixture(scope="class")
-    def apyvector(self, vector: cx.AbstractPosition):
+    def apyvector(self, vector: cx.AbstractPos):
         """Return an Astropy vector."""
         return convert(vector, apyc.CylindricalRepresentation)
 
@@ -202,10 +200,10 @@ class TestCylindricalPosition(AbstractPosition3DTest):
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_cylindrical_to_cartesian1d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition1D)``."""
-        cart1d = vector.represent_as(cx.CartesianPosition1D)
+        """Test ``coordinax.represent_as(CartesianPos1D)``."""
+        cart1d = vector.represent_as(cx.CartesianPos1D)
 
-        assert isinstance(cart1d, cx.CartesianPosition1D)
+        assert isinstance(cart1d, cx.CartesianPos1D)
         assert jnp.allclose(
             cart1d.x,
             Quantity([1.0, 1.0806047, -1.2484405, -3.95997], "kpc"),
@@ -214,18 +212,18 @@ class TestCylindricalPosition(AbstractPosition3DTest):
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_cylindrical_to_radial(self, vector):
-        """Test ``coordinax.represent_as(RadialPosition)``."""
-        radial = vector.represent_as(cx.RadialPosition)
+        """Test ``coordinax.represent_as(RadialPos)``."""
+        radial = vector.represent_as(cx.RadialPos)
 
-        assert isinstance(radial, cx.RadialPosition)
+        assert isinstance(radial, cx.RadialPos)
         assert jnp.array_equal(radial.r, Quantity([1, 2, 3, 4], "kpc"))
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_cylindrical_to_cartesian2d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition2D)``."""
-        cart2d = vector.represent_as(cx.CartesianPosition2D)
+        """Test ``coordinax.represent_as(CartesianPos2D)``."""
+        cart2d = vector.represent_as(cx.CartesianPos2D)
 
-        assert isinstance(cart2d, cx.CartesianPosition2D)
+        assert isinstance(cart2d, cx.CartesianPos2D)
         assert jnp.array_equal(
             cart2d.x, Quantity([1.0, 1.0806046, -1.2484405, -3.95997], "kpc")
         )
@@ -235,18 +233,18 @@ class TestCylindricalPosition(AbstractPosition3DTest):
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_cylindrical_to_polar(self, vector):
-        """Test ``coordinax.represent_as(PolarPosition)``."""
-        polar = vector.represent_as(cx.PolarPosition)
+        """Test ``coordinax.represent_as(PolarPos)``."""
+        polar = vector.represent_as(cx.PolarPos)
 
-        assert isinstance(polar, cx.PolarPosition)
+        assert isinstance(polar, cx.PolarPos)
         assert jnp.array_equal(polar.r, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(polar.phi, Quantity([0, 1, 2, 3], "rad"))
 
     def test_cylindrical_to_cartesian3d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition3D)``."""
-        cart3d = vector.represent_as(cx.CartesianPosition3D)
+        """Test ``coordinax.represent_as(CartesianPos3D)``."""
+        cart3d = vector.represent_as(cx.CartesianPos3D)
 
-        assert isinstance(cart3d, cx.CartesianPosition3D)
+        assert isinstance(cart3d, cx.CartesianPos3D)
         assert jnp.array_equal(
             cart3d.x, Quantity([1.0, 1.0806046, -1.2484405, -3.95997], "kpc")
         )
@@ -257,7 +255,7 @@ class TestCylindricalPosition(AbstractPosition3DTest):
 
     def test_cylindrical_to_cartesian3d_astropy(self, vector, apyvector):
         """Test Astropy equivalence."""
-        cart3d = vector.represent_as(cx.CartesianPosition3D)
+        cart3d = vector.represent_as(cx.CartesianPos3D)
 
         apycart3 = apyvector.represent_as(apyc.CartesianRepresentation)
         assert np.allclose(convert(cart3d.x, APYQuantity), apycart3.x)
@@ -265,10 +263,10 @@ class TestCylindricalPosition(AbstractPosition3DTest):
         assert np.allclose(convert(cart3d.z, APYQuantity), apycart3.z)
 
     def test_cylindrical_to_spherical(self, vector):
-        """Test ``coordinax.represent_as(SphericalPosition)``."""
-        spherical = vector.represent_as(cx.SphericalPosition)
+        """Test ``coordinax.represent_as(SphericalPos)``."""
+        spherical = vector.represent_as(cx.SphericalPos)
 
-        assert isinstance(spherical, cx.SphericalPosition)
+        assert isinstance(spherical, cx.SphericalPos)
         assert jnp.array_equal(spherical.r, Quantity([1, 2, 3, 4], "kpc"))
         assert jnp.array_equal(
             spherical.theta, Quantity(jnp.full(4, jnp.pi / 2), "rad")
@@ -277,25 +275,25 @@ class TestCylindricalPosition(AbstractPosition3DTest):
 
     def test_cylindrical_to_spherical_astropy(self, vector, apyvector):
         """Test Astropy equivalence."""
-        sph = vector.represent_as(cx.SphericalPosition)
+        sph = vector.represent_as(cx.SphericalPos)
         apysph = apyvector.represent_as(apyc.PhysicsSphericalRepresentation)
         assert np.allclose(convert(sph.r, APYQuantity), apysph.r)
         assert np.allclose(convert(sph.theta, APYQuantity), apysph.theta)
         assert np.allclose(convert(sph.phi, APYQuantity), apysph.phi)
 
     def test_cylindrical_to_cylindrical(self, vector):
-        """Test ``coordinax.represent_as(CylindricalPosition)``."""
+        """Test ``coordinax.represent_as(CylindricalPos)``."""
         # Jit can copy
-        newvec = vector.represent_as(cx.CylindricalPosition)
+        newvec = vector.represent_as(cx.CylindricalPos)
         assert jnp.array_equal(newvec, vector)
 
         # The normal `represent_as` method should return the same object
-        newvec = cx.represent_as(vector, cx.CylindricalPosition)
+        newvec = cx.represent_as(vector, cx.CylindricalPos)
         assert newvec is vector
 
     def test_cylindrical_to_cylindrical_astropy(self, vector, apyvector):
         """Test Astropy equivalence."""
-        cyl = vector.represent_as(cx.CylindricalPosition)
+        cyl = vector.represent_as(cx.CylindricalPos)
 
         apycyl = apyvector.represent_as(apyc.CylindricalRepresentation)
         assert np.allclose(convert(cyl.rho, APYQuantity), apycyl.rho)
@@ -303,20 +301,20 @@ class TestCylindricalPosition(AbstractPosition3DTest):
         assert np.allclose(convert(cyl.z, APYQuantity), apycyl.z)
 
 
-class TestSphericalPosition(AbstractPosition3DTest):
-    """Test :class:`coordinax.SphericalPosition`."""
+class TestSphericalPos(AbstractPos3DTest):
+    """Test :class:`coordinax.SphericalPos`."""
 
     @pytest.fixture(scope="class")
-    def vector(self) -> cx.SphericalPosition:
+    def vector(self) -> cx.SphericalPos:
         """Return a vector."""
-        return cx.SphericalPosition(
+        return cx.SphericalPos(
             r=Quantity([1, 2, 3, 4], "kpc"),
             theta=Quantity([1, 36, 142, 180 - 1e-4], "deg"),
             phi=Quantity([0, 65, 135, 270], "deg"),
         )
 
     @pytest.fixture(scope="class")
-    def apyvector(self, vector: cx.AbstractPosition):
+    def apyvector(self, vector: cx.AbstractPos):
         """Return an Astropy vector."""
         return convert(vector, apyc.PhysicsSphericalRepresentation)
 
@@ -325,10 +323,10 @@ class TestSphericalPosition(AbstractPosition3DTest):
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_spherical_to_cartesian1d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition1D)``."""
-        cart1d = vector.represent_as(cx.CartesianPosition1D)
+        """Test ``coordinax.represent_as(CartesianPos1D)``."""
+        cart1d = vector.represent_as(cx.CartesianPos1D)
 
-        assert isinstance(cart1d, cx.CartesianPosition1D)
+        assert isinstance(cart1d, cx.CartesianPos1D)
         assert jnp.allclose(
             cart1d.x,
             Quantity(
@@ -339,20 +337,18 @@ class TestSphericalPosition(AbstractPosition3DTest):
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_spherical_to_radial(self, vector):
-        """Test ``coordinax.represent_as(RadialPosition)``."""
-        radial = vector.represent_as(cx.RadialPosition)
+        """Test ``coordinax.represent_as(RadialPos)``."""
+        radial = vector.represent_as(cx.RadialPos)
 
-        assert isinstance(radial, cx.RadialPosition)
+        assert isinstance(radial, cx.RadialPos)
         assert jnp.array_equal(radial.r, Quantity([1, 2, 3, 4], "kpc"))
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_spherical_to_cartesian2d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition2D)``."""
-        cart2d = vector.represent_as(
-            cx.CartesianPosition2D, y=Quantity([5, 6, 7, 8], "km")
-        )
+        """Test ``coordinax.represent_as(CartesianPos2D)``."""
+        cart2d = vector.represent_as(cx.CartesianPos2D, y=Quantity([5, 6, 7, 8], "km"))
 
-        assert isinstance(cart2d, cx.CartesianPosition2D)
+        assert isinstance(cart2d, cx.CartesianPos2D)
         assert jnp.array_equal(
             cart2d.x,
             Quantity(
@@ -366,10 +362,10 @@ class TestSphericalPosition(AbstractPosition3DTest):
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
     def test_spherical_to_polar(self, vector):
-        """Test ``coordinax.represent_as(PolarPosition)``."""
-        polar = vector.represent_as(cx.PolarPosition, phi=Quantity([0, 1, 2, 3], "rad"))
+        """Test ``coordinax.represent_as(PolarPos)``."""
+        polar = vector.represent_as(cx.PolarPos, phi=Quantity([0, 1, 2, 3], "rad"))
 
-        assert isinstance(polar, cx.PolarPosition)
+        assert isinstance(polar, cx.PolarPos)
         assert jnp.array_equal(
             polar.r,
             Quantity([1.7452406e-02, 1.1755705e00, 1.8469844e00, 7.2797034e-06], "kpc"),
@@ -377,10 +373,10 @@ class TestSphericalPosition(AbstractPosition3DTest):
         assert jnp.array_equal(polar.phi, Quantity([0.0, 65.0, 135.0, 270.0], "deg"))
 
     def test_spherical_to_cartesian3d(self, vector):
-        """Test ``coordinax.represent_as(CartesianPosition3D)``."""
-        cart3d = vector.represent_as(cx.CartesianPosition3D)
+        """Test ``coordinax.represent_as(CartesianPos3D)``."""
+        cart3d = vector.represent_as(cx.CartesianPos3D)
 
-        assert isinstance(cart3d, cx.CartesianPosition3D)
+        assert isinstance(cart3d, cx.CartesianPos3D)
         assert jnp.array_equal(
             cart3d.x,
             Quantity(
@@ -397,7 +393,7 @@ class TestSphericalPosition(AbstractPosition3DTest):
 
     def test_spherical_to_cartesian3d_astropy(self, vector, apyvector):
         """Test Astropy equivalence."""
-        cart3d = vector.represent_as(cx.CartesianPosition3D)
+        cart3d = vector.represent_as(cx.CartesianPos3D)
 
         apycart3 = apyvector.represent_as(apyc.CartesianRepresentation)
         assert np.allclose(convert(cart3d.x, APYQuantity), apycart3.x)
@@ -405,12 +401,10 @@ class TestSphericalPosition(AbstractPosition3DTest):
         assert np.allclose(convert(cart3d.z, APYQuantity), apycart3.z)
 
     def test_spherical_to_cylindrical(self, vector):
-        """Test ``coordinax.represent_as(CylindricalPosition)``."""
-        cyl = vector.represent_as(
-            cx.CylindricalPosition, z=Quantity([9, 10, 11, 12], "m")
-        )
+        """Test ``coordinax.represent_as(CylindricalPos)``."""
+        cyl = vector.represent_as(cx.CylindricalPos, z=Quantity([9, 10, 11, 12], "m"))
 
-        assert isinstance(cyl, cx.CylindricalPosition)
+        assert isinstance(cyl, cx.CylindricalPos)
         assert jnp.array_equal(
             cyl.rho,
             Quantity([1.7452406e-02, 1.1755705e00, 1.8469844e00, 7.2797034e-06], "kpc"),
@@ -421,10 +415,8 @@ class TestSphericalPosition(AbstractPosition3DTest):
         )
 
     def test_spherical_to_cylindrical_astropy(self, vector, apyvector):
-        """Test ``coordinax.represent_as(CylindricalPosition)``."""
-        cyl = vector.represent_as(
-            cx.CylindricalPosition, z=Quantity([9, 10, 11, 12], "m")
-        )
+        """Test ``coordinax.represent_as(CylindricalPos)``."""
+        cyl = vector.represent_as(cx.CylindricalPos, z=Quantity([9, 10, 11, 12], "m"))
 
         apycyl = apyvector.represent_as(apyc.CylindricalRepresentation)
         # There's a 'bug' in Astropy where rho can be negative.
@@ -437,18 +429,18 @@ class TestSphericalPosition(AbstractPosition3DTest):
         assert np.allclose(convert(cyl.phi, APYQuantity) % mod, apycyl.phi % mod)
 
     def test_spherical_to_spherical(self, vector):
-        """Test ``coordinax.represent_as(SphericalPosition)``."""
+        """Test ``coordinax.represent_as(SphericalPos)``."""
         # Jit can copy
-        newvec = vector.represent_as(cx.SphericalPosition)
+        newvec = vector.represent_as(cx.SphericalPos)
         assert jnp.array_equal(newvec, vector)
 
         # The normal `represent_as` method should return the same object
-        newvec = cx.represent_as(vector, cx.SphericalPosition)
+        newvec = cx.represent_as(vector, cx.SphericalPos)
         assert newvec is vector
 
     def test_spherical_to_spherical_astropy(self, vector, apyvector):
         """Test Astropy equivalence."""
-        sph = vector.represent_as(cx.SphericalPosition)
+        sph = vector.represent_as(cx.SphericalPos)
 
         apysph = apyvector.represent_as(apyc.PhysicsSphericalRepresentation)
         assert np.allclose(convert(sph.r, APYQuantity), apysph.r)
@@ -456,26 +448,26 @@ class TestSphericalPosition(AbstractPosition3DTest):
         assert np.allclose(convert(sph.phi, APYQuantity), apysph.phi)
 
     def test_spherical_to_mathspherical(self, vector):
-        """Test ``coordinax.represent_as(MathSphericalPosition)``."""
-        newvec = cx.represent_as(vector, cx.MathSphericalPosition)
+        """Test ``coordinax.represent_as(MathSphericalPos)``."""
+        newvec = cx.represent_as(vector, cx.MathSphericalPos)
         assert jnp.array_equal(newvec.r, vector.r)
         assert jnp.array_equal(newvec.theta, vector.phi)
         assert jnp.array_equal(newvec.phi, vector.theta)
 
     def test_spherical_to_lonlatspherical(self, vector):
-        """Test ``coordinax.represent_as(LonLatSphericalPosition)``."""
+        """Test ``coordinax.represent_as(LonLatSphericalPos)``."""
         llsph = vector.represent_as(
-            cx.LonLatSphericalPosition, z=Quantity([9, 10, 11, 12], "m")
+            cx.LonLatSphericalPos, z=Quantity([9, 10, 11, 12], "m")
         )
 
-        assert isinstance(llsph, cx.LonLatSphericalPosition)
+        assert isinstance(llsph, cx.LonLatSphericalPos)
         assert jnp.array_equal(llsph.lon, vector.phi)
         assert jnp.array_equal(llsph.lat, Quantity(90, "deg") - vector.theta)
         assert jnp.array_equal(llsph.distance, vector.r)
 
     def test_spherical_to_lonlatspherical_astropy(self, vector, apyvector):
         """Test Astropy equivalence."""
-        llsph = vector.represent_as(cx.LonLatSphericalPosition)
+        llsph = vector.represent_as(cx.LonLatSphericalPos)
 
         apycart3 = apyvector.represent_as(apyc.SphericalRepresentation)
         assert np.allclose(convert(llsph.distance, APYQuantity), apycart3.distance)
@@ -509,9 +501,9 @@ class TestCartesianVelocity3D(AbstractVelocity3DTest):
         )
 
     @pytest.fixture(scope="class")
-    def vector(self) -> cx.CartesianPosition3D:
+    def vector(self) -> cx.CartesianPos3D:
         """Return a vector."""
-        return cx.CartesianPosition3D(
+        return cx.CartesianPos3D(
             x=Quantity([1, 2, 3, 4], "kpc"),
             y=Quantity([5, 6, 7, 8], "kpc"),
             z=Quantity([9, 10, 11, 12], "kpc"),
@@ -523,7 +515,7 @@ class TestCartesianVelocity3D(AbstractVelocity3DTest):
         return convert(difntl, apyc.CartesianDifferential)
 
     @pytest.fixture(scope="class")
-    def apyvector(self, vector: cx.CartesianPosition3D):
+    def apyvector(self, vector: cx.CartesianPos3D):
         """Return an Astropy vector."""
         return convert(vector, apyc.CartesianRepresentation)
 
@@ -532,7 +524,7 @@ class TestCartesianVelocity3D(AbstractVelocity3DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian3d_to_cartesian1d(self, difntl, vector):
-        """Test ``coordinax.represent_as(CartesianPosition1D)``."""
+        """Test ``coordinax.represent_as(CartesianPos1D)``."""
         cart1d = difntl.represent_as(cx.CartesianVelocity1D, vector)
 
         assert isinstance(cart1d, cx.CartesianVelocity1D)
@@ -541,16 +533,16 @@ class TestCartesianVelocity3D(AbstractVelocity3DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian3d_to_radial(self, difntl, vector):
-        """Test ``coordinax.represent_as(RadialPosition)``."""
-        radial = difntl.represent_as(cx.RadialPosition, vector)
+        """Test ``coordinax.represent_as(RadialPos)``."""
+        radial = difntl.represent_as(cx.RadialPos, vector)
 
-        assert isinstance(radial, cx.RadialPosition)
+        assert isinstance(radial, cx.RadialPos)
         assert jnp.array_equal(radial.d_r, Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian3d_to_cartesian2d(self, difntl, vector):
-        """Test ``coordinax.represent_as(CartesianPosition2D)``."""
+        """Test ``coordinax.represent_as(CartesianPos2D)``."""
         cart2d = difntl.represent_as(cx.CartesianVelocity2D, vector)
 
         assert isinstance(cart2d, cx.CartesianVelocity2D)
@@ -560,15 +552,15 @@ class TestCartesianVelocity3D(AbstractVelocity3DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian3d_to_polar(self, difntl, vector):
-        """Test ``coordinax.represent_as(PolarPosition)``."""
-        polar = difntl.represent_as(cx.PolarPosition, vector)
+        """Test ``coordinax.represent_as(PolarPos)``."""
+        polar = difntl.represent_as(cx.PolarPos, vector)
 
-        assert isinstance(polar, cx.PolarPosition)
+        assert isinstance(polar, cx.PolarPos)
         assert jnp.array_equal(polar.d_r, Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(polar.d_phi, Quantity([5, 6, 7, 8], "mas/yr"))
 
     def test_cartesian3d_to_cartesian3d(self, difntl, vector):
-        """Test ``coordinax.represent_as(CartesianPosition3D)``."""
+        """Test ``coordinax.represent_as(CartesianPos3D)``."""
         # Jit can copy
         newvec = difntl.represent_as(cx.CartesianVelocity3D, vector)
         assert jnp.array_equal(newvec, difntl)
@@ -668,9 +660,9 @@ class TestCylindricalVelocity(AbstractVelocity3DTest):
         )
 
     @pytest.fixture(scope="class")
-    def vector(self) -> cx.CylindricalPosition:
+    def vector(self) -> cx.CylindricalPos:
         """Return a vector."""
-        return cx.CylindricalPosition(
+        return cx.CylindricalPos(
             rho=Quantity([1, 2, 3, 4], "kpc"),
             phi=Quantity([0, 1, 2, 3], "rad"),
             z=Quantity([9, 10, 11, 12], "kpc"),
@@ -682,9 +674,7 @@ class TestCylindricalVelocity(AbstractVelocity3DTest):
         return convert(difntl, apyc.CylindricalDifferential)
 
     @pytest.fixture(scope="class")
-    def apyvector(
-        self, vector: cx.CylindricalPosition
-    ) -> apyc.CylindricalRepresentation:
+    def apyvector(self, vector: cx.CylindricalPos) -> apyc.CylindricalRepresentation:
         """Return an Astropy vector."""
         return convert(vector, apyc.CylindricalRepresentation)
 
@@ -693,7 +683,7 @@ class TestCylindricalVelocity(AbstractVelocity3DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cylindrical_to_cartesian1d(self, difntl, vector):
-        """Test ``coordinax.represent_as(CartesianPosition1D)``."""
+        """Test ``coordinax.represent_as(CartesianPos1D)``."""
         cart1d = difntl.represent_as(cx.CartesianVelocity1D, vector)
 
         assert isinstance(cart1d, cx.CartesianVelocity1D)
@@ -702,16 +692,16 @@ class TestCylindricalVelocity(AbstractVelocity3DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cylindrical_to_radial(self, difntl, vector):
-        """Test ``coordinax.represent_as(RadialPosition)``."""
-        radial = difntl.represent_as(cx.RadialPosition, vector)
+        """Test ``coordinax.represent_as(RadialPos)``."""
+        radial = difntl.represent_as(cx.RadialPos, vector)
 
-        assert isinstance(radial, cx.RadialPosition)
+        assert isinstance(radial, cx.RadialPos)
         assert jnp.array_equal(radial.d_r, Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cylindrical_to_cartesian2d(self, difntl, vector):
-        """Test ``coordinax.represent_as(CartesianPosition2D)``."""
+        """Test ``coordinax.represent_as(CartesianPos2D)``."""
         cart2d = difntl.represent_as(cx.CartesianVelocity2D, vector)
 
         assert isinstance(cart2d, cx.CartesianVelocity2D)
@@ -721,15 +711,15 @@ class TestCylindricalVelocity(AbstractVelocity3DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cylindrical_to_polar(self, difntl, vector):
-        """Test ``coordinax.represent_as(PolarPosition)``."""
-        polar = difntl.represent_as(cx.PolarPosition, vector)
+        """Test ``coordinax.represent_as(PolarPos)``."""
+        polar = difntl.represent_as(cx.PolarPos, vector)
 
-        assert isinstance(polar, cx.PolarPosition)
+        assert isinstance(polar, cx.PolarPos)
         assert jnp.array_equal(polar.d_r, Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(polar.d_phi, Quantity([5, 6, 7, 8], "mas/yr"))
 
     def test_cylindrical_to_cartesian3d(self, difntl, vector, apydifntl, apyvector):
-        """Test ``coordinax.represent_as(CartesianPosition3D)``."""
+        """Test ``coordinax.represent_as(CartesianPos3D)``."""
         cart3d = difntl.represent_as(cx.CartesianVelocity3D, vector)
 
         assert isinstance(cart3d, cx.CartesianVelocity3D)
@@ -810,9 +800,9 @@ class TestSphericalVelocity(AbstractVelocity3DTest):
         )
 
     @pytest.fixture(scope="class")
-    def vector(self) -> cx.SphericalPosition:
+    def vector(self) -> cx.SphericalPos:
         """Return a vector."""
-        return cx.SphericalPosition(
+        return cx.SphericalPos(
             r=Quantity([1, 2, 3, 4], "kpc"),
             theta=Quantity([3, 63, 90, 179.5], "deg"),
             phi=Quantity([0, 42, 160, 270], "deg"),
@@ -826,9 +816,7 @@ class TestSphericalVelocity(AbstractVelocity3DTest):
         return convert(difntl, apyc.PhysicsSphericalDifferential)
 
     @pytest.fixture(scope="class")
-    def apyvector(
-        self, vector: cx.SphericalPosition
-    ) -> apyc.PhysicsSphericalRepresentation:
+    def apyvector(self, vector: cx.SphericalPos) -> apyc.PhysicsSphericalRepresentation:
         """Return an Astropy vector."""
         return convert(vector, apyc.PhysicsSphericalRepresentation)
 
@@ -837,7 +825,7 @@ class TestSphericalVelocity(AbstractVelocity3DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_spherical_to_cartesian1d(self, difntl, vector):
-        """Test ``coordinax.represent_as(CartesianPosition1D)``."""
+        """Test ``coordinax.represent_as(CartesianPos1D)``."""
         cart1d = difntl.represent_as(cx.CartesianVelocity1D, vector)
 
         assert isinstance(cart1d, cx.CartesianVelocity1D)
@@ -846,16 +834,16 @@ class TestSphericalVelocity(AbstractVelocity3DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_spherical_to_radial(self, difntl, vector):
-        """Test ``coordinax.represent_as(RadialPosition)``."""
-        radial = difntl.represent_as(cx.RadialPosition, vector)
+        """Test ``coordinax.represent_as(RadialPos)``."""
+        radial = difntl.represent_as(cx.RadialPos, vector)
 
-        assert isinstance(radial, cx.RadialPosition)
+        assert isinstance(radial, cx.RadialPos)
         assert jnp.array_equal(radial.d_r, Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_spherical_to_cartesian2d(self, difntl, vector):
-        """Test ``coordinax.represent_as(CartesianPosition2D)``."""
+        """Test ``coordinax.represent_as(CartesianPos2D)``."""
         cart2d = difntl.represent_as(cx.CartesianVelocity2D, vector)
 
         assert isinstance(cart2d, cx.CartesianVelocity2D)
@@ -865,15 +853,15 @@ class TestSphericalVelocity(AbstractVelocity3DTest):
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_spherical_to_polar(self, difntl, vector):
-        """Test ``coordinax.represent_as(PolarPosition)``."""
-        polar = difntl.represent_as(cx.PolarPosition, vector)
+        """Test ``coordinax.represent_as(PolarPos)``."""
+        polar = difntl.represent_as(cx.PolarPos, vector)
 
-        assert isinstance(polar, cx.PolarPosition)
+        assert isinstance(polar, cx.PolarPos)
         assert jnp.array_equal(polar.d_r, Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(polar.d_phi, Quantity([5, 6, 7, 8], "mas/yr"))
 
     def test_spherical_to_cartesian3d(self, difntl, vector):
-        """Test ``coordinax.represent_as(CartesianPosition3D)``."""
+        """Test ``coordinax.represent_as(CartesianPos3D)``."""
         cart3d = difntl.represent_as(cx.CartesianVelocity3D, vector)
 
         assert isinstance(cart3d, cx.CartesianVelocity3D)

--- a/tests/test_jax_ops.py
+++ b/tests/test_jax_ops.py
@@ -9,33 +9,29 @@ from unxt import AbstractQuantity
 import coordinax as cx
 from coordinax._src.base.base_pos import POSITION_CLASSES
 
-POSITION_CLASSES_3D = [
-    c for c in POSITION_CLASSES if issubclass(c, cx.AbstractPosition3D)
-]
+POSITION_CLASSES_3D = [c for c in POSITION_CLASSES if issubclass(c, cx.AbstractPos3D)]
 
 
 # TODO: cycle through all representations
 @pytest.fixture(params=POSITION_CLASSES_3D)
-def q(request) -> cx.AbstractPosition:
+def q(request) -> cx.AbstractPos:
     """Fixture for 3D Vectors."""
-    q = cx.CartesianPosition3D.from_([1, 2, 3], "kpc")
+    q = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
     return q.represent_as(request.param)
 
 
 @eqx.filter_jit
-def func(
-    q: cx.AbstractPosition, target: type[cx.AbstractPosition]
-) -> cx.AbstractPosition:
+def func(q: cx.AbstractPos, target: type[cx.AbstractPos]) -> cx.AbstractPos:
     return q.represent_as(target)
 
 
 @pytest.mark.parametrize("target", POSITION_CLASSES_3D)
 def test_jax_through_representation(
-    q: cx.AbstractPosition, target: type[cx.AbstractPosition]
+    q: cx.AbstractPos, target: type[cx.AbstractPos]
 ) -> None:
     """Test using Jax operations through representation."""
     newq = func(q, target)
 
-    assert isinstance(newq, cx.AbstractPosition)
+    assert isinstance(newq, cx.AbstractPos)
     for k, f in field_items(newq):
         assert isinstance(f, AbstractQuantity), k


### PR DESCRIPTION
Shorten the names of most classes. Meaning still obvious.
When we add docs (hopefully soon) this will go into the conventions page.

@adrn what do you think?