### PR TITLE
💚 ci(ci): split test matrix by os and python support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
   # Many color libraries just need this to be set to any value, but at least
   # one distinguishes color depth, where "3" -> "256-bit color".
   FORCE_COLOR: 3
+  PYTHON_VERSIONS: '["3.11", "3.12", "3.13"]'
 
 jobs:
   format:
@@ -35,15 +36,70 @@ jobs:
       - name: Lint & type-check
         run: uv run --frozen nox -s lint
 
-  tests:
-    name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
-    runs-on: ${{ matrix.runs-on }}
+  prepare_test_matrix:
+    name: Prepare Test Matrix
+    runs-on: ubuntu-latest
     needs: [format]
+    outputs:
+      python-all: ${{ steps.matrix.outputs.python-all }}
+      python-edge: ${{ steps.matrix.outputs.python-edge }}
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v6
+
+      - name: Compute matrix versions
+        id: matrix
+        run: |
+          uv run python - <<'PY'
+          import json
+          import os
+
+          versions = json.loads(os.environ["PYTHON_VERSIONS"])
+          edge_versions = [versions[0], versions[-1]]
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
+              f.write(f"python-all={json.dumps(versions)}\n")
+              f.write(f"python-edge={json.dumps(edge_versions)}\n")
+          PY
+
+  tests_linux:
+    name: Check Python ${{ matrix.python-version }} on ubuntu-latest
+    runs-on: ubuntu-latest
+    needs: [prepare_test_matrix]
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ${{ fromJSON(needs.prepare_test_matrix.outputs.python-all) }}
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install
+        run: uv sync --no-default-groups --group nox --group test --locked
+
+      - name: Test package
+        run: |
+          uv run --frozen nox -s test -- --cov --cov-report=xml --cov-report=term --durations=20 --arraydiff -m"not slow"
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  tests_nonlinux:
+    name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
+    needs: [prepare_test_matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [macos-latest, windows-latest]
+        python-version: ${{ fromJSON(needs.prepare_test_matrix.outputs.python-edge) }}
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -113,7 +169,7 @@ jobs:
   status:
     name: CI Pass
     runs-on: ubuntu-latest
-    needs: [format, tests, check_oldest]
+    needs: [format, tests_linux, tests_nonlinux, check_oldest]
     if: always()
     steps:
       - name: All required jobs passed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,18 +44,15 @@ jobs:
       python-all: ${{ steps.matrix.outputs.python-all }}
       python-edge: ${{ steps.matrix.outputs.python-edge }}
     steps:
-      - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v6
-
       - name: Compute matrix versions
         id: matrix
         run: |
-          uv run python - <<'PY'
+          python - <<'PY'
           import json
           import os
 
           versions = json.loads(os.environ["PYTHON_VERSIONS"])
-          edge_versions = [versions[0], versions[-1]]
+          edge_versions = list(dict.fromkeys([versions[0], versions[-1]]))
 
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
               f.write(f"python-all={json.dumps(versions)}\n")


### PR DESCRIPTION
Reduce CI runtime and platform bottlenecks by running full Python coverage on Linux while keeping edge-version smoke coverage on macOS and Windows. This preserves broad compatibility checks without duplicating expensive cross-platform test jobs.