### PR TITLE
Add prolate spheroidal coordinates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ build-backend = "hatchling.build"
       "F821",    # undefined name '...'  <- jaxtyping
       "FIX002",  # Line contains TODO
       "ISC001",  # Conflicts with formatter
+      "N806",    # Variable in function should be lowercase
       "PD",      # Pandas
       "PLR09",   # Too many <...>
       "PLR2004", # Magic value used in comparison

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,6 @@ build-backend = "hatchling.build"
       "F821",    # undefined name '...'  <- jaxtyping
       "FIX002",  # Line contains TODO
       "ISC001",  # Conflicts with formatter
-      "N806",    # Variable in function should be lowercase
       "PD",      # Pandas
       "PLR09",   # Too many <...>
       "PLR2004", # Magic value used in comparison

--- a/src/coordinax/_src/typing.py
+++ b/src/coordinax/_src/typing.py
@@ -23,6 +23,10 @@ ScalarTime = Float[Quantity["time"], ""] | Int[Quantity["time"], ""]
 
 BatchableTime = Shaped[Quantity["time"], "*#batch"]
 
+BatchableArea = Shaped[Quantity["area"], "*#batch"]
+BatchableDiffusivity = Shaped[Quantity["diffusivity"], "*#batch"]
+BatchableSpecificEnergy = Shaped[Quantity["specific energy"], "*#batch"]
+
 BatchableSpeed = Shaped[Quantity["speed"], "*#batch"]
 BatchableAngularSpeed = Shaped[Quantity["angular speed"], "*#batch"]
 

--- a/src/coordinax/_src/vectors/checks.py
+++ b/src/coordinax/_src/vectors/checks.py
@@ -104,7 +104,7 @@ def check_non_negative(x: AbstractQuantity, /, name: str = "") -> AbstractQuanti
 
     """
     name = f" {name}" if name else name
-    return eqx.error_if(x, xp.any(x < 0), "The input{name} must be non-negative.")
+    return eqx.error_if(x, xp.any(x < 0), f"The input{name} must be non-negative.")
 
 
 def check_non_negative_non_zero(
@@ -135,7 +135,7 @@ def check_non_negative_non_zero(
     """
     name = f" {name}" if name else name
     return eqx.error_if(
-        x, xp.any(x <= 0), "The input{name} must be non-negative and non-zero."
+        x, xp.any(x <= 0), f"The input{name} must be non-negative and non-zero."
     )
 
 

--- a/src/coordinax/_src/vectors/checks.py
+++ b/src/coordinax/_src/vectors/checks.py
@@ -9,18 +9,15 @@ import quaxed.numpy as xp
 import unxt as u
 from unxt.quantity import AbstractQuantity
 
-from coordinax._src.angle import Angle, BatchableAngleQ
-from coordinax._src.distance import Distance
+from coordinax._src.angle import Angle
+from coordinax._src.typing import BatchableAngleQ
 
-_0m = Distance(0, "meter")
 _0d = Angle(0, "rad")
 _pid = Angle(180, "deg")
 _2pid = Angle(360, "deg")
 
 
-def check_r_non_negative(
-    r: AbstractQuantity, /, _l: Distance = _0m
-) -> AbstractQuantity:
+def check_r_non_negative(r: AbstractQuantity) -> AbstractQuantity:
     """Check that the radial distance is non-negative.
 
     Examples
@@ -40,7 +37,7 @@ def check_r_non_negative(
     ... except Exception: pass
 
     """
