### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/coordinax/security/code-scanning/1](https://github.com/GalacticDynamics/coordinax/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow to explicitly define the minimum required permissions for the `GITHUB_TOKEN`. Based on the actions used in the workflow, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `issues: write` for workflows that interact with issues (if applicable).
- `pull-requests: write` for workflows that interact with pull requests (if applicable).

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, we will add a root-level `permissions` block with `contents: read`, as this is the minimal starting point recommended by CodeQL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
