### PR TITLE
✨ feat(vecs): rename time-derivative field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ p = cx.CartesianVel3D(
     d_z=u.Quantity(jnp.arange(10, 20.0), "m/s"),
 )
 print(p)
-# <CartesianVel3D (d_x[m / s], d_y[m / s], d_z[m / s])
+# <CartesianVel3D (x[m / s], y[m / s], z[m / s])
 #     [[ 0.  5. 10.]
 #      [ 1.  6. 11.]
 #      ...
@@ -85,7 +85,7 @@ print(p)
 
 p2 = cx.vconvert(cx.SphericalVel, p, q)
 print(p2)
-# <SphericalVel (d_r[m / s], d_theta[m rad / (km s)], d_phi[m rad / (km s)])
+# <SphericalVel (r[m / s], theta[m rad / (km s)], phi[m rad / (km s)])
 #     [[ 1.118e+01 -3.886e-16  0.000e+00]
 #      [ 1.257e+01 -1.110e-16  0.000e+00]
 #      ...

--- a/src/coordinax/_coordinax_space_frames/frame_transforms.py
+++ b/src/coordinax/_coordinax_space_frames/frame_transforms.py
@@ -160,7 +160,7 @@ def frame_transform_op(from_frame: ICRS, to_frame: Galactocentric, /) -> Pipe:
     <CartesianPos3D (x[pc], y[pc], z[pc])
         [-8112.898    21.799    29.01...]>
     >>> print(vega_gcf_p.uconvert({u.dimension("speed"): "km/s"}))
-    <CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
+    <CartesianVel3D (x[km / s], y[km / s], z[km / s])
         [ 34.067 234.616 -28.76 ]>
 
     It matches!
@@ -185,7 +185,7 @@ def frame_transform_op(from_frame: ICRS, to_frame: Galactocentric, /) -> Pipe:
     >>> print(newq, newp, sep="\n")
     <CartesianPos3D (x[pc], y[pc], z[pc])
         [-8121.972     0.       20.8  ]>
-    <CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
+    <CartesianVel3D (x[km / s], y[km / s], z[km / s])
         [ 12.9  245.6    7.78]>
 
     """  # noqa: E501
@@ -281,7 +281,7 @@ def frame_transform_op(from_frame: Galactocentric, to_frame: ICRS, /) -> Pipe:
     <LonLatSphericalPos (lon[deg], lat[deg], distance[pc])
         [279.235  38.784  25.   ]>
     >>> print(vega_icrs_p.uconvert({u.dimension("angular speed"): "mas / yr", u.dimension("speed"): "km/s"}))
-    <LonCosLatSphericalVel (d_lon_coslat[mas / yr], d_lat[mas / yr], d_distance[km / s])
+    <LonCosLatSphericalVel (lon_coslat[mas / yr], lat[mas / yr], distance[km / s])
         [ 200.001 -286.  -13.9  ]>
 
     It matches!
@@ -306,7 +306,7 @@ def frame_transform_op(from_frame: Galactocentric, to_frame: ICRS, /) -> Pipe:
     >>> print(newq, newp, sep="\n")
     <CartesianPos3D (x[pc], y[pc], z[pc])
         [ -445.689 -7094.056 -3929.708]>
-    <CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
+    <CartesianVel3D (x[km / s], y[km / s], z[km / s])
         [-113.868  122.047 -180.79 ]>
 
     """  # noqa: E501

--- a/src/coordinax/_interop/coordinax_interop_astropy/constructors.py
+++ b/src/coordinax/_interop/coordinax_interop_astropy/constructors.py
@@ -28,8 +28,9 @@ def vector(obj: apyc.CartesianRepresentation, /) -> cx.CartesianPos3D:
 
     >>> cart = CartesianRepresentation(1, 2, 3, unit="m")
     >>> vec = cx.vector(cart)
-    >>> vec.x
-    Quantity['length'](Array(1., dtype=float32), unit='m')
+    >>> print(vec)
+    <CartesianPos3D (x[m], y[m], z[m])
+        [1. 2. 3.]>
 
     """
     return vector(cx.vecs.CartesianPos3D, obj)
@@ -50,8 +51,9 @@ def vector(obj: apyc.CylindricalRepresentation, /) -> cx.vecs.CylindricalPos:
     >>> cyl = CylindricalRepresentation(rho=1 * u.km, phi=2 * u.deg,
     ...                                 z=30 * u.m)
     >>> vec = cx.vector(cyl)
-    >>> vec.rho
-    Quantity['length'](Array(1., dtype=float32), unit='km')
+    >>> print(vec)
+    <CylindricalPos (rho[km], phi[deg], z[m])
+        [ 1.  2. 30.]>
 
     """
     return vector(cx.vecs.CylindricalPos, obj)
@@ -72,8 +74,9 @@ def vector(obj: apyc.PhysicsSphericalRepresentation, /) -> cx.SphericalPos:
     >>> sph = PhysicsSphericalRepresentation(r=1 * u.km, theta=2 * u.deg,
     ...                                      phi=3 * u.deg)
     >>> vec = cx.vector(sph)
-    >>> vec.r
-    Distance(Array(1., dtype=float32), unit='km')
+    >>> print(vec)
+    <SphericalPos (r[km], theta[deg], phi[deg])
+        [1. 2. 3.]>
 
     """
     return vector(cx.SphericalPos, obj)
@@ -94,8 +97,9 @@ def vector(obj: apyc.SphericalRepresentation, /) -> cx.vecs.LonLatSphericalPos:
     >>> sph = SphericalRepresentation(lon=3 * u.deg, lat=2 * u.deg,
     ...                               distance=1 * u.km)
     >>> vec = cx.vector(sph)
-    >>> vec.distance
-    Distance(Array(1., dtype=float32), unit='km')
+    >>> print(vec)
+    <LonLatSphericalPos (lon[deg], lat[deg], distance[km])
+        [3. 2. 1.]>
 
     """
     return vector(cx.vecs.LonLatSphericalPos, obj)
@@ -115,8 +119,9 @@ def vector(obj: apyc.UnitSphericalRepresentation) -> cx.vecs.TwoSpherePos:
 
     >>> sph = UnitSphericalRepresentation(lon=3 * u.deg, lat=2 * u.deg)
     >>> vec = cx.vector(sph)
-    >>> vec.theta
-    Angle(Array(2., dtype=float32), unit='deg')
+    >>> print(vec)
+    <TwoSpherePos (theta[deg], phi[deg])
+        [2. 3.]>
 
     """
     return vector(cx.vecs.TwoSpherePos, obj)
@@ -136,8 +141,9 @@ def vector(obj: apyc.CartesianDifferential, /) -> cx.CartesianVel3D:
 
     >>> dcart = CartesianDifferential(1, 2, 3, unit="km/s")
     >>> dif = cx.vector(dcart)
-    >>> dif.d_x
-    Quantity['speed'](Array(1., dtype=float32), unit='km / s')
+    >>> print(vec)
+    <TwoSpherePos (theta[deg], phi[deg])
+        [2. 3.]>
 
     """
     return vector(cx.CartesianVel3D, obj)
@@ -158,8 +164,9 @@ def vector(obj: apyc.CylindricalDifferential, /) -> cx.vecs.CylindricalVel:
     >>> dcyl = apyc.CylindricalDifferential(d_rho=1 * u.km / u.s, d_phi=2 * u.mas/u.yr,
     ...                                     d_z=2 * u.km / u.s)
     >>> dif = cx.vector(dcyl)
-    >>> dif.d_rho
-    Quantity['speed'](Array(1., dtype=float32), unit='km / s')
+    >>> print(vec)
+    <TwoSpherePos (theta[deg], phi[deg])
+        [2. 3.]>
 
     """
     return vector(cx.vecs.CylindricalVel, obj)
@@ -180,8 +187,9 @@ def vector(obj: apyc.PhysicsSphericalDifferential, /) -> cx.SphericalVel:
     >>> dsph = PhysicsSphericalDifferential(d_r=1 * u.km / u.s, d_theta=2 * u.mas/u.yr,
     ...                                     d_phi=3 * u.mas/u.yr)
     >>> dif = cx.vector(dsph)
-    >>> dif.d_r
-    Quantity['speed'](Array(1., dtype=float32), unit='km / s')
+    >>> print(vec)
+    <TwoSpherePos (theta[deg], phi[deg])
+        [2. 3.]>
 
     """
     return vector(cx.SphericalVel, obj)
@@ -203,8 +211,9 @@ def vector(obj: apyc.SphericalDifferential, /) -> cx.vecs.LonLatSphericalVel:
     ...                              d_lon=2 * u.mas/u.yr,
     ...                              d_lat=3 * u.mas/u.yr)
     >>> dif = cx.vector(dsph)
-    >>> dif.d_distance
-    Quantity['speed'](Array(1., dtype=float32), unit='km / s')
+    >>> print(vec)
+    <TwoSpherePos (theta[deg], phi[deg])
+        [2. 3.]>
 
     """
     return vector(cx.vecs.LonLatSphericalVel, obj)
@@ -226,14 +235,9 @@ def vector(obj: apyc.SphericalCosLatDifferential, /) -> cx.vecs.LonCosLatSpheric
     ...                                    d_lon_coslat=2 * u.mas/u.yr,
     ...                                    d_lat=3 * u.mas/u.yr)
     >>> dif = cx.vector(dsph)
-    >>> dif
-    LonCosLatSphericalVel(
-      d_lon_coslat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
-      d_lat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
-      d_distance=Quantity[...]( value=f32[], unit=Unit("km / s") )
-    )
-    >>> dif.d_distance
-    Quantity['speed'](Array(1., dtype=float32), unit='km / s')
+    >>> print(dif)
+    <LonCosLatSphericalVel (lon_coslat[mas / yr], lat[mas / yr], distance[km / s])
+        [2. 3. 1.]>
 
     """
     return vector(cx.vecs.LonCosLatSphericalVel, obj)
@@ -253,8 +257,9 @@ def vector(obj: apyc.UnitSphericalDifferential) -> cx.vecs.TwoSphereVel:
 
     >>> dsph = UnitSphericalDifferential(d_lon=3 * u.deg/u.s, d_lat=2 * u.deg/u.s)
     >>> vel = cx.vector(dsph)
-    >>> vel.d_phi
-    Quantity[...](Array(3., dtype=float32), unit='deg / s')
+    >>> print(vel)
+    <TwoSphereVel (theta[deg / s], phi[deg / s])
+        [2. 3.]>
 
     """
     return vector(cx.vecs.TwoSphereVel, obj)
@@ -277,8 +282,9 @@ def vector(
 
     >>> cart = CartesianRepresentation(1, 2, 3, unit="km")
     >>> vec = cx.CartesianPos3D.from_(cart)
-    >>> vec.x
-    Quantity['length'](Array(1., dtype=float32), unit='km')
+    >>> print(vec)
+    <CartesianPos3D (x[km], y[km], z[km])
+        [1. 2. 3.]>
 
     """
     obj = obj.represent_as(apyc.CartesianRepresentation)