-    return eqx.error_if(r, xp.any(r < _l), "The radial distance must be non-negative.")
+    return check_non_negative(r, "radial distance")
 
 
 def check_polar_range(
@@ -86,8 +83,32 @@ def check_polar_range(
     )
 
 
+def check_non_negative(x: AbstractQuantity, /, name: str = "") -> AbstractQuantity:
+    """Check that the input is non-negative.
+
+    Examples
+    --------
+    >>> from unxt import Quantity
+
+    Pass through the input if the value is non-negative.
+
+    >>> x = Quantity([0, 1, 2], "m")
+    >>> check_non_negative(x)
+    Quantity['length'](Array([0, 1, 2], dtype=int32), unit='m')
+
+    Raise an error if any value is negative.
+
+    >>> x = Quantity([-1, 1, 2], "m")
+    >>> try: check_non_negative(x)
+    ... except Exception: pass
+
+    """
+    name = f" {name}" if name else name
+    return eqx.error_if(x, xp.any(x < 0), "The input{name} must be non-negative.")
+
+
 def check_less_than_equal(
-    x: AbstractQuantity, max_val: AbstractQuantity
+    x: AbstractQuantity, max_val: AbstractQuantity, /, name: str = ""
 ) -> AbstractQuantity:
     """Check that the input value is less than or equal to the input maximum value.
 
@@ -102,12 +123,13 @@ def check_less_than_equal(
     ... except Exception: pass
 
     """
-    msg = "The input must be less than or equal to the specified maximum value."
+    name = f" {name}" if name else name
+    msg = f"The input{name} must be less than or equal to the specified maximum value."
     return eqx.error_if(x, xp.any(x > max_val), msg)
 
 
 def check_greater_than_equal(
-    x: AbstractQuantity, min_val: AbstractQuantity
+    x: AbstractQuantity, min_val: AbstractQuantity, /, name: str = ""
 ) -> AbstractQuantity:
     """Check that the input value is greater than or equal to the input minimum value.
 
@@ -122,5 +144,9 @@ def check_greater_than_equal(
     ... except Exception: pass
 
     """
-    msg = "The input must be greater than or equal to the specified minimum value."
+    name = f" {name}" if name else name
+    msg = (
+        f"The input{name} must be greater than or equal to the specified minimum "
+        "value."
+    )
     return eqx.error_if(x, xp.any(x < min_val), msg)

--- a/src/coordinax/_src/vectors/checks.py
+++ b/src/coordinax/_src/vectors/checks.py
@@ -9,8 +9,7 @@ import quaxed.numpy as xp
 import unxt as u
 from unxt.quantity import AbstractQuantity
 
-from coordinax._src.angle import Angle
-from coordinax._src.typing import BatchableAngleQ
+from coordinax._src.angle import Angle, BatchableAngleQ
 
 _0d = Angle(0, "rad")
 _pid = Angle(180, "deg")

--- a/src/coordinax/_src/vectors/checks.py
+++ b/src/coordinax/_src/vectors/checks.py
@@ -37,7 +37,7 @@ def check_r_non_negative(r: AbstractQuantity) -> AbstractQuantity:
     ... except Exception: pass
 
     """
-    return check_non_negative(r, "radial distance")
+    return check_non_negative(r, "radial distance r")
 
 
 def check_polar_range(
@@ -152,10 +152,15 @@ def check_less_than(
     --------
     >>> from unxt import Quantity
 
+    Pass through the input if the value is less than the max value:
+
+    >>> x = Quantity([1, 2, 3], "m")
+    >>> check_less_than(x, Quantity(4, "m"))
+    Quantity['length'](Array([1, 2, 3], dtype=int32), unit='m')
+
     Raise an error if the input is larger than the maximum value.
 
-    >>> x = Quantity([-1, 1, 2], "m")
-    >>> try: check_less_than(x, 1.5)
+    >>> try: check_less_than(x, Quantity(1.5, "m"))
     ... except Exception: pass
 
     """
@@ -177,10 +182,15 @@ def check_less_than_equal(
     --------
     >>> from unxt import Quantity
 
+    Pass through the input if the value is less than or equal to the max value:
+
+    >>> x = Quantity([1, 2, 3], "m")
+    >>> check_less_than_equal(x, Quantity(3, "m"))
+    Quantity['length'](Array([1, 2, 3], dtype=int32), unit='m')
+
     Raise an error if the input is larger than the maximum value.
 
-    >>> x = Quantity([-1, 1, 2], "m")
-    >>> try: check_less_than(x, 1.5)
+    >>> try: check_less_than_equal(x, Quantity(2, "m"))
     ... except Exception: pass
 
     """
@@ -202,10 +212,15 @@ def check_greater_than(
     --------
     >>> from unxt import Quantity
 
+    Pass through the input if the value is greater than the min value:
+
+    >>> x = Quantity([1, 2, 3], "m")
+    >>> check_greater_than(x, Quantity(0, "m"))
+    Quantity['length'](Array([1, 2, 3], dtype=int32), unit='m')
+
     Raise an error if the input is smaller than the minimum value.
 
-    >>> x = Quantity([-1, 1, 2], "m")
-    >>> try: check_greater_than(x, 1.0)
+    >>> try: check_greater_than(x, Quantity(4, "m"))
     ... except Exception: pass
 
     """
@@ -227,10 +242,15 @@ def check_greater_than_equal(
     --------
     >>> from unxt import Quantity
 
+    Pass through the input if the value is greater than or equal to the min value:
+
+    >>> x = Quantity([1, 2, 3], "m")
+    >>> check_greater_than_equal(x, Quantity(1, "m"))
+    Quantity['length'](Array([1, 2, 3], dtype=int32), unit='m')
+
     Raise an error if the input is smaller than the minimum value.
 
-    >>> x = Quantity([-1, 1, 2], "m")
-    >>> try: check_greater_than_equal(x, 1.0)
+    >>> try: check_greater_than_equal(x, Quantity(2, "m"))
     ... except Exception: pass
 
     """

--- a/src/coordinax/_src/vectors/checks.py
+++ b/src/coordinax/_src/vectors/checks.py
@@ -37,7 +37,7 @@ def check_r_non_negative(r: AbstractQuantity) -> AbstractQuantity:
     ... except Exception: pass
 
     """
-    return check_non_negative(r, "radial distance r")
+    return check_non_negative(r, name="radial distance r")
 
 
 def check_polar_range(

--- a/src/coordinax/_src/vectors/checks.py
+++ b/src/coordinax/_src/vectors/checks.py
@@ -83,7 +83,7 @@ def check_polar_range(
     )
 
 
-def check_non_negative(x: AbstractQuantity, /, name: str = "") -> AbstractQuantity:
+def check_non_negative(x: AbstractQuantity, /, *, name: str = "") -> AbstractQuantity:
     """Check that the input is non-negative.
 
     Examples
@@ -108,7 +108,7 @@ def check_non_negative(x: AbstractQuantity, /, name: str = "") -> AbstractQuanti
 
 
 def check_non_negative_non_zero(
-    x: AbstractQuantity, /, name: str = ""
+    x: AbstractQuantity, /, *, name: str = ""
 ) -> AbstractQuantity:
     """Check that the input is non-negative and non-zero.
 
@@ -143,6 +143,7 @@ def check_less_than(
     x: AbstractQuantity,
     max_val: AbstractQuantity,
     /,
+    *,
     name: str = "",
     comparison_name: str = "the specified maximum value",
 ) -> AbstractQuantity:
@@ -173,6 +174,7 @@ def check_less_than_equal(
     x: AbstractQuantity,
     max_val: AbstractQuantity,
     /,
+    *,
     name: str = "",
     comparison_name: str = "the specified maximum value",
 ) -> AbstractQuantity:
@@ -203,6 +205,7 @@ def check_greater_than(
     x: AbstractQuantity,
     min_val: AbstractQuantity,
     /,
+    *,
     name: str = "",
     comparison_name: str = "the specified minimum value",
 ) -> AbstractQuantity:
@@ -233,6 +236,7 @@ def check_greater_than_equal(
     x: AbstractQuantity,
     min_val: AbstractQuantity,
     /,
+    *,
     name: str = "",
     comparison_name: str = "the specified minimum value",
 ) -> AbstractQuantity:

--- a/src/coordinax/_src/vectors/checks.py
+++ b/src/coordinax/_src/vectors/checks.py
@@ -107,6 +107,59 @@ def check_non_negative(x: AbstractQuantity, /, name: str = "") -> AbstractQuanti
     return eqx.error_if(x, xp.any(x < 0), "The input{name} must be non-negative.")
 
 
+def check_non_negative_non_zero(
+    x: AbstractQuantity, /, name: str = ""
+) -> AbstractQuantity:
+    """Check that the input is non-negative and non-zero.
+
+    Examples
+    --------
+    >>> from unxt import Quantity
+
+    Pass through the input if the value is non-negative.
+
+    >>> x = Quantity([1, 2, 3], "m")
+    >>> check_non_negative_non_zero(x)
+    Quantity['length'](Array([1, 2, 3], dtype=int32), unit='m')
+
+    Raise an error if any value is negative or zero.
+
+    >>> x = Quantity([-1, 1, 2], "m")
+    >>> try: check_non_negative_non_zero(x)
+    ... except Exception: pass
+
+    >>> x = Quantity([0, 1, 2], "m")
+    >>> try: check_non_negative_non_zero(x)
+    ... except Exception: pass
+
+    """
+    name = f" {name}" if name else name
+    return eqx.error_if(
+        x, xp.any(x <= 0), "The input{name} must be non-negative and non-zero."
+    )
+
+
+def check_less_than(
+    x: AbstractQuantity, max_val: AbstractQuantity, /, name: str = ""
+) -> AbstractQuantity:
+    """Check that the input value is less than the input maximum value.
+
+    Examples
+    --------
+    >>> from unxt import Quantity
+
+    Raise an error if the input is larger than the maximum value.
+
+    >>> x = Quantity([-1, 1, 2], "m")
+    >>> try: check_less_than(x, 1.5)
+    ... except Exception: pass
+
+    """
+    name = f" {name}" if name else name
+    msg = f"The input{name} must be less than the specified maximum value."
+    return eqx.error_if(x, xp.any(x >= max_val), msg)
+
+
 def check_less_than_equal(
     x: AbstractQuantity, max_val: AbstractQuantity, /, name: str = ""
 ) -> AbstractQuantity:

--- a/src/coordinax/_src/vectors/checks.py
+++ b/src/coordinax/_src/vectors/checks.py
@@ -84,3 +84,43 @@ def check_polar_range(
         xp.any(xp.logical_or((polar < _l), (polar > _u))),
         "The inclination angle must be in the range [0, pi].",
     )
+
+
+def check_less_than_equal(
+    x: AbstractQuantity, max_val: AbstractQuantity
+) -> AbstractQuantity:
+    """Check that the input value is less than or equal to the input maximum value.
+
+    Examples
+    --------
+    >>> from unxt import Quantity
+
+    Raise an error if the input is larger than the maximum value.
+
+    >>> x = Quantity([-1, 1, 2], "m")
+    >>> try: check_less_than(x, 1.5)
+    ... except Exception: pass
+
+    """
+    msg = "The input must be less than or equal to the specified maximum value."
+    return eqx.error_if(x, xp.any(x > max_val), msg)
+
+
+def check_greater_than_equal(
+    x: AbstractQuantity, min_val: AbstractQuantity
+) -> AbstractQuantity:
+    """Check that the input value is greater than or equal to the input minimum value.
+
+    Examples
+    --------
+    >>> from unxt import Quantity
+
+    Raise an error if the input is smaller than the minimum value.
+
+    >>> x = Quantity([-1, 1, 2], "m")
+    >>> try: check_greater_than(x, 1.0)
+    ... except Exception: pass
+
+    """
+    msg = "The input must be greater than or equal to the specified minimum value."
+    return eqx.error_if(x, xp.any(x < min_val), msg)

--- a/src/coordinax/_src/vectors/checks.py
+++ b/src/coordinax/_src/vectors/checks.py
@@ -140,7 +140,11 @@ def check_non_negative_non_zero(
 
 
 def check_less_than(
-    x: AbstractQuantity, max_val: AbstractQuantity, /, name: str = ""
+    x: AbstractQuantity,
+    max_val: AbstractQuantity,
+    /,
+    name: str = "",
+    comparison_name: str = "the specified maximum value",
 ) -> AbstractQuantity:
     """Check that the input value is less than the input maximum value.
 
@@ -156,12 +160,16 @@ def check_less_than(
 
     """
     name = f" {name}" if name else name
-    msg = f"The input{name} must be less than the specified maximum value."
+    msg = f"The input{name} must be less than {comparison_name}."
     return eqx.error_if(x, xp.any(x >= max_val), msg)
 
 
 def check_less_than_equal(
-    x: AbstractQuantity, max_val: AbstractQuantity, /, name: str = ""
+    x: AbstractQuantity,
+    max_val: AbstractQuantity,
+    /,
+    name: str = "",
+    comparison_name: str = "the specified maximum value",
 ) -> AbstractQuantity:
     """Check that the input value is less than or equal to the input maximum value.
 
@@ -177,12 +185,16 @@ def check_less_than_equal(
 
     """
     name = f" {name}" if name else name
-    msg = f"The input{name} must be less than or equal to the specified maximum value."
+    msg = f"The input{name} must be less than or equal to {comparison_name}."
     return eqx.error_if(x, xp.any(x > max_val), msg)
 
 
 def check_greater_than(
-    x: AbstractQuantity, min_val: AbstractQuantity, /, name: str = ""
+    x: AbstractQuantity,
+    min_val: AbstractQuantity,
+    /,
+    name: str = "",
+    comparison_name: str = "the specified minimum value",
 ) -> AbstractQuantity:
     """Check that the input value is greater than the input minimum value.
 
@@ -198,12 +210,16 @@ def check_greater_than(
 
     """
     name = f" {name}" if name else name
-    msg = f"The input{name} must be greater than the specified minimum value."
+    msg = f"The input{name} must be greater than {comparison_name}."
     return eqx.error_if(x, xp.any(x <= min_val), msg)
 
 
 def check_greater_than_equal(
-    x: AbstractQuantity, min_val: AbstractQuantity, /, name: str = ""
+    x: AbstractQuantity,
+    min_val: AbstractQuantity,
+    /,
+    name: str = "",
+    comparison_name: str = "the specified minimum value",
 ) -> AbstractQuantity:
     """Check that the input value is greater than or equal to the input minimum value.
 
@@ -214,13 +230,10 @@ def check_greater_than_equal(
     Raise an error if the input is smaller than the minimum value.
 
     >>> x = Quantity([-1, 1, 2], "m")
-    >>> try: check_greater_than(x, 1.0)
+    >>> try: check_greater_than_equal(x, 1.0)
     ... except Exception: pass
 
     """
     name = f" {name}" if name else name
-    msg = (
-        f"The input{name} must be greater than or equal to the specified minimum "
-        "value."
-    )
+    msg = f"The input{name} must be greater than or equal to {comparison_name}."
     return eqx.error_if(x, xp.any(x < min_val), msg)

--- a/src/coordinax/_src/vectors/checks.py
+++ b/src/coordinax/_src/vectors/checks.py
@@ -128,6 +128,27 @@ def check_less_than_equal(
     return eqx.error_if(x, xp.any(x > max_val), msg)
 
 
+def check_greater_than(
+    x: AbstractQuantity, min_val: AbstractQuantity, /, name: str = ""
+) -> AbstractQuantity:
+    """Check that the input value is greater than the input minimum value.
+
+    Examples
+    --------
+    >>> from unxt import Quantity
+
+    Raise an error if the input is smaller than the minimum value.
+
+    >>> x = Quantity([-1, 1, 2], "m")
+    >>> try: check_greater_than(x, 1.0)
+    ... except Exception: pass
+
+    """
+    name = f" {name}" if name else name
+    msg = f"The input{name} must be greater than the specified minimum value."
+    return eqx.error_if(x, xp.any(x <= min_val), msg)
+
+
 def check_greater_than_equal(
     x: AbstractQuantity, min_val: AbstractQuantity, /, name: str = ""
 ) -> AbstractQuantity:

--- a/src/coordinax/_src/vectors/d3/__init__.py
+++ b/src/coordinax/_src/vectors/d3/__init__.py
@@ -31,6 +31,10 @@ __all__ = [
     "LonLatSphericalVel",
     "LonLatSphericalAcc",
     "LonCosLatSphericalVel",
+    # Prolate Spheroidal
+    "ProlateSpheroidalPos",
+    "ProlateSpheroidalVel",
+    "ProlateSpheroidalAcc",
     # Generic
     "CartesianGeneric3D",
 ]
@@ -52,6 +56,7 @@ from .lonlatspherical import (
 )
 from .mathspherical import MathSphericalAcc, MathSphericalPos, MathSphericalVel
 from .spherical import SphericalAcc, SphericalPos, SphericalVel
+from .spheroidal import ProlateSpheroidalAcc, ProlateSpheroidalPos, ProlateSpheroidalVel
 
 # isort: split
 from . import (

--- a/src/coordinax/_src/vectors/d3/spheroidal.py
+++ b/src/coordinax/_src/vectors/d3/spheroidal.py
@@ -9,20 +9,19 @@ from typing import final
 import equinox as eqx
 from jaxtyping import Shaped
 
-import quaxed.numpy as xp
+import quaxed.numpy as jnp
 from dataclassish.converters import Unless
 from unxt import Quantity
 
 import coordinax._src.typing as ct
 from .base import AbstractAcc3D, AbstractPos3D, AbstractVel3D
 from coordinax._src.angle import Angle
-from coordinax._src.distance import AbstractDistance, Distance
 from coordinax._src.utils import classproperty
 from coordinax._src.vectors.base import VectorAttribute
 from coordinax._src.vectors.checks import (
     check_greater_than_equal,
     check_less_than_equal,
-    check_r_non_negative,
+    check_non_negative,
 )
 from coordinax._src.vectors.converters import converter_azimuth_to_range
 
@@ -64,18 +63,17 @@ class ProlateSpheroidalPos(AbstractPos3D):
 
     _: KW_ONLY
     Delta: Shaped[Quantity["length"], ""] = eqx.field(
-        default=VectorAttribute(
-            converter=Unless(AbstractDistance, partial(Distance.from_, dtype=float))
-        ),
+        default=VectorAttribute(),
         repr=False,
     )
     """Focal length of the coordinate system."""
 
     def __check_init__(self) -> None:
         """Check the validity of the initialization."""
-        check_r_non_negative(self.mu)
+        check_non_negative(self.Delta, name="Delta")
+        check_non_negative(self.mu, name="mu")
         check_greater_than_equal(self.mu, self.Delta**2)
-        check_less_than_equal(xp.abs(self.nu), self.Delta**2)
+        check_less_than_equal(jnp.abs(self.nu), self.Delta**2)
 
     @classproperty
     @classmethod

--- a/src/coordinax/_src/vectors/d3/spheroidal.py
+++ b/src/coordinax/_src/vectors/d3/spheroidal.py
@@ -71,9 +71,7 @@ class ProlateSpheroidalPos(AbstractPos3D):
     r"""Azimuthal angle, generally :math:`\phi \in [0,360)`."""
 
     _: KW_ONLY
-    Delta: Shaped[Quantity["length"], ""] = eqx.field(
-        default=VectorAttribute(), repr=False
-    )
+    Delta: Shaped[Quantity["length"], ""] = VectorAttribute()
     """Focal length of the coordinate system."""
 
     def __check_init__(self) -> None:

--- a/src/coordinax/_src/vectors/d3/spheroidal.py
+++ b/src/coordinax/_src/vectors/d3/spheroidal.py
@@ -19,9 +19,9 @@ from coordinax._src.angle import Angle
 from coordinax._src.utils import classproperty
 from coordinax._src.vectors.base import VectorAttribute
 from coordinax._src.vectors.checks import (
+    check_greater_than,
     check_greater_than_equal,
     check_less_than_equal,
-    check_non_negative,
 )
 from coordinax._src.vectors.converters import converter_azimuth_to_range
 
@@ -29,6 +29,11 @@ from coordinax._src.vectors.converters import converter_azimuth_to_range
 @final
 class ProlateSpheroidalPos(AbstractPos3D):
     """Prolate spheroidal coordinates as defined by Dejonghe & de Zeeuw 1988.
+
+    Note that valid coordinates have:
+    - mu >= Delta^2
+    - |nu| <= Delta^2
+    - Delta > 0
 
     Parameters
     ----------
@@ -40,6 +45,10 @@ class ProlateSpheroidalPos(AbstractPos3D):
         Azimuthal angle [0, 360) [deg] where 0 is the x-axis.
     Delta : `coordinax.distance.Distance`
         The focal length of the coordinate system.
+
+    Examples
+    --------
+    TODO: add valid and invalid examples
 
     """
 
@@ -69,10 +78,9 @@ class ProlateSpheroidalPos(AbstractPos3D):
 
     def __check_init__(self) -> None:
         """Check the validity of the initialization."""
-        check_non_negative(self.Delta, name="Delta")
-        check_non_negative(self.mu, name="mu")
-        check_greater_than_equal(self.mu, self.Delta**2)
-        check_less_than_equal(jnp.abs(self.nu), self.Delta**2)
+        check_greater_than(self.Delta, 0.0, name="Delta")
+        check_greater_than_equal(self.mu, self.Delta**2, name="mu")
+        check_less_than_equal(jnp.abs(self.nu), self.Delta**2, name="nu")
 
     @classproperty
     @classmethod

--- a/src/coordinax/_src/vectors/d3/spheroidal.py
+++ b/src/coordinax/_src/vectors/d3/spheroidal.py
@@ -106,7 +106,9 @@ class ProlateSpheroidalPos(AbstractPos3D):
     r"""Azimuthal angle, generally :math:`\phi \in [0,360)`."""
 
     _: KW_ONLY
-    Delta: Shaped[Quantity["length"], ""] = VectorAttribute(converter=Quantity["length"].from_)
+    Delta: Shaped[Quantity["length"], ""] = VectorAttribute(
+        converter=Quantity["length"].from_
+    )
     """Focal length of the coordinate system."""
 
     def __check_init__(self) -> None:

--- a/src/coordinax/_src/vectors/d3/spheroidal.py
+++ b/src/coordinax/_src/vectors/d3/spheroidal.py
@@ -15,7 +15,7 @@ from unxt import Quantity
 
 import coordinax._src.typing as ct
 from .base import AbstractAcc3D, AbstractPos3D, AbstractVel3D
-from coordinax._src.angle import Angle
+from coordinax._src.angle import Angle, BatchableAngleQ
 from coordinax._src.utils import classproperty
 from coordinax._src.vectors.base import VectorAttribute
 from coordinax._src.vectors.checks import (
@@ -98,7 +98,7 @@ class ProlateSpheroidalPos(AbstractPos3D):
     )
     r"""Spheroidal nu coordinate :math:`\lambda \in [-\infty,+\infty)`."""
 
-    phi: ct.BatchableAngle = eqx.field(
+    phi: BatchableAngleQ = eqx.field(
         converter=Unless(
             Angle, lambda x: converter_azimuth_to_range(Angle.from_(x, dtype=float))
         )

--- a/src/coordinax/_src/vectors/d3/spheroidal.py
+++ b/src/coordinax/_src/vectors/d3/spheroidal.py
@@ -1,0 +1,135 @@
+"""Built-in vector classes."""
+
+__all__ = ["ProlateSpheroidalPos", "ProlateSpheroidalVel", "ProlateSpheroidalAcc"]
+
+from dataclasses import KW_ONLY
+from functools import partial
+from typing import final
+
+import equinox as eqx
+
+import quaxed.numpy as xp
+from dataclassish.converters import Unless
+from unxt import Quantity
+
+import coordinax._src.typing as ct
+from .base import AbstractAcc3D, AbstractPos3D, AbstractVel3D
+from coordinax._src.angle import Angle
+from coordinax._src.checks import (
+    check_greater_than_equal,
+    check_less_than_equal,
+    check_r_non_negative,
+)
+from coordinax._src.converters import converter_azimuth_to_range
+from coordinax._src.distance import AbstractDistance, Distance
+from coordinax._src.utils import classproperty
+
+
+@final
+class ProlateSpheroidalPos(AbstractPos3D):
+    """Prolate spheroidal coordinates as defined by Dejonghe & de Zeeuw 1988.
+
+    Parameters
+    ----------
+    mu : `coordinax.distance.Distance`
+        The spheroidal mu coordinate. This is called `lambda` by Dejonghe & de Zeeuw.
+    nu : `coordinax.distance.Distance`
+        The spheroidal nu coordinate.
+    phi : `coordinax.angle.Angle`
+        Azimuthal angle [0, 360) [deg] where 0 is the x-axis.
+    Delta : `coordinax.distance.Distance`
+        The focal length of the coordinate system.
+
+    """
+
+    mu: ct.BatchableArea = eqx.field(
+        converter=partial(Quantity["area"].from_, dtype=float)
+    )
+    r"""Spheroidal mu coordinate :math:`\mu \in [0,+\infty)` (called :math:`\lambda` in
+     some Galactic dynamics contexts)."""
+
+    nu: ct.BatchableArea = eqx.field(
+        converter=partial(Quantity["area"].from_, dtype=float)
+    )
+    r"""Spheroidal nu coordinate :math:`\lambda \in [-\infty,+\infty)`."""
+
+    phi: ct.BatchableAngle = eqx.field(
+        converter=Unless(
+            Angle, lambda x: converter_azimuth_to_range(Angle.from_(x, dtype=float))
+        )
+    )
+    r"""Azimuthal angle, generally :math:`\phi \in [0,360)`."""
+
+    _: KW_ONLY
+    Delta: ct.BatchableDistance = eqx.field(
+        converter=Unless(AbstractDistance, partial(Distance.from_, dtype=float)),
+        repr=False,  # TODO: this still seems to appear in __str__ and latex repr
+    )
+
+    """Focal length of the coordinate system."""
+
+    def __check_init__(self) -> None:
+        """Check the validity of the initialization."""
+        check_r_non_negative(self.mu)
+        check_greater_than_equal(self.mu, self.Delta**2)
+        check_less_than_equal(xp.abs(self.nu), self.Delta**2)
+
+    @classproperty
+    @classmethod
+    def differential_cls(cls) -> type["ProlateSpheroidalVel"]:
+        return ProlateSpheroidalVel
+
+
+@final
+class ProlateSpheroidalVel(AbstractVel3D):
+    """Prolate spheroidal differential representation."""
+
+    d_mu: ct.BatchableDiffusivity = eqx.field(
+        converter=partial(Quantity["diffusivity"].from_, dtype=float)
+    )
+    r"""Prolate spheroidal mu speed :math:`d\mu/dt \in [-\infty, \infty]."""
+
+    d_nu: ct.BatchableDiffusivity = eqx.field(
+        converter=partial(Quantity["diffusivity"].from_, dtype=float)
+    )
+    r"""Prolate spheroidal nu speed :math:`d\nu/dt \in [-\infty, \infty]."""
+
+    d_phi: ct.BatchableAngularSpeed = eqx.field(
+        converter=partial(Quantity["angular speed"].from_, dtype=float)
+    )
+    r"""Azimuthal speed :math:`d\phi/dt \in [-\infty, \infty]."""
+
+    @classproperty
+    @classmethod
+    def integral_cls(cls) -> type[ProlateSpheroidalPos]:
+        return ProlateSpheroidalPos
+
+    @classproperty
+    @classmethod
+    def differential_cls(cls) -> type["ProlateSpheroidalAcc"]:
+        return ProlateSpheroidalAcc
+
+
+@final
+class ProlateSpheroidalAcc(AbstractAcc3D):
+    """Prolate spheroidal acceleration representation."""
+
+    d2_mu: ct.BatchableSpecificEnergy = eqx.field(
+        converter=partial(Quantity["specific energy"].from_, dtype=float)
+    )
+    r"""Prolate spheroidal mu acceleration :math:`d^2\mu/dt^2 \in [-\infty, \infty]."""
+
+    d2_nu: ct.BatchableSpecificEnergy = eqx.field(
+        converter=partial(Quantity["specific energy"].from_, dtype=float)
+    )
+    r"""Prolate spheroidal nu acceleration :math:`d^2\nu/dt^2 \in [-\infty, \infty]."""
+
+    d2_phi: ct.BatchableAngularAcc = eqx.field(
+        converter=partial(Quantity["angular acceleration"].from_, dtype=float)
+    )
+    r"""Azimuthal acceleration :math:`d^2\phi/dt^2 \in [-\infty, \infty]."""
+
+    @classproperty
+    @classmethod
+    def integral_cls(cls) -> type[ProlateSpheroidalVel]:
+        return ProlateSpheroidalVel

--- a/src/coordinax/_src/vectors/d3/spheroidal.py
+++ b/src/coordinax/_src/vectors/d3/spheroidal.py
@@ -37,9 +37,9 @@ class ProlateSpheroidalPos(AbstractPos3D):
 
     Parameters
     ----------
-    mu : `coordinax.distance.Distance`
+    mu : Quantity["area"]
         The spheroidal mu coordinate. This is called `lambda` by Dejonghe & de Zeeuw.
-    nu : `coordinax.distance.Distance`
+    nu : Quantity["area"]
         The spheroidal nu coordinate.
     phi : `coordinax.angle.Angle`
         Azimuthal angle [0, 360) [deg] where 0 is the x-axis.
@@ -106,7 +106,7 @@ class ProlateSpheroidalPos(AbstractPos3D):
     r"""Azimuthal angle, generally :math:`\phi \in [0,360)`."""
 
     _: KW_ONLY
-    Delta: Shaped[Quantity["length"], ""] = VectorAttribute()
+    Delta: Shaped[Quantity["length"], ""] = VectorAttribute(converter=Quantity["length"].from_)
     """Focal length of the coordinate system."""
 
     def __check_init__(self) -> None:

--- a/src/coordinax/_src/vectors/d3/spheroidal.py
+++ b/src/coordinax/_src/vectors/d3/spheroidal.py
@@ -48,7 +48,42 @@ class ProlateSpheroidalPos(AbstractPos3D):
 
     Examples
     --------
-    TODO: add valid and invalid examples
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
+
+    >>> vec = cx.ProlateSpheroidalPos(
+    ...     mu=Quantity(3.0, "kpc2"),
+    ...     nu=Quantity(0.5, "kpc2"),
+    ...     phi=Quantity(0.25, "rad"),
+    ...     Delta=Quantity(1.5, "kpc"),
+    ... )
+    >>> vec
+    ProlateSpheroidalPos(
+      mu=Quantity[PhysicalType('area')](value=f32[], unit=Unit("kpc2")),
+      nu=Quantity[PhysicalType('area')](value=f32[], unit=Unit("kpc2")),
+      phi=Angle(value=f32[], unit=Unit("rad")),
+      Delta=Quantity[PhysicalType('length')](value=weak_f32[], unit=Unit("kpc"))
+    )
+
+    This fails with a zero or negative Delta:
+
+    >>> try: vec = cx.ProlateSpheroidalPos(
+    ...     mu=Quantity(3.0, "kpc2"),
+    ...     nu=Quantity(0.5, "kpc2"),
+    ...     phi=Quantity(0.25, "rad"),
+    ...     Delta=Quantity(0.0, "kpc"),
+    ... )
+    ... except Exception as e: pass
+
+    Or with invalid mu and nu:
+
+    >>> try: vec = cx.ProlateSpheroidalPos(
+    ...     mu=Quantity(0.5, "kpc2"),
+    ...     nu=Quantity(0.5, "kpc2"),
+    ...     phi=Quantity(0.25, "rad"),
+    ...     Delta=Quantity(1.5, "kpc"),
+    ... )
+    ... except Exception as e: pass
 
     """
 
@@ -77,8 +112,12 @@ class ProlateSpheroidalPos(AbstractPos3D):
     def __check_init__(self) -> None:
         """Check the validity of the initialization."""
         check_non_negative_non_zero(self.Delta, name="Delta")
-        check_greater_than_equal(self.mu, self.Delta**2, name="mu")
-        check_less_than_equal(jnp.abs(self.nu), self.Delta**2, name="nu")
+        check_greater_than_equal(
+            self.mu, self.Delta**2, name="mu", comparison_name="Delta^2"
+        )
+        check_less_than_equal(
+            jnp.abs(self.nu), self.Delta**2, name="nu", comparison_name="Delta^2"
+        )
 
     @classproperty
     @classmethod

--- a/src/coordinax/_src/vectors/d3/spheroidal.py
+++ b/src/coordinax/_src/vectors/d3/spheroidal.py
@@ -19,9 +19,9 @@ from coordinax._src.angle import Angle
 from coordinax._src.utils import classproperty
 from coordinax._src.vectors.base import VectorAttribute
 from coordinax._src.vectors.checks import (
-    check_greater_than,
     check_greater_than_equal,
     check_less_than_equal,
+    check_non_negative_non_zero,
 )
 from coordinax._src.vectors.converters import converter_azimuth_to_range
 
@@ -78,7 +78,7 @@ class ProlateSpheroidalPos(AbstractPos3D):
 
     def __check_init__(self) -> None:
         """Check the validity of the initialization."""
-        check_greater_than(self.Delta, 0.0, name="Delta")
+        check_non_negative_non_zero(self.Delta, name="Delta")
         check_greater_than_equal(self.mu, self.Delta**2, name="mu")
         check_less_than_equal(jnp.abs(self.nu), self.Delta**2, name="nu")
 

--- a/src/coordinax/_src/vectors/d3/spheroidal.py
+++ b/src/coordinax/_src/vectors/d3/spheroidal.py
@@ -43,8 +43,8 @@ class ProlateSpheroidalPos(AbstractPos3D):
         The spheroidal nu coordinate.
     phi : `coordinax.angle.Angle`
         Azimuthal angle [0, 360) [deg] where 0 is the x-axis.
-    Delta : `coordinax.distance.Distance`
-        The focal length of the coordinate system.
+    Delta : Quantity["length"]
+        The focal length of the coordinate system. Must be > 0.
 
     Examples
     --------

--- a/src/coordinax/_src/vectors/d3/spheroidal.py
+++ b/src/coordinax/_src/vectors/d3/spheroidal.py
@@ -1,12 +1,13 @@
 """Built-in vector classes."""
 
-__all__ = ["ProlateSpheroidalPos", "ProlateSpheroidalVel", "ProlateSpheroidalAcc"]
+__all__ = ["ProlateSpheroidalAcc", "ProlateSpheroidalPos", "ProlateSpheroidalVel"]
 
 from dataclasses import KW_ONLY
 from functools import partial
 from typing import final
 
 import equinox as eqx
+from jaxtyping import Shaped
 
 import quaxed.numpy as xp
 from dataclassish.converters import Unless
@@ -15,14 +16,15 @@ from unxt import Quantity
 import coordinax._src.typing as ct
 from .base import AbstractAcc3D, AbstractPos3D, AbstractVel3D
 from coordinax._src.angle import Angle
-from coordinax._src.checks import (
+from coordinax._src.distance import AbstractDistance, Distance
+from coordinax._src.utils import classproperty
+from coordinax._src.vectors.base import VectorAttribute
+from coordinax._src.vectors.checks import (
     check_greater_than_equal,
     check_less_than_equal,
     check_r_non_negative,
 )
-from coordinax._src.converters import converter_azimuth_to_range
-from coordinax._src.distance import AbstractDistance, Distance
-from coordinax._src.utils import classproperty
+from coordinax._src.vectors.converters import converter_azimuth_to_range
 
 
 @final
@@ -61,11 +63,12 @@ class ProlateSpheroidalPos(AbstractPos3D):
     r"""Azimuthal angle, generally :math:`\phi \in [0,360)`."""
 
     _: KW_ONLY
-    Delta: ct.BatchableDistance = eqx.field(
-        converter=Unless(AbstractDistance, partial(Distance.from_, dtype=float)),
-        repr=False,  # TODO: this still seems to appear in __str__ and latex repr
+    Delta: Shaped[Quantity["length"], ""] = eqx.field(
+        default=VectorAttribute(
+            converter=Unless(AbstractDistance, partial(Distance.from_, dtype=float))
+        ),
+        repr=False,
     )
-
     """Focal length of the coordinate system."""
 
     def __check_init__(self) -> None:

--- a/src/coordinax/_src/vectors/d3/spheroidal.py
+++ b/src/coordinax/_src/vectors/d3/spheroidal.py
@@ -106,9 +106,7 @@ class ProlateSpheroidalPos(AbstractPos3D):
     r"""Azimuthal angle, generally :math:`\phi \in [0,360)`."""
 
     _: KW_ONLY
-    Delta: Shaped[Quantity["length"], ""] = VectorAttribute(
-        converter=Quantity["length"].from_
-    )
+    Delta: Shaped[Quantity["length"], ""] = VectorAttribute()
     """Focal length of the coordinate system."""
 
     def __check_init__(self) -> None:

--- a/src/coordinax/_src/vectors/d3/spheroidal.py
+++ b/src/coordinax/_src/vectors/d3/spheroidal.py
@@ -63,8 +63,7 @@ class ProlateSpheroidalPos(AbstractPos3D):
 
     _: KW_ONLY
     Delta: Shaped[Quantity["length"], ""] = eqx.field(
-        default=VectorAttribute(),
-        repr=False,
+        default=VectorAttribute(), repr=False
     )
     """Focal length of the coordinate system."""
 

--- a/src/coordinax/_src/vectors/d3/transform.py
+++ b/src/coordinax/_src/vectors/d3/transform.py
@@ -20,6 +20,8 @@ from .lonlatspherical import (
 )
 from .mathspherical import MathSphericalPos, MathSphericalVel
 from .spherical import SphericalPos, SphericalVel
+from .spheroidal import ProlateSpheroidalPos, ProlateSpheroidalVel
+from coordinax._src.distance import AbstractDistance
 from coordinax._src.vectors.base import AbstractPos
 
 ###############################################################################
@@ -100,6 +102,7 @@ def represent_as(
         AbstractPos,
     ),
     (MathSphericalVel, type[MathSphericalVel], AbstractPos),
+    (ProlateSpheroidalVel, type[ProlateSpheroidalVel], AbstractPos),
 )
 def represent_as(
     current: AbstractVel3D,
@@ -573,6 +576,157 @@ def represent_as(
 
     """
     return target(r=current.r, theta=current.phi, phi=current.theta)
+
+
+# =============================================================================
+# ProlateSpheroidalPos
+
+
+@dispatch
+def represent_as(
+    current: ProlateSpheroidalPos, target: type[CylindricalPos], /, **kwargs: Any
+) -> CylindricalPos:
+    """ProlateSpheroidalPos -> CylindricalPos.
+
+    Examples
+    --------
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
+
+    >>> vec = cx.ProlateSpheroidalPos(
+    ...     mu=Quantity(1., "kpc2"),
+    ...     nu=Quantity(0.2, "kpc2"),
+    ...     phi=Quantity(90, "deg"),
+    ...     Delta=Quantity(0.5, "kpc")
+    ... )
+    >>> print(cx.represent_as(vec, cx.CylindricalPos))
+    TODO: add
+
+    """
+    Delta2 = current.Delta**2
+    absnu = xp.abs(current.nu)
+
+    mu_minus_delta = current.mu - Delta2
+    # nu_minus_delta = absnu - Delta2
+
+    R = xp.sqrt(mu_minus_delta * (1 - absnu / Delta2))
+    z = xp.sqrt(current.mu * absnu / Delta2) * xp.sign(current.nu)
+
+    return target(rho=R, phi=current.phi, z=z)
+
+
+@dispatch
+def represent_as(
+    current: CylindricalPos,
+    target: type[ProlateSpheroidalPos],
+    *,
+    Delta: AbstractDistance | Quantity["length"],  # noqa: N803
+    **kwargs: Any,
+) -> ProlateSpheroidalPos:
+    """CylindricalPos -> ProlateSpheroidalPos.
+
+    Examples
+    --------
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
+
+    >>> vec = cx.CylindricalPos(
+    ...     rho=Quantity(1., "kpc"),
+    ...     phi=Quantity(90, "deg"),
+    ...     z=Quantity(1, "kpc")
+    ... )
+    >>> print(vec.represent_as(cx.ProlateSpheroidalPos, Delta=Quantity(0.5, "kpc")))
+    <ProlateSpheroidalPos (mu[kpc2], nu[kpc2], phi[deg], Delta[kpc])
+        [ 2.133  0.117 90.     0.5  ]>
+
+    """
+    R2 = current.rho**2
+    z2 = current.z**2
+    Delta2 = Delta**2
+
+    sum_ = R2 + z2 + Delta2
+    diff_ = R2 + z2 - Delta2
+
+    # compute D = sqrt((R² + z² - Δ²)² + 4R²Δ²)
+    D = xp.sqrt(diff_**2 + 4 * R2 * Delta2)
+
+    # handle special cases for R=0 or z=0
+    # TODO: quaxed.numpy.select doesn't work with Quantity's?
+    # D = xp.select(
+    #     [current.z == 0, current.rho == 0, xp.full(current.rho.shape, 1, dtype=bool)],
+    #     [
+    #         sum_,  # z=0 case
+    #         xp.abs(diff_),  # R=0 case
+    #         D,  # otherwise
+    #     ],
+    # )
+    D = xp.where(current.z == 0, sum_, D)
+    D = xp.where(current.rho == 0, xp.abs(diff_), D)
+
+    # compute mu and nu depending on sign of diff_ - avoids dividing by a small number
+    pos_mu_minus_delta = 0.5 * (D + diff_)
+    pos_delta_minus_nu = Delta2 * R2 / pos_mu_minus_delta
+
+    neg_delta_minus_nu = 0.5 * (D - diff_)
+    neg_mu_minus_delta = Delta2 * R2 / neg_delta_minus_nu
+
+    # Select based on condition
+    mu_minus_delta = xp.where(diff_ >= 0, pos_mu_minus_delta, neg_mu_minus_delta)
+    delta_minus_nu = xp.where(diff_ >= 0, pos_delta_minus_nu, neg_delta_minus_nu)
+
+    # compute mu and nu:
+    mu = Delta2 + mu_minus_delta
+    abs_nu = 2 * Delta2 / (sum_ + D) * z2
+
+    # for numerical stability when Delta^2-|nu| is small
+    abs_nu = xp.where(abs_nu * 2 > Delta2, Delta2 - delta_minus_nu, abs_nu)
+
+    nu = abs_nu * xp.sign(current.z)
+
+    return target(mu=mu, nu=nu, phi=current.phi, Delta=Delta)
+
+
+@dispatch
+def represent_as(
+    current: ProlateSpheroidalPos, target: type[CartesianPos3D], /, **kwargs: Any
+) -> CartesianPos3D:
+    """ProlateSpheroidalPos -> CartesianPos3D."""
+    cyl = represent_as(current, CylindricalPos)
+    return represent_as(cyl, target)
+
+
+@dispatch
+def represent_as(
+    current: CartesianPos3D,
+    target: type[ProlateSpheroidalPos],
+    *,
+    Delta: AbstractDistance | Quantity["length"],  # noqa: N803
+    **kwargs: Any,
+) -> ProlateSpheroidalPos:
+    """CartesianPos3D -> ProlateSpheroidalPos."""
+    cyl = represent_as(current, CylindricalPos)
+    return represent_as(cyl, target, Delta=Delta)
+
+
+@dispatch
+def represent_as(
+    current: ProlateSpheroidalPos, target: type[ProlateSpheroidalPos], /
+) -> ProlateSpheroidalPos:
+    """ProlateSpheroidalPos -> ProlateSpheroidalPos."""
+    return current
+
+
+@dispatch
+def represent_as(
+    current: ProlateSpheroidalPos,
+    target: type[ProlateSpheroidalPos],
+    *,
+    Delta: AbstractDistance | Quantity["length"],  # noqa: N803
+    **kwargs: Any,
+) -> ProlateSpheroidalPos:
+    """ProlateSpheroidalPos -> ProlateSpheroidalPos."""
+    cyl = represent_as(current, CylindricalPos)
+    return represent_as(cyl, target, Delta=Delta)
 
 
 # =============================================================================

--- a/src/coordinax/_src/vectors/d3/transform.py
+++ b/src/coordinax/_src/vectors/d3/transform.py
@@ -610,7 +610,7 @@ def represent_as(
     nu_D2 = xp.abs(current.nu) / Delta2
 
     R = xp.sqrt((current.mu - Delta2) * (1 - nu_D2))
-    z = xp.sqrt(current.mu * nu_D2 * xp.sign(current.nu)
+    z = xp.sqrt(current.mu * nu_D2) * xp.sign(current.nu)
 
     return target(rho=R, phi=current.phi, z=z)
 

--- a/src/coordinax/_src/vectors/d3/transform.py
+++ b/src/coordinax/_src/vectors/d3/transform.py
@@ -723,6 +723,19 @@ def represent_as(
 
 @dispatch
 def represent_as(
+    current: CartesianPos3D, target: type[ProlateSpheroidalPos]
+) -> ProlateSpheroidalPos:
+    """CartesianPos3D -> ProlateSpheroidalPos.
+
+    This exists to catch the (invalid) case where the Delta is not provided, so that a
+    recursion error is not raised.
+    """
+    msg = "Delta must be provided for ProlateSpheroidalPos."
+    raise ValueError(msg)
+
+
+@dispatch
+def represent_as(
     current: ProlateSpheroidalPos, target: type[ProlateSpheroidalPos]
 ) -> ProlateSpheroidalPos:
     """ProlateSpheroidalPos -> ProlateSpheroidalPos.

--- a/src/coordinax/_src/vectors/d3/transform.py
+++ b/src/coordinax/_src/vectors/d3/transform.py
@@ -1,5 +1,5 @@
-# ruff: noqa: N803, N806
 """Representation of coordinates in different systems."""
+# ruff: noqa: N803, N806
 
 __all__: list[str] = []
 
@@ -607,13 +607,10 @@ def represent_as(
 
     """
     Delta2 = current.Delta**2
-    absnu = xp.abs(current.nu)
+    nu_D2 = xp.abs(current.nu) / Delta2
 
-    mu_minus_delta = current.mu - Delta2
-    # nu_minus_delta = absnu - Delta2
-
-    R = xp.sqrt(mu_minus_delta * (1 - absnu / Delta2))
-    z = xp.sqrt(current.mu * absnu / Delta2) * xp.sign(current.nu)
+    R = xp.sqrt((current.mu - Delta2) * (1 - nu_D2))
+    z = xp.sqrt(current.mu * nu_D2 * xp.sign(current.nu)
 
     return target(rho=R, phi=current.phi, z=z)
 

--- a/src/coordinax/_src/vectors/d3/transform.py
+++ b/src/coordinax/_src/vectors/d3/transform.py
@@ -633,7 +633,7 @@ def represent_as(
     ...     phi=Quantity(90, "deg"),
     ...     z=Quantity(1, "kpc")
     ... )
-    >>> print(vec.represent_as(cx.ProlateSpheroidalPos, Delta=Quantity(0.5, "kpc")))
+    >>> print(vec.represent_as(cx.ProlateSpheroidalPos, Quantity(0.5, "kpc")))
     <ProlateSpheroidalPos (mu[kpc2], nu[kpc2], phi[deg])
         [ 2.133  0.117 90.   ]>
 
@@ -766,7 +766,7 @@ def represent_as(
     ...     phi=Quantity(90, "deg"),
     ...     Delta=Quantity(0.5, "kpc")
     ... )
-    >>> print(cx.represent_as(vec, cx.ProlateSpheroidalPos, Delta=Quantity(0.5, "kpc")))
+    >>> print(cx.represent_as(vec, cx.ProlateSpheroidalPos, Quantity(0.5, "kpc")))
     <ProlateSpheroidalPos...>
 
     """

--- a/src/coordinax/_src/vectors/d3/transform.py
+++ b/src/coordinax/_src/vectors/d3/transform.py
@@ -712,11 +712,11 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: CartesianPos3D,
+    current: AbstractPos3D,
     target: type[ProlateSpheroidalPos],
     Delta: Quantity["length"],  # noqa: N803
 ) -> ProlateSpheroidalPos:
-    """CartesianPos3D -> ProlateSpheroidalPos."""
+    """AbstractPos3D -> ProlateSpheroidalPos."""
     cyl = represent_as(current, CylindricalPos)
     return represent_as(cyl, target, Delta)
 

--- a/src/coordinax/_src/vectors/d3/transform.py
+++ b/src/coordinax/_src/vectors/d3/transform.py
@@ -637,7 +637,7 @@ def represent_as(
     ...     phi=Quantity(90, "deg"),
     ...     z=Quantity(1, "kpc")
     ... )
-    >>> print(vec.represent_as(cx.ProlateSpheroidalPos, Quantity(0.5, "kpc")))
+    >>> print(vec.represent_as(cx.ProlateSpheroidalPos, Delta=Quantity(0.5, "kpc")))
     <ProlateSpheroidalPos (mu[kpc2], nu[kpc2], phi[deg])
         [ 2.133  0.117 90.   ]>
 
@@ -741,14 +741,14 @@ def represent_as(
     ...     phi=Quantity(90, "deg"),
     ...     Delta=Quantity(0.5, "kpc")
     ... )
-    >>> print(cx.represent_as(vec, cx.ProlateSpheroidalPos, Quantity(0.8, "kpc")))
+    >>> print(cx.represent_as(vec, cx.ProlateSpheroidalPos, Delta=Quantity(0.8, "kpc")))
     <ProlateSpheroidalPos...>
 
     Without changing the focal length, no transform is done:
 
     >>> vec2 = cx.represent_as(vec, cx.ProlateSpheroidalPos)
     >>> vec == vec2
-    True
+    Array(True, dtype=bool)
 
     """
     Delta = kwargs.get("Delta", current.Delta)
@@ -794,7 +794,7 @@ def represent_as(
     ...     phi=Quantity(90, "deg"),
     ...     Delta=Quantity(0.5, "kpc")
     ... )
-    >>> print(cx.represent_as(vec, cx.ProlateSpheroidalPos, Quantity(0.8, "kpc")))
+    >>> print(cx.represent_as(vec, cx.ProlateSpheroidalPos, Delta=Quantity(0.8, "kpc")))
     <ProlateSpheroidalPos...>
 
     """

--- a/src/coordinax/_src/vectors/d3/transform.py
+++ b/src/coordinax/_src/vectors/d3/transform.py
@@ -21,7 +21,6 @@ from .lonlatspherical import (
 from .mathspherical import MathSphericalPos, MathSphericalVel
 from .spherical import SphericalPos, SphericalVel
 from .spheroidal import ProlateSpheroidalPos, ProlateSpheroidalVel
-from coordinax._src.distance import AbstractDistance
 from coordinax._src.vectors.base import AbstractPos
 
 ###############################################################################
@@ -600,7 +599,8 @@ def represent_as(
     ...     Delta=Quantity(0.5, "kpc")
     ... )
     >>> print(cx.represent_as(vec, cx.CylindricalPos))
-    TODO: add
+    <CylindricalPos (rho[kpc], phi[deg], z[kpc])
+        [ 0.387 90.     0.894]>
 
     """
     Delta2 = current.Delta**2
@@ -619,9 +619,7 @@ def represent_as(
 def represent_as(
     current: CylindricalPos,
     target: type[ProlateSpheroidalPos],
-    *,
-    Delta: AbstractDistance | Quantity["length"],  # noqa: N803
-    **kwargs: Any,
+    Delta: Quantity["length"],  # noqa: N803
 ) -> ProlateSpheroidalPos:
     """CylindricalPos -> ProlateSpheroidalPos.
 
@@ -636,8 +634,8 @@ def represent_as(
     ...     z=Quantity(1, "kpc")
     ... )
     >>> print(vec.represent_as(cx.ProlateSpheroidalPos, Delta=Quantity(0.5, "kpc")))
-    <ProlateSpheroidalPos (mu[kpc2], nu[kpc2], phi[deg], Delta[kpc])
-        [ 2.133  0.117 90.     0.5  ]>
+    <ProlateSpheroidalPos (mu[kpc2], nu[kpc2], phi[deg])
+        [ 2.133  0.117 90.   ]>
 
     """
     R2 = current.rho**2
@@ -690,7 +688,24 @@ def represent_as(
 def represent_as(
     current: ProlateSpheroidalPos, target: type[CartesianPos3D], /, **kwargs: Any
 ) -> CartesianPos3D:
-    """ProlateSpheroidalPos -> CartesianPos3D."""
+    """ProlateSpheroidalPos -> CartesianPos3D.
+
+    Examples
+    --------
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
+
+    >>> vec = cx.ProlateSpheroidalPos(
+    ...     mu=Quantity(1., "kpc2"),
+    ...     nu=Quantity(0.2, "kpc2"),
+    ...     phi=Quantity(90, "deg"),
+    ...     Delta=Quantity(0.5, "kpc")
+    ... )
+    >>> print(cx.represent_as(vec, cx.CartesianPos3D))
+    <CartesianPos3D (x[kpc], y[kpc], z[kpc])
+        [-1.693e-08  3.873e-01  8.944e-01]>
+
+    """
     cyl = represent_as(current, CylindricalPos)
     return represent_as(cyl, target)
 
@@ -699,20 +714,34 @@ def represent_as(
 def represent_as(
     current: CartesianPos3D,
     target: type[ProlateSpheroidalPos],
-    *,
-    Delta: AbstractDistance | Quantity["length"],  # noqa: N803
-    **kwargs: Any,
+    Delta: Quantity["length"],  # noqa: N803
 ) -> ProlateSpheroidalPos:
     """CartesianPos3D -> ProlateSpheroidalPos."""
     cyl = represent_as(current, CylindricalPos)
-    return represent_as(cyl, target, Delta=Delta)
+    return represent_as(cyl, target, Delta)
 
 
 @dispatch
 def represent_as(
-    current: ProlateSpheroidalPos, target: type[ProlateSpheroidalPos], /
+    current: ProlateSpheroidalPos, target: type[ProlateSpheroidalPos]
 ) -> ProlateSpheroidalPos:
-    """ProlateSpheroidalPos -> ProlateSpheroidalPos."""
+    """ProlateSpheroidalPos -> ProlateSpheroidalPos.
+
+    Examples
+    --------
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
+
+    >>> vec = cx.ProlateSpheroidalPos(
+    ...     mu=Quantity(1., "kpc2"),
+    ...     nu=Quantity(0.2, "kpc2"),
+    ...     phi=Quantity(90, "deg"),
+    ...     Delta=Quantity(0.5, "kpc")
+    ... )
+    >>> print(cx.represent_as(vec, cx.ProlateSpheroidalPos))
+    <ProlateSpheroidalPos...>
+
+    """
     return current
 
 
@@ -720,13 +749,29 @@ def represent_as(
 def represent_as(
     current: ProlateSpheroidalPos,
     target: type[ProlateSpheroidalPos],
-    *,
-    Delta: AbstractDistance | Quantity["length"],  # noqa: N803
+    Delta: Quantity["length"],  # noqa: N803
+    /,
     **kwargs: Any,
 ) -> ProlateSpheroidalPos:
-    """ProlateSpheroidalPos -> ProlateSpheroidalPos."""
+    """ProlateSpheroidalPos -> ProlateSpheroidalPos.
+
+    Examples
+    --------
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
+
+    >>> vec = cx.ProlateSpheroidalPos(
+    ...     mu=Quantity(1., "kpc2"),
+    ...     nu=Quantity(0.2, "kpc2"),
+    ...     phi=Quantity(90, "deg"),
+    ...     Delta=Quantity(0.5, "kpc")
+    ... )
+    >>> print(cx.represent_as(vec, cx.ProlateSpheroidalPos, Delta=Quantity(0.5, "kpc")))
+    <ProlateSpheroidalPos...>
+
+    """
     cyl = represent_as(current, CylindricalPos)
-    return represent_as(cyl, target, Delta=Delta)
+    return represent_as(cyl, target, Delta)
 
 
 # =============================================================================

--- a/src/coordinax/_src/vectors/transform/d3.py
+++ b/src/coordinax/_src/vectors/transform/d3.py
@@ -15,6 +15,7 @@ from coordinax._src.vectors.d3 import (
     CartesianPos3D,
     CylindricalPos,
     MathSphericalPos,
+    ProlateSpheroidalPos,
     SphericalPos,
 )
 from coordinax._src.vectors.exceptions import IrreversibleDimensionChange
@@ -494,3 +495,137 @@ def represent_as(
     """
     warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
     return target(r=current.r * jnp.sin(current.phi), phi=current.theta)
+
+
+# =============================================================================
+# ProlateSpheroidalPos
+
+
+# -----------------------------------------------
+# 1D
+
+
+@dispatch
+def represent_as(
+    current: ProlateSpheroidalPos, target: type[CartesianPos1D], /, **kwargs: Any
+) -> CartesianPos1D:
+    """ProlateSpheroidalPos -> CartesianPos1D.
+
+    Examples
+    --------
+    >>> import warnings
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
+
+    >>> x = cx.ProlateSpheroidalPos(
+    ...     mu=Quantity(2.0, "kpc2"),
+    ...     nu=Quantity(0.5, "kpc2"),
+    ...     phi=Quantity(0.5, "rad"),
+    ...     Delta=Quantity(1.0, "kpc"),
+    ... )
+
+    >>> with warnings.catch_warnings():
+    ...     warnings.simplefilter("ignore")
+    ...     x2 = cx.represent_as(x, cx.CartesianPos1D)
+    >>> x2
+    CartesianPos1D(x=Quantity[...](value=f32[], unit=Unit("kpc")))
+
+    """
+    warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
+    return represent_as(represent_as(current, CartesianPos3D), target)
+
+
+@dispatch
+def represent_as(
+    current: ProlateSpheroidalPos, target: type[RadialPos], /, **kwargs: Any
+) -> RadialPos:
+    """ProlateSpheroidalPos -> RadialPos.
+
+    Examples
+    --------
+    >>> import warnings
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
+
+    >>> x = cx.ProlateSpheroidalPos(
+    ...     mu=Quantity(2.0, "kpc2"),
+    ...     nu=Quantity(0.5, "kpc2"),
+    ...     phi=Quantity(0.5, "rad"),
+    ...     Delta=Quantity(1.0, "kpc"),
+    ... )
+
+    >>> with warnings.catch_warnings():
+    ...     warnings.simplefilter("ignore")
+    ...     x2 = cx.represent_as(x, cx.RadialPos)
+    >>> x2
+    RadialPos(r=Distance(value=f32[], unit=Unit("kpc")))
+
+    """
+    warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
+    return represent_as(represent_as(current, CartesianPos3D), target)
+
+
+# -----------------------------------------------
+# 2D
+
+
+@dispatch
+def represent_as(
+    current: ProlateSpheroidalPos, target: type[CartesianPos2D], /, **kwargs: Any
+) -> CartesianPos2D:
+    """ProlateSpheroidalPos -> CartesianPos2D.
+
+    Examples
+    --------
+    >>> import warnings
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
+
+    >>> x = cx.ProlateSpheroidalPos(
+    ...     mu=Quantity(2.0, "kpc2"),
+    ...     nu=Quantity(0.5, "kpc2"),
+    ...     phi=Quantity(0.5, "rad"),
+    ...     Delta=Quantity(1.0, "kpc"),
+    ... )
+
+    >>> with warnings.catch_warnings():
+    ...     warnings.simplefilter("ignore")
+    ...     x2 = cx.represent_as(x, cx.CartesianPos2D)
+    >>> x2
+    CartesianPos2D( x=Quantity[...](value=f32[], unit=Unit("kpc")),
+                       y=Quantity[...](value=f32[], unit=Unit("kpc")) )
+
+    """
+    warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
+    return represent_as(represent_as(current, CartesianPos3D), target)
+
+
+@dispatch
+def represent_as(
+    current: ProlateSpheroidalPos, target: type[PolarPos], /, **kwargs: Any
+) -> PolarPos:
+    """ProlateSpheroidalPos -> PolarPos.
+
+    Examples
+    --------
+    >>> import warnings
+    >>> from unxt import Quantity
+    >>> import coordinax as cx
+
+    >>> x = cx.ProlateSpheroidalPos(
+    ...     mu=Quantity(2.0, "kpc2"),
+    ...     nu=Quantity(0.5, "kpc2"),
+    ...     phi=Quantity(0.5, "rad"),
+    ...     Delta=Quantity(1.0, "kpc"),
+    ... )
+
+    >>> with warnings.catch_warnings():
+    ...     warnings.simplefilter("ignore")
+    ...     x2 = cx.represent_as(x, cx.PolarPos)
+    >>> x2
+    PolarPos( r=Distance(value=f32[], unit=Unit("kpc")),
+              phi=Angle(value=f32[], unit=Unit("rad")) )
+
+    """
+    warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
+    return represent_as(represent_as(current, CartesianPos3D), target)

--- a/src/coordinax/_src/vectors/transform/d3.py
+++ b/src/coordinax/_src/vectors/transform/d3.py
@@ -9,7 +9,7 @@ from plum import dispatch
 
 import quaxed.numpy as jnp
 
-from coordinax._src.vectors.d1 import CartesianPos1D, RadialPos
+from coordinax._src.vectors.d1 import AbstractPos1D, CartesianPos1D, RadialPos
 from coordinax._src.vectors.d2 import AbstractPos2D, CartesianPos2D, PolarPos
 from coordinax._src.vectors.d3 import (
     CartesianPos3D,
@@ -507,9 +507,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: ProlateSpheroidalPos, target: type[CartesianPos1D], /, **kwargs: Any
-) -> CartesianPos1D:
-    """ProlateSpheroidalPos -> CartesianPos1D.
+    current: ProlateSpheroidalPos, target: type[AbstractPos1D], /, **kwargs: Any
+) -> AbstractPos1D:
+    """ProlateSpheroidalPos -> AbstractPos1D.
 
     Examples
     --------
@@ -532,30 +532,6 @@ def represent_as(
       x=Quantity[PhysicalType('length')](value=f32[], unit=Unit("kpc"))
     )
 
-    """
-    warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
-    return represent_as(represent_as(current, CartesianPos3D), target)
-
-
-@dispatch
-def represent_as(
-    current: ProlateSpheroidalPos, target: type[RadialPos], /, **kwargs: Any
-) -> RadialPos:
-    """ProlateSpheroidalPos -> RadialPos.
-
-    Examples
-    --------
-    >>> import warnings
-    >>> from unxt import Quantity
-    >>> import coordinax as cx
-
-    >>> x = cx.ProlateSpheroidalPos(
-    ...     mu=Quantity(2.0, "kpc2"),
-    ...     nu=Quantity(0.5, "kpc2"),
-    ...     phi=Quantity(0.5, "rad"),
-    ...     Delta=Quantity(1.0, "kpc"),
-    ... )
-
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")
     ...     x2 = cx.represent_as(x, cx.RadialPos)
@@ -573,9 +549,9 @@ def represent_as(
 
 @dispatch
 def represent_as(
-    current: ProlateSpheroidalPos, target: type[CartesianPos2D], /, **kwargs: Any
-) -> CartesianPos2D:
-    """ProlateSpheroidalPos -> CartesianPos2D.
+    current: ProlateSpheroidalPos, target: type[AbstractPos2D], /, **kwargs: Any
+) -> AbstractPos2D:
+    """ProlateSpheroidalPos -> AbstractPos2D.
 
     Examples
     --------
@@ -596,30 +572,6 @@ def represent_as(
     >>> x2
     CartesianPos2D( x=Quantity[...](value=f32[], unit=Unit("kpc")),
                        y=Quantity[...](value=f32[], unit=Unit("kpc")) )
-
-    """
-    warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)
-    return represent_as(represent_as(current, CartesianPos3D), target)
-
-
-@dispatch
-def represent_as(
-    current: ProlateSpheroidalPos, target: type[PolarPos], /, **kwargs: Any
-) -> PolarPos:
-    """ProlateSpheroidalPos -> PolarPos.
-
-    Examples
-    --------
-    >>> import warnings
-    >>> from unxt import Quantity
-    >>> import coordinax as cx
-
-    >>> x = cx.ProlateSpheroidalPos(
-    ...     mu=Quantity(2.0, "kpc2"),
-    ...     nu=Quantity(0.5, "kpc2"),
-    ...     phi=Quantity(0.5, "rad"),
-    ...     Delta=Quantity(1.0, "kpc"),
-    ... )
 
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter("ignore")

--- a/src/coordinax/_src/vectors/transform/d3.py
+++ b/src/coordinax/_src/vectors/transform/d3.py
@@ -528,7 +528,9 @@ def represent_as(
     ...     warnings.simplefilter("ignore")
     ...     x2 = cx.represent_as(x, cx.CartesianPos1D)
     >>> x2
-    CartesianPos1D(x=Quantity[...](value=f32[], unit=Unit("kpc")))
+    CartesianPos1D(
+      x=Quantity[PhysicalType('length')](value=f32[], unit=Unit("kpc"))
+    )
 
     """
     warn("irreversible dimension change", IrreversibleDimensionChange, stacklevel=2)

--- a/src/coordinax/_src/vectors/transform/differentials.py
+++ b/src/coordinax/_src/vectors/transform/differentials.py
@@ -16,6 +16,7 @@ from dataclassish import field_items
 
 from coordinax._src.distance import AbstractDistance
 from coordinax._src.vectors.base import AbstractPos, AbstractVel
+from coordinax._src.vectors.base.flags import AttrFilter
 from coordinax._src.vectors.d1 import AbstractVel1D
 from coordinax._src.vectors.d2 import AbstractVel2D
 from coordinax._src.vectors.d3 import AbstractVel3D
@@ -117,7 +118,7 @@ def represent_as(
         current_pos,
         **{
             k: v.distance
-            for k, v in field_items(current_pos)
+            for k, v in field_items(AttrFilter, current_pos)
             if isinstance(v, AbstractDistance)
         },
     )
@@ -136,9 +137,9 @@ def represent_as(
     jac_rows = {
         f"d_{k}": {
             kk: u.Quantity(vv.value, unit=v.unit / vv.unit)
-            for kk, vv in field_items(v.value)
+            for kk, vv in field_items(AttrFilter, v.value)
         }
-        for k, v in field_items(jac_nested_vecs)
+        for k, v in field_items(AttrFilter, jac_nested_vecs)
     }
 
     # Now we can use the Jacobian to transform the differential.

--- a/src/coordinax/_src/vectors/transform/differentials.py
+++ b/src/coordinax/_src/vectors/transform/differentials.py
@@ -3,6 +3,7 @@
 __all__: list[str] = []
 
 from dataclasses import replace
+from functools import partial
 from math import prod
 from typing import Any
 
@@ -129,6 +130,8 @@ def represent_as(
     # the correct numerator unit (of the Jacobian row). The value is a Vector of the
     # original type, with fields that are the columns of that row, but with only the
     # denomicator's units.
+    tmp = partial(represent_as, **kwargs)
+    jac_rep_as = eqx.filter_jit(jax.vmap(jax.jacfwd(tmp), in_axes=(0, None)))
     jac_nested_vecs = jac_rep_as(current_pos, target.integral_cls)
 
     # This changes the Jacobian to be a dictionary of each row, with the value
@@ -162,7 +165,3 @@ def represent_as(
     # TODO: add  df(q)/dt, which is 0 for all current transforms
 
     return newvec  # noqa: RET504
-
-
-# TODO: situate this better to show how represent_as is used
-jac_rep_as = eqx.filter_jit(jax.vmap(jax.jacfwd(represent_as), in_axes=(0, None)))

--- a/src/coordinax/_src/vectors/utils.py
+++ b/src/coordinax/_src/vectors/utils.py
@@ -30,5 +30,7 @@ def full_shaped(obj: "AbstractVector", /) -> "AbstractVector":
     (2,)
 
     """
-    arrays = jnp.broadcast_arrays(*field_values(obj))
+    from .base import AttrFilter
+
+    arrays = jnp.broadcast_arrays(*field_values(AttrFilter, obj))
     return _dataclass_replace(obj, **dict(zip(obj.components, arrays, strict=True)))

--- a/src/coordinax/_src/vectors/utils.py
+++ b/src/coordinax/_src/vectors/utils.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 import quaxed.numpy as jnp
 from dataclassish import field_values
 
+from .base.flags import AttrFilter
+
 if TYPE_CHECKING:
     from coordinax import AbstractVector
 
@@ -30,7 +32,5 @@ def full_shaped(obj: "AbstractVector", /) -> "AbstractVector":
     (2,)
 
     """
-    from .base import AttrFilter
-
     arrays = jnp.broadcast_arrays(*field_values(AttrFilter, obj))
     return _dataclass_replace(obj, **dict(zip(obj.components, arrays, strict=True)))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -171,7 +171,7 @@ class AbstractPosTest(AbstractVectorTest):
     def test_represent_as(self, vector, target):
         """Test :meth:`AbstractPos.represent_as`.
 
-        This just tests that the machiner works.
+        This just tests that the machinery works.
         """
         # Perform the conversion.
         # Detecting whether the conversion reduces the dimensionality.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -88,7 +88,10 @@ class AbstractVectorTest:
         # Test an explicitly shaped vector
         vec = replace(
             vector,
-            **{k: replace(v, value=jnp.ones((2, 4))) for k, v in field_items(vector)},
+            **{
+                k: replace(v, value=jnp.ones((2, 4)))
+                for k, v in field_items(cx.AttrFilter, vector)
+            },
         )
         flat = vec.flatten()
         assert isinstance(flat, type(vec))
@@ -109,7 +112,10 @@ class AbstractVectorTest:
         # Test an explicitly shaped vector
         vec = replace(
             vector,
-            **{k: replace(v, value=jnp.ones((2, 4))) for k, v in field_items(vector)},
+            **{
+                k: replace(v, value=jnp.ones((2, 4)))
+                for k, v in field_items(cx.AttrFilter, vector)
+            },
         )
         reshaped = vec.reshape(1, 8)
         assert isinstance(reshaped, type(vec))

--- a/tests/test_d3.py
+++ b/tests/test_d3.py
@@ -493,10 +493,10 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
     def vector(self) -> cx.AbstractPos:
         """Return a vector."""
         return cx.ProlateSpheroidalPos(
-            mu=Quantity([1, 2, 3, 4], "kpc2"),
-            nu=Quantity([0.1, 0.2, 0.3, 0.4], "kpc2"),
-            phi=Quantity([0, 1, 2, 3], "rad"),
-            Delta=Quantity(1.0, "kpc"),
+            mu=u.Quantity([1, 2, 3, 4], "kpc2"),
+            nu=u.Quantity([0.1, 0.2, 0.3, 0.4], "kpc2"),
+            phi=u.Quantity([0, 1, 2, 3], "rad"),
+            Delta=u.Quantity(1.0, "kpc"),
         )
 
     @pytest.mark.skip("No astropy equivalent")
@@ -557,13 +557,13 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
 
         assert isinstance(cart3d, cx.CartesianPos3D)
         assert jnp.array_equal(
-            cart3d.x, Quantity([0.0, 0.48326105, -0.4923916, -1.3282144], "kpc")
+            cart3d.x, u.Quantity([0.0, 0.48326105, -0.4923916, -1.3282144], "kpc")
         )
         assert jnp.array_equal(
-            cart3d.y, Quantity([0.0, 0.75263447, 1.0758952, 0.18933235], "kpc")
+            cart3d.y, u.Quantity([0.0, 0.75263447, 1.0758952, 0.18933235], "kpc")
         )
         assert jnp.array_equal(
-            cart3d.z, Quantity([0.31622776, 0.6324555, 0.9486833, 1.264911], "kpc")
+            cart3d.z, u.Quantity([0.31622776, 0.6324555, 0.9486833, 1.264911], "kpc")
         )
 
     def test_prolatespheroidal_to_cylindrical(self, vector):
@@ -572,11 +572,11 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
 
         assert isinstance(cyl, cx.CylindricalPos)
         assert jnp.array_equal(
-            cyl.rho, Quantity([0.0, 0.8944272, 1.183216, 1.3416408], "kpc")
+            cyl.rho, u.Quantity([0.0, 0.8944272, 1.183216, 1.3416408], "kpc")
         )
         assert jnp.array_equal(cyl.phi, vector.phi)
         assert jnp.array_equal(
-            cyl.z, Quantity([0.31622776, 0.6324555, 0.9486833, 1.264911], "kpc")
+            cyl.z, u.Quantity([0.31622776, 0.6324555, 0.9486833, 1.264911], "kpc")
         )
 
     def test_prolatespheroidal_to_spherical(self, vector):
@@ -585,11 +585,11 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
 
         assert isinstance(spherical, cx.SphericalPos)
         assert jnp.array_equal(
-            spherical.r, Quantity([0.31622776, 1.095445, 1.5165751, 1.8439089], "kpc")
+            spherical.r, u.Quantity([0.31622776, 1.095445, 1.5165751, 1.8439089], "kpc")
         )
         assert jnp.array_equal(spherical.phi, vector.phi)
         assert jnp.array_equal(
-            spherical.theta, Quantity([0.0, 0.95531654, 0.89496875, 0.8148269], "rad")
+            spherical.theta, u.Quantity([0.0, 0.95531654, 0.89496875, 0.8148269], "rad")
         )
 
     def test_prolatespheroidal_to_prolatespheroidal(self, vector):
@@ -602,7 +602,7 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
 
         # With a different focal length, should not be the same:
         newvec = vector.represent_as(
-            cx.ProlateSpheroidalPos, Delta=Quantity(0.7, "kpc")
+            cx.ProlateSpheroidalPos, Delta=u.Quantity(0.7, "kpc")
         )
         # assert not jnp.array_equal(newvec.mu, vector.mu)
         assert not jnp.array_equal(newvec.nu, vector.nu)

--- a/tests/test_d3.py
+++ b/tests/test_d3.py
@@ -593,8 +593,10 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
             spherical.r, u.Quantity([0.31622776, 1.095445, 1.5165751, 1.8439089], "kpc")
         )
         assert jnp.allclose(spherical.phi, vector.phi, atol=u.Quantity(1e-8, "rad"))
-        assert jnp.array_equal(
-            spherical.theta, u.Quantity([0.0, 0.95531654, 0.89496875, 0.8148269], "rad")
+        assert jnp.allclose(
+            spherical.theta,
+            u.Quantity([0.0, 0.95531654, 0.89496875, 0.8148269], "rad"),
+            atol=u.Quantity(1e-8, "rad"),
         )
 
     def test_prolatespheroidal_to_prolatespheroidal(self, vector):

--- a/tests/test_d3.py
+++ b/tests/test_d3.py
@@ -552,7 +552,7 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
         assert jnp.array_equal(
             polar.r, u.Quantity([0.0, 0.8944271, 1.183216, 1.3416408], "kpc")
         )
-        assert jnp.array_equal(polar.phi, u.Quantity([0, 1, 2, 3], "rad"))
+        assert jnp.allclose(polar.phi.value, jnp.array([0, 1, 2, 3]))
 
     def test_prolatespheroidal_to_cartesian3d(self, vector):
         """Test ``coordinax.represent_as(CartesianPos3D)``."""

--- a/tests/test_d3.py
+++ b/tests/test_d3.py
@@ -552,7 +552,9 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
         assert jnp.array_equal(
             polar.r, u.Quantity([0.0, 0.8944271, 1.183216, 1.3416408], "kpc")
         )
-        assert jnp.allclose(polar.phi.value, jnp.array([0, 1, 2, 3]))
+        assert jnp.allclose(
+            polar.phi, u.Quantity([0, 1, 2, 3], "rad"), atol=u.Quantity(1e-8, "rad")
+        )
 
     def test_prolatespheroidal_to_cartesian3d(self, vector):
         """Test ``coordinax.represent_as(CartesianPos3D)``."""
@@ -590,7 +592,7 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
         assert jnp.array_equal(
             spherical.r, u.Quantity([0.31622776, 1.095445, 1.5165751, 1.8439089], "kpc")
         )
-        assert jnp.array_equal(spherical.phi, vector.phi)
+        assert jnp.allclose(spherical.phi, vector.phi, atol=u.Quantity(1e-8, "rad"))
         assert jnp.array_equal(
             spherical.theta, u.Quantity([0.0, 0.95531654, 0.89496875, 0.8148269], "rad")
         )

--- a/tests/test_d3.py
+++ b/tests/test_d3.py
@@ -509,7 +509,7 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
     # represent_as
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
-    def test_cylindrical_to_cartesian1d(self, vector):
+    def test_prolatespheroidal_to_cartesian1d(self, vector):
         """Test ``coordinax.represent_as(CartesianPos1D)``."""
         cart1d = vector.represent_as(cx.CartesianPos1D)
 
@@ -521,7 +521,7 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
         )
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
-    def test_cylindrical_to_radial(self, vector):
+    def test_prolatespheroidal_to_radial(self, vector):
         """Test ``coordinax.represent_as(RadialPos)``."""
         radial = vector.represent_as(cx.RadialPos)
 
@@ -531,7 +531,7 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
         )
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
-    def test_cylindrical_to_cartesian2d(self, vector):
+    def test_prolatespheroidal_to_cartesian2d(self, vector):
         """Test ``coordinax.represent_as(CartesianPos2D)``."""
         cart2d = vector.represent_as(cx.CartesianPos2D)
 
@@ -544,7 +544,7 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
         )
 
     @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
-    def test_cylindrical_to_polar(self, vector):
+    def test_prolatespheroidal_to_polar(self, vector):
         """Test ``coordinax.represent_as(PolarPos)``."""
         polar = vector.represent_as(cx.PolarPos)
 
@@ -598,20 +598,23 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
     def test_prolatespheroidal_to_prolatespheroidal(self, vector):
         """Test ``coordinax.represent_as(ProlateSpheroidalPos)``."""
         # Jit can copy
-        newvec = vector.represent_as(cx.ProlateSpheroidalPos, vector.Delta)
+        newvec = vector.represent_as(cx.ProlateSpheroidalPos, Delta=vector.Delta)
         assert jnp.allclose(newvec.mu.value, vector.mu.value)
         assert jnp.allclose(newvec.nu.value, vector.nu.value)
         assert jnp.array_equal(newvec.phi, vector.phi)
 
         # With a different focal length, should not be the same:
-        newvec = vector.represent_as(cx.ProlateSpheroidalPos, u.Quantity(0.5, "kpc"))
+        newvec = vector.represent_as(
+            cx.ProlateSpheroidalPos, Delta=u.Quantity(0.5, "kpc")
+        )
         assert not jnp.allclose(newvec.mu.value, vector.mu.value)
         assert not jnp.allclose(newvec.nu.value, vector.nu.value)
         assert jnp.array_equal(newvec.phi, vector.phi)
 
         # The normal `represent_as` method should return the same object
         newvec = cx.represent_as(vector, cx.ProlateSpheroidalPos)
-        assert newvec is vector
+        # TODO: re-enable when equality is fixed for array-valued vectors
+        # assert newvec == vector
 
 
 class AbstractVel3DTest(AbstractVelTest):

--- a/tests/test_d3.py
+++ b/tests/test_d3.py
@@ -598,25 +598,20 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
     def test_prolatespheroidal_to_prolatespheroidal(self, vector):
         """Test ``coordinax.represent_as(ProlateSpheroidalPos)``."""
         # Jit can copy
-        newvec = vector.represent_as(cx.ProlateSpheroidalPos, Delta=vector.Delta)
-        assert jnp.array_equal(newvec.mu, vector.mu)
+        newvec = vector.represent_as(cx.ProlateSpheroidalPos, vector.Delta)
+        assert jnp.allclose(newvec.mu.value, vector.mu.value)
         assert jnp.allclose(newvec.nu.value, vector.nu.value)
         assert jnp.array_equal(newvec.phi, vector.phi)
 
         # With a different focal length, should not be the same:
-        newvec = vector.represent_as(
-            cx.ProlateSpheroidalPos, Delta=u.Quantity(0.7, "kpc")
-        )
-        # assert not jnp.array_equal(newvec.mu, vector.mu)
-        assert not jnp.array_equal(newvec.nu, vector.nu)
-        # assert not jnp.array_equal(newvec.phi, vector.phi)
+        newvec = vector.represent_as(cx.ProlateSpheroidalPos, u.Quantity(0.5, "kpc"))
+        assert not jnp.allclose(newvec.mu.value, vector.mu.value)
+        assert not jnp.allclose(newvec.nu.value, vector.nu.value)
+        assert jnp.array_equal(newvec.phi, vector.phi)
 
         # The normal `represent_as` method should return the same object
-        # TODO: this fails because (I think) the output gets wrapped in a call of the
-        # initializer cx.ProlateSpheroidalPos(...), which then does not have the
-        # Delta=... argument
-        # newvec = cx.represent_as(vector, cx.ProlateSpheroidalPos)
-        # assert newvec is vector
+        newvec = cx.represent_as(vector, cx.ProlateSpheroidalPos)
+        assert newvec is vector
 
 
 class AbstractVel3DTest(AbstractVelTest):

--- a/tests/test_d3.py
+++ b/tests/test_d3.py
@@ -508,48 +508,51 @@ class TestProlateSpheroidalPos(AbstractPos3DTest):
     # ==========================================================================
     # represent_as
 
-    # TODO: do we enable these for ProlateSpheroidal?
-    # @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
-    # def test_cylindrical_to_cartesian1d(self, vector):
-    #     """Test ``coordinax.represent_as(CartesianPos1D)``."""
-    #     cart1d = vector.represent_as(cx.CartesianPos1D)
+    @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
+    def test_cylindrical_to_cartesian1d(self, vector):
+        """Test ``coordinax.represent_as(CartesianPos1D)``."""
+        cart1d = vector.represent_as(cx.CartesianPos1D)
 
-    #     assert isinstance(cart1d, cx.CartesianPos1D)
-    #     assert jnp.allclose(
-    #         cart1d.x,
-    #         Quantity([1.0, 1.0806047, -1.2484405, -3.95997], "kpc"),
-    #         atol=Quantity(1e-8, "kpc"),
-    #     )
+        assert isinstance(cart1d, cx.CartesianPos1D)
+        assert jnp.allclose(
+            cart1d.x,
+            u.Quantity([0.0, 0.48326105, -0.4923916, -1.3282144], "kpc"),
+            atol=u.Quantity(1e-8, "kpc"),
+        )
 
-    # @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
-    # def test_cylindrical_to_radial(self, vector):
-    #     """Test ``coordinax.represent_as(RadialPos)``."""
-    #     radial = vector.represent_as(cx.RadialPos)
+    @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
+    def test_cylindrical_to_radial(self, vector):
+        """Test ``coordinax.represent_as(RadialPos)``."""
+        radial = vector.represent_as(cx.RadialPos)
 
-    #     assert isinstance(radial, cx.RadialPos)
-    #     assert jnp.array_equal(radial.r, Quantity([1, 2, 3, 4], "kpc"))
+        assert isinstance(radial, cx.RadialPos)
+        assert jnp.array_equal(
+            radial.r, u.Quantity([0.31622776, 1.095445, 1.5165751, 1.8439089], "kpc")
+        )
 
-    # @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
-    # def test_cylindrical_to_cartesian2d(self, vector):
-    #     """Test ``coordinax.represent_as(CartesianPos2D)``."""
-    #     cart2d = vector.represent_as(cx.CartesianPos2D)
+    @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
+    def test_cylindrical_to_cartesian2d(self, vector):
+        """Test ``coordinax.represent_as(CartesianPos2D)``."""
+        cart2d = vector.represent_as(cx.CartesianPos2D)
 
-    #     assert isinstance(cart2d, cx.CartesianPos2D)
-    #     assert jnp.array_equal(
-    #         cart2d.x, Quantity([1.0, 1.0806046, -1.2484405, -3.95997], "kpc")
-    #     )
-    #     assert jnp.array_equal(
-    #         cart2d.y, Quantity([0.0, 1.6829419, 2.7278922, 0.56448], "kpc")
-    #     )
+        assert isinstance(cart2d, cx.CartesianPos2D)
+        assert jnp.array_equal(
+            cart2d.x, u.Quantity([0.0, 0.48326105, -0.4923916, -1.3282144], "kpc")
+        )
+        assert jnp.array_equal(
+            cart2d.y, u.Quantity([0.0, 0.75263447, 1.0758952, 0.18933235], "kpc")
+        )
 
-    # @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
-    # def test_cylindrical_to_polar(self, vector):
-    #     """Test ``coordinax.represent_as(PolarPos)``."""
-    #     polar = vector.represent_as(cx.PolarPos)
+    @pytest.mark.filterwarnings("ignore:Irreversible dimension change")
+    def test_cylindrical_to_polar(self, vector):
+        """Test ``coordinax.represent_as(PolarPos)``."""
+        polar = vector.represent_as(cx.PolarPos)
 
-    #     assert isinstance(polar, cx.PolarPos)
-    #     assert jnp.array_equal(polar.r, Quantity([1, 2, 3, 4], "kpc"))
-    #     assert jnp.array_equal(polar.phi, Quantity([0, 1, 2, 3], "rad"))
+        assert isinstance(polar, cx.PolarPos)
+        assert jnp.array_equal(
+            polar.r, u.Quantity([0.0, 0.8944271, 1.183216, 1.3416408], "kpc")
+        )
+        assert jnp.array_equal(polar.phi, u.Quantity([0, 1, 2, 3], "rad"))
 
     def test_prolatespheroidal_to_cartesian3d(self, vector):
         """Test ``coordinax.represent_as(CartesianPos3D)``."""

--- a/tests/test_jax_ops.py
+++ b/tests/test_jax_ops.py
@@ -4,7 +4,7 @@ import equinox as eqx
 import pytest
 
 from dataclassish import field_items
-from unxt.quantity import AbstractQuantity
+from unxt.quantity import AbstractQuantity, Quantity
 
 import coordinax as cx
 from coordinax._src.vectors.base.base_pos import POSITION_CLASSES
@@ -17,12 +17,23 @@ POSITION_CLASSES_3D = [c for c in POSITION_CLASSES if issubclass(c, cx.AbstractP
 def q(request) -> cx.AbstractPos:
     """Fixture for 3D Vectors."""
     q = cx.CartesianPos3D.from_([1, 2, 3], "kpc")
-    return q.represent_as(request.param)
+
+    # Special case ProlateSpheroidalPos, which requires a value of Delta to define the
+    # coordinate system
+    args = (
+        () if request.param is not cx.ProlateSpheroidalPos else (Quantity(1.0, "kpc"),)
+    )
+
+    return q.represent_as(request.param, *args)
 
 
 @eqx.filter_jit
 def func(q: cx.AbstractPos, target: type[cx.AbstractPos]) -> cx.AbstractPos:
-    return q.represent_as(target)
+    # Special case ProlateSpheroidalPos, which requires a value of Delta to define the
+    # coordinate system
+    args = () if target is not cx.ProlateSpheroidalPos else (Quantity(1.0, "kpc"),)
+
+    return q.represent_as(target, *args)
 
 
 @pytest.mark.parametrize("target", POSITION_CLASSES_3D)

--- a/tests/test_jax_ops.py
+++ b/tests/test_jax_ops.py
@@ -20,20 +20,24 @@ def q(request) -> cx.AbstractPos:
 
     # Special case ProlateSpheroidalPos, which requires a value of Delta to define the
     # coordinate system
-    args = (
-        () if request.param is not cx.ProlateSpheroidalPos else (Quantity(1.0, "kpc"),)
+    kwargs = (
+        {}
+        if request.param is not cx.ProlateSpheroidalPos
+        else {"Delta": Quantity(1.0, "kpc")}
     )
 
-    return q.represent_as(request.param, *args)
+    return q.represent_as(request.param, **kwargs)
 
 
 @eqx.filter_jit
 def func(q: cx.AbstractPos, target: type[cx.AbstractPos]) -> cx.AbstractPos:
     # Special case ProlateSpheroidalPos, which requires a value of Delta to define the
     # coordinate system
-    args = () if target is not cx.ProlateSpheroidalPos else (Quantity(1.0, "kpc"),)
+    kwargs = (
+        {} if target is not cx.ProlateSpheroidalPos else {"Delta": Quantity(1.0, "kpc")}
+    )
 
-    return q.represent_as(target, *args)
+    return q.represent_as(target, **kwargs)
 
 
 @pytest.mark.parametrize("target", POSITION_CLASSES_3D)


### PR DESCRIPTION
I'm gearing up to add the Staeckel Fudge to Galax, so it would be useful to have a representation of prolate spheroidal coordinates. Transformations to this coordinate system need to specify [a focal length parameter](https://en.wikipedia.org/wiki/Prolate_spheroidal_coordinates), `Delta`, so it's a bit different from other d3 representations. Thoughts on this approach?