### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,8 @@ jobs:
   dist:
     name: Distribution build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/coordinax/security/code-scanning/2](https://github.com/GalacticDynamics/coordinax/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the `dist` job in the workflow file. Since the job only requires read access to the repository contents, we will set `contents: read` as the permission. This ensures the job adheres to the principle of least privilege and avoids granting unnecessary write permissions.

The changes will be made to the `.github/workflows/cd.yml` file:
1. Add a `permissions` block under the `dist` job.
2. Set the permissions to `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
