### PR TITLE
build: bump equinox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@
   dependencies = [
     "astropy>=6.1.4",
     "dataclassish>=0.3.1",
-    "equinox==0.11.7",
+    "equinox>=0.11.8",
     "jax>=0.4.33",
     "jaxlib>=0.4.33",
     "jaxtyping>=0.2.34",

--- a/src/coordinax/_src/space.py
+++ b/src/coordinax/_src/space.py
@@ -49,7 +49,7 @@ def _can_broadcast_shapes(*shapes: tuple[int, ...]) -> bool:
 #       running afoul of Jax's tree flattening, where ImmutableMap and
 #       eqx.Module differ.
 @final
-class Space(ImmutableMap[Dimension, AbstractVector], AbstractVector):  # type: ignore[misc]
+class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: ignore[misc]
     """A collection of vectors that acts like the primary vector.
 
     Parameters
@@ -100,7 +100,7 @@ class Space(ImmutableMap[Dimension, AbstractVector], AbstractVector):  # type: i
 
     """  # noqa: E501
 
-    _data: dict[Dimension, AbstractVector]
+    _data: dict[Dimension, AbstractVector] = eqx.field(init=False)
 
     def __init__(  # pylint: disable=super-init-not-called  # TODO: resolve this
         self,
@@ -127,7 +127,7 @@ class Space(ImmutableMap[Dimension, AbstractVector], AbstractVector):  # type: i
             "vector shapes are not broadcastable.",
         )
 
-        super().__init__(dict(zip(keys, raw.values(), strict=True)))
+        ImmutableMap.__init__(self, dict(zip(keys, raw.values(), strict=True)))
 
     # ===============================================================
     # Mapping API
@@ -237,7 +237,7 @@ class Space(ImmutableMap[Dimension, AbstractVector], AbstractVector):  # type: i
         if isinstance(key, Dimension):
             key = _get_dimension_name(key)
 
-        return super().__getitem__(key)
+        return ImmutableMap.__getitem__(self, key)
 
     # ===============================================================
     # Quax

--- a/uv.lock
+++ b/uv.lock
@@ -363,7 +363,7 @@ dev = [
 requires-dist = [
     { name = "astropy", specifier = ">=6.1.4" },
     { name = "dataclassish", specifier = ">=0.3.1" },
-    { name = "equinox", specifier = "==0.11.7" },
+    { name = "equinox", specifier = ">=0.11.8" },
     { name = "furo", marker = "extra == 'all'", specifier = ">=2023.8.17" },
     { name = "furo", marker = "extra == 'docs'", specifier = ">=2023.8.17" },
     { name = "hypothesis", extras = ["numpy"], marker = "extra == 'all'" },
@@ -546,16 +546,16 @@ wheels = [
 
 [[package]]
 name = "equinox"
-version = "0.11.7"
+version = "0.11.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jax" },
     { name = "jaxtyping" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/48/ed7ba0849bea18b8be49f471b8e597ca6e5975f75ed05c3be84c1e0ef7c4/equinox-0.11.7.tar.gz", hash = "sha256:96e0216a9d822ec4b1465b0cbfbab14a36fb7e7d62c55f521287db3aaaa251be", size = 139909 }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/d6/ada74487b24395d1572cb133953429bb195cdfe3bd9fd71d7c8ade2a55ef/equinox-0.11.8.tar.gz", hash = "sha256:d1e91a05e41bb9538db72a8e15d26daf958348c26714533434c88c5ec0c0b0ef", size = 140801 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/3f/2fa4627a902a38cd836aa8f7e5a0753114bb23d6b4d2a73784dd9f5ff2e6/equinox-0.11.7-py3-none-any.whl", hash = "sha256:1177354e1795061fbad71535fe54096d8887dc059b4ab7d400fea2d47dfaa283", size = 178416 },
+    { url = "https://files.pythonhosted.org/packages/15/9f/3be7f03bf66c8d7d2956b727d984595e4af899f3c15ef2c653029008bf3b/equinox-0.11.8-py3-none-any.whl", hash = "sha256:552292b473956693e8e8973bdae9b58aaec54fd48e192921beb82995e3a9c995", size = 179319 },
 ]
 
 [[package]]


### PR DESCRIPTION
Unpinning from #208 
Also forced to rearrange Space. Not sure this is the desired long-term solution.
Equinox made changes to how Modules are made, which is causing errors when it does `object.__setattr__(self, "__class__", cls)`