@@ -300,8 +306,9 @@ def vector(
     >>> cyl = CylindricalRepresentation(rho=1 * u.km, phi=2 * u.deg,
     ...                                 z=30 * u.m)
     >>> vec = cx.vecs.CylindricalPos.from_(cyl)
-    >>> vec.rho
-    Quantity['length'](Array(1., dtype=float32), unit='km')
+    >>> print(vec)
+    <CylindricalPos (rho[km], phi[deg], z[m])
+        [ 1.  2. 30.]>
 
     """
     obj = obj.represent_as(apyc.CylindricalRepresentation)
@@ -323,8 +330,9 @@ def vector(
     >>> sph = PhysicsSphericalRepresentation(r=1 * u.km, theta=2 * u.deg,
     ...                                      phi=3 * u.deg)
     >>> vec = cx.SphericalPos.from_(sph)
-    >>> vec.r
-    Distance(Array(1., dtype=float32), unit='km')
+    >>> print(vec)
+    <SphericalPos (r[km], theta[deg], phi[deg])
+        [1. 2. 3.]>
 
     """
     obj = obj.represent_as(apyc.PhysicsSphericalRepresentation)
@@ -346,8 +354,9 @@ def vector(
     >>> sph = SphericalRepresentation(lon=3 * u.deg, lat=2 * u.deg,
     ...                               distance=1 * u.km)
     >>> vec = cx.vecs.LonLatSphericalPos.from_(sph)
-    >>> vec.distance
-    Distance(Array(1., dtype=float32), unit='km')
+    >>> print(vec)
+    <LonLatSphericalPos (lon[deg], lat[deg], distance[km])
+        [3. 2. 1.]>
 
     """
     obj = obj.represent_as(apyc.SphericalRepresentation)
@@ -368,8 +377,9 @@ def vector(
 
     >>> sph = UnitSphericalRepresentation(lon=3 * u.deg, lat=2 * u.deg)
     >>> vec = cx.vecs.TwoSpherePos.from_(sph)
-    >>> vec.theta
-    Angle(Array(2., dtype=float32), unit='deg')
+    >>> print(vec)
+    <TwoSpherePos (theta[deg], phi[deg])
+        [2. 3.]>
 
     """
     obj = obj.represent_as(apyc.UnitSphericalRepresentation)
@@ -390,11 +400,12 @@ def vector(
 
     >>> dcart = CartesianDifferential(1, 2, 3, unit="km/s")
     >>> dif = cx.CartesianVel3D.from_(dcart)
-    >>> dif.d_x
-    Quantity['speed'](Array(1., dtype=float32), unit='km / s')
+    >>> print(vec)
+    <TwoSpherePos (theta[deg], phi[deg])
+        [2. 3.]>
 
     """
-    return cls(d_x=obj.d_x, d_y=obj.d_y, d_z=obj.d_z)
+    return cls(x=obj.d_x, y=obj.d_y, z=obj.d_z)
 
 
 @dispatch
@@ -411,12 +422,13 @@ def vector(
 
     >>> dcyl = apyc.CylindricalDifferential(d_rho=1 * u.km / u.s, d_phi=2 * u.mas/u.yr,
     ...                                     d_z=2 * u.km / u.s)
-    >>> dif = cx.vecs.CylindricalVel.from_(dcyl)
-    >>> dif.d_rho
-    Quantity['speed'](Array(1., dtype=float32), unit='km / s')
+    >>> vec = cx.vecs.CylindricalVel.from_(dcyl)
+    >>> print(vec)
+    <CylindricalVel (rho[km / s], phi[mas / yr], z[km / s])
+        [1. 2. 2.]>
 
     """
-    return cls(d_rho=obj.d_rho, d_phi=obj.d_phi, d_z=obj.d_z)
+    return cls(rho=obj.d_rho, phi=obj.d_phi, z=obj.d_z)
 
 
 @dispatch
@@ -433,12 +445,13 @@ def vector(
 
     >>> dsph = PhysicsSphericalDifferential(d_r=1 * u.km / u.s, d_theta=2 * u.mas/u.yr,
     ...                                     d_phi=3 * u.mas/u.yr)
-    >>> dif = cx.SphericalVel.from_(dsph)
-    >>> dif.d_r
-    Quantity['speed'](Array(1., dtype=float32), unit='km / s')
+    >>> vec = cx.SphericalVel.from_(dsph)
+    >>> print(vec)
+    <SphericalVel (r[km / s], theta[mas / yr], phi[mas / yr])
+        [1. 2. 3.]>
 
     """
-    return cls(d_r=obj.d_r, d_phi=obj.d_phi, d_theta=obj.d_theta)
+    return cls(r=obj.d_r, phi=obj.d_phi, theta=obj.d_theta)
 
 
 @dispatch
@@ -456,12 +469,13 @@ def vector(
     >>> dsph = SphericalDifferential(d_distance=1 * u.km / u.s,
     ...                              d_lon=2 * u.mas/u.yr,
     ...                              d_lat=3 * u.mas/u.yr)
-    >>> dif = cx.vecs.LonLatSphericalVel.from_(dsph)
-    >>> dif.d_distance
-    Quantity['speed'](Array(1., dtype=float32), unit='km / s')
+    >>> vec = cx.vecs.LonLatSphericalVel.from_(dsph)
+    >>> print(vec)
+    <LonLatSphericalVel (lon[mas / yr], lat[mas / yr], distance[km / s])
+        [2. 3. 1.]>
 
     """
-    return cls(d_distance=obj.d_distance, d_lon=obj.d_lon, d_lat=obj.d_lat)
+    return cls(distance=obj.d_distance, lon=obj.d_lon, lat=obj.d_lat)
 
 
 @dispatch
@@ -479,20 +493,13 @@ def vector(
     >>> dsph = SphericalCosLatDifferential(d_distance=1 * u.km / u.s,
     ...                                    d_lon_coslat=2 * u.mas/u.yr,
     ...                                    d_lat=3 * u.mas/u.yr)
-    >>> dif = cx.vecs.LonCosLatSphericalVel.from_(dsph)
-    >>> dif
-    LonCosLatSphericalVel(
-      d_lon_coslat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
-      d_lat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
-      d_distance=Quantity[...]( value=f32[], unit=Unit("km / s") )
-    )
-    >>> dif.d_distance
-    Quantity['speed'](Array(1., dtype=float32), unit='km / s')
+    >>> vec = cx.vecs.LonCosLatSphericalVel.from_(dsph)
+    >>> print(vec)
+    <LonCosLatSphericalVel (lon_coslat[mas / yr], lat[mas / yr], distance[km / s])
+        [2. 3. 1.]>
 
     """
-    return cls(
-        d_distance=obj.d_distance, d_lon_coslat=obj.d_lon_coslat, d_lat=obj.d_lat
-    )
+    return cls(distance=obj.d_distance, lon_coslat=obj.d_lon_coslat, lat=obj.d_lat)
 
 
 @dispatch
@@ -508,12 +515,13 @@ def vector(
     >>> from astropy.coordinates import UnitSphericalDifferential
 
     >>> sph = UnitSphericalDifferential(d_lon=3 * u.deg/u.s, d_lat=2 * u.deg/u.s)
-    >>> vel = cx.vecs.TwoSphereVel.from_(sph)
-    >>> vel.d_phi
-    Quantity[...](Array(3., dtype=float32), unit='deg / s')
+    >>> vec = cx.vecs.TwoSphereVel.from_(sph)
+    >>> print(vec)
+    <TwoSphereVel (theta[deg / s], phi[deg / s])
+        [2. 3.]>
 
     """
-    return cls(d_phi=obj.d_lon, d_theta=obj.d_lat)
+    return cls(phi=obj.d_lon, theta=obj.d_lat)
 
 
 #####################################################################
@@ -531,8 +539,7 @@ def vector(obj: apyu.Quantity, /) -> cx.vecs.AbstractVector:
     >>> from astropy.units import Quantity
     >>> import coordinax as cx
 
-    >>> xs = Quantity([1, 2, 3], "meter")
-    >>> vec = cx.vector(xs)
+    >>> vec = cx.vector(Quantity([1, 2, 3], "meter"))
     >>> print(vec)
     <CartesianPos3D (x[m], y[m], z[m])
         [1. 2. 3.]>
@@ -570,12 +577,12 @@ def vector(
 
     >>> vec = cx.CartesianVel3D.from_(Quantity([1, 2, 3], "m/s"))
     >>> print(vec)
-    <CartesianVel3D (d_x[m / s], d_y[m / s], d_z[m / s])
+    <CartesianVel3D (x[m / s], y[m / s], z[m / s])
         [1. 2. 3.]>
 
     >>> vec = cx.vecs.CartesianAcc3D.from_(Quantity([1, 2, 3], "m/s2"))
     >>> print(vec)
-    <CartesianAcc3D (d2_x[m / s2], d2_y[m / s2], d2_z[m / s2])
+    <CartesianAcc3D (x[m / s2], y[m / s2], z[m / s2])
         [1. 2. 3.]>
 
     >>> xs = Quantity([0, 1, 2, 3], "meter")  # [ct, x, y, z]

--- a/src/coordinax/_interop/coordinax_interop_astropy/converters.py
+++ b/src/coordinax/_interop/coordinax_interop_astropy/converters.py
@@ -312,9 +312,9 @@ def diffcart3_to_apycart3(obj: cx.CartesianVel3D, /) -> apyc.CartesianDifferenti
 
     """
     return apyc.CartesianDifferential(
-        d_x=convert(obj.d_x, apyu.Quantity),
-        d_y=convert(obj.d_y, apyu.Quantity),
-        d_z=convert(obj.d_z, apyu.Quantity),
+        d_x=convert(obj.x, apyu.Quantity),
+        d_y=convert(obj.y, apyu.Quantity),
+        d_z=convert(obj.z, apyu.Quantity),
     )
 
 
@@ -332,9 +332,9 @@ def apycart3_to_diffcart3(obj: apyc.CartesianDifferential, /) -> cx.CartesianVel
     >>> dcart = CartesianDifferential(1, 2, 3, unit="km/s")
     >>> convert(dcart, cx.CartesianVel3D)
     CartesianVel3D(
-      d_x=Quantity[...]( value=f32[], unit=Unit("km / s") ),
-      d_y=Quantity[...]( value=f32[], unit=Unit("km / s") ),
-      d_z=Quantity[...]( value=f32[], unit=Unit("km / s") )
+      x=Quantity[...]( value=f32[], unit=Unit("km / s") ),
+      y=Quantity[...]( value=f32[], unit=Unit("km / s") ),
+      z=Quantity[...]( value=f32[], unit=Unit("km / s") )
     )
 
     """
@@ -356,9 +356,9 @@ def diffcyl_to_apycyl(obj: cx.vecs.CylindricalVel, /) -> apyc.CylindricalDiffere
     >>> import coordinax as cx
     >>> import astropy.coordinates as apyc
 
-    >>> dif = cx.vecs.CylindricalVel(d_rho=u.Quantity(1, unit="km/s"),
-    ...                              d_phi=u.Quantity(2, unit="mas/yr"),
-    ...                              d_z=u.Quantity(3, unit="km/s"))
+    >>> dif = cx.vecs.CylindricalVel(rho=u.Quantity(1, unit="km/s"),
+    ...                              phi=u.Quantity(2, unit="mas/yr"),
+    ...                              z=u.Quantity(3, unit="km/s"))
     >>> convert(dif, apyc.CylindricalDifferential)
     <CylindricalDifferential (d_rho, d_phi, d_z) in (km / s, mas / yr, km / s)
         (1., 2., 3.)>
@@ -369,9 +369,9 @@ def diffcyl_to_apycyl(obj: cx.vecs.CylindricalVel, /) -> apyc.CylindricalDiffere
 
     """
     return apyc.CylindricalDifferential(
-        d_rho=convert(obj.d_rho, apyu.Quantity),
-        d_phi=convert(obj.d_phi, apyu.Quantity),
-        d_z=convert(obj.d_z, apyu.Quantity),
+        d_rho=convert(obj.rho, apyu.Quantity),
+        d_phi=convert(obj.phi, apyu.Quantity),
+        d_z=convert(obj.z, apyu.Quantity),
     )
 
 
@@ -391,9 +391,9 @@ def apycyl_to_diffcyl(obj: apyc.CylindricalDifferential, /) -> cx.vecs.Cylindric
     ...                                     d_z=2 * u.km / u.s)
     >>> convert(dcyl, cx.vecs.CylindricalVel)
     CylindricalVel(
-      d_rho=Quantity[...]( value=f32[], unit=Unit("km / s") ),
-      d_phi=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
-      d_z=Quantity[...]( value=f32[], unit=Unit("km / s") )
+      rho=Quantity[...]( value=f32[], unit=Unit("km / s") ),
+      phi=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
+      z=Quantity[...]( value=f32[], unit=Unit("km / s") )
     )
 
     """
@@ -414,9 +414,9 @@ def diffsph_to_apysph(obj: cx.SphericalVel, /) -> apyc.PhysicsSphericalDifferent
     >>> import unxt as u
     >>> import coordinax as cx
 
-    >>> dif = cx.SphericalVel(d_r=u.Quantity(1, unit="km/s"),
-    ...                       d_theta=u.Quantity(2, unit="mas/yr"),
-    ...                       d_phi=u.Quantity(3, unit="mas/yr"))
+    >>> dif = cx.SphericalVel(r=u.Quantity(1, unit="km/s"),
+    ...                       theta=u.Quantity(2, unit="mas/yr"),
+    ...                       phi=u.Quantity(3, unit="mas/yr"))
     >>> convert(dif, apyc.PhysicsSphericalDifferential)
     <PhysicsSphericalDifferential (d_phi, d_theta, d_r) in (mas / yr, mas / yr, km / s)
         (3., 2., 1.)>
@@ -427,9 +427,9 @@ def diffsph_to_apysph(obj: cx.SphericalVel, /) -> apyc.PhysicsSphericalDifferent
 
     """
     return apyc.PhysicsSphericalDifferential(
-        d_r=convert(obj.d_r, apyu.Quantity),
-        d_theta=convert(obj.d_theta, apyu.Quantity),
-        d_phi=convert(obj.d_phi, apyu.Quantity),
+        d_r=convert(obj.r, apyu.Quantity),
+        d_theta=convert(obj.theta, apyu.Quantity),
+        d_phi=convert(obj.phi, apyu.Quantity),
     )
 
 
@@ -449,9 +449,9 @@ def apysph_to_diffsph(obj: apyc.PhysicsSphericalDifferential, /) -> cx.Spherical
     ...                                    d_phi=3 * u.mas/u.yr)
     >>> convert(dif, cx.SphericalVel)
     SphericalVel(
-      d_r=Quantity[...]( value=f32[], unit=Unit("km / s") ),
-      d_theta=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
-      d_phi=Quantity[...]( value=f32[], unit=Unit("mas / yr") )
+      r=Quantity[...]( value=f32[], unit=Unit("km / s") ),
+      theta=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
+      phi=Quantity[...]( value=f32[], unit=Unit("mas / yr") )
     )
 
     """
@@ -474,9 +474,9 @@ def difflonlatsph_to_apysph(
     >>> import unxt as u
     >>> import coordinax as cx
 
-    >>> dif = cx.vecs.LonLatSphericalVel(d_distance=u.Quantity(1, unit="km/s"),
-    ...                                  d_lat=u.Quantity(2, unit="mas/yr"),
-    ...                                  d_lon=u.Quantity(3, unit="mas/yr"))
+    >>> dif = cx.vecs.LonLatSphericalVel(distance=u.Quantity(1, unit="km/s"),
+    ...                                  lat=u.Quantity(2, unit="mas/yr"),
+    ...                                  lon=u.Quantity(3, unit="mas/yr"))
     >>> convert(dif, apyc.SphericalDifferential)
     <SphericalDifferential (d_lon, d_lat, d_distance) in (mas / yr, mas / yr, km / s)
         (3., 2., 1.)>
@@ -487,9 +487,9 @@ def difflonlatsph_to_apysph(
 
     """
     return apyc.SphericalDifferential(
-        d_distance=convert(obj.d_distance, apyu.Quantity),
-        d_lon=convert(obj.d_lon, apyu.Quantity),
-        d_lat=convert(obj.d_lat, apyu.Quantity),
+        d_distance=convert(obj.distance, apyu.Quantity),
+        d_lon=convert(obj.lon, apyu.Quantity),
+        d_lat=convert(obj.lat, apyu.Quantity),
     )
 
 
@@ -511,9 +511,9 @@ def apysph_to_difflonlatsph(
     ...                             d_lon=3 * u.mas/u.yr)
     >>> convert(dif, cx.vecs.LonLatSphericalVel)
     LonLatSphericalVel(
-      d_lon=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
-      d_lat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
-      d_distance=Quantity[...]( value=f32[], unit=Unit("km / s") )
+      lon=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
+      lat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
+      distance=Quantity[...]( value=f32[], unit=Unit("km / s") )
     )
 
     """
@@ -536,9 +536,9 @@ def diffloncoslatsph_to_apysph(
     >>> import unxt as u
     >>> import coordinax as cx
 
-    >>> dif = cx.vecs.LonCosLatSphericalVel(d_distance=u.Quantity(1, unit="km/s"),
-    ...                                     d_lat=u.Quantity(2, unit="mas/yr"),
-    ...                                     d_lon_coslat=u.Quantity(3, unit="mas/yr"))
+    >>> dif = cx.vecs.LonCosLatSphericalVel(distance=u.Quantity(1, unit="km/s"),
+    ...                                     lat=u.Quantity(2, unit="mas/yr"),
+    ...                                     lon_coslat=u.Quantity(3, unit="mas/yr"))
     >>> convert(dif, apyc.SphericalCosLatDifferential)
     <SphericalCosLatDifferential (d_lon_coslat, d_lat, d_distance) in (mas / yr, mas / yr, km / s)
         (3., 2., 1.)>
@@ -549,9 +549,9 @@ def diffloncoslatsph_to_apysph(
 
     """  # noqa: E501
     return apyc.SphericalCosLatDifferential(
-        d_distance=convert(obj.d_distance, apyu.Quantity),
-        d_lon_coslat=convert(obj.d_lon_coslat, apyu.Quantity),
-        d_lat=convert(obj.d_lat, apyu.Quantity),
+        d_distance=convert(obj.distance, apyu.Quantity),
+        d_lon_coslat=convert(obj.lon_coslat, apyu.Quantity),
+        d_lat=convert(obj.lat, apyu.Quantity),
     )
 
 
@@ -574,9 +574,9 @@ def apysph_to_diffloncoslatsph(
     ...                                   d_lon_coslat=3 * u.mas/u.yr)
     >>> convert(dif, cx.vecs.LonCosLatSphericalVel)
     LonCosLatSphericalVel(
-      d_lon_coslat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
-      d_lat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
-      d_distance=Quantity[...]( value=f32[], unit=Unit("km / s") )
+      lon_coslat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
+      lat=Quantity[...]( value=f32[], unit=Unit("mas / yr") ),
+      distance=Quantity[...]( value=f32[], unit=Unit("km / s") )
     )
 
     """

--- a/src/coordinax/_src/frames/xfm.py
+++ b/src/coordinax/_src/frames/xfm.py
@@ -60,7 +60,7 @@ class TransformedReferenceFrame(AbstractReferenceFrame):
     >>> print(q_frame, v_frame, sep="\n")
     <CartesianPos3D (x[kpc], y[kpc], z[kpc])
         [ 0. -1.  0.]>
-    <CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
+    <CartesianVel3D (x[km / s], y[km / s], z[km / s])
         [ 0. -1.  0.]>
 
     >>> op.inverse(q_frame, v_frame) == (q_icrs, v_icrs)

--- a/src/coordinax/_src/operators/base.py
+++ b/src/coordinax/_src/operators/base.py
@@ -125,11 +125,11 @@ class AbstractOperator(eqx.Module):
                 [0. 0. 1.]]),
             translation=GalileanTranslation(<FourVector (t[s], q=(x[km], y[km], z[km]))
                     [0. 2. 3. 4.]>),
-            velocity=GalileanBoost(<CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
+            velocity=GalileanBoost(<CartesianVel3D (x[km / s], y[km / s], z[km / s])
                     [1. 2. 3.]>)
         )
 
-        """  # noqa: E501
+        """
         name = self.__class__.__name__
         fitems = field_items(flags.FilterRepr, self)
         if len(fitems) == 1:
@@ -226,7 +226,7 @@ def from_(
 
     >>> op = cx.ops.GalileanBoost.from_([1, 1, 1], "km/s")
     >>> print(op.velocity)
-    <CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
+    <CartesianVel3D (x[km / s], y[km / s], z[km / s])
         [1 1 1]>
 
     """

--- a/src/coordinax/_src/operators/boost.py
+++ b/src/coordinax/_src/operators/boost.py
@@ -98,7 +98,7 @@ class VelocityBoost(AbstractOperator):
         VelocityBoost(CartesianVel3D( ... ))
 
         >>> print(op.inverse.velocity)
-        <CartesianVel3D (d_x[m / s], d_y[m / s], d_z[m / s])
+        <CartesianVel3D (x[m / s], y[m / s], z[m / s])
             [-1 -2 -3]>
 
         """
@@ -120,7 +120,7 @@ class VelocityBoost(AbstractOperator):
 
         >>> p = cx.CartesianVel3D.from_([0, 0, 0], "m/s")
         >>> print(op(p))
-        <CartesianVel3D (d_x[m / s], d_y[m / s], d_z[m / s])
+        <CartesianVel3D (x[m / s], y[m / s], z[m / s])
             [1 2 3]>
 
         """
@@ -139,7 +139,7 @@ class VelocityBoost(AbstractOperator):
 
         >>> op = cx.ops.VelocityBoost.from_([1, 0, 0], "m/s")
         >>> print((-op).velocity)
-        <CartesianVel3D (d_x[m / s], d_y[m / s], d_z[m / s])
+        <CartesianVel3D (x[m / s], y[m / s], z[m / s])
             [-1 0 0]>
 
         """
@@ -176,7 +176,7 @@ def call(
     >>> print(newq, newp, sep="\n")
     <CartesianPos3D (x[m], y[m], z[m])
         [0 0 0]>
-    <CartesianVel3D (d_x[m / s], d_y[m / s], d_z[m / s])
+    <CartesianVel3D (x[m / s], y[m / s], z[m / s])
         [1 2 3]>
 
     """

--- a/src/coordinax/_src/operators/compat.py
+++ b/src/coordinax/_src/operators/compat.py
@@ -301,7 +301,7 @@ def call(self: AbstractOperator, space: Space, /, **__: Any) -> Space:
     >>> new_space.keys()
     dict_keys(['length', 'speed'])
     >>> print(new_space["speed"])
-    <CartesianVel3D (d_x[m / s], d_y[m / s], d_z[m / s])
+    <CartesianVel3D (x[m / s], y[m / s], z[m / s])
         [5. 7. 9.]>
 
     """

--- a/src/coordinax/_src/operators/galilean/boost.py
+++ b/src/coordinax/_src/operators/galilean/boost.py
@@ -117,7 +117,7 @@ class GalileanBoost(AbstractGalileanOperator):
         GalileanBoost(CartesianVel3D( ... ))
 
         >>> print(op.inverse.velocity)
-        <CartesianVel3D (d_x[m / s], d_y[m / s], d_z[m / s])
+        <CartesianVel3D (x[m / s], y[m / s], z[m / s])
             [-1 -2 -3]>
 
         """
@@ -189,7 +189,7 @@ class GalileanBoost(AbstractGalileanOperator):
 
         >>> op = cx.ops.GalileanBoost.from_([1, 0, 0], "m/s")
         >>> print((-op).velocity)
-        <CartesianVel3D (d_x[m / s], d_y[m / s], d_z[m / s])
+        <CartesianVel3D (x[m / s], y[m / s], z[m / s])
             [-1 0 0]>
 
         """

--- a/src/coordinax/_src/operators/galilean/rotation.py
+++ b/src/coordinax/_src/operators/galilean/rotation.py
@@ -365,7 +365,7 @@ def call(
     >>> print(newq, newp, sep="\n")
     <CartesianPos3D (x[m], y[m], z[m])
         [0. 1. 0.]>
-    <CartesianVel3D (d_x[m / s], d_y[m / s], d_z[m / s])
+    <CartesianVel3D (x[m / s], y[m / s], z[m / s])
         [0. 1. 0.]>
 
     """

--- a/src/coordinax/_src/operators/galilean/spatial_translation.py
+++ b/src/coordinax/_src/operators/galilean/spatial_translation.py
@@ -334,7 +334,7 @@ def call(
     >>> print(newq, newp, sep="\n")
     <CartesianPos3D (x[km], y[km], z[km])
         [1 1 1]>
-    <CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
+    <CartesianVel3D (x[km / s], y[km / s], z[km / s])
         [1. 2. 3.]>
 
     """
@@ -392,7 +392,7 @@ def call(
     >>> print(newq, newp, sep="\n")
     <CartesianPos3D (x[km], y[km], z[km])
         [1 1 1]>
-    <CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
+    <CartesianVel3D (x[km / s], y[km / s], z[km / s])
         [1. 2. 3.]>
 
     """

--- a/src/coordinax/_src/operators/pipe.py
+++ b/src/coordinax/_src/operators/pipe.py
@@ -85,7 +85,7 @@ class Pipe(AbstractCompositeOperator):
     >>> print(*pipe(pos, vel), sep="\n")
     <CartesianPos3D (x[km], y[km], z[km])
         [2 4 6]>
-    <CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
+    <CartesianVel3D (x[km / s], y[km / s], z[km / s])
         [5. 7. 9.]>
 
     """

--- a/src/coordinax/_src/vectors/base/register_constructors.py
+++ b/src/coordinax/_src/vectors/base/register_constructors.py
@@ -102,30 +102,30 @@ def vector(cls: type[AbstractVector], obj: AbstractQuantity, /) -> AbstractVecto
     Vel 1D:
 
     >>> cx.vecs.CartesianVel1D.from_(u.Quantity(1, "m/s"))
-    CartesianVel1D( d_x=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
+    CartesianVel1D( x=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
 
     >>> cx.vecs.CartesianVel1D.from_(u.Quantity([1], "m/s"))
-    CartesianVel1D( d_x=Quantity[...]( value=i32[], unit=Unit("m / s") ) )
+    CartesianVel1D( x=Quantity[...]( value=i32[], unit=Unit("m / s") ) )
 
     >>> cx.vecs.RadialVel.from_(u.Quantity(1, "m/s"))
-    RadialVel( d_r=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
+    RadialVel( r=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
 
     >>> cx.vecs.RadialVel.from_(u.Quantity([1], "m/s"))
-    RadialVel( d_r=Quantity[...]( value=i32[], unit=Unit("m / s") ) )
+    RadialVel( r=Quantity[...]( value=i32[], unit=Unit("m / s") ) )
 
     Acc 1D:
 
     >>> cx.vecs.CartesianAcc1D.from_(u.Quantity(1, "m/s2"))
-    CartesianAcc1D( d2_x=... )
+    CartesianAcc1D( x=... )
 
     >>> cx.vecs.CartesianAcc1D.from_(u.Quantity([1], "m/s2"))
-    CartesianAcc1D( d2_x=Quantity[...](value=i32[], unit=Unit("m / s2")) )
+    CartesianAcc1D( x=Quantity[...](value=i32[], unit=Unit("m / s2")) )
 
     >>> cx.vecs.RadialAcc.from_(u.Quantity(1, "m/s2"))
-    RadialAcc( d2_r=... )
+    RadialAcc( r=... )
 
     >>> cx.vecs.RadialAcc.from_(u.Quantity([1], "m/s2"))
-    RadialAcc( d2_r=Quantity[...](value=i32[], unit=Unit("m / s2")) )
+    RadialAcc( r=Quantity[...](value=i32[], unit=Unit("m / s2")) )
 
     Pos 2D:
 
@@ -140,14 +140,14 @@ def vector(cls: type[AbstractVector], obj: AbstractQuantity, /) -> AbstractVecto
 
     >>> vec = cx.vecs.CartesianVel2D.from_(u.Quantity([1, 2], "m/s"))
     >>> print(vec)
-    <CartesianVel2D (d_x[m / s], d_y[m / s])
+    <CartesianVel2D (x[m / s], y[m / s])
         [1 2]>
 
     Acc 2D:
 
     >>> vec = cx.vecs.CartesianAcc2D.from_(u.Quantity([1, 2], "m/s2"))
     >>> print(vec)
-    <CartesianAcc2D (d2_x[m / s2], d2_y[m / s2])
+    <CartesianAcc2D (x[m / s2], y[m / s2])
         [1 2]>
 
     Pos 3D:
@@ -161,14 +161,14 @@ def vector(cls: type[AbstractVector], obj: AbstractQuantity, /) -> AbstractVecto
 
     >>> vec = cx.CartesianVel3D.from_(u.Quantity([1, 2, 3], "m/s"))
     >>> print(vec)
-    <CartesianVel3D (d_x[m / s], d_y[m / s], d_z[m / s])
+    <CartesianVel3D (x[m / s], y[m / s], z[m / s])
         [1 2 3]>
 
     Acc 3D:
 
     >>> vec = cx.vecs.CartesianAcc3D.from_(u.Quantity([1, 2, 3], "m/s2"))
     >>> print(vec)
-    <CartesianAcc3D (d2_x[m / s2], d2_y[m / s2], d2_z[m / s2])
+    <CartesianAcc3D (x[m / s2], y[m / s2], z[m / s2])
         [1 2 3]>
 
     Generic 3D:

--- a/src/coordinax/_src/vectors/base/register_primitives.py
+++ b/src/coordinax/_src/vectors/base/register_primitives.py
@@ -39,17 +39,17 @@ def broadcast_in_dim_p(
     Quantity['length'](Array([1], dtype=int32), unit='m')
 
     >>> p = cx.vecs.CartesianVel1D.from_([1], "m/s")
-    >>> p.d_x
+    >>> p.x
     Quantity['speed'](Array(1, dtype=int32), unit='m / s')
 
-    >>> jnp.broadcast_to(p, (1, 1)).d_x
+    >>> jnp.broadcast_to(p, (1, 1)).x
     Quantity['speed'](Array([1], dtype=int32), unit='m / s')
 
     >>> a = cx.vecs.CartesianAcc1D.from_([1], "m/s2")
-    >>> a.d2_x
+    >>> a.x
      Quantity['acceleration'](Array(1, dtype=int32), unit='m / s2')
 
-    >>> jnp.broadcast_to(a, (1, 1)).d2_x
+    >>> jnp.broadcast_to(a, (1, 1)).x
     Quantity['acceleration'](Array([1], dtype=int32), unit='m / s2')
 
 
@@ -63,17 +63,17 @@ def broadcast_in_dim_p(
     Distance(Array([1], dtype=int32), unit='m')
 
     >>> p = cx.vecs.RadialVel.from_([1], "m/s")
-    >>> p.d_r
+    >>> p.r
     Quantity['speed'](Array(1, dtype=int32), unit='m / s')
 
-    >>> jnp.broadcast_to(p, (1, 1)).d_r
+    >>> jnp.broadcast_to(p, (1, 1)).r
     Quantity['speed'](Array([1], dtype=int32), unit='m / s')
 
     >>> a = cx.vecs.RadialAcc.from_([1], "m/s2")
-    >>> a.d2_r
+    >>> a.r
     Quantity['acceleration'](Array(1, dtype=int32), unit='m / s2')
 
-    >>> jnp.broadcast_to(a, (1, 1)).d2_r
+    >>> jnp.broadcast_to(a, (1, 1)).r
     Quantity['acceleration'](Array([1], dtype=int32), unit='m / s2')
 
 
@@ -90,20 +90,20 @@ def broadcast_in_dim_p(
 
     >>> p = cx.vecs.CartesianVel2D.from_([1, 2], "m/s")
     >>> print(p)
-    <CartesianVel2D (d_x[m / s], d_y[m / s])
+    <CartesianVel2D (x[m / s], y[m / s])
         [1 2]>
 
     >>> print(jnp.broadcast_to(p, (1, 2)))
-    <CartesianVel2D (d_x[m / s], d_y[m / s])
+    <CartesianVel2D (x[m / s], y[m / s])
         [[1 2]]>
 
     >>> a = cx.vecs.CartesianAcc2D.from_([1, 2], "m/s2")
     >>> print(a)
-    <CartesianAcc2D (d2_x[m / s2], d2_y[m / s2])
+    <CartesianAcc2D (x[m / s2], y[m / s2])
         [1 2]>
 
     >>> print(jnp.broadcast_to(a, (1, 2)))
-    <CartesianAcc2D (d2_x[m / s2], d2_y[m / s2])
+    <CartesianAcc2D (x[m / s2], y[m / s2])
         [[1 2]]>
 
     Cartesian 3D position, velocity, and acceleration:
@@ -116,19 +116,19 @@ def broadcast_in_dim_p(
     Quantity['length'](Array([1], dtype=int32), unit='m')
 
     >>> p = cx.CartesianVel3D.from_([1, 2, 3], "m/s")
-    >>> p.d_x
+    >>> p.x
     Quantity['speed'](Array(1, dtype=int32), unit='m / s')
 
-    >>> jnp.broadcast_to(p, (1, 3)).d_x
+    >>> jnp.broadcast_to(p, (1, 3)).x
     Quantity['speed'](Array([1], dtype=int32), unit='m / s')
 
     >>> a = cx.vecs.CartesianAcc3D.from_([1, 2, 3], "m/s2")
     >>> print(a)
-    <CartesianAcc3D (d2_x[m / s2], d2_y[m / s2], d2_z[m / s2])
+    <CartesianAcc3D (x[m / s2], y[m / s2], z[m / s2])
         [1 2 3]>
 
     >>> print(jnp.broadcast_to(a, (1, 3)))
-    <CartesianAcc3D (d2_x[m / s2], d2_y[m / s2], d2_z[m / s2])
+    <CartesianAcc3D (x[m / s2], y[m / s2], z[m / s2])
         [[1 2 3]]>
 
     """

--- a/src/coordinax/_src/vectors/base/vector.py
+++ b/src/coordinax/_src/vectors/base/vector.py
@@ -154,7 +154,7 @@ class AbstractVector(
         >>> a_sph = a_cart.vconvert(cx.vecs.SphericalAcc, v_cart, q_cart)
         >>> a_sph
         SphericalAcc( ... )
-        >>> a_sph.d2_r
+        >>> a_sph.r
         Quantity['acceleration'](Array(13.363062, dtype=float32), unit='m / s2')
 
         """
@@ -440,7 +440,7 @@ class AbstractVector(
 
         >>> vel1 = cx.vecs.CartesianVel2D.from_([[1, 3], [2, 4]], "km/s")
         >>> vel2 = cx.vecs.CartesianVel2D.from_([[1, 3], [0, 4]], "km/s")
-        >>> vel1.d_x
+        >>> vel1.x
         Quantity['speed'](Array([1, 2], dtype=int32), unit='km / s')
         >>> jnp.equal(vel1, vel2)
         Array([ True, False], dtype=bool)
@@ -449,7 +449,7 @@ class AbstractVector(
 
         >>> acc1 = cx.vecs.CartesianAcc2D.from_([[1, 3], [2, 4]], "km/s2")
         >>> acc2 = cx.vecs.CartesianAcc2D.from_([[1, 3], [0, 4]], "km/s2")
-        >>> acc1.d2_x
+        >>> acc1.x
         Quantity['acceleration'](Array([1, 2], dtype=int32), unit='km / s2')
         >>> jnp.equal(acc1, acc2)
         Array([ True, False], dtype=bool)
@@ -458,7 +458,7 @@ class AbstractVector(
 
         >>> vel1 = cx.CartesianVel3D.from_([[1, 2, 3], [4, 5, 6]], "km/s")
         >>> vel2 = cx.CartesianVel3D.from_([[1, 2, 3], [4, 5, 0]], "km/s")
-        >>> vel1.d_x
+        >>> vel1.x
         Quantity['speed'](Array([1, 4], dtype=int32), unit='km / s')
         >>> jnp.equal(vel1, vel2)
         Array([ True, False], dtype=bool)
@@ -780,7 +780,7 @@ class AbstractVector(
         >>> cx.SphericalPos.components
         ('r', 'theta', 'phi')
         >>> cx.vecs.RadialVel.components
-        ('d_r',)
+        ('r',)
 
         """
         return tuple(f.name for f in fields(AttrFilter, cls))

--- a/src/coordinax/_src/vectors/base_acc/register_primitives.py
+++ b/src/coordinax/_src/vectors/base_acc/register_primitives.py
@@ -32,17 +32,13 @@ def mul_acc_time(lhs: AbstractAcc, rhs: u.Quantity["time"]) -> AbstractVel:
 
     >>> d2r = cx.vecs.RadialAcc(u.Quantity(1, "m/s2"))
     >>> vec = lax.mul(d2r, u.Quantity(2, "s"))
-    >>> vec
-    RadialVel( d_r=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
-    >>> vec.d_r
-    Quantity['speed'](Array(2, dtype=int32, ...), unit='m / s')
-
-    >>> (d2r * u.Quantity(2, "s")).d_r
-    Quantity['speed'](Array(2, dtype=int32, ...), unit='m / s')
+    >>> print(vec)
+    <RadialVel (r[m / s])
+        [2]>
 
     """
     # TODO: better access to corresponding fields
-    fs = {k.replace("2", ""): jnp.multiply(v, rhs) for k, v in field_items(lhs)}
+    fs = {k: jnp.multiply(v, rhs) for k, v in field_items(lhs)}
     return cast(AbstractVel, lhs.integral_cls.from_(fs))
 
 
@@ -58,10 +54,9 @@ def mul_time_acc(lhs: u.Quantity["time"], rhs: AbstractAcc) -> AbstractVel:
 
     >>> d2r = cx.vecs.RadialAcc(u.Quantity(1, "m/s2"))
     >>> vec = lax.mul(u.Quantity(2, "s"), d2r)
-    >>> vec
-    RadialVel( d_r=Quantity[...]( value=...i32[], unit=Unit("m / s") ) )
-    >>> vec.d_r
-    Quantity['speed'](Array(2, dtype=int32, ...), unit='m / s')
+    >>> print(vec)
+    <RadialVel (r[m / s])
+        [2]>
 
     """
     return cast(AbstractVel, qlax.mul(rhs, lhs))  # type: ignore[arg-type]  # pylint: disable=arguments-out-of-order
@@ -90,7 +85,7 @@ def mul_acc_time2(lhs: AbstractAcc, rhs: u.Quantity["s2"]) -> AbstractPos:
     """
     # TODO: better access to corresponding fields
     pos_cls = lhs.integral_cls.integral_cls
-    fs = {k.replace("d2_", ""): v * rhs for k, v in field_items(lhs)}
+    fs = {k: v * rhs for k, v in field_items(lhs)}
     return cast(AbstractPos, pos_cls.from_(fs))
 
 
@@ -130,7 +125,7 @@ def neg_acc(vec: AbstractAcc) -> AbstractAcc:
     >>> d2r = cx.vecs.RadialAcc(u.Quantity(1, "m/s2"))
     >>> vec = lax.neg(d2r)
     >>> print(vec)
-    <RadialAcc (d2_r[m / s2])
+    <RadialAcc (r[m / s2])
         [-1]>
 
     """

--- a/src/coordinax/_src/vectors/base_vel/core.py
+++ b/src/coordinax/_src/vectors/base_vel/core.py
@@ -101,8 +101,7 @@ class AbstractVel(AvalMixin, AbstractVector):  # pylint: disable=abstract-method
         >>> import coordinax as cx
 
         >>> q = cx.vecs.CartesianPos2D.from_([1, 1], "km")
-        >>> p = cx.vecs.PolarVel(d_r=u.Quantity(1, "km/s"),
-        ...                      d_phi=u.Quantity(1, "deg/s"))
+        >>> p = cx.vecs.PolarVel(r=u.Quantity(1, "km/s"), phi=u.Quantity(1, "deg/s"))
 
         >>> p.norm(q)
         Quantity['speed'](Array(1.0003046, dtype=float32), unit='km / s')

--- a/src/coordinax/_src/vectors/base_vel/register_primitives.py
+++ b/src/coordinax/_src/vectors/base_vel/register_primitives.py
@@ -38,7 +38,7 @@ def _mul_vel_q(self: AbstractVel, other: u.Quantity["time"]) -> AbstractPos:
         [2]>
 
     """
-    fs = {k[2:]: v * other for k, v in field_items(self)}
+    fs = {k: v * other for k, v in field_items(self)}
     return cast(AbstractPos, self.integral_cls.from_(fs))
 
 
@@ -57,16 +57,16 @@ def neg_vel(vec: AbstractVel, /) -> AbstractVel:
 
     >>> dr = cx.vecs.RadialVel.from_([1], "m/s")
     >>> print(lax.neg(dr))
-    <RadialVel (d_r[m / s])
+    <RadialVel (r[m / s])
         [-1]>
 
     >>> -dr
-    RadialVel( d_r=Quantity[...]( value=i32[], unit=Unit("m / s") ) )
+    RadialVel( r=Quantity[...]( value=i32[], unit=Unit("m / s") ) )
 
     >>> dp = cx.vecs.PolarVel(u.Quantity(1, "m/s"), u.Quantity(1, "mas/yr"))
     >>> neg_dp = -dp
     >>> print(neg_dp)
-    <PolarVel (d_r[m / s], d_phi[mas / yr])
+    <PolarVel (r[m / s], phi[mas / yr])
         [-1 -1]>
 
     """

--- a/src/coordinax/_src/vectors/d1/cartesian.py
+++ b/src/coordinax/_src/vectors/d1/cartesian.py
@@ -60,7 +60,7 @@ class CartesianPos1D(AbstractCartesian, AbstractPos1D):
 class CartesianVel1D(AbstractCartesian, AbstractVel1D):
     """Cartesian differential representation."""
 
-    d_x: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
+    x: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
     r"""X differential :math:`dx/dt \in (-\infty,+\infty`)`."""
 
     @override
@@ -88,7 +88,7 @@ class CartesianVel1D(AbstractCartesian, AbstractVel1D):
         Quantity['speed'](Array(1, dtype=int32), unit='km / s')
 
         """
-        return jnp.abs(self.d_x)
+        return jnp.abs(self.x)
 
 
 #####################################################################
@@ -98,7 +98,7 @@ class CartesianVel1D(AbstractCartesian, AbstractVel1D):
 class CartesianAcc1D(AbstractCartesian, AbstractAcc1D):
     """Cartesian differential representation."""
 
-    d2_x: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
+    x: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
     r"""X differential :math:`d^2x/dt^2 \in (-\infty,+\infty`)`."""
 
     @override
@@ -123,4 +123,4 @@ class CartesianAcc1D(AbstractCartesian, AbstractAcc1D):
         Quantity['acceleration'](Array(1, dtype=int32), unit='km / s2')
 
         """
-        return jnp.abs(self.d2_x)
+        return jnp.abs(self.x)

--- a/src/coordinax/_src/vectors/d1/radial.py
+++ b/src/coordinax/_src/vectors/d1/radial.py
@@ -61,12 +61,12 @@ class RadialVel(AbstractVel1D):
 
     >>> vec = cx.vecs.RadialVel(u.Quantity([2], "m/s"))
     >>> print(vec)
-    <RadialVel (d_r[m / s])
+    <RadialVel (r[m / s])
         [[2]]>
 
     """
 
-    d_r: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
+    r: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
     r"""Radial speed :math:`dr/dt \in (-\infty,+\infty)`."""
 
     @override
@@ -96,12 +96,12 @@ class RadialAcc(AbstractAcc1D):
 
     >>> vec = cx.vecs.RadialAcc(u.Quantity([2], "m/s2"))
     >>> print(vec)
-    <RadialAcc (d2_r[m / s2])
+    <RadialAcc (r[m / s2])
         [[2]]>
 
     """
 
-    d2_r: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
+    r: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
     r"""Radial acceleration :math:`d^2r/dt^2 \in (-\infty,+\infty)`."""
 
     @override

--- a/src/coordinax/_src/vectors/d1/register_primitives.py
+++ b/src/coordinax/_src/vectors/d1/register_primitives.py
@@ -58,12 +58,12 @@ def add_pp(lhs: CartesianVel1D, rhs: CartesianVel1D, /) -> CartesianVel1D:
     >>> vec = jnp.add(v, v)
     >>> vec
     CartesianVel1D(
-       d_x=Quantity[...]( value=i32[], unit=Unit("km / s") )
+       x=Quantity[...]( value=i32[], unit=Unit("km / s") )
     )
-    >>> vec.d_x
+    >>> vec.x
     Quantity['speed'](Array(2, dtype=int32), unit='km / s')
 
-    >>> (v + v).d_x
+    >>> (v + v).x
     Quantity['speed'](Array(2, dtype=int32), unit='km / s')
 
     """
@@ -83,12 +83,12 @@ def add_aa(lhs: CartesianAcc1D, rhs: CartesianAcc1D, /) -> CartesianAcc1D:
     >>> vec = jnp.add(v, v)
     >>> vec
     CartesianAcc1D(
-        d2_x=Quantity[...](value=i32[], unit=Unit("km / s2"))
+        x=Quantity[...](value=i32[], unit=Unit("km / s2"))
     )
-    >>> vec.d2_x
+    >>> vec.x
     Quantity['acceleration'](Array(2, dtype=int32), unit='km / s2')
 
-    >>> (v + v).d2_x
+    >>> (v + v).x
     Quantity['acceleration'](Array(2, dtype=int32), unit='km / s2')
 
     """
@@ -165,13 +165,13 @@ def mul_vcart(lhs: ArrayLike, rhs: CartesianVel1D, /) -> CartesianVel1D:
     >>> vec = jnp.multiply(2, v)
     >>> vec
     CartesianVel1D(
-      d_x=Quantity[...]( value=...i32[], unit=Unit("m / s") )
+      x=Quantity[...]( value=...i32[], unit=Unit("m / s") )
     )
 
-    >>> vec.d_x
+    >>> vec.x
     Quantity['speed'](Array(2, dtype=int32), unit='m / s')
 
-    >>> (2 * v).d_x
+    >>> (2 * v).x
     Quantity['speed'](Array(2, dtype=int32, ...), unit='m / s')
 
     """
@@ -181,7 +181,7 @@ def mul_vcart(lhs: ArrayLike, rhs: CartesianVel1D, /) -> CartesianVel1D:
     )
 
     # Scale the components
-    return replace(rhs, d_x=lhs * rhs.d_x)
+    return replace(rhs, x=lhs * rhs.x)
 
 
 @register(jax.lax.mul_p)
@@ -196,12 +196,12 @@ def mul_aq(lhs: ArrayLike, rhs: CartesianAcc1D, /) -> CartesianAcc1D:
     >>> v = cx.vecs.CartesianAcc1D.from_(1, "m/s2")
     >>> vec = jnp.multiply(2, v)
     >>> vec
-    CartesianAcc1D( d2_x=... )
+    CartesianAcc1D( x=... )
 
-    >>> vec.d2_x
+    >>> vec.x
     Quantity['acceleration'](Array(2, dtype=int32), unit='m / s2')
 
-    >>> (2 * v).d2_x
+    >>> (2 * v).x
     Quantity['acceleration'](Array(2, dtype=int32, ...), unit='m / s2')
 
     """
@@ -211,7 +211,7 @@ def mul_aq(lhs: ArrayLike, rhs: CartesianAcc1D, /) -> CartesianAcc1D:
     )
 
     # Scale the components
-    return replace(rhs, d2_x=lhs * rhs.d2_x)
+    return replace(rhs, x=lhs * rhs.x)
 
 
 # ------------------------------------------------
@@ -273,12 +273,12 @@ def sub_a1_a1(self: CartesianAcc1D, other: CartesianAcc1D, /) -> CartesianAcc1D:
     >>> v2 = cx.vecs.CartesianAcc1D.from_(2, "m/s2")
     >>> vec = lax.sub(v1, v2)
     >>> vec
-    CartesianAcc1D( d2_x=... )
+    CartesianAcc1D( x=... )
 
-    >>> vec.d2_x
+    >>> vec.x
     Quantity['acceleration'](Array(-1, dtype=int32, ...), unit='m / s2')
 
-    >>> (v1 - v2).d2_x
+    >>> (v1 - v2).x
     Quantity['acceleration'](Array(-1, dtype=int32, ...), unit='m / s2')
 
     """

--- a/src/coordinax/_src/vectors/d2/cartesian.py
+++ b/src/coordinax/_src/vectors/d2/cartesian.py
@@ -63,15 +63,15 @@ class CartesianVel2D(AbstractCartesian, AbstractVel2D):
 
     >>> vec = cx.vecs.CartesianVel2D.from_([1, 2], "m/s")
     >>> print(vec)
-    <CartesianVel2D (d_x[m / s], d_y[m / s])
+    <CartesianVel2D (x[m / s], y[m / s])
         [1 2]>
 
     """
 
-    d_x: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
+    x: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
     r"""X coordinate differential :math:`\dot{x} \in (-\infty,+\infty)`."""
 
-    d_y: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
+    y: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
     r"""Y coordinate differential :math:`\dot{y} \in (-\infty,+\infty)`."""
 
     @override
@@ -107,7 +107,7 @@ class CartesianVel2D(AbstractCartesian, AbstractVel2D):
         Quantity['speed'](Array(5., dtype=float32), unit='km / s')
 
         """
-        return jnp.sqrt(self.d_x**2 + self.d_y**2)
+        return jnp.sqrt(self.x**2 + self.y**2)
 
 
 #####################################################################
@@ -123,15 +123,15 @@ class CartesianAcc2D(AbstractCartesian, AbstractAcc2D):
 
     >>> vec = cx.vecs.CartesianAcc2D.from_([1, 2], "m/s2")
     >>> print(vec)
-    <CartesianAcc2D (d2_x[m / s2], d2_y[m / s2])
+    <CartesianAcc2D (x[m / s2], y[m / s2])
         [1 2]>
 
     """
 
-    d2_x: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
+    x: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
     r"""X coordinate acceleration :math:`\frac{d^2 x}{dt^2} \in (-\infty,+\infty)`."""
 
-    d2_y: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
+    y: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
     r"""Y coordinate acceleration :math:`\frac{d^2 y}{dt^2} \in (-\infty,+\infty)`."""
 
     @override
@@ -155,4 +155,4 @@ class CartesianAcc2D(AbstractCartesian, AbstractAcc2D):
         Quantity['acceleration'](Array(5., dtype=float32), unit='km / s2')
 
         """
-        return jnp.sqrt(self.d2_x**2 + self.d2_y**2)
+        return jnp.sqrt(self.x**2 + self.y**2)

--- a/src/coordinax/_src/vectors/d2/polar.py
+++ b/src/coordinax/_src/vectors/d2/polar.py
@@ -80,17 +80,17 @@ class PolarVel(AbstractVel2D):
     >>> import unxt as u
     >>> import coordinax as cx
 
-    >>> vev = cx.vecs.PolarVel(d_r=u.Quantity(1, "m/s"), d_phi=u.Quantity(90, "deg/s"))
+    >>> vev = cx.vecs.PolarVel(r=u.Quantity(1, "m/s"), phi=u.Quantity(90, "deg/s"))
     >>> print(vev)
-    <PolarVel (d_r[m / s], d_phi[deg / s])
+    <PolarVel (r[m / s], phi[deg / s])
         [ 1 90]>
 
     """
 
-    d_r: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
+    r: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
     r"""Radial speed :math:`dr/dt \in [-\infty,+\infty]`."""
 
-    d_phi: ct.BatchableAngularSpeed = eqx.field(
+    phi: ct.BatchableAngularSpeed = eqx.field(
         converter=u.Quantity["angular speed"].from_
     )
     r"""Polar angular speed :math:`d\phi/dt \in [-\infty,+\infty]`."""
@@ -120,18 +120,18 @@ class PolarAcc(AbstractAcc2D):
     >>> import unxt as u
     >>> import coordinax as cx
 
-    >>> acc = cx.vecs.PolarAcc(d2_r=u.Quantity(1, "m/s2"),
-    ...                        d2_phi=u.Quantity(3, "deg/s2"))
+    >>> acc = cx.vecs.PolarAcc(r=u.Quantity(1, "m/s2"),
+    ...                        phi=u.Quantity(3, "deg/s2"))
     >>> print(acc)
-    <PolarAcc (d2_r[m / s2], d2_phi[deg / s2])
+    <PolarAcc (r[m / s2], phi[deg / s2])
         [1 3]>
 
     """
 
-    d2_r: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
+    r: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
     r"""Radial acceleration :math:`d^2r/dt^2 \in [-\infty,+\infty]`."""
 
-    d2_phi: ct.BatchableAngularAcc = eqx.field(
+    phi: ct.BatchableAngularAcc = eqx.field(
         converter=u.Quantity["angular acceleration"].from_
     )
     r"""Polar angular acceleration :math:`d^2\phi/dt^2 \in [-\infty,+\infty]`."""

--- a/src/coordinax/_src/vectors/d2/register_primitives.py
+++ b/src/coordinax/_src/vectors/d2/register_primitives.py
@@ -58,11 +58,11 @@ def add_pp(lhs: CartesianVel2D, rhs: CartesianVel2D, /) -> CartesianVel2D:
 
     >>> v = cx.vecs.CartesianVel2D.from_([1, 2], "km/s")
     >>> print(v + v)
-    <CartesianVel2D (d_x[km / s], d_y[km / s])
+    <CartesianVel2D (x[km / s], y[km / s])
         [2 4]>
 
     >>> print(jnp.add(v, v))
-    <CartesianVel2D (d_x[km / s], d_y[km / s])
+    <CartesianVel2D (x[km / s], y[km / s])
         [2 4]>
 
     """
@@ -80,11 +80,11 @@ def add_aa(lhs: CartesianAcc2D, rhs: CartesianAcc2D, /) -> CartesianAcc2D:
 
     >>> v = cx.vecs.CartesianAcc2D.from_([3, 4], "km/s2")
     >>> print(v + v)
-    <CartesianAcc2D (d2_x[km / s2], d2_y[km / s2])
+    <CartesianAcc2D (x[km / s2], y[km / s2])
         [6 8]>
 
     >>> print(jnp.add(v, v))
-    <CartesianAcc2D (d2_x[km / s2], d2_y[km / s2])
+    <CartesianAcc2D (x[km / s2], y[km / s2])
         [6 8]>
 
     """
@@ -158,11 +158,11 @@ def mul_vp(lhs: ArrayLike, rhs: CartesianVel2D, /) -> CartesianVel2D:
 
     >>> v = cx.vecs.CartesianVel2D.from_([3, 4], "m/s")
     >>> print(5 * v)
-    <CartesianVel2D (d_x[m / s], d_y[m / s])
+    <CartesianVel2D (x[m / s], y[m / s])
         [15 20]>
 
     >>> print(jnp.multiply(5, v))
-    <CartesianVel2D (d_x[m / s], d_y[m / s])
+    <CartesianVel2D (x[m / s], y[m / s])
         [15 20]>
 
     """
@@ -172,11 +172,11 @@ def mul_vp(lhs: ArrayLike, rhs: CartesianVel2D, /) -> CartesianVel2D:
     )
 
     # Scale the components
-    return replace(rhs, d_x=lhs * rhs.d_x, d_y=lhs * rhs.d_y)
+    return replace(rhs, x=lhs * rhs.x, y=lhs * rhs.y)
 
 
 @register(jax.lax.mul_p)
-def mul_va(lhs: ArrayLike, rhts: CartesianAcc2D, /) -> CartesianAcc2D:
+def mul_va(lhs: ArrayLike, rhs: CartesianAcc2D, /) -> CartesianAcc2D:
     """Scale a cartesian 2D acceleration by a scalar.
 
     Examples
@@ -185,10 +185,10 @@ def mul_va(lhs: ArrayLike, rhts: CartesianAcc2D, /) -> CartesianAcc2D:
     >>> import coordinax as cx
 
     >>> v = cx.vecs.CartesianAcc2D.from_([3, 4], "m/s2")
-    >>> jnp.multiply(5, v).d2_x
+    >>> jnp.multiply(5, v).x
     Quantity['acceleration'](Array(15, dtype=int32), unit='m / s2')
 
-    >>> (5 * v).d2_x
+    >>> (5 * v).x
     Quantity['acceleration'](Array(15, dtype=int32), unit='m / s2')
 
     """
@@ -198,7 +198,7 @@ def mul_va(lhs: ArrayLike, rhts: CartesianAcc2D, /) -> CartesianAcc2D:
     )
 
     # Scale the components
-    return replace(rhts, d2_x=lhs * rhts.d2_x, d2_y=lhs * rhts.d2_y)
+    return replace(rhs, x=lhs * rhs.x, y=lhs * rhs.y)
 
 
 @register(jax.lax.mul_p)

--- a/src/coordinax/_src/vectors/d2/spherical.py
+++ b/src/coordinax/_src/vectors/d2/spherical.py
@@ -101,9 +101,9 @@ class TwoSphereVel(AbstractVel2D):
 
     Parameters
     ----------
-    d_theta : Quantity['angular speed']
+    theta : Quantity['angular speed']
         Inclination speed $`d\theta/dt \in [-\infty, \infty]$.
-    d_phi : Quantity['angular speed']
+    phi : Quantity['angular speed']
         Azimuthal speed $d\phi/dt \in [-\infty, \infty]$.
 
     See Also
@@ -118,8 +118,8 @@ class TwoSphereVel(AbstractVel2D):
 
     We can construct a 2-spherical velocity:
 
-    >>> s2 = cx.vecs.TwoSphereVel(d_theta=u.Quantity(0, "deg/s"),
-    ...                           d_phi=u.Quantity(2, "deg/s"))
+    >>> s2 = cx.vecs.TwoSphereVel(theta=u.Quantity(0, "deg/s"),
+    ...                           phi=u.Quantity(2, "deg/s"))
 
     This coordinate has corresponding position and acceleration class:
 
@@ -131,12 +131,12 @@ class TwoSphereVel(AbstractVel2D):
 
     """
 
-    d_theta: ct.BatchableAngularSpeed = eqx.field(
+    theta: ct.BatchableAngularSpeed = eqx.field(
         converter=u.Quantity["angular speed"].from_
     )
     r"""Inclination speed :math:`d\theta/dt \in [-\infty, \infty]."""
 
-    d_phi: ct.BatchableAngularSpeed = eqx.field(
+    phi: ct.BatchableAngularSpeed = eqx.field(
         converter=u.Quantity["angular speed"].from_
     )
     r"""Azimuthal speed :math:`d\phi/dt \in [-\infty, \infty]."""
@@ -174,9 +174,9 @@ class TwoSphereAcc(AbstractAcc2D):
 
     Parameters
     ----------
-    d2_theta : Quantity['angular acceleration']
+    theta : Quantity['angular acceleration']
         Inclination acceleration $`d^2\theta/dt^2 \in [-\infty, \infty]$.
-    d2_phi : Quantity['angular acceleration']
+    phi : Quantity['angular acceleration']
         Azimuthal acceleration $d^2\phi/dt^2 \in [-\infty, \infty]$.
 
     See Also
@@ -191,8 +191,8 @@ class TwoSphereAcc(AbstractAcc2D):
 
     We can construct a 2-spherical acceleration:
 
-    >>> s2 = cx.vecs.TwoSphereAcc(d2_theta=u.Quantity(0, "deg/s2"),
-    ...                           d2_phi=u.Quantity(2, "deg/s2"))
+    >>> s2 = cx.vecs.TwoSphereAcc(theta=u.Quantity(0, "deg/s2"),
+    ...                           phi=u.Quantity(2, "deg/s2"))
 
     This coordinate has corresponding velocity class:
 
@@ -201,12 +201,12 @@ class TwoSphereAcc(AbstractAcc2D):
 
     """
 
-    d2_theta: ct.BatchableAngularAcc = eqx.field(
+    theta: ct.BatchableAngularAcc = eqx.field(
         converter=u.Quantity["angular acceleration"].from_
     )
     r"""Inclination acceleration :math:`d^2\theta/dt^2 \in [-\infty, \infty]."""
 
-    d2_phi: ct.BatchableAngularAcc = eqx.field(
+    phi: ct.BatchableAngularAcc = eqx.field(
         converter=u.Quantity["angular acceleration"].from_
     )
     r"""Azimuthal acceleration :math:`d^2\phi/dt^2 \in [-\infty, \infty]."""

--- a/src/coordinax/_src/vectors/d3/cartesian.py
+++ b/src/coordinax/_src/vectors/d3/cartesian.py
@@ -6,29 +6,21 @@ __all__ = [
     "CartesianVel3D",
 ]
 
-from dataclasses import replace
 from functools import partial
-from typing import Any, final
+from typing import final
 from typing_extensions import override
 
 import equinox as eqx
 import jax
-from jaxtyping import ArrayLike
-from plum import dispatch
-from quax import register
 
-import quaxed.lax as qlax
 import quaxed.numpy as jnp
 import unxt as u
-from unxt.quantity import AbstractQuantity
 
 import coordinax._src.typing as ct
 from .base import AbstractAcc3D, AbstractPos3D, AbstractVel3D
-from .generic import CartesianGeneric3D
 from coordinax._src.distances import BatchableLength
-from coordinax._src.utils import classproperty, is_any_quantity
+from coordinax._src.utils import classproperty
 from coordinax._src.vectors.base.cartesian import AbstractCartesian
-from coordinax._src.vectors.base_pos import AbstractPos
 
 #####################################################################
 # Position
@@ -75,133 +67,6 @@ class CartesianPos3D(AbstractCartesian, AbstractPos3D):
         return CartesianVel3D
 
 
-# =====================================================
-# Primitives
-
-
-@register(jax.lax.add_p)
-def _add_cart3d_pos(lhs: CartesianPos3D, rhs: AbstractPos, /) -> CartesianPos3D:
-    """Subtract two vectors.
-
-    Examples
-    --------
-    >>> import unxt as u
-    >>> import coordinax as cx
-    >>> q = cx.CartesianPos3D.from_([1, 2, 3], "km")
-    >>> s = cx.SphericalPos(r=u.Quantity(1, "km"), theta=u.Quantity(90, "deg"),
-    ...                     phi=u.Quantity(0, "deg"))
-    >>> print(q + s)
-    <CartesianPos3D (x[km], y[km], z[km])
-        [2. 2. 3.]>
-
-    """
-    cart = rhs.vconvert(CartesianPos3D)
-    return jax.tree.map(jnp.add, lhs, cart, is_leaf=is_any_quantity)
-
-
-# ------------------------------------------------
-# Dot product
-# TODO: see implementation in https://github.com/google/tree-math for how to do
-# this more generally.
-
-
-@register(jax.lax.dot_general_p)
-def _dot_general_cart3d(
-    lhs: CartesianPos3D, rhs: CartesianPos3D, /, **kwargs: Any
-) -> AbstractQuantity:
-    """Dot product of two vectors.
-
-    Examples
-    --------
-    >>> import quaxed.numpy as jnp
-    >>> import unxt as u
-    >>> import coordinax as cx
-
-    >>> q1 = cx.vecs.CartesianPos3D.from_([1, 2, 3], "m")
-    >>> q2 = cx.vecs.CartesianPos3D.from_([4, 5, 6], "m")
-
-    >>> jnp.dot(q1, q2)
-    Quantity['area'](Array(32, dtype=int32), unit='m2')
-
-    """
-    return lhs.x * rhs.x + lhs.y * rhs.y + lhs.z * rhs.z
-
-
-# ------------------------------------------------
-
-
-@register(jax.lax.neg_p)
-def _neg_p_cart3d_pos(obj: CartesianPos3D, /) -> CartesianPos3D:
-    """Negate the `coordinax.CartesianPos3D`.
-
-    Examples
-    --------
-    >>> import coordinax as cx
-    >>> q = cx.CartesianPos3D.from_([1, 2, 3], "km")
-    >>> print(-q)
-    <CartesianPos3D (x[km], y[km], z[km])
-        [-1 -2 -3]>
-
-    """
-    return jax.tree.map(qlax.neg, obj)
-
-
-@register(jax.lax.sub_p)
-def _sub_cart3d_pos(lhs: CartesianPos3D, rhs: AbstractPos, /) -> CartesianPos3D:
-    """Subtract two vectors.
-
-    Examples
-    --------
-    >>> import unxt as u
-    >>> import coordinax as cx
-    >>> q = cx.CartesianPos3D.from_([1, 2, 3], "km")
-    >>> s = cx.SphericalPos(r=u.Quantity(1, "km"), theta=u.Quantity(90, "deg"),
-    ...                     phi=u.Quantity(0, "deg"))
-    >>> print(q - s)
-    <CartesianPos3D (x[km], y[km], z[km])
-        [0. 2. 3.]>
-
-    """
-    cart = rhs.vconvert(CartesianPos3D)
-    return jax.tree.map(jnp.subtract, lhs, cart)
-
-
-# =====================================================
-# Functions
-
-
-# from coordinax.vectors.funcs
-@dispatch
-@partial(eqx.filter_jit, inline=True)
-def normalize_vector(obj: CartesianPos3D, /) -> CartesianGeneric3D:
-    """Return the norm of the vector.
-
-    This has length 1.
-
-    .. note::
-
-        The unit vector is dimensionless, even if the input vector has units.
-        This is because the unit vector is a ratio of two quantities: each
-        component and the norm of the vector.
-
-    Returns
-    -------
-    CartesianGeneric3D
-        The norm of the vector.
-
-    Examples
-    --------
-    >>> import coordinax as cx
-    >>> q = cx.CartesianPos3D.from_([1, 2, 3], "km")
-    >>> print(cx.vecs.normalize_vector(q))
-    <CartesianGeneric3D (x[], y[], z[])
-        [0.267 0.535 0.802]>
-
-    """
-    norm: AbstractQuantity = obj.norm()  # type: ignore[misc]
-    return CartesianGeneric3D(x=obj.x / norm, y=obj.y / norm, z=obj.z / norm)
-
-
 #####################################################################
 # Velocity
 
@@ -216,18 +81,18 @@ class CartesianVel3D(AbstractCartesian, AbstractVel3D):
 
     >>> vec = cx.CartesianVel3D.from_([1, 2, 3], "m/s")
     >>> print(vec)
-    <CartesianVel3D (d_x[m / s], d_y[m / s], d_z[m / s])
+    <CartesianVel3D (x[m / s], y[m / s], z[m / s])
         [1 2 3]>
 
     """
 
-    d_x: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
+    x: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
     r"""X speed :math:`dx/dt \in [-\infty, \infty]."""
 
-    d_y: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
+    y: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
     r"""Y speed :math:`dy/dt \in [-\infty, \infty]."""
 
-    d_z: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
+    z: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
     r"""Z speed :math:`dz/dt \in [-\infty, \infty]."""
 
     @override
@@ -263,44 +128,7 @@ class CartesianVel3D(AbstractCartesian, AbstractVel3D):
         Quantity['speed'](Array(3.7416575, dtype=float32), unit='km / s')
 
         """
-        return jnp.sqrt(self.d_x**2 + self.d_y**2 + self.d_z**2)
-
-
-# -----------------------------------------------------
-# Method dispatches
-
-
-@register(jax.lax.add_p)
-def _add_pp(lhs: CartesianVel3D, rhs: CartesianVel3D, /) -> CartesianVel3D:
-    """Add two Cartesian velocities.
-
-    Examples
-    --------
-    >>> import coordinax as cx
-
-    >>> q = cx.CartesianVel3D.from_([1, 2, 3], "km/s")
-    >>> print(q + q)
-    <CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
-        [2 4 6]>
-
-    """
-    return jax.tree.map(jnp.add, lhs, rhs)
-
-
-@register(jax.lax.sub_p)
-def _sub_v3_v3(lhs: CartesianVel3D, other: CartesianVel3D, /) -> CartesianVel3D:
-    """Subtract two differentials.
-
-    Examples
-    --------
-    >>> from coordinax import CartesianPos3D, CartesianVel3D
-    >>> q = CartesianVel3D.from_([1, 2, 3], "km/s")
-    >>> print(q - q)
-    <CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
-        [0 0 0]>
-
-    """
-    return jax.tree.map(jnp.subtract, lhs, other)
+        return jnp.sqrt(self.x**2 + self.y**2 + self.z**2)
 
 
 #####################################################################
@@ -311,13 +139,13 @@ def _sub_v3_v3(lhs: CartesianVel3D, other: CartesianVel3D, /) -> CartesianVel3D:
 class CartesianAcc3D(AbstractCartesian, AbstractAcc3D):
     """Cartesian differential representation."""
 
-    d2_x: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
+    x: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
     r"""X acceleration :math:`d^2x/dt^2 \in [-\infty, \infty]."""
 
-    d2_y: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
+    y: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
     r"""Y acceleration :math:`d^2y/dt^2 \in [-\infty, \infty]."""
 
-    d2_z: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
+    z: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
     r"""Z acceleration :math:`d^2z/dt^2 \in [-\infty, \infty]."""
 
     @override
@@ -344,71 +172,4 @@ class CartesianAcc3D(AbstractCartesian, AbstractAcc3D):
         Quantity['acceleration'](Array(3.7416575, dtype=float32), unit='km / s2')
 
         """
-        return jnp.sqrt(self.d2_x**2 + self.d2_y**2 + self.d2_z**2)
-
-
-# -----------------------------------------------------
-# Method dispatches
-
-
-@register(jax.lax.add_p)
-def _add_aa(lhs: CartesianAcc3D, rhs: CartesianAcc3D, /) -> CartesianAcc3D:
-    """Add two Cartesian accelerations.
-
-    Examples
-    --------
-    >>> import coordinax as cx
-
-    >>> q = cx.vecs.CartesianAcc3D.from_([1, 2, 3], "km/s2")
-    >>> print(q + q)
-    <CartesianAcc3D (d2_x[km / s2], d2_y[km / s2], d2_z[km / s2])
-        [2 4 6]>
-
-    """
-    return jax.tree.map(jnp.add, lhs, rhs)
-
-
-@register(jax.lax.mul_p)
-def _mul_ac3(lhs: ArrayLike, rhs: CartesianPos3D, /) -> CartesianPos3D:
-    """Scale a position by a scalar.
-
-    Examples
-    --------
-    >>> import quaxed.numpy as jnp
-    >>> import coordinax as cx
-
-    >>> v = cx.CartesianPos3D.from_([1, 2, 3], "km")
-
-    >>> print(2 * v)
-    <CartesianPos3D (x[km], y[km], z[km])
-        [2 4 6]>
-
-    >>> print(jnp.multiply(2, v))
-    <CartesianPos3D (x[km], y[km], z[km])
-        [2 4 6]>
-
-    """
-    # Validation
-    lhs = eqx.error_if(
-        lhs, any(jax.numpy.shape(lhs)), f"must be a scalar, not {type(lhs)}"
-    )
-
-    # Scale the components
-    return replace(rhs, x=lhs * rhs.x, y=lhs * rhs.y, z=lhs * rhs.z)
-
-
-@register(jax.lax.sub_p)
-def _sub_a3_a3(lhs: CartesianAcc3D, rhs: CartesianAcc3D, /) -> CartesianAcc3D:
-    """Subtract two accelerations.
-
-    Examples
-    --------
-    >>> import coordinax as cx
-
-    >>> q = cx.vecs.CartesianAcc3D.from_([1, 2, 3], "km/s2")
-    >>> print(q - q)
-    <CartesianAcc3D (d2_x[km / s2], d2_y[km / s2], d2_z[km / s2])
-        [0 0 0]>
-
-    """
-    return jax.tree.map(jnp.subtract, lhs, rhs)
+        return jnp.sqrt(self.x**2 + self.y**2 + self.z**2)

--- a/src/coordinax/_src/vectors/d3/cylindrical.py
+++ b/src/coordinax/_src/vectors/d3/cylindrical.py
@@ -82,24 +82,24 @@ class CylindricalVel(AbstractVel3D):
     >>> import unxt as u
     >>> import coordinax as cx
 
-    >>> vec = cx.vecs.CylindricalVel(d_rho=u.Quantity(1, "km/s"),
-    ...                              d_phi=u.Quantity(2, "deg/s"),
-    ...                              d_z=u.Quantity(3, "km/s"))
+    >>> vec = cx.vecs.CylindricalVel(rho=u.Quantity(1, "km/s"),
+    ...                              phi=u.Quantity(2, "deg/s"),
+    ...                              z=u.Quantity(3, "km/s"))
     >>> print(vec)
-    <CylindricalVel (d_rho[km / s], d_phi[deg / s], d_z[km / s])
+    <CylindricalVel (rho[km / s], phi[deg / s], z[km / s])
         [1 2 3]>
 
     """
 
-    d_rho: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
+    rho: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
     r"""Cyindrical radial speed :math:`d\rho/dt \in [-\infty, \infty]."""
 
-    d_phi: ct.BatchableAngularSpeed = eqx.field(
+    phi: ct.BatchableAngularSpeed = eqx.field(
         converter=u.Quantity["angular speed"].from_
     )
     r"""Azimuthal speed :math:`d\phi/dt \in [-\infty, \infty]."""
 
-    d_z: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
+    z: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
     r"""Vertical speed :math:`dz/dt \in [-\infty, \infty]."""
 
     @override
@@ -124,24 +124,24 @@ class CylindricalAcc(AbstractAcc3D):
     >>> import unxt as u
     >>> import coordinax as cx
 
-    >>> vec = cx.vecs.CylindricalAcc(d2_rho=u.Quantity(1, "km/s2"),
-    ...                              d2_phi=u.Quantity(2, "deg/s2"),
-    ...                              d2_z=u.Quantity(3, "km/s2"))
+    >>> vec = cx.vecs.CylindricalAcc(rho=u.Quantity(1, "km/s2"),
+    ...                              phi=u.Quantity(2, "deg/s2"),
+    ...                              z=u.Quantity(3, "km/s2"))
     >>> print(vec)
-    <CylindricalAcc (d2_rho[km / s2], d2_phi[deg / s2], d2_z[km / s2])
+    <CylindricalAcc (rho[km / s2], phi[deg / s2], z[km / s2])
         [1 2 3]>
 
     """
 
-    d2_rho: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
+    rho: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
     r"""Cyindrical radial acceleration :math:`d^2\rho/dt^2 \in [-\infty, \infty]."""
 
-    d2_phi: ct.BatchableAngularAcc = eqx.field(
+    phi: ct.BatchableAngularAcc = eqx.field(
         converter=u.Quantity["angular acceleration"].from_
     )
     r"""Azimuthal acceleration :math:`d^2\phi/dt^2 \in [-\infty, \infty]."""
 
-    d2_z: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
+    z: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
     r"""Vertical acceleration :math:`d^2z/dt^2 \in [-\infty, \infty]."""
 
     @override

--- a/src/coordinax/_src/vectors/d3/mathspherical.py
+++ b/src/coordinax/_src/vectors/d3/mathspherical.py
@@ -11,23 +11,15 @@ from typing import final
 from typing_extensions import override
 
 import equinox as eqx
-import jax
-from jaxtyping import ArrayLike
-from plum import dispatch
-from quax import register
 
-import quaxed.numpy as jnp
-from dataclassish import replace
 from dataclassish.converters import Unless
-from unxt.quantity import AbstractQuantity, Quantity
+from unxt.quantity import Quantity
 
 import coordinax._src.typing as ct
 from .base_spherical import (
     AbstractSphericalAcc,
     AbstractSphericalPos,
     AbstractSphericalVel,
-    _180d,
-    _360d,
 )
 from coordinax._src.angles import Angle, BatchableAngle
 from coordinax._src.distances import AbstractDistance, BatchableDistance, Distance
@@ -96,113 +88,6 @@ class MathSphericalPos(AbstractSphericalPos):
         return self.r
 
 
-@dispatch
-def vector(
-    cls: type[MathSphericalPos],
-    *,
-    r: AbstractQuantity,
-    theta: AbstractQuantity,
-    phi: AbstractQuantity,
-) -> MathSphericalPos:
-    """Construct MathSphericalPos, allowing for out-of-range values.
-
-    Examples
-    --------
-    >>> import unxt as u
-    >>> import coordinax as cx
-
-    Let's start with a valid input:
-
-    >>> vec = cx.vecs.MathSphericalPos.from_(r=u.Quantity(3, "km"),
-    ...                                      theta=u.Quantity(90, "deg"),
-    ...                                      phi=u.Quantity(0, "deg"))
-    >>> print(vec)
-    <MathSphericalPos (r[km], theta[deg], phi[deg])
-        [ 3 90  0]>
-
-    The radial distance can be negative, which wraps the azimuthal angle by 180
-    degrees and flips the polar angle:
-
-    >>> vec = cx.vecs.MathSphericalPos.from_(r=u.Quantity(-3, "km"),
-    ...                                      theta=u.Quantity(100, "deg"),
-    ...                                      phi=u.Quantity(45, "deg"))
-    >>> print(vec)
-    <MathSphericalPos (r[km], theta[deg], phi[deg])
-        [  3 280 135]>
-
-    The polar angle can be outside the [0, 180] deg range, causing the azimuthal
-    angle to be shifted by 180 degrees:
-
-    >>> vec = cx.vecs.MathSphericalPos.from_(r=u.Quantity(3, "km"),
-    ...                                      theta=u.Quantity(0, "deg"),
-    ...                                      phi=u.Quantity(190, "deg"))
-    >>> print(vec)
-    <MathSphericalPos (r[km], theta[deg], phi[deg])
-        [  3 180 170]>
-
-    The azimuth can be outside the [0, 360) deg range. This is wrapped to the
-    [0, 360) deg range (actually the base constructor does this):
-
-    >>> vec = cx.vecs.MathSphericalPos.from_(r=u.Quantity(3, "km"),
-    ...                                      theta=u.Quantity(365, "deg"),
-    ...                                      phi=u.Quantity(90, "deg"))
-    >>> vec.theta
-    Angle(Array(5, dtype=int32, ...), unit='deg')
-
-    """
-    # 1) Convert the inputs
-    fields = MathSphericalPos.__dataclass_fields__
-    r = fields["r"].metadata["converter"](r)
-    theta = fields["theta"].metadata["converter"](theta)
-    phi = fields["phi"].metadata["converter"](phi)
-
-    # 2) handle negative distances
-    r_pred = r < jnp.zeros_like(r)
-    r = jnp.where(r_pred, -r, r)
-    theta = jnp.where(r_pred, theta + _180d, theta)
-    phi = jnp.where(r_pred, _180d - phi, phi)
-
-    # 3) Handle polar angle outside of [0, 180] degrees
-    phi = jnp.mod(phi, _360d)  # wrap to [0, 360) deg
-    phi_pred = phi < _180d
-    phi = jnp.where(phi_pred, phi, _360d - phi)
-    theta = jnp.where(phi_pred, theta, theta + _180d)
-
-    # 4) Construct. This also handles the azimuthal angle wrapping
-    return cls(r=r, theta=theta, phi=phi)
-
-
-@register(jax.lax.mul_p)
-def _mul_p_vmsph(lhs: ArrayLike, rhs: MathSphericalPos, /) -> MathSphericalPos:
-    """Scale the polar position by a scalar.
-
-    Examples
-    --------
-    >>> import unxt as u
-    >>> import coordinax as cx
-    >>> import quaxed.numpy as jnp
-
-    >>> v = cx.vecs.MathSphericalPos(r=u.Quantity(3, "km"),
-    ...                              theta=u.Quantity(90, "deg"),
-    ...                              phi=u.Quantity(0, "deg"))
-
-    >>> jnp.linalg.vector_norm(v, axis=-1)
-    UncheckedQuantity(Array(3., dtype=float32), unit='km')
-
-    >>> nv = jnp.multiply(2, v)
-    >>> print(nv)
-    <MathSphericalPos (r[km], theta[deg], phi[deg])
-        [ 6 90  0]>
-
-    """
-    # Validation
-    lhs = eqx.error_if(
-        lhs, any(jax.numpy.shape(lhs)), f"must be a scalar, not {type(lhs)}"
-    )
-    # Scale the radial distance
-    return replace(rhs, r=lhs * rhs.r)
-
-
 ##############################################################################
 
 
@@ -210,17 +95,15 @@ def _mul_p_vmsph(lhs: ArrayLike, rhs: MathSphericalPos, /) -> MathSphericalPos:
 class MathSphericalVel(AbstractSphericalVel):
     """Spherical differential representation."""
 
-    d_r: ct.BatchableSpeed = eqx.field(converter=Quantity["speed"].from_)
+    r: ct.BatchableSpeed = eqx.field(converter=Quantity["speed"].from_)
     r"""Radial speed :math:`dr/dt \in [-\infty, \infty]."""
 
-    d_theta: ct.BatchableAngularSpeed = eqx.field(
+    theta: ct.BatchableAngularSpeed = eqx.field(
         converter=Quantity["angular speed"].from_
     )
     r"""Azimuthal speed :math:`d\theta/dt \in [-\infty, \infty]."""
 
-    d_phi: ct.BatchableAngularSpeed = eqx.field(
-        converter=Quantity["angular speed"].from_
-    )
+    phi: ct.BatchableAngularSpeed = eqx.field(converter=Quantity["angular speed"].from_)
     r"""Inclination speed :math:`d\phi/dt \in [-\infty, \infty]."""
 
     @override
@@ -243,15 +126,15 @@ class MathSphericalVel(AbstractSphericalVel):
 class MathSphericalAcc(AbstractSphericalAcc):
     """Spherical acceleration representation."""
 
-    d2_r: ct.BatchableAcc = eqx.field(converter=Quantity["acceleration"].from_)
+    r: ct.BatchableAcc = eqx.field(converter=Quantity["acceleration"].from_)
     r"""Radial acceleration :math:`d^2r/dt^2 \in [-\infty, \infty]."""
 
-    d2_theta: ct.BatchableAngularAcc = eqx.field(
+    theta: ct.BatchableAngularAcc = eqx.field(
         converter=Quantity["angular acceleration"].from_
     )
     r"""Azimuthal acceleration :math:`d^2\theta/dt^2 \in [-\infty, \infty]."""
 
-    d2_phi: ct.BatchableAngularAcc = eqx.field(
+    phi: ct.BatchableAngularAcc = eqx.field(
         converter=Quantity["angular acceleration"].from_
     )
     r"""Inclination acceleration :math:`d^2\phi/dt^2 \in [-\infty, \infty]."""

--- a/src/coordinax/_src/vectors/d3/register_primitives.py
+++ b/src/coordinax/_src/vectors/d3/register_primitives.py
@@ -3,12 +3,189 @@
 __all__: list[str] = []
 
 
+from dataclasses import replace
+from typing import Any, cast
+
+import equinox as eqx
 import jax
+from jaxtyping import ArrayLike
 from quax import register
 
+import quaxed.lax as qlax
 import quaxed.numpy as jnp
+from unxt.quantity import AbstractQuantity
 
+from .cartesian import CartesianAcc3D, CartesianPos3D, CartesianVel3D
 from .generic import CartesianGeneric3D
+from .mathspherical import MathSphericalPos
+from coordinax._src.utils import is_any_quantity
+from coordinax._src.vectors.base_pos import AbstractPos
+
+# ------------------------------------------------
+
+
+@register(jax.lax.add_p)
+def _add_cart3d_pos(lhs: CartesianPos3D, rhs: AbstractPos, /) -> CartesianPos3D:
+    """Subtract two vectors.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax as cx
+    >>> q = cx.CartesianPos3D.from_([1, 2, 3], "km")
+    >>> s = cx.SphericalPos(r=u.Quantity(1, "km"), theta=u.Quantity(90, "deg"),
+    ...                     phi=u.Quantity(0, "deg"))
+    >>> print(q + s)
+    <CartesianPos3D (x[km], y[km], z[km])
+        [2. 2. 3.]>
+
+    """
+    cart = rhs.vconvert(CartesianPos3D)
+    return jax.tree.map(jnp.add, lhs, cart, is_leaf=is_any_quantity)
+
+
+@register(jax.lax.add_p)
+def _add_pp(lhs: CartesianVel3D, rhs: CartesianVel3D, /) -> CartesianVel3D:
+    """Add two Cartesian velocities.
+
+    Examples
+    --------
+    >>> import coordinax as cx
+
+    >>> q = cx.CartesianVel3D.from_([1, 2, 3], "km/s")
+    >>> print(q + q)
+    <CartesianVel3D (x[km / s], y[km / s], z[km / s])
+        [2 4 6]>
+
+    """
+    return jax.tree.map(jnp.add, lhs, rhs)
+
+
+@register(jax.lax.add_p)
+def _add_aa(lhs: CartesianAcc3D, rhs: CartesianAcc3D, /) -> CartesianAcc3D:
+    """Add two Cartesian accelerations.
+
+    Examples
+    --------
+    >>> import coordinax as cx
+
+    >>> q = cx.vecs.CartesianAcc3D.from_([1, 2, 3], "km/s2")
+    >>> print(q + q)
+    <CartesianAcc3D (x[km / s2], y[km / s2], z[km / s2])
+        [2 4 6]>
+
+    """
+    return jax.tree.map(jnp.add, lhs, rhs)
+
+
+# ------------------------------------------------
+# Dot product
+# TODO: see implementation in https://github.com/google/tree-math for how to do
+# this more generally.
+
+
+@register(jax.lax.dot_general_p)
+def _dot_general_cart3d(
+    lhs: CartesianPos3D, rhs: CartesianPos3D, /, **kwargs: Any
+) -> AbstractQuantity:
+    """Dot product of two vectors.
+
+    Examples
+    --------
+    >>> import quaxed.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax as cx
+
+    >>> q1 = cx.vecs.CartesianPos3D.from_([1, 2, 3], "m")
+    >>> q2 = cx.vecs.CartesianPos3D.from_([4, 5, 6], "m")
+
+    >>> jnp.dot(q1, q2)
+    Quantity['area'](Array(32, dtype=int32), unit='m2')
+
+    """
+    return lhs.x * rhs.x + lhs.y * rhs.y + lhs.z * rhs.z
+
+
+# ------------------------------------------------
+
+
+@register(jax.lax.mul_p)
+def _mul_p_vmsph(lhs: ArrayLike, rhs: MathSphericalPos, /) -> MathSphericalPos:
+    """Scale the polar position by a scalar.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax as cx
+    >>> import quaxed.numpy as jnp
+
+    >>> v = cx.vecs.MathSphericalPos(r=u.Quantity(3, "km"),
+    ...                              theta=u.Quantity(90, "deg"),
+    ...                              phi=u.Quantity(0, "deg"))
+
+    >>> jnp.linalg.vector_norm(v, axis=-1)
+    UncheckedQuantity(Array(3., dtype=float32), unit='km')
+
+    >>> nv = jnp.multiply(2, v)
+    >>> print(nv)
+    <MathSphericalPos (r[km], theta[deg], phi[deg])
+        [ 6 90  0]>
+
+    """
+    # Validation
+    lhs = eqx.error_if(
+        lhs, any(jax.numpy.shape(lhs)), f"must be a scalar, not {type(lhs)}"
+    )
+    # Scale the radial distance
+    return replace(rhs, r=cast(AbstractQuantity, lhs * rhs.r))
+
+
+@register(jax.lax.mul_p)
+def _mul_ac3(lhs: ArrayLike, rhs: CartesianPos3D, /) -> CartesianPos3D:
+    """Scale a position by a scalar.
+
+    Examples
+    --------
+    >>> import quaxed.numpy as jnp
+    >>> import coordinax as cx
+
+    >>> v = cx.CartesianPos3D.from_([1, 2, 3], "km")
+
+    >>> print(2 * v)
+    <CartesianPos3D (x[km], y[km], z[km])
+        [2 4 6]>
+
+    >>> print(jnp.multiply(2, v))
+    <CartesianPos3D (x[km], y[km], z[km])
+        [2 4 6]>
+
+    """
+    # Validation
+    lhs = eqx.error_if(
+        lhs, any(jax.numpy.shape(lhs)), f"must be a scalar, not {type(lhs)}"
+    )
+
+    # Scale the components
+    return replace(rhs, x=lhs * rhs.x, y=lhs * rhs.y, z=lhs * rhs.z)
+
+
+# ------------------------------------------------
+
+
+@register(jax.lax.neg_p)
+def _neg_p_cart3d_pos(obj: CartesianPos3D, /) -> CartesianPos3D:
+    """Negate the `coordinax.CartesianPos3D`.
+
+    Examples
+    --------
+    >>> import coordinax as cx
+    >>> q = cx.CartesianPos3D.from_([1, 2, 3], "km")
+    >>> print(-q)
+    <CartesianPos3D (x[km], y[km], z[km])
+        [-1 -2 -3]>
+
+    """
+    return jax.tree.map(qlax.neg, obj)
 
 
 @register(jax.lax.neg_p)
@@ -25,3 +202,59 @@ def neg_genericcart3d(obj: CartesianGeneric3D, /) -> CartesianGeneric3D:
 
     """
     return jax.tree.map(jnp.negative, obj)
+
+
+# ------------------------------------------------
+
+
+@register(jax.lax.sub_p)
+def _sub_cart3d_pos(lhs: CartesianPos3D, rhs: AbstractPos, /) -> CartesianPos3D:
+    """Subtract two vectors.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax as cx
+    >>> q = cx.CartesianPos3D.from_([1, 2, 3], "km")
+    >>> s = cx.SphericalPos(r=u.Quantity(1, "km"), theta=u.Quantity(90, "deg"),
+    ...                     phi=u.Quantity(0, "deg"))
+    >>> print(q - s)
+    <CartesianPos3D (x[km], y[km], z[km])
+        [0. 2. 3.]>
+
+    """
+    cart = rhs.vconvert(CartesianPos3D)
+    return jax.tree.map(jnp.subtract, lhs, cart)
+
+
+@register(jax.lax.sub_p)
+def _sub_v3_v3(lhs: CartesianVel3D, other: CartesianVel3D, /) -> CartesianVel3D:
+    """Subtract two differentials.
+
+    Examples
+    --------
+    >>> from coordinax import CartesianPos3D, CartesianVel3D
+    >>> q = CartesianVel3D.from_([1, 2, 3], "km/s")
+    >>> print(q - q)
+    <CartesianVel3D (x[km / s], y[km / s], z[km / s])
+        [0 0 0]>
+
+    """
+    return jax.tree.map(jnp.subtract, lhs, other)
+
+
+@register(jax.lax.sub_p)
+def _sub_a3_a3(lhs: CartesianAcc3D, rhs: CartesianAcc3D, /) -> CartesianAcc3D:
+    """Subtract two accelerations.
+
+    Examples
+    --------
+    >>> import coordinax as cx
+
+    >>> q = cx.vecs.CartesianAcc3D.from_([1, 2, 3], "km/s2")
+    >>> print(q - q)
+    <CartesianAcc3D (x[km / s2], y[km / s2], z[km / s2])
+        [0 0 0]>
+
+    """
+    return jax.tree.map(jnp.subtract, lhs, rhs)

--- a/src/coordinax/_src/vectors/d3/spherical.py
+++ b/src/coordinax/_src/vectors/d3/spherical.py
@@ -6,20 +6,15 @@ from typing import final
 from typing_extensions import override
 
 import equinox as eqx
-from plum import dispatch
 
-import quaxed.numpy as jnp
 import unxt as u
 from dataclassish.converters import Unless
-from unxt.quantity import AbstractQuantity
 
 import coordinax._src.typing as ct
 from .base_spherical import (
     AbstractSphericalAcc,
     AbstractSphericalPos,
     AbstractSphericalVel,
-    _180d,
-    _360d,
 )
 from coordinax._src.angles import Angle, BatchableAngle
 from coordinax._src.distances import AbstractDistance, BatchableDistance, Distance
@@ -73,82 +68,6 @@ class SphericalPos(AbstractSphericalPos):
         return SphericalVel
 
 
-@dispatch
-def vector(
-    cls: type[SphericalPos],
-    *,
-    r: AbstractQuantity,
-    theta: AbstractQuantity,
-    phi: AbstractQuantity,
-) -> SphericalPos:
-    """Construct SphericalPos, allowing for out-of-range values.
-
-    Examples
-    --------
-    >>> import unxt as u
-    >>> import coordinax as cx
-
-    Let's start with a valid input:
-
-    >>> vec = cx.SphericalPos.from_(r=u.Quantity(3, "km"),
-    ...                             theta=u.Quantity(90, "deg"),
-    ...                             phi=u.Quantity(0, "deg"))
-    >>> print(vec)
-    <SphericalPos (r[km], theta[deg], phi[deg])
-        [ 3 90  0]>
-
-    The radial distance can be negative, which wraps the azimuthal angle by 180
-    degrees and flips the polar angle:
-
-    >>> vec = cx.SphericalPos.from_(r=u.Quantity(-3, "km"),
-    ...                             theta=u.Quantity(45, "deg"),
-    ...                             phi=u.Quantity(0, "deg"))
-    >>> print(vec)
-    <SphericalPos (r[km], theta[deg], phi[deg])
-        [  3 135 180]>
-
-    The polar angle can be outside the [0, 180] deg range, causing the azimuthal
-    angle to be shifted by 180 degrees:
-
-    >>> vec = cx.SphericalPos.from_(r=u.Quantity(3, "km"),
-    ...                             theta=u.Quantity(190, "deg"),
-    ...                             phi=u.Quantity(0, "deg"))
-    >>> print(vec)
-    <SphericalPos (r[km], theta[deg], phi[deg])
-        [  3 170 180]>
-
-    The azimuth can be outside the [0, 360) deg range. This is wrapped to the
-    [0, 360) deg range (actually the base from_ does this):
-
-    >>> vec = cx.SphericalPos.from_(r=u.Quantity(3, "km"),
-    ...                             theta=u.Quantity(90, "deg"),
-    ...                             phi=u.Quantity(365, "deg"))
-    >>> vec.phi
-    Angle(Array(5, dtype=int32, ...), unit='deg')
-
-    """
-    # 1) Convert the inputs
-    fields = SphericalPos.__dataclass_fields__
-    r = fields["r"].metadata["converter"](r)
-    theta = fields["theta"].metadata["converter"](theta)
-    phi = fields["phi"].metadata["converter"](phi)
-
-    # 2) handle negative distances
-    r_pred = r < jnp.zeros_like(r)
-    r = jnp.where(r_pred, -r, r)
-    phi = jnp.where(r_pred, phi + _180d, phi)
-    theta = jnp.where(r_pred, _180d - theta, theta)
-
-    # 3) Handle polar angle outside of [0, 180] degrees
-    theta = jnp.mod(theta, _360d)  # wrap to [0, 360) deg
-    theta_pred = theta < _180d
-    theta = jnp.where(theta_pred, theta, _360d - theta)
-    phi = jnp.where(theta_pred, phi, phi + _180d)
-
-    # 4) Construct. This also handles the azimuthal angle wrapping
-    return cls(r=r, theta=theta, phi=phi)
-
-
 ##############################################################################
 
 
@@ -156,15 +75,15 @@ def vector(
 class SphericalVel(AbstractSphericalVel):
     """Spherical velocity."""
 
-    d_r: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
+    r: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
     r"""Radial speed :math:`dr/dt \in [-\infty, \infty]."""
 
-    d_theta: ct.BatchableAngularSpeed = eqx.field(
+    theta: ct.BatchableAngularSpeed = eqx.field(
         converter=u.Quantity["angular speed"].from_
     )
     r"""Inclination speed :math:`d\theta/dt \in [-\infty, \infty]."""
 
-    d_phi: ct.BatchableAngularSpeed = eqx.field(
+    phi: ct.BatchableAngularSpeed = eqx.field(
         converter=u.Quantity["angular speed"].from_
     )
     r"""Azimuthal speed :math:`d\phi/dt \in [-\infty, \infty]."""
@@ -189,15 +108,15 @@ class SphericalVel(AbstractSphericalVel):
 class SphericalAcc(AbstractSphericalAcc):
     """Spherical differential representation."""
 
-    d2_r: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
+    r: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
     r"""Radial acceleration :math:`d^2r/dt^2 \in [-\infty, \infty]."""
 
-    d2_theta: ct.BatchableAngularAcc = eqx.field(
+    theta: ct.BatchableAngularAcc = eqx.field(
         converter=u.Quantity["angular acceleration"].from_
     )
     r"""Inclination acceleration :math:`d^2\theta/dt^2 \in [-\infty, \infty]."""
 
-    d2_phi: ct.BatchableAngularAcc = eqx.field(
+    phi: ct.BatchableAngularAcc = eqx.field(
         converter=u.Quantity["angular acceleration"].from_
     )
     r"""Azimuthal acceleration :math:`d^2\phi/dt^2 \in [-\infty, \infty]."""

--- a/src/coordinax/_src/vectors/d3/spheroidal.py
+++ b/src/coordinax/_src/vectors/d3/spheroidal.py
@@ -124,13 +124,13 @@ class ProlateSpheroidalPos(AbstractPos3D):
 class ProlateSpheroidalVel(AbstractVel3D):
     """Prolate spheroidal differential representation."""
 
-    d_mu: ct.BatchableDiffusivity = eqx.field(converter=u.Quantity["diffusivity"].from_)
+    mu: ct.BatchableDiffusivity = eqx.field(converter=u.Quantity["diffusivity"].from_)
     r"""Prolate spheroidal mu speed :math:`d\mu/dt \in [-\infty, \infty]."""
 
-    d_nu: ct.BatchableDiffusivity = eqx.field(converter=u.Quantity["diffusivity"].from_)
+    nu: ct.BatchableDiffusivity = eqx.field(converter=u.Quantity["diffusivity"].from_)
     r"""Prolate spheroidal nu speed :math:`d\nu/dt \in [-\infty, \infty]."""
 
-    d_phi: ct.BatchableAngularSpeed = eqx.field(
+    phi: ct.BatchableAngularSpeed = eqx.field(
         converter=u.Quantity["angular speed"].from_
     )
     r"""Azimuthal speed :math:`d\phi/dt \in [-\infty, \infty]."""
@@ -152,17 +152,17 @@ class ProlateSpheroidalVel(AbstractVel3D):
 class ProlateSpheroidalAcc(AbstractAcc3D):
     """Prolate spheroidal acceleration representation."""
 
-    d2_mu: ct.BatchableSpecificEnergy = eqx.field(
+    mu: ct.BatchableSpecificEnergy = eqx.field(
         converter=u.Quantity["specific energy"].from_
     )
     r"""Prolate spheroidal mu acceleration :math:`d^2\mu/dt^2 \in [-\infty, \infty]."""
 
-    d2_nu: ct.BatchableSpecificEnergy = eqx.field(
+    nu: ct.BatchableSpecificEnergy = eqx.field(
         converter=u.Quantity["specific energy"].from_
     )
     r"""Prolate spheroidal nu acceleration :math:`d^2\nu/dt^2 \in [-\infty, \infty]."""
 
-    d2_phi: ct.BatchableAngularAcc = eqx.field(
+    phi: ct.BatchableAngularAcc = eqx.field(
         converter=u.Quantity["angular acceleration"].from_
     )
     r"""Azimuthal acceleration :math:`d^2\phi/dt^2 \in [-\infty, \infty]."""

--- a/src/coordinax/_src/vectors/dn/base.py
+++ b/src/coordinax/_src/vectors/dn/base.py
@@ -156,7 +156,7 @@ class AbstractPosND(AbstractPos):
 class AbstractVelND(AbstractVel):
     """Abstract representation of N-D vector differentials."""
 
-    d_q: eqx.AbstractVar[ct.BatchableSpeed]
+    q: eqx.AbstractVar[ct.BatchableSpeed]
 
     @override
     @classproperty
@@ -204,7 +204,7 @@ class AbstractVelND(AbstractVel):
             f"x must be at least two-dimensional for matrix_transpose; got {ndim=}",
         )
         axes = (*range(ndim - 3), ndim - 1, ndim - 2, ndim)
-        return replace(self, d_q=qlax.transpose(self.d_q, axes))
+        return replace(self, q=qlax.transpose(self.q, axes))
 
     @property
     def shape(self) -> tuple[int, ...]:
@@ -222,7 +222,7 @@ class AbstractVelND(AbstractVel):
         (2,)
 
         """
-        return self.d_q.shape[:-1]
+        return self.q.shape[:-1]
 
     @property
     def T(self) -> "Self":  # noqa: N802
@@ -241,7 +241,7 @@ class AbstractVelND(AbstractVel):
 
         """
         return replace(
-            self, d_q=qlax.transpose(self.d_q, (*range(self.ndim)[::-1], self.ndim))
+            self, q=qlax.transpose(self.q, (*range(self.ndim)[::-1], self.ndim))
         )
 
     # ===============================================================
@@ -257,11 +257,11 @@ class AbstractVelND(AbstractVel):
         >>> vec = cx.vecs.CartesianVelND.from_([[1, 2], [3, 4]], "m/s")
         >>> vec.flatten()
         CartesianVelND(
-            d_q=Quantity[...]( value=i32[2,2], unit=Unit("m / s") )
+            q=Quantity[...]( value=i32[2,2], unit=Unit("m / s") )
         )
 
         """
-        return replace(self, d_q=self.d_q.reshape(-1, self.d_q.shape[-1]))
+        return replace(self, q=self.q.reshape(-1, self.q.shape[-1]))
 
     def reshape(self, *shape: Any, order: str = "C") -> "Self":
         """Reshape the vector.
@@ -278,9 +278,7 @@ class AbstractVelND(AbstractVel):
         (1, 1)
 
         """
-        return replace(
-            self, d_q=self.d_q.reshape(*shape, self.d_q.shape[-1], order=order)
-        )
+        return replace(self, q=self.q.reshape(*shape, self.q.shape[-1], order=order))
 
 
 #####################################################################
@@ -289,7 +287,7 @@ class AbstractVelND(AbstractVel):
 class AbstractAccND(AbstractAcc):
     """Abstract representation of N-D vector differentials."""
 
-    d2_q: eqx.AbstractVar[ct.BatchableAcc]
+    q: eqx.AbstractVar[ct.BatchableAcc]
 
     @override
     @classproperty
@@ -338,7 +336,7 @@ class AbstractAccND(AbstractAcc):
             f"x must be at least two-dimensional for matrix_transpose; got {ndim=}",
         )
         axes = (*range(ndim - 3), ndim - 1, ndim - 2, ndim)
-        return replace(self, d2_q=qlax.transpose(self.d2_q, axes))
+        return replace(self, q=qlax.transpose(self.q, axes))
 
     @property
     def shape(self) -> tuple[int, ...]:
@@ -357,7 +355,7 @@ class AbstractAccND(AbstractAcc):
         (2, 1)
 
         """
-        return self.d2_q.shape[:-1]
+        return self.q.shape[:-1]
 
     @property
     def T(self) -> "Self":  # noqa: N802
@@ -375,7 +373,7 @@ class AbstractAccND(AbstractAcc):
         """
         return replace(
             self,
-            d2_q=qlax.transpose(self.d2_q, (*range(self.ndim)[::-1], self.ndim)),
+            q=qlax.transpose(self.q, (*range(self.ndim)[::-1], self.ndim)),
         )
 
     # ===============================================================
@@ -395,7 +393,7 @@ class AbstractAccND(AbstractAcc):
         (2,)
 
         """
-        return replace(self, d2_q=self.d2_q.reshape(-1, self.d2_q.shape[-1]))
+        return replace(self, q=self.q.reshape(-1, self.q.shape[-1]))
 
     def reshape(self, *shape: Any, order: str = "C") -> "Self":
         """Reshape the vector.
@@ -411,6 +409,4 @@ class AbstractAccND(AbstractAcc):
         (1, 1)
 
         """
-        return replace(
-            self, d2_q=self.d2_q.reshape(*shape, self.d2_q.shape[-1], order=order)
-        )
+        return replace(self, q=self.q.reshape(*shape, self.q.shape[-1], order=order))

--- a/src/coordinax/_src/vectors/dn/cartesian.py
+++ b/src/coordinax/_src/vectors/dn/cartesian.py
@@ -158,7 +158,7 @@ class CartesianVelND(AbstractCartesian, AbstractVelND):
     A 1D vector:
 
     >>> q = cx.vecs.CartesianVelND(u.Quantity([[1]], "km/s"))
-    >>> q.d_q
+    >>> q.q
     Quantity['speed'](Array([[1]], dtype=int32), unit='km / s')
     >>> q.shape
     (1,)
@@ -166,7 +166,7 @@ class CartesianVelND(AbstractCartesian, AbstractVelND):
     A 2D vector:
 
     >>> q = cx.vecs.CartesianVelND(u.Quantity([1, 2], "km/s"))
-    >>> q.d_q
+    >>> q.q
     Quantity['speed'](Array([1, 2], dtype=int32), unit='km / s')
     >>> q.shape
     ()
@@ -174,7 +174,7 @@ class CartesianVelND(AbstractCartesian, AbstractVelND):
     A 3D vector:
 
     >>> q = cx.vecs.CartesianVelND(u.Quantity([1, 2, 3], "km/s"))
-    >>> q.d_q
+    >>> q.q
     Quantity['speed'](Array([1, 2, 3], dtype=int32), unit='km / s')
     >>> q.shape
     ()
@@ -182,7 +182,7 @@ class CartesianVelND(AbstractCartesian, AbstractVelND):
     A 4D vector:
 
     >>> q = cx.vecs.CartesianVelND(u.Quantity([1, 2, 3, 4], "km/s"))
-    >>> q.d_q
+    >>> q.q
     Quantity['speed'](Array([1, 2, 3, 4], dtype=int32), unit='km / s')
     >>> q.shape
     ()
@@ -190,14 +190,14 @@ class CartesianVelND(AbstractCartesian, AbstractVelND):
     A 5D vector:
 
     >>> q = cx.vecs.CartesianVelND(u.Quantity([1, 2, 3, 4, 5], "km/s"))
-    >>> q.d_q
+    >>> q.q
     Quantity['speed'](Array([1, 2, 3, 4, 5], dtype=int32), unit='km / s')
     >>> q.shape
     ()
 
     """
 
-    d_q: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
+    q: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
     r"""N-D speed :math:`d\vec{x}/dt \in (-\infty, \infty).
 
     Should have shape (*batch, F) where F is the number of features /
@@ -218,7 +218,7 @@ class CartesianVelND(AbstractCartesian, AbstractVelND):
         3
 
         """
-        return self.d_q.shape[-1]
+        return self.q.shape[-1]
 
     @override
     @classproperty
@@ -267,7 +267,7 @@ class CartesianVelND(AbstractCartesian, AbstractVelND):
         Quantity['speed'](Array(3.7416575, dtype=float32), unit='km / s')
 
         """
-        return jnp.linalg.vector_norm(self.d_q, axis=-1)
+        return jnp.linalg.vector_norm(self.q, axis=-1)
 
 
 ##############################################################################
@@ -286,7 +286,7 @@ class CartesianAccND(AbstractCartesian, AbstractAccND):
     A 1D vector:
 
     >>> q = cx.vecs.CartesianAccND(u.Quantity([[1]], "km/s2"))
-    >>> q.d2_q
+    >>> q.q
     Quantity['acceleration'](Array([[1]], dtype=int32), unit='km / s2')
     >>> q.shape
     (1,)
@@ -294,7 +294,7 @@ class CartesianAccND(AbstractCartesian, AbstractAccND):
     A 2D vector:
 
     >>> q = cx.vecs.CartesianAccND(u.Quantity([1, 2], "km/s2"))
-    >>> q.d2_q
+    >>> q.q
     Quantity['acceleration'](Array([1, 2], dtype=int32), unit='km / s2')
     >>> q.shape
     ()
@@ -302,7 +302,7 @@ class CartesianAccND(AbstractCartesian, AbstractAccND):
     A 3D vector:
 
     >>> q = cx.vecs.CartesianAccND(u.Quantity([1, 2, 3], "km/s2"))
-    >>> q.d2_q
+    >>> q.q
     Quantity['acceleration'](Array([1, 2, 3], dtype=int32), unit='km / s2')
     >>> q.shape
     ()
@@ -310,7 +310,7 @@ class CartesianAccND(AbstractCartesian, AbstractAccND):
     A 4D vector:
 
     >>> q = cx.vecs.CartesianAccND(u.Quantity([1, 2, 3, 4], "km/s2"))
-    >>> q.d2_q
+    >>> q.q
     Quantity['acceleration'](Array([1, 2, 3, 4], dtype=int32), unit='km / s2')
     >>> q.shape
     ()
@@ -318,14 +318,14 @@ class CartesianAccND(AbstractCartesian, AbstractAccND):
     A 5D vector:
 
     >>> q = cx.vecs.CartesianAccND(u.Quantity([1, 2, 3, 4, 5], "km/s2"))
-    >>> q.d2_q
+    >>> q.q
     Quantity['acceleration'](Array([1, 2, 3, 4, 5], dtype=int32), unit='km / s2')
     >>> q.shape
     ()
 
     """
 
-    d2_q: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
+    q: ct.BatchableAcc = eqx.field(converter=u.Quantity["acceleration"].from_)
     r"""N-D acceleration :math:`d\vec{x}/dt^2 \in (-\infty, \infty).
 
     Should have shape (*batch, F) where F is the number of features /
@@ -346,7 +346,7 @@ class CartesianAccND(AbstractCartesian, AbstractAccND):
         3
 
         """
-        return self.d2_q.shape[-1]
+        return self.q.shape[-1]
 
     @override
     @classproperty
@@ -401,4 +401,4 @@ class CartesianAccND(AbstractCartesian, AbstractAccND):
         Quantity['acceleration'](Array(3.7416575, dtype=float32), unit='km / s2')
 
         """
-        return jnp.linalg.vector_norm(self.d2_q, axis=-1)
+        return jnp.linalg.vector_norm(self.q, axis=-1)

--- a/src/coordinax/_src/vectors/dn/poincare.py
+++ b/src/coordinax/_src/vectors/dn/poincare.py
@@ -30,13 +30,13 @@ class PoincarePolarVector(AbstractPos):  # TODO: better name
     z: BatchableLength = eqx.field(converter=u.Quantity["length"].from_)
     r"""Height :math:`z \in (-\infty,+\infty)`."""
 
-    d_rho: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
+    dt_rho: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
     r"""Cyindrical radial speed :math:`d\rho/dt \in [-\infty, \infty]."""
 
-    d_pp_phi: Shaped[u.Quantity, "*#batch"] = eqx.field()  # TODO: dimension annotation
+    dt_pp_phi: Shaped[u.Quantity, "*#batch"] = eqx.field()  # TODO: dimension annotation
     r"""Poincare phi-like velocity variable."""
 
-    d_z: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
+    dt_z: ct.BatchableSpeed = eqx.field(converter=u.Quantity["speed"].from_)
     r"""Vertical speed :math:`dz/dt \in [-\infty, \infty]."""
 
     @classmethod

--- a/src/coordinax/_src/vectors/dn/register_plum.py
+++ b/src/coordinax/_src/vectors/dn/register_plum.py
@@ -11,8 +11,12 @@ from unxt.quantity import AbstractQuantity
 from .cartesian import CartesianAccND, CartesianPosND, CartesianVelND
 
 
+@conversion_method(CartesianAccND, AbstractQuantity)  # type: ignore[arg-type]
+@conversion_method(CartesianVelND, AbstractQuantity)
 @conversion_method(CartesianPosND, AbstractQuantity)
-def vec_to_q(obj: CartesianPosND, /) -> Shaped[AbstractQuantity, "*batch N"]:
+def vec_to_q(
+    obj: CartesianPosND | CartesianVelND | CartesianAccND, /
+) -> Shaped[AbstractQuantity, "*batch N"]:
     """`coordinax.AbstractPos3D` -> `unxt.Quantity`.
 
     Examples
@@ -25,41 +29,13 @@ def vec_to_q(obj: CartesianPosND, /) -> Shaped[AbstractQuantity, "*batch N"]:
     >>> convert(vec, u.Quantity)
     Quantity['length'](Array([1, 2, 3, 4, 5], dtype=int32), unit='km')
 
-    """
-    return obj.q
-
-
-@conversion_method(CartesianVelND, AbstractQuantity)
-def vec_to_q(obj: CartesianVelND, /) -> Shaped[AbstractQuantity, "*batch N"]:
-    """`coordinax.AbstractPos3D` -> `unxt.Quantity`.
-
-    Examples
-    --------
-    >>> from plum import convert
-    >>> import unxt as u
-    >>> import coordinax as cx
-
     >>> vec = cx.vecs.CartesianVelND(u.Quantity([1, 2, 3, 4, 5], unit="km/s"))
     >>> convert(vec, u.Quantity)
     Quantity['speed'](Array([1, 2, 3, 4, 5], dtype=int32), unit='km / s')
-
-    """
-    return obj.d_q
-
-
-@conversion_method(CartesianAccND, AbstractQuantity)
-def vec_to_q(obj: CartesianAccND, /) -> Shaped[AbstractQuantity, "*batch N"]:
-    """`coordinax.AbstractPos3D` -> `unxt.Quantity`.
-
-    Examples
-    --------
-    >>> from plum import convert
-    >>> import unxt as u
-    >>> import coordinax as cx
 
     >>> vec = cx.vecs.CartesianAccND(u.Quantity([1, 2, 3, 4, 5], unit="km/s2"))
     >>> convert(vec, u.Quantity)
     Quantity['acceleration'](Array([1, 2, 3, 4, 5], dtype=int32), unit='km / s2')
 
     """
-    return obj.d2_q
+    return obj.q

--- a/src/coordinax/_src/vectors/dn/register_vectorapi.py
+++ b/src/coordinax/_src/vectors/dn/register_vectorapi.py
@@ -42,22 +42,22 @@ def vector(
 
     >>> cx.vecs.CartesianVelND.from_(u.Quantity(1, "km/s"))
     CartesianVelND(
-      d_q=Quantity[...]( value=...i32[1], unit=Unit("km / s") )
+      q=Quantity[...]( value=...i32[1], unit=Unit("km / s") )
     )
 
     >>> cx.vecs.CartesianVelND.from_(u.Quantity([1], "km/s"))
     CartesianVelND(
-      d_q=Quantity[...]( value=...i32[1], unit=Unit("km / s") )
+      q=Quantity[...]( value=...i32[1], unit=Unit("km / s") )
     )
 
     >>> cx.vecs.CartesianAccND.from_(u.Quantity(1, "km/s2"))
     CartesianAccND(
-      d2_q=Quantity[...]( value=...i32[1], unit=Unit("km / s2") )
+      q=Quantity[...]( value=...i32[1], unit=Unit("km / s2") )
     )
 
     >>> cx.vecs.CartesianAccND.from_(u.Quantity([1], "km/s2"))
     CartesianAccND(
-      d2_q=Quantity[...]( value=...i32[1], unit=Unit("km / s2") )
+      q=Quantity[...](value=i32[1], unit=Unit("km / s2"))
     )
 
     2D vector:
@@ -69,12 +69,12 @@ def vector(
 
     >>> cx.vecs.CartesianVelND.from_(u.Quantity([1, 2], "km/s"))
     CartesianVelND(
-      d_q=Quantity[...]( value=...i32[2], unit=Unit("km / s") )
+      q=Quantity[...]( value=...i32[2], unit=Unit("km / s") )
     )
 
     >>> cx.vecs.CartesianAccND.from_(u.Quantity([1, 2], "km/s2"))
     CartesianAccND(
-      d2_q=Quantity[...]( value=...i32[2], unit=Unit("km / s2") )
+      q=Quantity[...](value=i32[2], unit=Unit("km / s2"))
     )
 
     3D vector:
@@ -86,12 +86,12 @@ def vector(
 
     >>> cx.vecs.CartesianVelND.from_(u.Quantity([1, 2, 3], "km/s"))
     CartesianVelND(
-      d_q=Quantity[...]( value=...i32[3], unit=Unit("km / s") )
+      q=Quantity[...]( value=...i32[3], unit=Unit("km / s") )
     )
 
     >>> cx.vecs.CartesianAccND.from_(u.Quantity([1, 2, 3], "km/s2"))
     CartesianAccND(
-      d2_q=Quantity[...]( value=...i32[3], unit=Unit("km / s2") )
+      q=Quantity[...](value=i32[3], unit=Unit("km / s2"))
     )
 
     4D vector:
@@ -103,12 +103,12 @@ def vector(
 
     >>> cx.vecs.CartesianVelND.from_(u.Quantity([1, 2, 3, 4], "km/s"))
     CartesianVelND(
-      d_q=Quantity[...]( value=...i32[4], unit=Unit("km / s") )
+      q=Quantity[...]( value=...i32[4], unit=Unit("km / s") )
     )
 
     >>> cx.vecs.CartesianAccND.from_(u.Quantity([1, 2, 3, 4], "km/s2"))
     CartesianAccND(
-      d2_q=Quantity[...]( value=...i32[4], unit=Unit("km / s2") )
+      q=Quantity[...](value=i32[4], unit=Unit("km / s2"))
     )
 
     """

--- a/src/coordinax/_src/vectors/mixins.py
+++ b/src/coordinax/_src/vectors/mixins.py
@@ -69,7 +69,7 @@ class AvalMixin:
         >>> vec.aval()
         ShapedArray(int32[2])
 
-        >>> vec = cx.vecs.PolarVel(d_r=u.Quantity(1, "m/s"), d_phi=u.Quantity(0, "rad/s"))
+        >>> vec = cx.vecs.PolarVel(r=u.Quantity(1, "m/s"), phi=u.Quantity(0, "rad/s"))
         >>> vec.aval()
         ShapedArray(int32[2])
 
@@ -77,7 +77,7 @@ class AvalMixin:
         >>> vec.aval()
         ShapedArray(int32[2])
 
-        >>> vec = cx.vecs.PolarAcc(d2_r=u.Quantity(1, "m/s2"), d2_phi=u.Quantity(0, "rad/s2"))
+        >>> vec = cx.vecs.PolarAcc(r=u.Quantity(1, "m/s2"), phi=u.Quantity(0, "rad/s2"))
         >>> vec.aval()
         ShapedArray(int32[2])
 
@@ -99,7 +99,7 @@ class AvalMixin:
         >>> vec.aval()
         ShapedArray(int32[3])
 
-        >>> vec = cx.SphericalVel(d_r=u.Quantity(1, "m/s"), d_phi=u.Quantity(0, "rad/s"), d_theta=u.Quantity(0, "rad/s"))
+        >>> vec = cx.SphericalVel(r=u.Quantity(1, "m/s"), phi=u.Quantity(0, "rad/s"), theta=u.Quantity(0, "rad/s"))
         >>> vec.aval()
         ShapedArray(int32[3])
 
@@ -107,7 +107,7 @@ class AvalMixin:
         >>> vec.aval()
         ShapedArray(int32[3])
 
-        >>> vec = cx.vecs.SphericalAcc(d2_r=u.Quantity(1, "m/s2"), d2_phi=u.Quantity(0, "rad/s2"), d2_theta=u.Quantity(0, "rad/s2"))
+        >>> vec = cx.vecs.SphericalAcc(r=u.Quantity(1, "m/s2"), phi=u.Quantity(0, "rad/s2"), theta=u.Quantity(0, "rad/s2"))
         >>> vec.aval()
         ShapedArray(int32[3])
 
@@ -249,10 +249,9 @@ class AstropyRepresentationAPIMixin:
 
         >>> a_cart = cx.vecs.CartesianAcc3D.from_([7, 8, 9], "m/s2")
         >>> a_sph = a_cart.represent_as(cx.vecs.SphericalAcc, v_cart, q_cart)
-        >>> a_sph
-        SphericalAcc( ... )
-        >>> a_sph.d2_r
-        Quantity['acceleration'](Array(13.363062, dtype=float32), unit='m / s2')
+        >>> print(a_sph)
+        <SphericalAcc (r[m / s2], theta[rad / s2], phi[rad / s2])
+            [13.363  0.767 -1.2  ]>
 
         """
         return vconvert(target, self, *args, **kwargs)

--- a/src/coordinax/_src/vectors/register_unxt.py
+++ b/src/coordinax/_src/vectors/register_unxt.py
@@ -66,19 +66,19 @@ def vector(q: AbstractQuantity, /) -> AbstractVector:  # noqa: C901
         [1]>
 
     >>> print(cx.vecs.vector(u.Quantity(1, "km/s")))
-    <CartesianVel1D (d_x[km / s])
+    <CartesianVel1D (x[km / s])
         [1]>
 
     >>> print(cx.vecs.vector(u.Quantity([1], "km/s")))
-    <CartesianVel1D (d_x[km / s])
+    <CartesianVel1D (x[km / s])
         [1]>
 
     >>> print(cx.vecs.vector(u.Quantity(1, "km/s2")))
-    <CartesianAcc1D (d2_x[km / s2])
+    <CartesianAcc1D (x[km / s2])
         [1]>
 
     >>> print(cx.vecs.vector(u.Quantity([1], "km/s2")))
-    <CartesianAcc1D (d2_x[km / s2])
+    <CartesianAcc1D (x[km / s2])
         [1]>
 
     >>> print(cx.vecs.vector(u.Quantity([1, 2], "km")))
@@ -86,11 +86,11 @@ def vector(q: AbstractQuantity, /) -> AbstractVector:  # noqa: C901
         [1 2]>
 
     >>> print(cx.vecs.vector(u.Quantity([1, 2], "km/s")))
-    <CartesianVel2D (d_x[km / s], d_y[km / s])
+    <CartesianVel2D (x[km / s], y[km / s])
         [1 2]>
 
     >>> print(cx.vecs.vector(u.Quantity([1, 2], "km/s2")))
-    <CartesianAcc2D (d2_x[km / s2], d2_y[km / s2])
+    <CartesianAcc2D (x[km / s2], y[km / s2])
         [1 2]>
 
     >>> print(cx.vecs.vector(u.Quantity([1, 2, 3], "km")))
@@ -98,11 +98,11 @@ def vector(q: AbstractQuantity, /) -> AbstractVector:  # noqa: C901
         [1 2 3]>
 
     >>> print(cx.vecs.vector(u.Quantity([1, 2, 3], "km/s")))
-    <CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
+    <CartesianVel3D (x[km / s], y[km / s], z[km / s])
         [1 2 3]>
 
     >>> print(cx.vecs.vector(u.Quantity([1, 2, 3], "km/s2")))
-    <CartesianAcc3D (d2_x[km / s2], d2_y[km / s2], d2_z[km / s2])
+    <CartesianAcc3D (x[km / s2], y[km / s2], z[km / s2])
         [1 2 3]>
 
     >>> print(cx.vecs.vector(u.Quantity([0, 1, 2, 3], "km")))
@@ -113,14 +113,14 @@ def vector(q: AbstractQuantity, /) -> AbstractVector:  # noqa: C901
          [3]]>
 
     >>> print(cx.vecs.vector(u.Quantity([0, 1, 2, 3], "km/s")))
-    <CartesianVelND (d_q[km / s])
+    <CartesianVelND (q[km / s])
         [[0]
          [1]
          [2]
          [3]]>
 
     >>> print(cx.vecs.vector(u.Quantity([0, 1, 2, 3], "km/s2")))
-    <CartesianAccND (d2_q[km / s2])
+    <CartesianAccND (q[km / s2])
         [[0]
          [1]
          [2]

--- a/src/coordinax/_src/vectors/register_vconvert/accelerations.py
+++ b/src/coordinax/_src/vectors/register_vconvert/accelerations.py
@@ -78,10 +78,10 @@ def vconvert(
     Let's start in 1D:
 
     >>> q = cx.vecs.CartesianPos1D(x=u.Quantity(1.0, "km"))
-    >>> p = cx.vecs.CartesianVel1D(d_x=u.Quantity(1.0, "km/s"))
-    >>> a = cx.vecs.CartesianAcc1D(d2_x=u.Quantity(1.0, "km/s2"))
+    >>> p = cx.vecs.CartesianVel1D(x=u.Quantity(1.0, "km/s"))
+    >>> a = cx.vecs.CartesianAcc1D(x=u.Quantity(1.0, "km/s2"))
     >>> cx.vconvert(cx.vecs.RadialAcc, a, p, q)
-    RadialAcc( d2_r=Quantity[...](value=f32[], unit=Unit("km / s2")) )
+    RadialAcc( r=Quantity[...](value=f32[], unit=Unit("km / s2")) )
 
     Now in 2D:
 
@@ -90,8 +90,8 @@ def vconvert(
     >>> a = cx.vecs.CartesianAcc2D.from_([1.0, 2.0], "km/s2")
     >>> cx.vconvert(cx.vecs.PolarAcc, a, p, q)
     PolarAcc(
-      d2_r=Quantity[...](value=f32[], unit=Unit("km / s2")),
-      d2_phi=Quantity[...]( value=f32[], unit=Unit("rad / s2") )
+      r=Quantity[...](value=f32[], unit=Unit("km / s2")),
+      phi=Quantity[...]( value=f32[], unit=Unit("rad / s2") )
     )
 
     And in 3D:
@@ -101,9 +101,9 @@ def vconvert(
     >>> a = cx.vecs.CartesianAcc3D.from_([1.0, 2.0, 3.0], "km/s2")
     >>> cx.vconvert(cx.vecs.SphericalAcc, a, p, q)
     SphericalAcc(
-      d2_r=Quantity[...](value=f32[], unit=Unit("km / s2")),
-      d2_theta=Quantity[...]( value=f32[], unit=Unit("rad / s2") ),
-      d2_phi=Quantity[...]( value=f32[], unit=Unit("rad / s2") )
+      r=Quantity[...](value=f32[], unit=Unit("km / s2")),
+      theta=Quantity[...]( value=f32[], unit=Unit("rad / s2") ),
+      phi=Quantity[...]( value=f32[], unit=Unit("rad / s2") )
     )
 
     If given a position as a Quantity, it will be converted to the appropriate
@@ -113,9 +113,9 @@ def vconvert(
     ...             u.Quantity([1.0, 2.0, 3.0], "km/s"),
     ...             u.Quantity([1.0, 2.0, 3.0], "km"))
     SphericalAcc(
-      d2_r=Quantity[...](value=f32[], unit=Unit("km / s2")),
-      d2_theta=Quantity[...]( value=f32[], unit=Unit("rad / s2") ),
-      d2_phi=Quantity[...]( value=f32[], unit=Unit("rad / s2") )
+      r=Quantity[...](value=f32[], unit=Unit("km / s2")),
+      theta=Quantity[...]( value=f32[], unit=Unit("rad / s2") ),
+      phi=Quantity[...]( value=f32[], unit=Unit("rad / s2") )
     )
 
     """
@@ -169,7 +169,7 @@ def vconvert(
     # being that row's column as a dictionary, now with the correct units for
     # each element:  {row_i: {col_j: Quantity(value, row.unit / column.unit)}}
     jac_rows = {
-        f"d2_{k}": {
+        k: {
             kk: u.Quantity(vv.value, unit=v.unit / vv.unit)
             for kk, vv in field_items(v.value)
         }
@@ -182,10 +182,7 @@ def vconvert(
         **{  # Each field is the dot product of the row of the J and the diff column.
             k: jnp.sum(  # Doing the dot product.
                 jnp.stack(
-                    tuple(
-                        j_c * getattr(flat_current, f"d2_{kk}")
-                        for kk, j_c in j_r.items()
-                    )
+                    tuple(j_c * getattr(flat_current, kk) for kk, j_c in j_r.items())
                 ),
                 axis=0,
             )

--- a/src/coordinax/_src/vectors/register_vconvert/dn.py
+++ b/src/coordinax/_src/vectors/register_vconvert/dn.py
@@ -33,9 +33,9 @@ def vconvert(target: type[Space], w: PoincarePolarVector, /) -> Space:
         rho=Quantity[...](value=f32[1,2], unit=Unit("m")),
         pp_phi=Quantity[...]( value=f32[1,2], unit=Unit("m rad(1/2) / s(1/2)") ),
       z=Quantity[...](value=i32[1,2], unit=Unit("m")),
-      d_rho=Quantity[...]( value=f32[1,2], unit=Unit("m / s") ),
-      d_pp_phi=Quantity[...]( value=f32[1,2], unit=Unit("m rad(1/2) / s(1/2)") ),
-      d_z=Quantity[...]( value=f32[1,2], unit=Unit("m / s") )
+      dt_rho=Quantity[...]( value=f32[1,2], unit=Unit("m / s") ),
+      dt_pp_phi=Quantity[...]( value=f32[1,2], unit=Unit("m rad(1/2) / s(1/2)") ),
+      dt_z=Quantity[...]( value=f32[1,2], unit=Unit("m / s") )
     )
 
     >>> cx.vconvert(cx.Space, w)
@@ -46,17 +46,17 @@ def vconvert(target: type[Space], w: PoincarePolarVector, /) -> Space:
             z=Quantity[...](value=i32[1,2], unit=Unit("m"))
         ),
         'speed': CartesianVel3D(
-            d_x=Quantity[...]( value=i32[1,2], unit=Unit("m / s") ),
-            d_y=Quantity[...]( value=i32[1,2], unit=Unit("m / s") ),
-            d_z=Quantity[...]( value=i32[1,2], unit=Unit("m / s") )
+            x=Quantity[...]( value=i32[1,2], unit=Unit("m / s") ),
+            y=Quantity[...]( value=i32[1,2], unit=Unit("m / s") ),
+            z=Quantity[...]( value=i32[1,2], unit=Unit("m / s") )
         )
     })
 
     """
-    phi = cast(AbstractQuantity, jnp.atan2(w.d_pp_phi, w.pp_phi))
-    d_phi = (w.pp_phi**2 + w.d_pp_phi**2) / 2 / w.rho**2  # TODO: note the abs
+    phi = cast(AbstractQuantity, jnp.atan2(w.dt_pp_phi, w.pp_phi))
+    dt_phi = (w.pp_phi**2 + w.dt_pp_phi**2) / 2 / w.rho**2  # TODO: note the abs
 
     return Space(
         length=CylindricalPos(rho=w.rho, z=w.z, phi=phi),
-        speed=CylindricalVel(d_rho=w.d_rho, d_z=w.d_z, d_phi=d_phi),
+        speed=CylindricalVel(rho=w.dt_rho, z=w.dt_z, phi=dt_phi),
     )

--- a/src/coordinax/_src/vectors/register_vconvert/space.py
+++ b/src/coordinax/_src/vectors/register_vconvert/space.py
@@ -51,9 +51,9 @@ def vconvert(target: type[PoincarePolarVector], w: Space, /) -> PoincarePolarVec
       rho=Quantity[...](value=f32[1,2], unit=Unit("m")),
       pp_phi=Quantity[...]( value=f32[1,2], unit=Unit("m rad(1/2) / s(1/2)") ),
       z=Quantity[...](value=i32[1,2], unit=Unit("m")),
-      d_rho=Quantity[...]( value=f32[1,2], unit=Unit("m / s") ),
-      d_pp_phi=Quantity[...]( value=f32[1,2], unit=Unit("m rad(1/2) / s(1/2)") ),
-      d_z=Quantity[...]( value=f32[1,2], unit=Unit("m / s") )
+      dt_rho=Quantity[...]( value=f32[1,2], unit=Unit("m / s") ),
+      dt_pp_phi=Quantity[...]( value=f32[1,2], unit=Unit("m rad(1/2) / s(1/2)") ),
+      dt_z=Quantity[...]( value=f32[1,2], unit=Unit("m / s") )
     )
 
     """
@@ -61,10 +61,10 @@ def vconvert(target: type[PoincarePolarVector], w: Space, /) -> PoincarePolarVec
     p = w["speed"].vconvert(CylindricalVel, q)
 
     # pg. 437, Papaphillipou & Laskar (1996)
-    sqrt2theta = jnp.sqrt(jnp.abs(2 * q.rho**2 * p.d_phi))
+    sqrt2theta = jnp.sqrt(jnp.abs(2 * q.rho**2 * p.phi))
     pp_phi = sqrt2theta * jnp.cos(q.phi)
     pp_phidot = sqrt2theta * jnp.sin(q.phi)
 
     return PoincarePolarVector(
-        rho=q.rho, pp_phi=pp_phi, z=q.z, d_rho=p.d_rho, d_pp_phi=pp_phidot, d_z=p.d_z
+        rho=q.rho, pp_phi=pp_phi, z=q.z, dt_rho=p.rho, dt_pp_phi=pp_phidot, dt_z=p.z
     )

--- a/src/coordinax/_src/vectors/register_vconvert/velocities.py
+++ b/src/coordinax/_src/vectors/register_vconvert/velocities.py
@@ -63,7 +63,7 @@ def vconvert(
     >>> q = cx.vecs.CartesianPos1D.from_(1.0, "km")
     >>> p = cx.vecs.CartesianVel1D.from_(1.0, "km/s")
     >>> cx.vconvert(cx.vecs.RadialVel, p, q)
-    RadialVel( d_r=Quantity[...]( value=f32[], unit=Unit("km / s") ) )
+    RadialVel( r=Quantity[...]( value=f32[], unit=Unit("km / s") ) )
 
     Now in 2D:
 
@@ -71,8 +71,8 @@ def vconvert(
     >>> p = cx.vecs.CartesianVel2D.from_([1.0, 2.0], "km/s")
     >>> cx.vconvert(cx.vecs.PolarVel, p, q)
     PolarVel(
-      d_r=Quantity[...]( value=f32[], unit=Unit("km / s") ),
-      d_phi=Quantity[...]( value=f32[], unit=Unit("rad / s") )
+      r=Quantity[...]( value=f32[], unit=Unit("km / s") ),
+      phi=Quantity[...]( value=f32[], unit=Unit("rad / s") )
     )
 
     And in 3D:
@@ -81,9 +81,9 @@ def vconvert(
     >>> p = cx.CartesianVel3D.from_([1.0, 2.0, 3.0], "km/s")
     >>> cx.vconvert(cx.SphericalVel, p, q)
     SphericalVel(
-      d_r=Quantity[...]( value=f32[], unit=Unit("km / s") ),
-      d_theta=Quantity[...]( value=f32[], unit=Unit("rad / s") ),
-      d_phi=Quantity[...]( value=f32[], unit=Unit("rad / s") )
+      r=Quantity[...]( value=f32[], unit=Unit("km / s") ),
+      theta=Quantity[...]( value=f32[], unit=Unit("rad / s") ),
+      phi=Quantity[...]( value=f32[], unit=Unit("rad / s") )
     )
 
     If given a position as a Quantity, it will be converted to the appropriate
@@ -92,9 +92,9 @@ def vconvert(
     >>> p = cx.CartesianVel3D.from_([1.0, 2.0, 3.0], "km/s")
     >>> cx.vconvert(cx.SphericalVel, p, u.Quantity([1.0, 2.0, 3.0], "km"))
     SphericalVel(
-      d_r=Quantity[...]( value=f32[], unit=Unit("km / s") ),
-      d_theta=Quantity[...]( value=f32[], unit=Unit("rad / s") ),
-      d_phi=Quantity[...]( value=f32[], unit=Unit("rad / s") )
+      r=Quantity[...]( value=f32[], unit=Unit("km / s") ),
+      theta=Quantity[...]( value=f32[], unit=Unit("rad / s") ),
+      phi=Quantity[...]( value=f32[], unit=Unit("rad / s") )
     )
 
     """
@@ -142,7 +142,7 @@ def vconvert(
     # being that row's column as a dictionary, now with the correct units for
     # each element:  {row_i: {col_j: Quantity(value, row.unit / column.unit)}}
     jac_rows = {
-        f"d_{k}": {
+        k: {
             kk: u.Quantity(vv.value, unit=v.unit / vv.unit)
             for kk, vv in field_items(AttrFilter, v.value)
         }
@@ -155,10 +155,7 @@ def vconvert(
         **{  # Each field is the dot product of the row of the J and the diff column.
             k: jnp.sum(  # Doing the dot product.
                 jnp.stack(
-                    tuple(
-                        j_c * getattr(flat_current, f"d_{kk}")
-                        for kk, j_c in j_r.items()
-                    )
+                    tuple(j_c * getattr(flat_current, kk) for kk, j_c in j_r.items())
                 ),
                 axis=0,
             )

--- a/src/coordinax/_src/vectors/space/core.py
+++ b/src/coordinax/_src/vectors/space/core.py
@@ -56,9 +56,9 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
     Space({
        'length': <CartesianPos3D (x[km], y[km], z[km])
            [1 2 3]>,
-       'speed': <CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
+       'speed': <CartesianVel3D (x[km / s], y[km / s], z[km / s])
            [4 5 6]>,
-       'acceleration': <CartesianAcc3D (d2_x[km / s2], d2_y[km / s2], d2_z[km / s2])
+       'acceleration': <CartesianAcc3D (x[km / s2], y[km / s2], z[km / s2])
            [7 8 9]>
     })
 
@@ -73,7 +73,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
        'length': <CartesianPos3D (x[kpc], y[kpc], z[kpc])
            [[ 8.5  0.   0. ]
             [10.   0.   0. ]]>,
-       'speed': <CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
+       'speed': <CartesianVel3D (x[km / s], y[km / s], z[km / s])
            [  0 200   0]>
     })
 
@@ -127,7 +127,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
     Space({
        'length': <CartesianPos3D (x[km], y[km], z[km])
            [1 2 3]>,
-       'speed': <CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
+       'speed': <CartesianVel3D (x[km / s], y[km / s], z[km / s])
            [4 5 6]>
     })
 
@@ -203,9 +203,9 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
                 y=Quantity[...](value=i32[2], unit=Unit("m")),
                 z=Quantity[...](value=i32[2], unit=Unit("m")) ),
             'speed': CartesianVel3D(
-                d_x=Quantity[...]( value=i32[2], unit=Unit("m / s") ),
-                d_y=Quantity[...]( value=i32[2], unit=Unit("m / s") ),
-                d_z=Quantity[...]( value=i32[2], unit=Unit("m / s") ) )
+                x=Quantity[...]( value=i32[2], unit=Unit("m / s") ),
+                y=Quantity[...]( value=i32[2], unit=Unit("m / s") ),
+                z=Quantity[...]( value=i32[2], unit=Unit("m / s") ) )
         })
 
         By slice:
@@ -217,9 +217,9 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
                 y=Quantity[...](value=i32[0,2], unit=Unit("m")),
                 z=Quantity[...](value=i32[0,2], unit=Unit("m")) ),
             'speed': CartesianVel3D(
-                d_x=Quantity[...]( value=i32[0,2], unit=Unit("m / s") ),
-                d_y=Quantity[...]( value=i32[0,2], unit=Unit("m / s") ),
-                d_z=Quantity[...]( value=i32[0,2], unit=Unit("m / s") ) )
+                x=Quantity[...]( value=i32[0,2], unit=Unit("m / s") ),
+                y=Quantity[...]( value=i32[0,2], unit=Unit("m / s") ),
+                z=Quantity[...]( value=i32[0,2], unit=Unit("m / s") ) )
         })
 
         By Ellipsis:
@@ -231,9 +231,9 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
                 y=Quantity[...](value=i32[1,2], unit=Unit("m")),
                 z=Quantity[...](value=i32[1,2], unit=Unit("m")) ),
             'speed': CartesianVel3D(
-                d_x=Quantity[...]( value=i32[1,2], unit=Unit("m / s") ),
-                d_y=Quantity[...]( value=i32[1,2], unit=Unit("m / s") ),
-                d_z=Quantity[...]( value=i32[1,2], unit=Unit("m / s") ) )
+                x=Quantity[...]( value=i32[1,2], unit=Unit("m / s") ),
+                y=Quantity[...]( value=i32[1,2], unit=Unit("m / s") ),
+                z=Quantity[...]( value=i32[1,2], unit=Unit("m / s") ) )
         })
 
         By tuple[int, ...]:
@@ -245,9 +245,9 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
                 y=Quantity[...](value=i32[], unit=Unit("m")),
                 z=Quantity[...](value=i32[], unit=Unit("m")) ),
             'speed': CartesianVel3D(
-                d_x=Quantity[...]( value=i32[], unit=Unit("m / s") ),
-                d_y=Quantity[...]( value=i32[], unit=Unit("m / s") ),
-                d_z=Quantity[...]( value=i32[], unit=Unit("m / s") ) )
+                x=Quantity[...]( value=i32[], unit=Unit("m / s") ),
+                y=Quantity[...]( value=i32[], unit=Unit("m / s") ),
+                z=Quantity[...]( value=i32[], unit=Unit("m / s") ) )
         })
 
         This also supports numpy index arrays. But this example section
@@ -358,9 +358,9 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
                 z=Quantity[...](value=i32[], unit=Unit("m"))
             ),
             'speed': CartesianVel3D(
-                d_x=Quantity[...]( value=i32[], unit=Unit("m / s") ),
-                d_y=Quantity[...]( value=i32[], unit=Unit("m / s") ),
-                d_z=Quantity[...]( value=i32[], unit=Unit("m / s") )
+                x=Quantity[...]( value=i32[], unit=Unit("m / s") ),
+                y=Quantity[...]( value=i32[], unit=Unit("m / s") ),
+                z=Quantity[...]( value=i32[], unit=Unit("m / s") )
             ) })
 
         """
@@ -382,7 +382,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
         Space({
             'length': <CartesianPos3D (x[m], y[m], z[m])
                 [1 2 3]>,
-            'speed': <CartesianVel3D (d_x[m / s], d_y[m / s], d_z[m / s])
+            'speed': <CartesianVel3D (x[m / s], y[m / s], z[m / s])
                 [4 5 6]>
         })
 
@@ -448,7 +448,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> w.dtypes
         mappingproxy({'length': mappingproxy({'x': dtype('int32'), 'y': dtype('int32'), 'z': dtype('int32')}),
-                      'speed': mappingproxy({'d_x': dtype('int32'), 'd_y': dtype('int32'), 'd_z': dtype('int32')})})
+                      'speed': mappingproxy({'x': dtype('int32'), 'y': dtype('int32'), 'z': dtype('int32')})})
 
         """  # noqa: E501
         return MappingProxyType({k: v.dtypes for k, v in self.items()})
@@ -469,7 +469,7 @@ class Space(AbstractVector, ImmutableMap[Dimension, AbstractVector]):  # type: i
 
         >>> w.devices
         mappingproxy({'length': mappingproxy({'x': CpuDevice(id=0), 'y': CpuDevice(id=0), 'z': CpuDevice(id=0)}),
-                      'speed': mappingproxy({'d_x': CpuDevice(id=0), 'd_y': CpuDevice(id=0), 'd_z': CpuDevice(id=0)})})
+                      'speed': mappingproxy({'x': CpuDevice(id=0), 'y': CpuDevice(id=0), 'z': CpuDevice(id=0)})})
 
         """  # noqa: E501
         return MappingProxyType({k: v.devices for k, v in self.items()})

--- a/src/coordinax/_src/vectors/space/register_primitives.py
+++ b/src/coordinax/_src/vectors/space/register_primitives.py
@@ -27,7 +27,7 @@ def neg_space(space: Space, /) -> Space:
        'length': <CartesianPos3D (x[m], y[m], z[m])
            [[[-1 -2 -3]
              [-4 -5 -6]]]>,
-       'speed': <CartesianVel3D (d_x[m / s], d_y[m / s], d_z[m / s])
+       'speed': <CartesianVel3D (x[m / s], y[m / s], z[m / s])
            [[[-1 -2 -3]
              [-4 -5 -6]]]>
     })

--- a/src/coordinax/frames.py
+++ b/src/coordinax/frames.py
@@ -33,7 +33,7 @@ This can also transform a velocity:
 >>> print(q_frame, v_frame, sep="\n")
 <CartesianPos3D (x[kpc], y[kpc], z[kpc])
     [ 0. -1.  0.]>
-<CartesianVel3D (d_x[km / s], d_y[km / s], d_z[km / s])
+<CartesianVel3D (x[km / s], y[km / s], z[km / s])
     [ 0. -1.  0.]>
 
 >>> op.inverse(q_frame, v_frame) == (q_icrs, v_icrs)

--- a/tests/test_d1.py
+++ b/tests/test_d1.py
@@ -197,7 +197,7 @@ class TestCartesianVel1D(AbstractVel1DTest):
     @pytest.fixture(scope="class")
     def difntl(self) -> cx.vecs.CartesianVel1D:
         """Return a vector."""
-        return cx.vecs.CartesianVel1D(d_x=u.Quantity([1.0, 2, 3, 4], "km/s"))
+        return cx.vecs.CartesianVel1D(x=u.Quantity([1.0, 2, 3, 4], "km/s"))
 
     @pytest.fixture(scope="class")
     def vector(self) -> cx.vecs.CartesianPos1D:
@@ -224,31 +224,31 @@ class TestCartesianVel1D(AbstractVel1DTest):
         radial = difntl.vconvert(cx.vecs.RadialVel, vector)
 
         assert isinstance(radial, cx.vecs.RadialVel)
-        assert jnp.array_equal(radial.d_r, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(radial.r, u.Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian1d_to_cartesian2d(self, difntl, vector):
         """Test ``difntl.vconvert(CartesianVel2D)``."""
         cart2d = difntl.vconvert(
-            cx.vecs.CartesianVel2D, vector, d_y=u.Quantity([5, 6, 7, 8], "km")
+            cx.vecs.CartesianVel2D, vector, y=u.Quantity([5, 6, 7, 8], "km")
         )
 
         assert isinstance(cart2d, cx.vecs.CartesianVel2D)
-        assert jnp.array_equal(cart2d.d_x, u.Quantity([1, 2, 3, 4], "km/s"))
-        assert jnp.array_equal(cart2d.d_y, u.Quantity([5, 6, 7, 8], "km/s"))
+        assert jnp.array_equal(cart2d.x, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(cart2d.y, u.Quantity([5, 6, 7, 8], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian1d_to_polar(self, difntl, vector):
         """Test ``difntl.vconvert(PolarVel)``."""
         polar = difntl.vconvert(
-            cx.vecs.PolarVel, vector, d_phi=u.Quantity([0, 1, 2, 3], "rad")
+            cx.vecs.PolarVel, vector, phi=u.Quantity([0, 1, 2, 3], "rad")
         )
 
         assert isinstance(polar, cx.vecs.PolarVel)
-        assert jnp.array_equal(polar.d_r, u.Quantity([1, 2, 3, 4], "km/s"))
-        assert jnp.array_equal(polar.d_phi, u.Quantity([0, 1, 2, 3], "rad/s"))
+        assert jnp.array_equal(polar.r, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(polar.phi, u.Quantity([0, 1, 2, 3], "rad/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -257,14 +257,14 @@ class TestCartesianVel1D(AbstractVel1DTest):
         cart3d = difntl.vconvert(
             cx.CartesianVel3D,
             vector,
-            d_y=u.Quantity([5, 6, 7, 8], "km"),
-            d_z=u.Quantity([9, 10, 11, 12], "m"),
+            y=u.Quantity([5, 6, 7, 8], "km"),
+            z=u.Quantity([9, 10, 11, 12], "m"),
         )
 
         assert isinstance(cart3d, cx.CartesianVel3D)
-        assert jnp.array_equal(cart3d.d_x, u.Quantity([1, 2, 3, 4], "kpc"))
-        assert jnp.array_equal(cart3d.d_y, u.Quantity([5, 6, 7, 8], "km"))
-        assert jnp.array_equal(cart3d.d_z, u.Quantity([9, 10, 11, 12], "m"))
+        assert jnp.array_equal(cart3d.x, u.Quantity([1, 2, 3, 4], "kpc"))
+        assert jnp.array_equal(cart3d.y, u.Quantity([5, 6, 7, 8], "km"))
+        assert jnp.array_equal(cart3d.z, u.Quantity([9, 10, 11, 12], "m"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -305,7 +305,7 @@ class TestRadialVel(AbstractVel1DTest):
     @pytest.fixture(scope="class")
     def difntl(self) -> cx.vecs.RadialVel:
         """Return a vector."""
-        return cx.vecs.RadialVel(d_r=u.Quantity([1, 2, 3, 4], "km/s"))
+        return cx.vecs.RadialVel(r=u.Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.fixture(scope="class")
     def vector(self) -> cx.vecs.RadialPos:
@@ -321,7 +321,7 @@ class TestRadialVel(AbstractVel1DTest):
         cart1d = difntl.vconvert(cx.vecs.CartesianVel1D, vector)
 
         assert isinstance(cart1d, cx.vecs.CartesianVel1D)
-        assert jnp.array_equal(cart1d.d_x, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(cart1d.x, u.Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_radial_to_radial(self, difntl, vector):
@@ -339,24 +339,24 @@ class TestRadialVel(AbstractVel1DTest):
     def test_radial_to_cartesian2d(self, difntl, vector):
         """Test ``difntl.vconvert(CartesianVel2D)``."""
         cart2d = difntl.vconvert(
-            cx.vecs.CartesianVel2D, vector, d_y=u.Quantity([5, 6, 7, 8], "km")
+            cx.vecs.CartesianVel2D, vector, y=u.Quantity([5, 6, 7, 8], "km")
         )
 
         assert isinstance(cart2d, cx.vecs.CartesianVel2D)
-        assert jnp.array_equal(cart2d.d_x, u.Quantity([1, 2, 3, 4], "kpc"))
-        assert jnp.array_equal(cart2d.d_y, u.Quantity([5, 6, 7, 8], "km"))
+        assert jnp.array_equal(cart2d.x, u.Quantity([1, 2, 3, 4], "kpc"))
+        assert jnp.array_equal(cart2d.y, u.Quantity([5, 6, 7, 8], "km"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_radial_to_polar(self, difntl, vector):
         """Test ``difntl.vconvert(PolarVel)``."""
         polar = difntl.vconvert(
-            cx.vecs.PolarVel, vector, d_phi=u.Quantity([0, 1, 2, 3], "rad")
+            cx.vecs.PolarVel, vector, phi=u.Quantity([0, 1, 2, 3], "rad")
         )
 
         assert isinstance(polar, cx.vecs.PolarVel)
-        assert jnp.array_equal(polar.d_r, u.Quantity([1, 2, 3, 4], "kpc"))
-        assert jnp.array_equal(polar.d_phi, u.Quantity([0, 1, 2, 3], "rad"))
+        assert jnp.array_equal(polar.r, u.Quantity([1, 2, 3, 4], "kpc"))
+        assert jnp.array_equal(polar.phi, u.Quantity([0, 1, 2, 3], "rad"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -365,14 +365,14 @@ class TestRadialVel(AbstractVel1DTest):
         cart3d = difntl.vconvert(
             cx.CartesianVel3D,
             vector,
-            d_y=u.Quantity([5, 6, 7, 8], "km"),
-            d_z=u.Quantity([9, 10, 11, 12], "m"),
+            y=u.Quantity([5, 6, 7, 8], "km"),
+            z=u.Quantity([9, 10, 11, 12], "m"),
         )
 
         assert isinstance(cart3d, cx.CartesianVel3D)
-        assert jnp.array_equal(cart3d.d_x, u.Quantity([1, 2, 3, 4], "kpc"))
-        assert jnp.array_equal(cart3d.d_y, u.Quantity([5, 6, 7, 8], "km"))
-        assert jnp.array_equal(cart3d.d_z, u.Quantity([9, 10, 11, 12], "m"))
+        assert jnp.array_equal(cart3d.x, u.Quantity([1, 2, 3, 4], "kpc"))
+        assert jnp.array_equal(cart3d.y, u.Quantity([5, 6, 7, 8], "km"))
+        assert jnp.array_equal(cart3d.z, u.Quantity([9, 10, 11, 12], "m"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -381,14 +381,14 @@ class TestRadialVel(AbstractVel1DTest):
         spherical = difntl.vconvert(
             cx.SphericalVel,
             vector,
-            d_theta=u.Quantity([4, 5, 6, 7], "rad"),
-            d_phi=u.Quantity([0, 1, 2, 3], "rad"),
+            theta=u.Quantity([4, 5, 6, 7], "rad"),
+            phi=u.Quantity([0, 1, 2, 3], "rad"),
         )
 
         assert isinstance(spherical, cx.SphericalVel)
-        assert jnp.array_equal(spherical.d_r, u.Quantity([1, 2, 3, 4], "kpc"))
-        assert spherical.d_theta == u.Quantity([4, 5, 6, 7], "rad")
-        assert jnp.array_equal(spherical.d_phi, u.Quantity([0, 1, 2, 3], "rad"))
+        assert jnp.array_equal(spherical.r, u.Quantity([1, 2, 3, 4], "kpc"))
+        assert spherical.theta == u.Quantity([4, 5, 6, 7], "rad")
+        assert jnp.array_equal(spherical.phi, u.Quantity([0, 1, 2, 3], "rad"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -397,11 +397,11 @@ class TestRadialVel(AbstractVel1DTest):
         cylindrical = difntl.vconvert(
             cx.vecs.CylindricalVel,
             vector,
-            d_phi=u.Quantity([0, 1, 2, 3], "rad"),
-            d_z=u.Quantity([4, 5, 6, 7], "m"),
+            phi=u.Quantity([0, 1, 2, 3], "rad"),
+            z=u.Quantity([4, 5, 6, 7], "m"),
         )
 
         assert isinstance(cylindrical, cx.vecs.CylindricalVel)
-        assert jnp.array_equal(cylindrical.d_rho, u.Quantity([1, 2, 3, 4], "kpc"))
-        assert jnp.array_equal(cylindrical.d_phi, u.Quantity([0, 1, 2, 3], "rad"))
-        assert jnp.array_equal(cylindrical.d_z, u.Quantity([4, 5, 6, 7], "m"))
+        assert jnp.array_equal(cylindrical.rho, u.Quantity([1, 2, 3, 4], "kpc"))
+        assert jnp.array_equal(cylindrical.phi, u.Quantity([0, 1, 2, 3], "rad"))
+        assert jnp.array_equal(cylindrical.z, u.Quantity([4, 5, 6, 7], "m"))

--- a/tests/test_d2.py
+++ b/tests/test_d2.py
@@ -221,8 +221,7 @@ class TestCartesianVel2D(AbstractVel2DTest):
     def difntl(self) -> cx.vecs.CartesianVel2D:
         """Return a differential."""
         return cx.vecs.CartesianVel2D(
-            d_x=u.Quantity([1, 2, 3, 4], "km/s"),
-            d_y=u.Quantity([5, 6, 7, 8], "km/s"),
+            x=u.Quantity([1, 2, 3, 4], "km/s"), y=u.Quantity([5, 6, 7, 8], "km/s")
         )
 
     @pytest.fixture(scope="class")
@@ -242,7 +241,7 @@ class TestCartesianVel2D(AbstractVel2DTest):
         cart1d = difntl.vconvert(cx.vecs.CartesianVel1D, vector)
 
         assert isinstance(cart1d, cx.vecs.CartesianVel1D)
-        assert jnp.array_equal(cart1d.d_x, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(cart1d.x, u.Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -251,7 +250,7 @@ class TestCartesianVel2D(AbstractVel2DTest):
         radial = difntl.vconvert(cx.vecs.RadialVel, vector)
 
         assert isinstance(radial, cx.vecs.RadialVel)
-        assert jnp.array_equal(radial.d_r, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(radial.r, u.Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian2d_to_cartesian2d(self, difntl, vector):
@@ -270,9 +269,9 @@ class TestCartesianVel2D(AbstractVel2DTest):
         polar = difntl.vconvert(cx.vecs.PolarVel, vector)
 
         assert isinstance(polar, cx.vecs.PolarVel)
-        assert jnp.array_equal(polar.d_r, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(polar.r, u.Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(
-            polar.d_phi,
+            polar.phi,
             u.Quantity([5.0, 3.0, 2.3333335, 1.9999999], "km rad / (kpc s)"),
         )
 
@@ -281,13 +280,13 @@ class TestCartesianVel2D(AbstractVel2DTest):
     def test_cartesian2d_to_cartesian3d(self, difntl, vector):
         """Test ``difntl.vconvert(CartesianVel3D, vector)``."""
         cart3d = difntl.vconvert(
-            cx.CartesianVel3D, vector, d_z=u.Quantity([9, 10, 11, 12], "m/s")
+            cx.CartesianVel3D, vector, z=u.Quantity([9, 10, 11, 12], "m/s")
         )
 
         assert isinstance(cart3d, cx.CartesianVel3D)
-        assert jnp.array_equal(cart3d.d_x, u.Quantity([1, 2, 3, 4], "km/s"))
-        assert jnp.array_equal(cart3d.d_y, u.Quantity([5, 6, 7, 8], "km/s"))
-        assert jnp.array_equal(cart3d.d_z, u.Quantity([9, 10, 11, 12], "m/s"))
+        assert jnp.array_equal(cart3d.x, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(cart3d.y, u.Quantity([5, 6, 7, 8], "km/s"))
+        assert jnp.array_equal(cart3d.z, u.Quantity([9, 10, 11, 12], "m/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -298,22 +297,22 @@ class TestCartesianVel2D(AbstractVel2DTest):
         )
 
         assert isinstance(spherical, cx.SphericalVel)
-        assert jnp.array_equal(spherical.d_r, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(spherical.r, u.Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(spherical.d_theta, u.Quantity([4, 5, 6, 7], "rad"))
-        assert jnp.array_equal(spherical.d_phi, u.Quantity([5, 6, 7, 8], "km/s"))
+        assert jnp.array_equal(spherical.phi, u.Quantity([5, 6, 7, 8], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_cartesian2d_to_cylindrical(self, difntl, vector):
         """Test ``difntl.vconvert(CylindricalVel, vector)``."""
         cylindrical = difntl.vconvert(
-            cx.vecs.CylindricalVel, vector, d_z=u.Quantity([9, 10, 11, 12], "m/s")
+            cx.vecs.CylindricalVel, vector, z=u.Quantity([9, 10, 11, 12], "m/s")
         )
 
         assert isinstance(cylindrical, cx.vecs.CylindricalVel)
-        assert jnp.array_equal(cylindrical.d_rho, u.Quantity([1, 2, 3, 4], "km/s"))
-        assert jnp.array_equal(cylindrical.d_phi, u.Quantity([5, 6, 7, 8], "km/s"))
-        assert jnp.array_equal(cylindrical.d_z, u.Quantity([9, 10, 11, 12], "m/s"))
+        assert jnp.array_equal(cylindrical.rho, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(cylindrical.phi, u.Quantity([5, 6, 7, 8], "km/s"))
+        assert jnp.array_equal(cylindrical.z, u.Quantity([9, 10, 11, 12], "m/s"))
 
 
 class TestPolarVel(AbstractVel2DTest):
@@ -323,8 +322,8 @@ class TestPolarVel(AbstractVel2DTest):
     def difntl(self) -> cx.vecs.PolarVel:
         """Return a differential."""
         return cx.vecs.PolarVel(
-            d_r=u.Quantity([1, 2, 3, 4], "km/s"),
-            d_phi=u.Quantity([5, 6, 7, 8], "mas/yr"),
+            r=u.Quantity([1, 2, 3, 4], "km/s"),
+            phi=u.Quantity([5, 6, 7, 8], "mas/yr"),
         )
 
     @pytest.fixture(scope="class")
@@ -344,7 +343,7 @@ class TestPolarVel(AbstractVel2DTest):
         cart1d = difntl.vconvert(cx.vecs.CartesianVel1D, vector)
 
         assert isinstance(cart1d, cx.vecs.CartesianVel1D)
-        assert jnp.array_equal(cart1d.d_x, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(cart1d.x, u.Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -353,7 +352,7 @@ class TestPolarVel(AbstractVel2DTest):
         radial = difntl.vconvert(cx.vecs.RadialVel, vector)
 
         assert isinstance(radial, cx.vecs.RadialVel)
-        assert jnp.array_equal(radial.d_r, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(radial.r, u.Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_polar_to_cartesian2d(self, difntl, vector):
@@ -362,10 +361,10 @@ class TestPolarVel(AbstractVel2DTest):
 
         assert isinstance(cart2d, cx.vecs.CartesianVel2D)
         assert jnp.array_equal(
-            cart2d.d_x, u.Quantity([1.0, -46.787014, -91.76889, -25.367176], "km/s")
+            cart2d.x, u.Quantity([1.0, -46.787014, -91.76889, -25.367176], "km/s")
         )
         assert jnp.array_equal(
-            cart2d.d_y,
+            cart2d.y,
             u.Quantity([23.702353, 32.418385, -38.69947, -149.61249], "km/s"),
         )
 
@@ -385,13 +384,13 @@ class TestPolarVel(AbstractVel2DTest):
     def test_polar_to_cartesian3d(self, difntl, vector):
         """Test ``difntl.vconvert(CartesianVel3D, vector)``."""
         cart3d = difntl.vconvert(
-            cx.CartesianVel3D, vector, d_z=u.Quantity([9, 10, 11, 12], "m/s")
+            cx.CartesianVel3D, vector, z=u.Quantity([9, 10, 11, 12], "m/s")
         )
 
         assert isinstance(cart3d, cx.CartesianVel3D)
-        assert jnp.array_equal(cart3d.d_x, u.Quantity([1, 2, 3, 4], "km/s"))
-        assert jnp.array_equal(cart3d.d_y, u.Quantity([5, 6, 7, 8], "km/s"))
-        assert jnp.array_equal(cart3d.d_z, u.Quantity([9, 10, 11, 12], "m/s"))
+        assert jnp.array_equal(cart3d.x, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(cart3d.y, u.Quantity([5, 6, 7, 8], "km/s"))
+        assert jnp.array_equal(cart3d.z, u.Quantity([9, 10, 11, 12], "m/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -402,19 +401,19 @@ class TestPolarVel(AbstractVel2DTest):
         )
 
         assert isinstance(spherical, cx.SphericalVel)
-        assert jnp.array_equal(spherical.d_r, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(spherical.r, u.Quantity([1, 2, 3, 4], "km/s"))
         assert jnp.array_equal(spherical.d_theta, u.Quantity([4, 5, 6, 7], "rad"))
-        assert jnp.array_equal(spherical.d_phi, u.Quantity([5, 6, 7, 8], "km/s"))
+        assert jnp.array_equal(spherical.phi, u.Quantity([5, 6, 7, 8], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
     def test_polar_to_cylindrical(self, difntl, vector):
         """Test ``difntl.vconvert(CylindricalVel, vector)``."""
         cylindrical = difntl.vconvert(
-            cx.vecs.CylindricalVel, vector, d_z=u.Quantity([9, 10, 11, 12], "m/s")
+            cx.vecs.CylindricalVel, vector, z=u.Quantity([9, 10, 11, 12], "m/s")
         )
 
         assert isinstance(cylindrical, cx.vecs.CylindricalVel)
-        assert jnp.array_equal(cylindrical.d_rho, u.Quantity([1, 2, 3, 4], "km/s"))
-        assert jnp.array_equal(cylindrical.d_phi, u.Quantity([5, 6, 7, 8], "km/s"))
-        assert jnp.array_equal(cylindrical.d_z, u.Quantity([9, 10, 11, 12], "m/s"))
+        assert jnp.array_equal(cylindrical.rho, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(cylindrical.phi, u.Quantity([5, 6, 7, 8], "km/s"))
+        assert jnp.array_equal(cylindrical.z, u.Quantity([9, 10, 11, 12], "m/s"))

--- a/tests/test_d3.py
+++ b/tests/test_d3.py
@@ -646,9 +646,9 @@ class TestCartesianVel3D(AbstractVel3DTest):
     def difntl(self) -> cx.CartesianVel3D:
         """Return a differential."""
         return cx.CartesianVel3D(
-            d_x=u.Quantity([5, 6, 7, 8], "km/s"),
-            d_y=u.Quantity([9, 10, 11, 12], "km/s"),
-            d_z=u.Quantity([13, 14, 15, 16], "km/s"),
+            x=u.Quantity([5, 6, 7, 8], "km/s"),
+            y=u.Quantity([9, 10, 11, 12], "km/s"),
+            z=u.Quantity([13, 14, 15, 16], "km/s"),
         )
 
     @pytest.fixture(scope="class")
@@ -679,7 +679,7 @@ class TestCartesianVel3D(AbstractVel3DTest):
         cart1d = difntl.vconvert(cx.vecs.CartesianVel1D, vector)
 
         assert isinstance(cart1d, cx.vecs.CartesianVel1D)
-        assert jnp.array_equal(cart1d.d_x, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(cart1d.x, u.Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -688,7 +688,7 @@ class TestCartesianVel3D(AbstractVel3DTest):
         radial = difntl.vconvert(cx.vecs.RadialPos, vector)
 
         assert isinstance(radial, cx.vecs.RadialPos)
-        assert jnp.array_equal(radial.d_r, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(radial.r, u.Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -697,8 +697,8 @@ class TestCartesianVel3D(AbstractVel3DTest):
         cart2d = difntl.vconvert(cx.vecs.CartesianVel2D, vector)
 
         assert isinstance(cart2d, cx.vecs.CartesianVel2D)
-        assert jnp.array_equal(cart2d.d_x, u.Quantity([1, 2, 3, 4], "km/s"))
-        assert jnp.array_equal(cart2d.d_y, u.Quantity([5, 6, 7, 8], "km/s"))
+        assert jnp.array_equal(cart2d.x, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(cart2d.y, u.Quantity([5, 6, 7, 8], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -707,8 +707,8 @@ class TestCartesianVel3D(AbstractVel3DTest):
         polar = difntl.vconvert(cx.vecs.PolarPos, vector)
 
         assert isinstance(polar, cx.vecs.PolarPos)
-        assert jnp.array_equal(polar.d_r, u.Quantity([1, 2, 3, 4], "km/s"))
-        assert jnp.array_equal(polar.d_phi, u.Quantity([5, 6, 7, 8], "mas/yr"))
+        assert jnp.array_equal(polar.r, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(polar.phi, u.Quantity([5, 6, 7, 8], "mas/yr"))
 
     def test_cartesian3d_to_cartesian3d(self, difntl, vector):
         """Test ``coordinax.vconvert(CartesianPos3D)``."""
@@ -727,9 +727,9 @@ class TestCartesianVel3D(AbstractVel3DTest):
         cart3 = difntl.vconvert(cx.CartesianVel3D, vector)
 
         apycart3 = apydifntl.represent_as(apyc.CartesianDifferential, apyvector)
-        assert np.allclose(convert(cart3.d_x, APYQuantity), apycart3.d_x)
-        assert np.allclose(convert(cart3.d_y, APYQuantity), apycart3.d_y)
-        assert np.allclose(convert(cart3.d_z, APYQuantity), apycart3.d_z)
+        assert np.allclose(convert(cart3.x, APYQuantity), apycart3.d_x)
+        assert np.allclose(convert(cart3.y, APYQuantity), apycart3.d_y)
+        assert np.allclose(convert(cart3.z, APYQuantity), apycart3.d_z)
 
     def test_cartesian3d_to_spherical(self, difntl, vector):
         """Test ``coordinax.vconvert(SphericalVel)``."""
@@ -737,19 +737,19 @@ class TestCartesianVel3D(AbstractVel3DTest):
 
         assert isinstance(spherical, cx.SphericalVel)
         assert jnp.allclose(
-            spherical.d_r,
+            spherical.r,
             u.Quantity([16.1445, 17.917269, 19.657543, 21.380898], "km/s"),
             atol=u.Quantity(1e-8, "km/s"),
         )
         assert jnp.allclose(
-            spherical.d_phi,
+            spherical.phi,
             u.Quantity(
                 [-0.61538464, -0.40000004, -0.275862, -0.19999999], "km rad / (kpc s)"
             ),
             atol=u.Quantity(1e-8, "mas/Myr"),
         )
         assert jnp.allclose(
-            spherical.d_theta,
+            spherical.theta,
             u.Quantity(
                 [0.2052807, 0.1807012, 0.15257944, 0.12777519], "km rad / (kpc s)"
             ),
@@ -763,9 +763,9 @@ class TestCartesianVel3D(AbstractVel3DTest):
         sph = difntl.vconvert(cx.SphericalVel, vector)
 
         apysph = apydifntl.represent_as(apyc.PhysicsSphericalDifferential, apyvector)
-        assert np.allclose(convert(sph.d_r, APYQuantity), apysph.d_r)
-        assert np.allclose(convert(sph.d_theta, APYQuantity), apysph.d_theta, atol=1e-9)
-        assert np.allclose(convert(sph.d_phi, APYQuantity), apysph.d_phi, atol=1e-7)
+        assert np.allclose(convert(sph.r, APYQuantity), apysph.d_r)
+        assert np.allclose(convert(sph.theta, APYQuantity), apysph.d_theta, atol=1e-9)
+        assert np.allclose(convert(sph.phi, APYQuantity), apysph.d_phi, atol=1e-7)
 
     def test_cartesian3d_to_cylindrical(self, difntl, vector):
         """Test ``coordinax.vconvert(CylindricalVel)``."""
@@ -773,18 +773,18 @@ class TestCartesianVel3D(AbstractVel3DTest):
 
         assert isinstance(cylindrical, cx.vecs.CylindricalVel)
         assert jnp.array_equal(
-            cylindrical.d_rho,
+            cylindrical.rho,
             u.Quantity([9.805806, 11.384199, 12.86803, 14.310835], "km/s"),
         )
         assert jnp.allclose(
-            cylindrical.d_phi,
+            cylindrical.phi,
             u.Quantity(
                 [-0.61538464, -0.40000004, -0.275862, -0.19999999], "km rad / (kpc s)"
             ),
             atol=u.Quantity(1e-8, "mas/Myr"),
         )
         assert jnp.array_equal(
-            cylindrical.d_z, u.Quantity([13.0, 14.0, 15.0, 16], "km/s")
+            cylindrical.z, u.Quantity([13.0, 14.0, 15.0, 16], "km/s")
         )
 
     def test_cartesian3d_to_cylindrical_astropy(
@@ -793,9 +793,9 @@ class TestCartesianVel3D(AbstractVel3DTest):
         """Test Astropy equivalence."""
         cyl = difntl.vconvert(cx.vecs.CylindricalVel, vector)
         apycyl = apydifntl.represent_as(apyc.CylindricalDifferential, apyvector)
-        assert np.allclose(convert(cyl.d_rho, APYQuantity), apycyl.d_rho)
-        assert np.allclose(convert(cyl.d_phi, APYQuantity), apycyl.d_phi)
-        assert np.allclose(convert(cyl.d_z, APYQuantity), apycyl.d_z)
+        assert np.allclose(convert(cyl.rho, APYQuantity), apycyl.d_rho)
+        assert np.allclose(convert(cyl.phi, APYQuantity), apycyl.d_phi)
+        assert np.allclose(convert(cyl.z, APYQuantity), apycyl.d_z)
 
 
 class TestCylindricalVel(AbstractVel3DTest):
@@ -805,9 +805,9 @@ class TestCylindricalVel(AbstractVel3DTest):
     def difntl(self) -> cx.vecs.CylindricalVel:
         """Return a differential."""
         return cx.vecs.CylindricalVel(
-            d_rho=u.Quantity([5, 6, 7, 8], "km/s"),
-            d_phi=u.Quantity([9, 10, 11, 12], "mas/yr"),
-            d_z=u.Quantity([13, 14, 15, 16], "km/s"),
+            rho=u.Quantity([5, 6, 7, 8], "km/s"),
+            phi=u.Quantity([9, 10, 11, 12], "mas/yr"),
+            z=u.Quantity([13, 14, 15, 16], "km/s"),
         )
 
     @pytest.fixture(scope="class")
@@ -840,7 +840,7 @@ class TestCylindricalVel(AbstractVel3DTest):
         cart1d = difntl.vconvert(cx.vecs.CartesianVel1D, vector)
 
         assert isinstance(cart1d, cx.vecs.CartesianVel1D)
-        assert jnp.array_equal(cart1d.d_x, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(cart1d.x, u.Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -849,7 +849,7 @@ class TestCylindricalVel(AbstractVel3DTest):
         radial = difntl.vconvert(cx.vecs.RadialPos, vector)
 
         assert isinstance(radial, cx.vecs.RadialPos)
-        assert jnp.array_equal(radial.d_r, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(radial.r, u.Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -858,8 +858,8 @@ class TestCylindricalVel(AbstractVel3DTest):
         cart2d = difntl.vconvert(cx.vecs.CartesianVel2D, vector)
 
         assert isinstance(cart2d, cx.vecs.CartesianVel2D)
-        assert jnp.array_equal(cart2d.d_x, u.Quantity([1, 2, 3, 4], "km/s"))
-        assert jnp.array_equal(cart2d.d_y, u.Quantity([5, 6, 7, 8], "km/s"))
+        assert jnp.array_equal(cart2d.x, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(cart2d.y, u.Quantity([5, 6, 7, 8], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -868,8 +868,8 @@ class TestCylindricalVel(AbstractVel3DTest):
         polar = difntl.vconvert(cx.vecs.PolarPos, vector)
 
         assert isinstance(polar, cx.vecs.PolarPos)
-        assert jnp.array_equal(polar.d_r, u.Quantity([1, 2, 3, 4], "km/s"))
-        assert jnp.array_equal(polar.d_phi, u.Quantity([5, 6, 7, 8], "mas/yr"))
+        assert jnp.array_equal(polar.r, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(polar.phi, u.Quantity([5, 6, 7, 8], "mas/yr"))
 
     def test_cylindrical_to_cartesian3d(self, difntl, vector, apydifntl, apyvector):
         """Test ``coordinax.vconvert(CartesianPos3D)``."""
@@ -877,18 +877,18 @@ class TestCylindricalVel(AbstractVel3DTest):
 
         assert isinstance(cart3d, cx.CartesianVel3D)
         assert jnp.array_equal(
-            cart3d.d_x, u.Quantity([5.0, -76.537544, -145.15944, -40.03075], "km/s")
+            cart3d.x, u.Quantity([5.0, -76.537544, -145.15944, -40.03075], "km/s")
         )
         assert jnp.array_equal(
-            cart3d.d_y,
+            cart3d.y,
             u.Quantity([42.664234, 56.274563, -58.73506, -224.13647], "km/s"),
         )
-        assert jnp.array_equal(cart3d.d_z, u.Quantity([13.0, 14.0, 15.0, 16.0], "km/s"))
+        assert jnp.array_equal(cart3d.z, u.Quantity([13.0, 14.0, 15.0, 16.0], "km/s"))
 
         apycart3 = apydifntl.represent_as(apyc.CartesianDifferential, apyvector)
-        assert np.allclose(convert(cart3d.d_x, APYQuantity), apycart3.d_x)
-        assert np.allclose(convert(cart3d.d_y, APYQuantity), apycart3.d_y)
-        assert np.allclose(convert(cart3d.d_z, APYQuantity), apycart3.d_z)
+        assert np.allclose(convert(cart3d.x, APYQuantity), apycart3.d_x)
+        assert np.allclose(convert(cart3d.y, APYQuantity), apycart3.d_y)
+        assert np.allclose(convert(cart3d.z, APYQuantity), apycart3.d_z)
 
     def test_cylindrical_to_spherical(self, difntl, vector):
         """Test ``coordinax.vconvert(SphericalVel)``."""
@@ -896,18 +896,18 @@ class TestCylindricalVel(AbstractVel3DTest):
 
         assert isinstance(dsph, cx.SphericalVel)
         assert jnp.array_equal(
-            dsph.d_r,
+            dsph.r,
             u.Quantity([13.472646, 14.904826, 16.313278, 17.708754], "km/s"),
         )
         assert jnp.allclose(
-            dsph.d_theta,
+            dsph.theta,
             u.Quantity(
                 [0.3902412, 0.30769292, 0.24615361, 0.19999981], "km rad / (kpc s)"
             ),
             atol=u.Quantity(5e-7, "km rad / (kpc s)"),
         )
         assert jnp.array_equal(
-            dsph.d_phi,
+            dsph.phi,
             u.Quantity(
                 [42.664234, 47.404705, 52.145176, 56.885643], "km rad / (kpc s)"
             ),
@@ -919,9 +919,9 @@ class TestCylindricalVel(AbstractVel3DTest):
         """Test Astropy equivalence."""
         sph = difntl.vconvert(cx.SphericalVel, vector)
         apysph = apydifntl.represent_as(apyc.PhysicsSphericalDifferential, apyvector)
-        assert np.allclose(convert(sph.d_r, APYQuantity), apysph.d_r)
-        assert np.allclose(convert(sph.d_theta, APYQuantity), apysph.d_theta)
-        assert np.allclose(convert(sph.d_phi, APYQuantity), apysph.d_phi)
+        assert np.allclose(convert(sph.r, APYQuantity), apysph.d_r)
+        assert np.allclose(convert(sph.theta, APYQuantity), apysph.d_theta)
+        assert np.allclose(convert(sph.phi, APYQuantity), apysph.d_phi)
 
     def test_cylindrical_to_cylindrical(self, difntl, vector):
         """Test ``coordinax.vconvert(CylindricalVel)``."""
@@ -937,9 +937,9 @@ class TestCylindricalVel(AbstractVel3DTest):
         """Test Astropy equivalence."""
         cyl = difntl.vconvert(cx.vecs.CylindricalVel, vector)
         apycyl = apydifntl.represent_as(apyc.CylindricalDifferential, apyvector)
-        assert np.allclose(convert(cyl.d_rho, APYQuantity), apycyl.d_rho)
-        assert np.allclose(convert(cyl.d_phi, APYQuantity), apycyl.d_phi)
-        assert np.allclose(convert(cyl.d_z, APYQuantity), apycyl.d_z)
+        assert np.allclose(convert(cyl.rho, APYQuantity), apycyl.d_rho)
+        assert np.allclose(convert(cyl.phi, APYQuantity), apycyl.d_phi)
+        assert np.allclose(convert(cyl.z, APYQuantity), apycyl.d_z)
 
 
 class TestSphericalVel(AbstractVel3DTest):
@@ -949,9 +949,9 @@ class TestSphericalVel(AbstractVel3DTest):
     def difntl(self) -> cx.SphericalVel:
         """Return a differential."""
         return cx.SphericalVel(
-            d_r=u.Quantity([5, 6, 7, 8], "km/s"),
-            d_theta=u.Quantity([13, 14, 15, 16], "mas/yr"),
-            d_phi=u.Quantity([9, 10, 11, 12], "mas/yr"),
+            r=u.Quantity([5, 6, 7, 8], "km/s"),
+            theta=u.Quantity([13, 14, 15, 16], "mas/yr"),
+            phi=u.Quantity([9, 10, 11, 12], "mas/yr"),
         )
 
     @pytest.fixture(scope="class")
@@ -982,7 +982,7 @@ class TestSphericalVel(AbstractVel3DTest):
         cart1d = difntl.vconvert(cx.vecs.CartesianVel1D, vector)
 
         assert isinstance(cart1d, cx.vecs.CartesianVel1D)
-        assert jnp.array_equal(cart1d.d_x, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(cart1d.x, u.Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -991,7 +991,7 @@ class TestSphericalVel(AbstractVel3DTest):
         radial = difntl.vconvert(cx.vecs.RadialPos, vector)
 
         assert isinstance(radial, cx.vecs.RadialPos)
-        assert jnp.array_equal(radial.d_r, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(radial.r, u.Quantity([1, 2, 3, 4], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -1000,8 +1000,8 @@ class TestSphericalVel(AbstractVel3DTest):
         cart2d = difntl.vconvert(cx.vecs.CartesianVel2D, vector)
 
         assert isinstance(cart2d, cx.vecs.CartesianVel2D)
-        assert jnp.array_equal(cart2d.d_x, u.Quantity([1, 2, 3, 4], "km/s"))
-        assert jnp.array_equal(cart2d.d_y, u.Quantity([5, 6, 7, 8], "km/s"))
+        assert jnp.array_equal(cart2d.x, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(cart2d.y, u.Quantity([5, 6, 7, 8], "km/s"))
 
     @pytest.mark.xfail(reason="Not implemented")
     @pytest.mark.filterwarnings("ignore:Explicitly requested dtype")
@@ -1010,8 +1010,8 @@ class TestSphericalVel(AbstractVel3DTest):
         polar = difntl.vconvert(cx.vecs.PolarPos, vector)
 
         assert isinstance(polar, cx.vecs.PolarPos)
-        assert jnp.array_equal(polar.d_r, u.Quantity([1, 2, 3, 4], "km/s"))
-        assert jnp.array_equal(polar.d_phi, u.Quantity([5, 6, 7, 8], "mas/yr"))
+        assert jnp.array_equal(polar.r, u.Quantity([1, 2, 3, 4], "km/s"))
+        assert jnp.array_equal(polar.phi, u.Quantity([5, 6, 7, 8], "mas/yr"))
 
     def test_spherical_to_cartesian3d(self, difntl, vector):
         """Test ``coordinax.vconvert(CartesianPos3D)``."""
@@ -1019,17 +1019,17 @@ class TestSphericalVel(AbstractVel3DTest):
 
         assert isinstance(cart3d, cx.CartesianVel3D)
         assert jnp.allclose(
-            cart3d.d_x,
+            cart3d.x,
             u.Quantity([61.803337, -7.770853, -60.081947, 1.985678], "km/s"),
             atol=u.Quantity(1e-8, "km/s"),
         )
         assert jnp.allclose(
-            cart3d.d_y,
+            cart3d.y,
             u.Quantity([2.2328734, 106.6765, -144.60716, 303.30875], "km/s"),
             atol=u.Quantity(1e-8, "km/s"),
         )
         assert jnp.allclose(
-            cart3d.d_z,
+            cart3d.z,
             u.Quantity([1.7678856, -115.542175, -213.32118, -10.647271], "km/s"),
             atol=u.Quantity(1e-8, "km/s"),
         )
@@ -1041,9 +1041,9 @@ class TestSphericalVel(AbstractVel3DTest):
         cart3d = difntl.vconvert(cx.CartesianVel3D, vector)
 
         apycart3 = apydifntl.represent_as(apyc.CartesianDifferential, apyvector)
-        assert np.allclose(convert(cart3d.d_x, APYQuantity), apycart3.d_x)
-        assert np.allclose(convert(cart3d.d_y, APYQuantity), apycart3.d_y)
-        assert np.allclose(convert(cart3d.d_z, APYQuantity), apycart3.d_z)
+        assert np.allclose(convert(cart3d.x, APYQuantity), apycart3.d_x)
+        assert np.allclose(convert(cart3d.y, APYQuantity), apycart3.d_y)
+        assert np.allclose(convert(cart3d.z, APYQuantity), apycart3.d_z)
 
     def test_spherical_to_cylindrical(self, difntl, vector):
         """Test ``coordinax.vconvert(CylindricalVel)``."""
@@ -1051,19 +1051,19 @@ class TestSphericalVel(AbstractVel3DTest):
 
         assert isinstance(cylindrical, cx.vecs.CylindricalVel)
         assert jnp.allclose(
-            cylindrical.d_rho,
+            cylindrical.rho,
             u.Quantity([61.803337, 65.60564, 6.9999905, -303.30875], "km/s"),
             atol=u.Quantity(1e-8, "km/s"),
         )
         assert jnp.allclose(
-            cylindrical.d_phi,
+            cylindrical.phi,
             u.Quantity(
                 [2444.4805, 2716.0894, 2987.6985, 3259.3074], "deg km / (kpc s)"
             ),
             atol=u.Quantity(1e-8, "mas/yr"),
         )
         assert jnp.allclose(
-            cylindrical.d_z,
+            cylindrical.z,
             u.Quantity([1.7678856, -115.542175, -213.32118, -10.647271], "km/s"),
             atol=u.Quantity(1e-8, "km/s"),
         )
@@ -1074,9 +1074,9 @@ class TestSphericalVel(AbstractVel3DTest):
         """Test Astropy equivalence."""
         cyl = difntl.vconvert(cx.vecs.CylindricalVel, vector)
         apycyl = apydifntl.represent_as(apyc.CylindricalDifferential, apyvector)
-        assert np.allclose(convert(cyl.d_rho, APYQuantity), apycyl.d_rho)
-        assert np.allclose(convert(cyl.d_phi, APYQuantity), apycyl.d_phi)
-        assert np.allclose(convert(cyl.d_z, APYQuantity), apycyl.d_z)
+        assert np.allclose(convert(cyl.rho, APYQuantity), apycyl.d_rho)
+        assert np.allclose(convert(cyl.phi, APYQuantity), apycyl.d_phi)
+        assert np.allclose(convert(cyl.z, APYQuantity), apycyl.d_z)
 
     def test_spherical_to_spherical(self, difntl, vector):
         """Test ``coordinax.vconvert(SphericalVel)``."""
@@ -1092,19 +1092,19 @@ class TestSphericalVel(AbstractVel3DTest):
         """Test Astropy equivalence."""
         sph = difntl.vconvert(cx.SphericalVel, vector)
         apysph = apydifntl.represent_as(apyc.PhysicsSphericalDifferential, apyvector)
-        assert np.allclose(convert(sph.d_r, APYQuantity), apysph.d_r)
-        assert np.allclose(convert(sph.d_theta, APYQuantity), apysph.d_theta)
-        assert np.allclose(convert(sph.d_phi, APYQuantity), apysph.d_phi)
+        assert np.allclose(convert(sph.r, APYQuantity), apysph.d_r)
+        assert np.allclose(convert(sph.theta, APYQuantity), apysph.d_theta)
+        assert np.allclose(convert(sph.phi, APYQuantity), apysph.d_phi)
 
     def test_spherical_to_lonlatspherical(self, difntl, vector):
         """Test ``coordinax.vconvert(LonLatSphericalVel)``."""
         llsph = difntl.vconvert(cx.vecs.LonLatSphericalVel, vector)
 
         assert isinstance(llsph, cx.vecs.LonLatSphericalVel)
-        assert jnp.array_equal(llsph.d_distance, difntl.d_r)
-        assert jnp.array_equal(llsph.d_lon, difntl.d_phi)
+        assert jnp.array_equal(llsph.distance, difntl.r)
+        assert jnp.array_equal(llsph.lon, difntl.phi)
         assert jnp.allclose(
-            llsph.d_lat,
+            llsph.lat,
             u.Quantity([-13.0, -14.0, -15.0, -16.0], "mas/yr"),
             atol=u.Quantity(1e-8, "mas/yr"),
         )
@@ -1116,15 +1116,15 @@ class TestSphericalVel(AbstractVel3DTest):
         cart3d = difntl.vconvert(cx.vecs.LonLatSphericalVel, vector)
 
         apycart3 = apydifntl.represent_as(apyc.SphericalDifferential, apyvector)
-        assert np.allclose(convert(cart3d.d_distance, APYQuantity), apycart3.d_distance)
-        assert np.allclose(convert(cart3d.d_lon, APYQuantity), apycart3.d_lon)
-        assert np.allclose(convert(cart3d.d_lat, APYQuantity), apycart3.d_lat)
+        assert np.allclose(convert(cart3d.distance, APYQuantity), apycart3.d_distance)
+        assert np.allclose(convert(cart3d.lon, APYQuantity), apycart3.d_lon)
+        assert np.allclose(convert(cart3d.lat, APYQuantity), apycart3.d_lat)
 
     def test_spherical_to_mathspherical(self, difntl, vector):
         """Test ``coordinax.vconvert(MathSpherical)``."""
         llsph = difntl.vconvert(cx.vecs.MathSphericalVel, vector)
 
         assert isinstance(llsph, cx.vecs.MathSphericalVel)
-        assert jnp.array_equal(llsph.d_r, difntl.d_r)
-        assert jnp.array_equal(llsph.d_phi, difntl.d_theta)
-        assert jnp.array_equal(llsph.d_theta, difntl.d_phi)
+        assert jnp.array_equal(llsph.r, difntl.r)
+        assert jnp.array_equal(llsph.phi, difntl.theta)
+        assert jnp.array_equal(llsph.theta, difntl.phi)


### PR DESCRIPTION
Following suggestion from @adrn, this is a major rename of the velocity & acceleration fields.
By removing the `d_` prefix this simplifies the current implementation and will further simplify tree operations.
Moreover it will make supporting jerk, snap, crackle, pop, etc. And also non time derivatives.