### PR TITLE
✨ feat(representations): add change_basis function

### DIFF
--- a/docs/api/representations.md
+++ b/docs/api/representations.md
@@ -101,8 +101,7 @@ For point data, `cconvert` dispatches through chart-level point conversion laws.
 
 - Representations are orthogonal to charts: chart choice and representation choice are independent concerns.
 - The current built-in flow is point-first, centered on `(point_geom, no_basis, loc)`.
-- `change_basis` is currently limited to tangent data in Cartesian charts, with `CoordinateBasis` $
-ightleftarrows$ `PhysicalBasis` conversions.
+- `change_basis` currently supports tangent-data conversions between `CoordinateBasis` $\rightleftarrows$ `PhysicalBasis`, including Cartesian, spherical, and metric-based conversions.
 
 ```{eval-rst}
 

--- a/docs/api/representations.md
+++ b/docs/api/representations.md
@@ -40,11 +40,19 @@ This is separate from charts and manifolds:
 {'r': Array(3.74165739, dtype=float64, ...),
  'theta': Array(0.64052231, dtype=float64),
  'phi': Array(1.10714872, dtype=float64, ...)}
+
+# Change tangent components between basis conventions in the same chart.
+>>> v = {"r": u.Q(1.0, "km/s"), "theta": u.Q(0.0, "rad/s"), "phi": u.Q(0.0, "rad/s")}
+>>> at = {"r": u.Q(2.0, "km"), "theta": u.Q(3.0, "rad"), "phi": u.Q(4.0, "rad")}
+>>> v2 = cxr.change_basis(v, cxc.cart2d, cxr.coord_basis, cxr.phys_basis, at=at)
+>>> v2
+{'r': Q(1., 'km / s'), 'theta': Q(0., 'rad / s'), 'phi': Q(0., 'rad / s')}
 ```
 
 ## Functional API
 
 - `cconvert`: representation-aware coordinate conversion API
+- `change_basis`: same-chart tangent basis conversion API
 - `cmap`: partial-function builder around `cconvert`
 - `guess_basis_kind`: infer basis kind from dimensions/data
 - `guess_geometry_kind`: infer geometric kind from dimensions/data
@@ -58,6 +66,7 @@ For point data, `cconvert` dispatches through chart-level point conversion laws.
 ### Conversion Functions
 
 - `cconvert`: convert data across charts/representations
+- `change_basis`: change tangent basis without changing chart
 - `cmap`: build reusable conversion callables
 - `guess_basis_kind`: infer a basis kind
 - `guess_geometry_kind`: infer a geometry kind
@@ -92,6 +101,8 @@ For point data, `cconvert` dispatches through chart-level point conversion laws.
 
 - Representations are orthogonal to charts: chart choice and representation choice are independent concerns.
 - The current built-in flow is point-first, centered on `(point_geom, no_basis, loc)`.
+- `change_basis` is currently limited to tangent data in Cartesian charts, with `CoordinateBasis` $
+ightleftarrows$ `PhysicalBasis` conversions.
 
 ```{eval-rst}
 

--- a/docs/api/representations.md
+++ b/docs/api/representations.md
@@ -44,9 +44,9 @@ This is separate from charts and manifolds:
 # Change tangent components between basis conventions in the same chart.
 >>> v = {"r": u.Q(1.0, "km/s"), "theta": u.Q(0.0, "rad/s"), "phi": u.Q(0.0, "rad/s")}
 >>> at = {"r": u.Q(2.0, "km"), "theta": u.Q(3.0, "rad"), "phi": u.Q(4.0, "rad")}
->>> v2 = cxr.change_basis(v, cxc.cart2d, cxr.coord_basis, cxr.phys_basis, at=at)
+>>> v2 = cxr.change_basis(v, cxc.sph3d, cxr.coord_basis, cxr.phys_basis, at=at)
 >>> v2
-{'r': Q(1., 'km / s'), 'theta': Q(0., 'rad / s'), 'phi': Q(0., 'rad / s')}
+{'r': Q(1., 'km / s'), 'theta': Q(0., 'km / s'), 'phi': Q(0., 'km / s')}
 ```
 
 ## Functional API

--- a/docs/guides/representations.md
+++ b/docs/guides/representations.md
@@ -144,8 +144,8 @@ The representation design is intentionally extensible. Future geometric kinds (f
 
 - supported basis changes: `CoordinateBasis` $\rightleftarrows$ `PhysicalBasis`
 - supported representations: tangent representations such as `coord_disp` and `phys_disp`
-- unsupported: point data (`NoBasis`)
-- non-Cartesian support: available for charts with basis-change rules (for example `sph3d`), and generally via an explicit metric/manifold
+- point representations are not supported as genuine basis-changing inputs; however, `NoBasis -> CoordinateBasis` and `NoBasis -> PhysicalBasis` are supported as identity reinterpretations when the dimensions are compatible
+- non-Cartesian support: available for tangent basis changes on charts with basis-change rules (for example `sph3d`), and generally via an explicit metric/manifold
 
 ```{code-block} python
 >>> import coordinax.charts as cxc

--- a/docs/guides/representations.md
+++ b/docs/guides/representations.md
@@ -138,12 +138,40 @@ Current built-in representation conversions are point-first:
 
 The representation design is intentionally extensible. Future geometric kinds (for example tangent and cotangent objects) can use different transformation categories (such as Jacobian pushforward/pullback) while keeping the same chart and manifold interfaces.
 
+## Tangent Basis Changes
+
+`change_basis` handles a narrower problem than `cconvert`: it keeps the chart fixed and only changes how tangent components are interpreted with respect to a basis.
+
+In the current v1 implementation, this is intentionally limited to tangent data in Cartesian charts:
+
+- supported basis changes: `CoordinateBasis` $
+ightleftarrows$ `PhysicalBasis`
+- supported representations: tangent representations such as `coord_disp` and `phys_disp`
+- unsupported: point data (`NoBasis`) and non-Cartesian charts
+
+```{code-block} python
+>>> import coordinax.charts as cxc
+>>> import coordinax.representations as cxr
+
+>>> v = {"x": 1.0, "y": 0.0}
+>>> at = {"x": 2.0, "y": 3.0}
+
+>>> cxr.change_basis(v, cxc.cart2d, cxr.coord_basis, cxr.phys_basis, at=at)
+{'x': 1.0, 'y': 0.0}
+
+>>> cxr.change_basis(v, cxc.cart2d, cxr.coord_disp, cxr.phys_disp, at=at)
+{'x': 1.0, 'y': 0.0}
+```
+
+In Cartesian charts the coordinate basis and physical basis coincide, so the component values are unchanged. The API exists so code can state basis intent explicitly and remain extensible to nontrivial basis changes later.
+
 ## Quick Reference
 
 - Need only a same-manifold coordinate rewrite: `pt_map`
 - Need general point mapping behavior: `pt_map`
 - Need manifold compatibility checks: manifold methods like `M.pt_map`
 - Need representation-aware conversions: `cconvert`
+- Need same-chart tangent basis conversion: `change_basis`
 - Need reusable conversion callables: `cmap`
 - Need to infer basis kind from data: `guess_basis_kind`
 - Need to infer semantic kind from data: `guess_semantic_kind`

--- a/docs/guides/representations.md
+++ b/docs/guides/representations.md
@@ -142,16 +142,15 @@ The representation design is intentionally extensible. Future geometric kinds (f
 
 `change_basis` handles a narrower problem than `cconvert`: it keeps the chart fixed and only changes how tangent components are interpreted with respect to a basis.
 
-In the current v1 implementation, this is intentionally limited to tangent data in Cartesian charts:
-
-- supported basis changes: `CoordinateBasis` $
-ightleftarrows$ `PhysicalBasis`
+- supported basis changes: `CoordinateBasis` $\rightleftarrows$ `PhysicalBasis`
 - supported representations: tangent representations such as `coord_disp` and `phys_disp`
-- unsupported: point data (`NoBasis`) and non-Cartesian charts
+- unsupported: point data (`NoBasis`)
+- non-Cartesian support: available for charts with basis-change rules (for example `sph3d`), and generally via an explicit metric/manifold
 
 ```{code-block} python
 >>> import coordinax.charts as cxc
 >>> import coordinax.representations as cxr
+>>> import jax.numpy as jnp
 
 >>> v = {"x": 1.0, "y": 0.0}
 >>> at = {"x": 2.0, "y": 3.0}
@@ -161,9 +160,30 @@ ightleftarrows$ `PhysicalBasis`
 
 >>> cxr.change_basis(v, cxc.cart2d, cxr.coord_disp, cxr.phys_disp, at=at)
 {'x': 1.0, 'y': 0.0}
+
+>>> import coordinax.manifolds as cxm
+>>> import unxt as u
+
+>>> v_sph = {
+...     "r": u.Q(5, "m/s"),
+...     "theta": u.Q(1, "rad/s"),
+...     "phi": u.Q(1, "rad/s"),
+... }
+>>> at_sph = {
+...     "r": u.Q(2, "m"),
+...     "theta": u.Q(jnp.pi / 2, "rad"),
+...     "phi": u.Q(0, "rad"),
+... }
+
+>>> cxr.change_basis(v_sph, cxc.sph3d, cxr.coord_basis, cxr.phys_basis, at=at_sph)
+{'r': Q(5, 'm / s'), 'theta': Q(2, 'm / s'), 'phi': Q(2., 'm / s')}
+
+>>> metric = cxm.EuclideanMetric(3)
+>>> cxr.change_basis(v_sph, cxc.sph3d, metric, cxr.coord_basis, cxr.phys_basis, at=at_sph)
+{'r': Q(5, 'm / s'), 'theta': Q(2, 'm / s'), 'phi': Q(2., 'm / s')}
 ```
 
-In Cartesian charts the coordinate basis and physical basis coincide, so the component values are unchanged. The API exists so code can state basis intent explicitly and remain extensible to nontrivial basis changes later.
+In Cartesian charts the coordinate basis and physical basis coincide, so the component values are unchanged. In non-Cartesian charts (for example spherical), basis changes are generally nontrivial and depend on the base point `at` and metric. The API exists so code can state basis intent explicitly while supporting both cases.
 
 ## Quick Reference
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -946,7 +946,7 @@ A non-exhaustive table of exported objects are:
 | `coordinax.angles` | `AbstractAngle`, `Angle`, `wrap_to` |
 | `coordinax.distances` | `AbstractDistance`, `Distance` |
 | `coordinax.charts` | `CartesianProductChart`, </br> `cartesian_chart`, `guess_chart`, `cdict`, `pt_map`, `jac_pt_map`, </br> `cart0d`, </br> `cart1d`, `radial1d`, `time1d`, </br> `cart2d`, `polar2d`, </br> `cart3d`, `cyl3d`, `sph3d`, `lonlat_sph3d`, `loncoslat_sph3d`, `math_sph3d`, </br> `cartnd`, </br> `spacetimect` |
-| `coordinax.representations` | `cconvert`, </br> `Representation`, `point`, `coord_disp`, `coord_vel`, `coord_acc`, `phys_disp`, `phys_vel`, `phys_acc`, </br> `PointGeometry`, `point_geom`, `TangentGeometry`, `tangent_geom`, </br> `NoBasis`, `no_basis`, `CoordinateBasis`, `coord_basis`, `PhysicalBasis`, `phys_basis`, </br> `Location`, `loc`, `Displacement`, `dpl`, `Velocity`, `vel`, `Acceleration`, `acc`, </br> `guess_geometry_kind`, `guess_semantic_kind`, `guess_rep` |
+| `coordinax.representations` | `cconvert`, `change_basis`, </br> `Representation`, `point`, `coord_disp`, `coord_vel`, `coord_acc`, `phys_disp`, `phys_vel`, `phys_acc`, </br> `PointGeometry`, `point_geom`, `TangentGeometry`, `tangent_geom`, </br> `NoBasis`, `no_basis`, `CoordinateBasis`, `coord_basis`, `PhysicalBasis`, `phys_basis`, </br> `Location`, `loc`, `Displacement`, `dpl`, `Velocity`, `vel`, `Acceleration`, `acc`, </br> `guess_geometry_kind`, `guess_semantic_kind`, `guess_rep` |
 | `coordinax.vectors` | `Point`, `ToUnitsOptions` |
 | `coordinax.manifolds` | `guess_manifold`, `scale_factors`, `angle_between`, </br> `EuclideanManifold`, `EuclideanMetric`, `euclidean3d`, </br> `EmbeddedManifold`, `EmbeddedChart` </br> `twosphere`, `embedded_twosphere`, </br> `CustomManifold`,`CustomAtlas`, |
 | `coordinax.transforms` | `act`, `simplify`, `compose`, `materialize_transform`, </br> `AbstractTransform`, `Identity`, `Composed`, `Translate`, `Rotate`, `Reflect`, `Scale`, `Shear`, `identity`, </br> `AbstractTransformGroup`, `IdentityGroup`, `DiffeomorphismGroup`, `AffineGroup`, `EuclideanGroup`, `OrthogonalGroup`, `SpecialOrthogonalGroup`, `PoincareGroup`, `LorentzGroup`, `ProperOrthochronousLorentzGroup` |
@@ -2624,6 +2624,90 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
     - [`EuclideanMetric`](#software-spec-euclideanmetric): flat Riemannian metric on $\mathbb{R}^n$; identity in Cartesian charts, computed via Jacobian pullback in curvilinear charts.
     - [`MinkowskiMetric`](#software-spec-minkowskimetric): Lorentzian metric $\eta = \operatorname{diag}(-1, 1, 1, 1)$ on Minkowski spacetime; diagonal in the canonical Cartesian spacetime chart.
     - [`HyperSphericalMetric`](#software-spec-hypersphericalmetric): round metric on $S^{n-1}$; diagonal entries follow the cumulative-sine rule $g_{kk} = \prod_{j < k}\sin^2\!\theta_j$.
+
+(software-spec-abstractdiagonalmetric)=
+
+!!! info `AbstractDiagonalMetric`
+
+    `AbstractDiagonalMetric` is an abstract subclass of `AbstractMetric` for metrics whose matrix is diagonal at every base point in every compatible chart.
+
+    A metric is **diagonal** (equivalently, the coordinate chart is an **orthogonal coordinate system**) when all off-diagonal entries of the metric matrix vanish:
+
+    $$g_{ij}(p) = 0 \quad \text{for } i \neq j \quad \forall\, p \in U.$$
+
+    The coordinate basis vectors $\partial/\partial q^i$ are mutually orthogonal. The diagonal entries $g_{ii}(p)$ give the squared scale factors
+
+    $$h_i(p)^2 = g_{ii}(p),$$
+
+    and the infinitesimal line element simplifies to
+
+    $$ds^2 = \sum_i g_{ii}(q)\,(dq^i)^2.$$
+
+    **Role: structural marker, not behavioral interface.**
+
+    `AbstractDiagonalMetric` adds no new abstract methods beyond those of `AbstractMetric`.  Its sole purpose is to **declare** that `metric_matrix` will always return a diagonal matrix.  This allows:
+
+    - Dispatch specialisations that compute `scale_factors` more efficiently
+      (e.g., extracting only the diagonal of $g$, or using squared Jacobian
+      column norms instead of the full $J^\top J$).
+    - Type-level distinction between orthogonal and general metrics in
+      multiple-dispatch registrations.
+
+    **Subclassing contract:**
+
+    Subclasses must implement the two abstract members inherited from
+    `AbstractMetric`:
+
+    - `signature` (abstract property): a tuple of $\pm 1$ of length `ndim`
+      encoding the metric signature in coordinate order.  Positive entries
+      are Riemannian (space-like); a ``-1`` entry is pseudo-Riemannian
+      (time-like).
+    - `metric_matrix(chart, /, *, at, usys=None)` (abstract method): must
+      return a diagonal `QuantityMatrix` (or plain `Array`) of shape
+      `(ndim, ndim)` with all off-diagonal entries exactly zero.
+
+    All other behavioral requirements of `AbstractMetric` also apply:
+    immutability (frozen dataclass), static JAX PyTree registration, and
+    `jit`/`vmap` compatibility.
+
+    **Relationship to `AbstractMetric.is_diagonal`:**
+
+    `AbstractMetric.is_diagonal(chart, at=at)` inspects the metric matrix at
+    a **specific base point** and returns a `bool`.
+    `AbstractDiagonalMetric` makes this an unconditional **structural
+    promise** across all base points: instances are always diagonal,
+    regardless of which chart or point is supplied.
+
+    **Concrete subclasses (built-in):**
+
+    | Class | Manifold | Diagonal in |
+    |-------|----------|-------------|
+    | [`EuclideanMetric`](#software-spec-euclideanmetric) | $\mathbb{R}^n$ | Cartesian charts; orthogonal curvilinear charts via $g = J^\top J$ |
+    | [`HyperSphericalMetric`](#software-spec-hypersphericalmetric) | $S^{n-1}$ | Intrinsic hyperspherical chart; cumulative-sine rule $g_{kk} = \prod_{j<k}\sin^2\!\theta_j$ |
+    | [`MinkowskiMetric`](#software-spec-minkowskimetric) | $\mathbb{R}^{1,3}$ | Canonical Cartesian spacetime chart $\eta = \operatorname{diag}(-1,1,1,1)$ |
+
+    **Example**
+
+    ```pycon
+    >>> from coordinax.manifolds._src.diagonal import AbstractDiagonalMetric
+    >>> import coordinax.manifolds as cxm
+
+    >>> isinstance(cxm.EuclideanMetric(3), AbstractDiagonalMetric)
+    True
+
+    >>> isinstance(cxm.MinkowskiMetric(), AbstractDiagonalMetric)
+    True
+
+    >>> import unxt as u
+    >>> isinstance(
+    ...     cxm.InducedMetric(
+    ...         cxm.TwoSphereIn3D(radius=u.Q(1.0, "m")),
+    ...         cxm.EuclideanMetric(3),
+    ...     ),
+    ...     AbstractDiagonalMetric,
+    ... )
+    False
+    ```
 
 (software-spec-abstractmanifold)=
 

--- a/docs/tutorials/cdict_objects.md
+++ b/docs/tutorials/cdict_objects.md
@@ -184,11 +184,9 @@ Identity transform returns the exact same object:
 True
 ```
 
-## Changing Tangent Basis In-Place
+## Changing Tangent Basis
 
-Use `cxr.change_basis()` when a CDict already lives in the correct chart and you only need to reinterpret tangent components with respect to a different basis.
-
-In v1 this supports Cartesian tangent data only. For Cartesian charts, coordinate and physical bases coincide, so the values are preserved.
+Use `cxr.change_basis()` when a you want to change the tangent basis of a CDict without changing its chart or representation.
 
 ```{code-block} python
 >>> d = {"x": 1.0, "y": 0.0}

--- a/docs/tutorials/cdict_objects.md
+++ b/docs/tutorials/cdict_objects.md
@@ -186,7 +186,7 @@ True
 
 ## Changing Tangent Basis
 
-Use `cxr.change_basis()` when a you want to change the tangent basis of a CDict without changing its chart or representation.
+Use `cxr.change_basis()` when you want to change the tangent basis of a CDict without changing its chart, geometry, or semantics.
 
 ```{code-block} python
 >>> d = {"x": 1.0, "y": 0.0}

--- a/docs/tutorials/cdict_objects.md
+++ b/docs/tutorials/cdict_objects.md
@@ -184,6 +184,25 @@ Identity transform returns the exact same object:
 True
 ```
 
+## Changing Tangent Basis In-Place
+
+Use `cxr.change_basis()` when a CDict already lives in the correct chart and you only need to reinterpret tangent components with respect to a different basis.
+
+In v1 this supports Cartesian tangent data only. For Cartesian charts, coordinate and physical bases coincide, so the values are preserved.
+
+```{code-block} python
+>>> d = {"x": 1.0, "y": 0.0}
+>>> at = {"x": 2.0, "y": 3.0}
+
+>>> cxr.change_basis(d, cxc.cart2d, cxr.coord_basis, cxr.phys_basis, at=at)
+{'x': 1.0, 'y': 0.0}
+
+>>> cxr.change_basis(d, cxc.cart2d, cxr.coord_disp, cxr.phys_disp, at=at)
+{'x': 1.0, 'y': 0.0}
+```
+
+Use `cconvert()` instead when the chart itself must change.
+
 ## Upgrading To A Point
 
 Promote a CDict to a `Point` by providing chart context:

--- a/packages/coordinax.api/src/coordinax/api/representations.py
+++ b/packages/coordinax.api/src/coordinax/api/representations.py
@@ -3,6 +3,7 @@
 __all__ = (
     "add",
     "cconvert",
+    "change_basis",
     "guess_basis_kind",
     "guess_geometry_kind",
     "guess_rep",
@@ -13,6 +14,25 @@ __all__ = (
 from typing import Any
 
 import plum
+
+
+@plum.dispatch.abstract
+def change_basis(*args: Any, **kwargs: Any) -> Any:
+    """Change the basis of a tangent vector's components.
+
+    Supports both basis-object and representation-object overloads.
+    Tangent-only in v1: only CoordinateBasis <-> PhysicalBasis conversions are supported.
+
+    Examples
+    --------
+    >>> import coordinax.representations as cxr
+    >>> import coordinax.charts as cxc
+    >>> v = {"x": 1.0, "y": 0.0}
+    >>> at = {"x": 1.0, "y": 0.0}
+    >>> cxr.change_basis(v, cxc.cart2d, cxr.coord_basis, cxr.phys_basis, at=at)
+    {'x': 1.0, 'y': 0.0}
+    """
+    raise NotImplementedError  # pragma: no cover
 
 
 @plum.dispatch.abstract

--- a/packages/coordinax.api/src/coordinax/api/representations.py
+++ b/packages/coordinax.api/src/coordinax/api/representations.py
@@ -20,9 +20,6 @@ import plum
 def change_basis(*args: Any, **kwargs: Any) -> Any:
     """Change the basis of a tangent vector's components.
 
-    Supports both basis-object and representation-object overloads.
-    Tangent-only in v1: only CoordinateBasis <-> PhysicalBasis conversions are supported.
-
     Examples
     --------
     >>> import coordinax.representations as cxr

--- a/src/coordinax/main/__init__.py
+++ b/src/coordinax/main/__init__.py
@@ -78,6 +78,7 @@ __all__ = (  # distances
     "phys_disp",
     "phys_vel",
     "phys_acc",
+    "change_basis",
     # vectors
     "Point",
     "ToUnitsOptions",
@@ -134,6 +135,7 @@ from coordinax.representations import (
     acc,
     add,
     cconvert,
+    change_basis,
     coord_acc,
     coord_basis,
     coord_disp,

--- a/src/coordinax/representations/__init__.py
+++ b/src/coordinax/representations/__init__.py
@@ -96,6 +96,7 @@ __all__ = (
     "guess_rep",
     "guess_semantic_kind",
     "subtract",
+    "change_basis",
     # Representations
     "Representation",
     "point",
@@ -154,6 +155,7 @@ with install_import_hook("coordinax.representations"):
         TangentGeometry,
         Velocity,
         acc,
+        change_basis,
         cmap,
         coord_acc,
         coord_basis,

--- a/src/coordinax/representations/_src/__init__.py
+++ b/src/coordinax/representations/_src/__init__.py
@@ -1,6 +1,7 @@
 """Representations."""
 
 from .basis import *
+from .basis_change import *
 from .core import *
 from .geom import *
 from .guess import *

--- a/src/coordinax/representations/_src/basis_change.py
+++ b/src/coordinax/representations/_src/basis_change.py
@@ -3,7 +3,7 @@
 __all__ = ("change_basis",)
 
 from jaxtyping import ArrayLike
-from typing import Any, TypeVar
+from typing import Any
 
 import jax
 import jax.scipy.linalg
@@ -27,8 +27,6 @@ from .geom import TangentGeometry
 from .rep import Representation
 from coordinax.internal import QuantityMatrix, UnitsMatrix
 from coordinax.internal.custom_types import CDict, OptUSys
-
-T = TypeVar("T", bound=u.Quantity)
 
 _RAD = u.unit("rad")
 
@@ -63,7 +61,7 @@ def _qm_triangular_solve(E: QuantityMatrix, b: QuantityMatrix) -> QuantityMatrix
     # D^{-1} b → b_norm[i] = b.value[i] / E.value[i,i]
     diag_vals = jnp.diagonal(E.value, axis1=-2, axis2=-1)
     b_norm = b.value / diag_vals  # shape (..., n), element-wise divide by diagonal
-    E_norm = E.value / diag_vals[:, None]  # normalise each row by its diagonal
+    E_norm = E.value / diag_vals[..., :, None]  # normalise each row by its diagonal
     x_vals = jax.scipy.linalg.solve_triangular(E_norm, b_norm, lower=False)
     return QuantityMatrix(x_vals, unit=x_units)
 
@@ -599,7 +597,7 @@ def change_basis(
     return {
         "r": v["r"],
         "theta": r * _drop_rad_unit(v["theta"]),
-        "phi": (r * jnp.sin(at["theta"])) * _drop_rad_unit(v["phi"]),
+        "phi": r * jnp.sin(at["theta"]) * _drop_rad_unit(v["phi"]),
     }
 
 

--- a/src/coordinax/representations/_src/basis_change.py
+++ b/src/coordinax/representations/_src/basis_change.py
@@ -1,0 +1,809 @@
+"""Vector Conversion."""
+
+__all__ = ("change_basis",)
+
+from jaxtyping import ArrayLike
+from typing import Any, TypeVar
+
+import jax
+import jax.scipy.linalg
+import plum
+
+import quaxed.numpy as jnp
+import unxt as u
+from unxt.quantity import BareQuantity, is_any_quantity
+
+import coordinax.api.representations as cxrapi
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+from .basis import (
+    AbstractBasis,
+    AbstractLinearBasis,
+    CoordinateBasis,
+    NoBasis,
+    PhysicalBasis,
+)
+from .geom import TangentGeometry
+from .rep import Representation
+from coordinax.internal import QuantityMatrix, UnitsMatrix
+from coordinax.internal.custom_types import CDict, OptUSys
+
+T = TypeVar("T", bound=u.Quantity)
+
+_RAD = u.unit("rad")
+
+
+def _drop_rad_unit(q: ArrayLike | u.AbstractQuantity) -> ArrayLike | u.AbstractQuantity:
+    """Drop the "rad" unit from a quantity, otherwise return unchanged."""
+    return BareQuantity(q.value, unit=q.unit / _RAD) if is_any_quantity(q) else q
+
+
+def _add_rad_unit(q: ArrayLike | u.AbstractQuantity) -> ArrayLike | u.AbstractQuantity:
+    """Add the "rad" unit to a quantity, otherwise return unchanged."""
+    return BareQuantity(q.value, unit=q.unit * _RAD) if is_any_quantity(q) else q
+
+
+def _qm_triangular_solve(E: QuantityMatrix, b: QuantityMatrix) -> QuantityMatrix:
+    """Solve upper-triangular system E @ x = b for x, respecting units.
+
+    Uses the fact that E is upper-triangular (vielbein = L^T from Cholesky).
+    Unit of x[i] is unit(b[i]) / unit(E[i,i]).
+
+    Works on raw values: normalises E by its diagonal so E_norm is
+    dimensionless (unit diagonal = 1), solves the normalised system, and
+    reattaches output units.
+    """
+    n = E.unit.shape[0]
+    x_units = UnitsMatrix(tuple(b.unit[i] / E.unit[i, i] for i in range(n)))
+    # Scale b[i] → b_norm[i] = b.value[i] / E.value[i,i]  (dimensionless in
+    # the sense that both numerator and denominator carry the same combined unit)
+    # Since x[i] = b[i]/E[i,i] dimensionally, the raw solve gives the right
+    # magnitude when we factor out the diagonal scaling from E.
+    # D = diag(E.value[i,i]);  E_norm = D^{-1} E  (upper-triangular, unit diagonal)
+    # D^{-1} b → b_norm[i] = b.value[i] / E.value[i,i]
+    diag_vals = jnp.diagonal(E.value, axis1=-2, axis2=-1)
+    b_norm = b.value / diag_vals  # shape (..., n), element-wise divide by diagonal
+    E_norm = E.value / diag_vals[:, None]  # normalise each row by its diagonal
+    x_vals = jax.scipy.linalg.solve_triangular(E_norm, b_norm, lower=False)
+    return QuantityMatrix(x_vals, unit=x_units)
+
+
+##############################################################################
+# With a metric
+
+
+@plum.dispatch
+def change_basis(
+    v: CDict,
+    chart: cxc.AbstractChart,
+    metric: cxm.AbstractMetric,
+    from_basis: CoordinateBasis,
+    to_basis: PhysicalBasis,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Change from coordinate basis to physical basis using a general metric.
+
+    This overload handles any metric that is **not** an
+    `~coordinax.manifolds.AbstractDiagonalMetric` (e.g.
+    `~coordinax.manifolds.InducedMetric`).  The algorithm uses the Cholesky
+    vielbein $E = L^\top$.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+    >>> import coordinax.representations as cxr
+
+    ``InducedMetric`` is an ``AbstractMetric`` but not an
+    ``AbstractDiagonalMetric``, so this dispatch is selected:
+
+    >>> embed_map = cxm.TwoSphereIn3D(radius=u.Q(1.0, "km"))
+    >>> metric = cxm.InducedMetric(embed_map, cxm.EuclideanMetric(3))
+
+    >>> v = {"theta": u.Q(1.0, "rad/s"), "phi": u.Q(2.0, "rad/s")}
+    >>> at = {"theta": u.Q(jnp.pi / 3, "rad"), "phi": u.Q(0.0, "rad")}
+    >>> cxr.change_basis(v, cxc.sph2, metric, cxr.coord_basis, cxr.phys_basis, at=at)
+    {'theta': Q(..., 'km / s'), 'phi': Q(..., 'km / s')}
+
+    >>> v = {"theta": 1.0, "phi": 2.0}
+    >>> at = {"theta": jnp.pi / 3, "phi": 0.0}
+    >>> usys = u.unitsystems.si
+    >>> cxr.change_basis(v, cxc.sph2, metric, cxr.coord_basis, cxr.phys_basis,
+    ...                  at=at, usys=usys)
+    {'theta': Q(1., 'km'), 'phi': Q(1.73205081, 'km')}
+
+    """
+    at = chart.check_data(at, keys=True)
+    keys = chart.components
+    # Cholesky vielbein E = L^T,  hat_v = E @ v
+    L = metric.cholesky(chart, at=at, usys=usys)
+    E = jnp.transpose(L, axes=(-2, -1))  # E = L^T, upper-triangular vielbein
+    v_vec = QuantityMatrix.from_cdict(v, keys)
+    hat_v_vec = jnp.matmul(E, v_vec)
+    return cxc.cdict(hat_v_vec, keys)  # ty: ignore[invalid-return-type]
+
+
+@plum.dispatch
+def change_basis(
+    v: CDict,
+    chart: cxc.AbstractChart,
+    metric: cxm.AbstractMetric,
+    from_basis: PhysicalBasis,
+    to_basis: CoordinateBasis,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Change from physical basis to coordinate basis using a general metric.
+
+    This overload handles any metric that is **not** an
+    `~coordinax.manifolds.AbstractDiagonalMetric` (e.g.
+    `~coordinax.manifolds.InducedMetric`).  The algorithm uses the Cholesky
+    vielbein $E = L^\top$, solved as a triangular system $v = E^{-1}\hat{v}$.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+    >>> import coordinax.representations as cxr
+
+    ``InducedMetric`` is an ``AbstractMetric`` but not an
+    ``AbstractDiagonalMetric``, so this dispatch is selected:
+
+    >>> embed_map = cxm.TwoSphereIn3D(radius=u.Q(1.0, "km"))
+    >>> metric = cxm.InducedMetric(embed_map, cxm.EuclideanMetric(3))
+    >>> v = {"theta": u.Q(1.0, "km/s"), "phi": u.Q(2.0, "km/s")}
+    >>> at = {"theta": u.Q(jnp.pi / 3, "rad"), "phi": u.Q(0.0, "rad")}
+    >>> cxr.change_basis(v, cxc.sph2, metric, cxr.phys_basis, cxr.coord_basis, at=at)
+    {'theta': Q(..., 'rad / s'), 'phi': Q(..., 'rad / s')}
+
+    """
+    at = chart.check_data(at, keys=True)
+    keys = chart.components
+    # Cholesky vielbein E = L^T,  v = E^{-1} hat_v  (triangular solve)
+    L = metric.cholesky(chart, at=at, usys=usys)
+    E = jnp.transpose(L, axes=(-2, -1))  # E = L^T, upper-triangular vielbein
+    hat_v_vec = QuantityMatrix.from_cdict(v, keys)
+    v_vec = _qm_triangular_solve(E, hat_v_vec)
+    return cxc.cdict(v_vec, keys)  # ty: ignore[invalid-return-type]
+
+
+# ==============================================
+
+
+@plum.dispatch
+def change_basis(
+    v: CDict,
+    chart: cxc.AbstractChart,
+    manifold: cxm.AbstractManifold,
+    from_basis: CoordinateBasis,
+    to_basis: PhysicalBasis,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Change from coordinate basis to physical basis using a general metric.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+    >>> import coordinax.representations as cxr
+
+    Use an embedded two-sphere manifold, whose induced metric is non-diagonal in
+    the general case:
+
+    >>> manifold = cxm.EmbeddedManifold(
+    ...     intrinsic=cxm.HyperSphericalManifold(),
+    ...     ambient=cxm.EuclideanManifold(3),
+    ...     embed_map=cxm.TwoSphereIn3D(radius=u.Q(1.0, "km")),
+    ... )
+    >>> v = {"theta": u.Q(1.0, "rad/s"), "phi": u.Q(2.0, "rad/s")}
+    >>> at = {"theta": u.Q(jnp.pi / 3, "rad"), "phi": u.Q(0.0, "rad")}
+    >>> cxr.change_basis(v, cxc.sph2, manifold, cxr.coord_basis, cxr.phys_basis, at=at)
+    {'theta': Q(..., 'km / s'), 'phi': Q(..., 'km / s')}
+
+    """
+    return cxrapi.change_basis(
+        v, chart, manifold.metric, from_basis, to_basis, at=at, usys=usys
+    )  # ty: ignore[invalid-return-type]
+
+
+@plum.dispatch
+def change_basis(
+    v: CDict,
+    chart: cxc.AbstractChart,
+    manifold: cxm.AbstractManifold,
+    from_basis: PhysicalBasis,
+    to_basis: CoordinateBasis,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Change from physical basis to coordinate basis using a general metric.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+    >>> import coordinax.representations as cxr
+
+    >>> manifold = cxm.EmbeddedManifold(
+    ...     intrinsic=cxm.HyperSphericalManifold(),
+    ...     ambient=cxm.EuclideanManifold(3),
+    ...     embed_map=cxm.TwoSphereIn3D(radius=u.Q(1.0, "km")),
+    ... )
+    >>> v = {"theta": u.Q(1.0, "km/s"), "phi": u.Q(2.0, "km/s")}
+    >>> at = {"theta": u.Q(jnp.pi / 3, "rad"), "phi": u.Q(0.0, "rad")}
+    >>> cxr.change_basis(v, cxc.sph2, manifold, cxr.phys_basis, cxr.coord_basis, at=at)
+    {'theta': Q(..., 'rad / s'), 'phi': Q(..., 'rad / s')}
+
+    """
+    return cxrapi.change_basis(
+        v, chart, manifold.metric, from_basis, to_basis, at=at, usys=usys
+    )  # ty: ignore[invalid-return-type]
+
+
+# ==============================================
+# Diagonal metrics
+
+
+@plum.dispatch
+def change_basis(
+    v: CDict,
+    chart: cxc.AbstractChart,
+    metric: cxm.AbstractDiagonalMetric,
+    from_basis: CoordinateBasis,
+    to_basis: PhysicalBasis,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Change from coordinate basis to physical basis using a metric.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+    >>> import coordinax.representations as cxr
+
+    Spherical chart, Quantity components:
+
+    >>> metric = cxm.EuclideanMetric(3)
+    >>> v = {"r": u.Q(5, "m/s"), "theta": u.Q(1, "rad/s"), "phi": u.Q(2, "rad/s")}
+    >>> at = {"r": u.Q(3, "m"), "theta": u.Q(0.5, "rad"), "phi": u.Q(0, "rad")}
+    >>> cxr.change_basis(v, cxc.sph3d, metric, cxr.coord_basis, cxr.phys_basis, at=at)
+    {'r': Q(5, 'm / s'), 'theta': Q(3, 'm / s'), 'phi': Q(2.87655323, 'm / s')}
+
+    """
+    at = chart.check_data(at, keys=True)
+    gdiag = metric.scale_factors(chart, at=at, usys=usys)
+    return {k: jnp.sqrt(gdiag[i]) * v[k] for i, k in enumerate(chart.components)}
+
+
+@plum.dispatch
+def change_basis(
+    v: CDict,
+    chart: cxc.AbstractChart,
+    metric: cxm.AbstractDiagonalMetric,
+    from_basis: PhysicalBasis,
+    to_basis: CoordinateBasis,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Change from physical basis to coordinate basis using a metric.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+    >>> import coordinax.representations as cxr
+
+    Spherical chart, Quantity components:
+
+    >>> metric = cxm.EuclideanMetric(3)
+    >>> v = {"r": u.Q(5, "m/s"), "theta": u.Q(3, "m/s"), "phi": u.Q(2.876553, "m/s")}
+    >>> at = {"r": u.Q(3, "m"), "theta": u.Q(0.5, "rad"), "phi": u.Q(0.5, "rad")}
+    >>> cxr.change_basis(v, cxc.sph3d, metric, cxr.phys_basis, cxr.coord_basis, at=at)
+    {'r': Q(5, 'm / s'), 'theta': Q(1., 'rad / s'), 'phi': Q(1.99999..., 'rad / s')}
+
+    """
+    at = chart.check_data(at, keys=True)
+    gdiag = metric.scale_factors(chart, at=at, usys=usys)
+    return {k: v[k] / jnp.sqrt(gdiag[i]) for i, k in enumerate(chart.components)}
+
+
+# ==============================================
+# Special Cases
+
+
+@plum.dispatch
+def change_basis(
+    v: CDict,
+    chart: cxc.AbstractChart,
+    from_basis: NoBasis | CoordinateBasis,
+    to_basis: CoordinateBasis,
+    /,
+    **kw: Any,
+) -> CDict:
+    """Reinterpret unknown basis components as coordinate-basis components.
+
+    This is an identity on component values: no numeric basis transform is
+    possible from an unknown basis, so values are preserved and only the
+    representation-level basis label changes.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    The conversion is an identity map on values:
+
+    >>> v = {"x": jnp.array(1.0), "y": jnp.array(-2.0)}
+    >>> at = {"x": jnp.array(0.0), "y": jnp.array(0.0)}
+    >>> cxr.change_basis(v, cxc.cart2d, cxr.no_basis, cxr.coord_basis, at=at)
+    {'x': Array(1., dtype=float64, ...), 'y': Array(-2., dtype=float64, ...)}
+
+    "at" is accepted and ignored for this basis-only reinterpretation:
+
+    >>> cxr.change_basis(v, cxc.cart2d, cxr.no_basis, cxr.coord_basis)
+    {'x': Array(1., dtype=float64, ...), 'y': Array(-2., dtype=float64, ...)}
+
+    """
+    # TODO: check dimensions up to time powers
+    del chart, from_basis, to_basis, kw
+    return v
+
+
+@plum.dispatch
+def change_basis(
+    v: CDict,
+    chart: cxc.AbstractChart,
+    from_basis: NoBasis | PhysicalBasis,
+    to_basis: PhysicalBasis,
+    /,
+    **kw: Any,
+) -> CDict:
+    """Reinterpret unknown basis components as physical-basis components.
+
+    This conversion is only well-defined when all components share the same
+    physical dimension. No numeric transform is applied; values are preserved.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    Same-dimension components (even with different units) are accepted:
+
+    >>> v = {"x": u.Q(1.0, "m / s"), "y": u.Q(2.0, "km / s")}
+    >>> at = {"x": jnp.array(0.0), "y": jnp.array(0.0)}
+    >>> cxr.change_basis(v, cxc.cart2d, cxr.no_basis, cxr.phys_basis, at=at)
+    {'x': Q(1., 'm / s'), 'y': Q(2., 'km / s')}
+
+    Mixed dimensions are rejected:
+
+    >>> v_bad = {"x": u.Q(1.0, "m / s"), "y": u.Q(2.0, "m")}
+    >>> cxr.change_basis(v_bad, cxc.cart2d, cxr.no_basis, cxr.phys_basis)
+    Traceback (most recent call last):
+    ...
+    ValueError: change_basis from NoBasis to PhysicalBasis requires all
+    components to have the same dimension, got ...
+
+    """
+    chart.check_data(v, keys=True, values=False)
+    dims = {u.dimension_of(value) for value in v.values()}
+    if len(dims) > 1:
+        msg = (
+            "change_basis from NoBasis to PhysicalBasis requires all "
+            f"components to have the same dimension, got {dims}"
+        )
+        raise ValueError(msg)
+
+    del chart, from_basis, to_basis, kw
+    return v
+
+
+# ----------------------------------------------
+# Cartesian
+
+
+@plum.dispatch(precedence=1)  # ty: ignore[no-matching-overload]
+def change_basis(
+    v: CDict,
+    chart: cxc.Cart0D | cxc.Cart1D | cxc.Cart2D | cxc.Cart3D | cxc.CartND,
+    from_basis: CoordinateBasis | PhysicalBasis,
+    to_basis: CoordinateBasis | PhysicalBasis,
+    /,
+    **kw: Any,
+) -> CDict:
+    r"""Change the basis used to interpret tangent components.
+
+    In a Cartesian chart every scale factor equals one,
+
+    $$h_x = h_y = h_z = 1,$$
+
+    so the coordinate basis vectors are already unit vectors
+    ($\hat{e}_i = \partial_i$) and the transformation matrix is the
+    identity ($H = I$).  The coordinate basis **is** the physical basis,
+    so this conversion is always the identity map and ``v`` is returned
+    unchanged regardless of the direction of the conversion.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    Coordinate basis to physical basis in a 2-D Cartesian chart — identity:
+
+    >>> v = {"x": u.Q(3.0, "m/s"), "y": u.Q(4.0, "m/s")}
+    >>> at = {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m")}
+    >>> cxr.change_basis(v, cxc.cart2d, cxr.coord_basis, cxr.phys_basis, at=at)
+    {'x': Q(3., 'm / s'), 'y': Q(4., 'm / s')}
+
+    The reverse direction is equally a no-op:
+
+    >>> cxr.change_basis(v, cxc.cart2d, cxr.phys_basis, cxr.coord_basis, at=at)
+    {'x': Q(3., 'm / s'), 'y': Q(4., 'm / s')}
+
+    Works for any Cartesian dimensionality; ``at`` is optional:
+
+    >>> v3 = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")}
+    >>> cxr.change_basis(v3, cxc.cart3d, cxr.coord_basis, cxr.phys_basis)
+    {'x': Q(1., 'm / s'), 'y': Q(2., 'm / s'), 'z': Q(3., 'm / s')}
+
+    """
+    del chart, from_basis, to_basis, kw
+    return v
+
+
+@plum.dispatch(precedence=1)  #  ty: ignore[no-matching-overload]
+def change_basis(
+    v: CDict,
+    chart: cxc.Cart0D | cxc.Cart1D | cxc.Cart2D | cxc.Cart3D | cxc.CartND,
+    metric: cxm.EuclideanMetric,
+    from_basis: AbstractLinearBasis,
+    to_basis: AbstractLinearBasis,
+    /,
+    **kw: Any,
+) -> CDict:
+    r"""Change the basis used to interpret tangent components.
+
+    In a Cartesian chart every scale factor equals one,
+
+    $$h_x = h_y = h_z = 1,$$
+
+    so the coordinate basis vectors are already unit vectors
+    ($\hat{e}_i = \partial_i$) and the transformation matrix is the
+    identity ($H = I$).  The coordinate basis **is** the physical basis,
+    so this conversion is always the identity map and ``v`` is returned
+    unchanged regardless of the direction of the conversion.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    Coordinate basis to physical basis in a 2-D Cartesian chart — identity:
+
+    >>> v = {"x": u.Q(3.0, "m/s"), "y": u.Q(4.0, "m/s")}
+    >>> at = {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m")}
+    >>> metric2 = cxm.EuclideanMetric(2)
+    >>> cxr.change_basis(v, cxc.cart2d, metric2, cxr.coord_basis, cxr.phys_basis, at=at)
+    {'x': Q(3., 'm / s'), 'y': Q(4., 'm / s')}
+
+    The reverse direction is equally a no-op:
+
+    >>> cxr.change_basis(v, cxc.cart2d, metric2, cxr.phys_basis, cxr.coord_basis, at=at)
+    {'x': Q(3., 'm / s'), 'y': Q(4., 'm / s')}
+
+    Works for any Cartesian dimensionality; ``at`` is optional:
+
+    >>> v3 = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")}
+    >>> metric3 = cxm.EuclideanMetric(3)
+    >>> cxr.change_basis(v3, cxc.cart3d, metric3, cxr.coord_basis, cxr.phys_basis)
+    {'x': Q(1., 'm / s'), 'y': Q(2., 'm / s'), 'z': Q(3., 'm / s')}
+
+    """
+    # Check the metric is compatible with the chart
+    assert metric.ndim == chart.ndim  # noqa: S101
+    # Re-dispatch to metric-less version.
+    return cxrapi.change_basis(v, chart, from_basis, to_basis, **kw)  # ty: ignore[invalid-return-type]
+
+
+# ----------------------------------------------
+# Spherical
+
+
+@plum.dispatch
+def change_basis(
+    v: CDict,
+    chart: cxc.Spherical3D,
+    from_basis: CoordinateBasis,
+    to_basis: PhysicalBasis,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Change from coordinate basis to physical basis in a 3-D spherical chart.
+
+    In spherical coordinates $(r, \theta, \phi)$ the scale factors are
+
+    $$h_r = 1, \quad h_\theta = r, \quad h_\phi = r \sin\theta,$$
+
+    so the transformation matrix is
+
+    $$
+    H = \begin{pmatrix}
+        1 & 0 & 0 \\
+        0 & r & 0 \\
+        0 & 0 & r\sin\theta
+    \end{pmatrix}.
+    $$
+
+    Given coordinate-basis components $(v^r, v^\theta, v^\phi)$, the
+    physical-basis components are
+
+    $$
+    \hat{v} = H v
+        \implies
+        \hat{v}^r = v^r, \quad
+        \hat{v}^\theta = r\, v^\theta, \quad
+        \hat{v}^\phi = r\sin\theta\, v^\phi.
+    $$
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> v = {"r": u.Q(5, "m/s"), "theta": u.Q(1, "rad/s"), "phi": u.Q(2, "rad/s")}
+    >>> at = {"r": u.Q(3, "m"), "theta": u.Q(0.5, "rad"), "phi": u.Q(0, "rad")}
+    >>> cxr.change_basis(v, cxc.sph3d, cxr.coord_basis, cxr.phys_basis, at=at)
+    {'r': Q(5, 'm / s'), 'theta': Q(3, 'm / s'), 'phi': Q(2.87655323, 'm / s')}
+
+    >>> v = {"r": 5, "theta": 1, "phi": 2}  # unitless
+    >>> at = {"r": 3, "theta": 0.5, "phi": 0}  # unitless
+    >>> cxr.change_basis(v, cxc.sph3d, cxr.coord_basis, cxr.phys_basis, at=at)
+    {'r': 5, 'theta': 3, 'phi': Array(2.87655323, dtype=float64, ...)}
+
+    """
+    del chart, usys
+    r = at["r"]
+    return {
+        "r": v["r"],
+        "theta": r * _drop_rad_unit(v["theta"]),
+        "phi": (r * jnp.sin(at["theta"])) * _drop_rad_unit(v["phi"]),
+    }
+
+
+@plum.dispatch
+def change_basis(
+    v: CDict,
+    chart: cxc.Spherical3D,
+    metric: cxm.EuclideanMetric,
+    from_basis: CoordinateBasis,
+    to_basis: PhysicalBasis,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Change from coordinate basis to physical basis in a 3-D spherical chart.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> v = {"r": u.Q(5, "m/s"), "theta": u.Q(1, "rad/s"), "phi": u.Q(2, "rad/s")}
+    >>> at = {"r": u.Q(3, "m"), "theta": u.Q(0.5, "rad"), "phi": u.Q(0, "rad")}
+    >>> cxr.change_basis(v, cxc.sph3d, cxr.coord_basis, cxr.phys_basis, at=at)
+    {'r': Q(5, 'm / s'), 'theta': Q(3, 'm / s'), 'phi': Q(2.87655323, 'm / s')}
+
+    >>> v = {"r": 5, "theta": 1, "phi": 2}  # unitless
+    >>> at = {"r": 3, "theta": 0.5, "phi": 0}  # unitless
+    >>> cxr.change_basis(v, cxc.sph3d, cxr.coord_basis, cxr.phys_basis, at=at)
+    {'r': 5, 'theta': 3, 'phi': Array(2.87655323, dtype=float64, ...)}
+
+    """
+    # Check the metric is compatible with the chart
+    assert metric.ndim == chart.ndim  # noqa: S101
+    # Re-dispatch to metric-less version.
+    return cxrapi.change_basis(v, chart, from_basis, to_basis, at=at, usys=usys)  # ty: ignore[invalid-return-type]
+
+
+# ------------
+
+
+@plum.dispatch
+def change_basis(
+    v: CDict,
+    chart: cxc.Spherical3D,
+    from_basis: PhysicalBasis,
+    to_basis: CoordinateBasis,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Change from physical basis to coordinate basis in a 3-D spherical chart.
+
+    In spherical coordinates $(r, \theta, \phi)$ the inverse transformation
+    matrix is
+
+    $$
+    H^{-1} = \begin{pmatrix}
+        1 & 0 & 0 \\
+        0 & 1/r & 0 \\
+        0 & 0 & 1/(r\sin\theta)
+    \end{pmatrix}.
+    $$
+
+    Given physical-basis components $(\hat{v}^r, \hat{v}^\theta, \hat{v}^\phi)$,
+    the coordinate-basis components are
+
+    $$
+    v = H^{-1} \hat{v}
+        \implies
+        v^r = \hat{v}^r, \quad
+        v^\theta = \hat{v}^\theta / r, \quad
+        v^\phi = \hat{v}^\phi / (r\sin\theta).
+    $$
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> v = {"r": u.Q(5, "m/s"), "theta": u.Q(3, "m/s"), "phi": u.Q(2.876553, "m/s")}
+    >>> at = {"r": u.Q(3, "m"), "theta": u.Q(0.5, "rad"), "phi": u.Q(0.5, "rad")}
+    >>> cxr.change_basis(v, cxc.sph3d, cxr.phys_basis, cxr.coord_basis, at=at)
+    {'r': Q(5, 'm / s'), 'theta': Q(1., 'rad / s'), 'phi': Q(1.99999984, 'rad / s')}
+
+    >>> v = {"r": 5, "theta": 3, "phi": 2.876553}  # unitless
+    >>> at = {"r": 3, "theta": 0.5, "phi": 0.5}  # unitless
+    >>> cxr.change_basis(v, cxc.sph3d, cxr.phys_basis, cxr.coord_basis, at=at)
+    {'r': 5, 'theta': 1.0, 'phi': Array(1.99999984, dtype=float64, ...)}
+
+    """
+    del chart, usys
+    r = at["r"]
+    return {
+        "r": v["r"],
+        "theta": _add_rad_unit(v["theta"]) / r,
+        "phi": _add_rad_unit(v["phi"]) / (r * jnp.sin(at["theta"])),
+    }
+
+
+@plum.dispatch
+def change_basis(
+    v: CDict,
+    chart: cxc.Spherical3D,
+    metric: cxm.EuclideanMetric,
+    from_basis: PhysicalBasis,
+    to_basis: CoordinateBasis,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Change from physical basis to coordinate basis in a 3-D spherical chart.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import coordinax.manifolds as cxm
+
+    >>> metric = cxm.EuclideanMetric(3)
+
+    >>> v = {"r": u.Q(5, "m/s"), "theta": u.Q(3, "m/s"), "phi": u.Q(2.876553, "m/s")}
+    >>> at = {"r": u.Q(3, "m"), "theta": u.Q(0.5, "rad"), "phi": u.Q(0.5, "rad")}
+    >>> cxr.change_basis(v, cxc.sph3d, metric, cxr.phys_basis, cxr.coord_basis, at=at)
+    {'r': Q(5, 'm / s'), 'theta': Q(1., 'rad / s'), 'phi': Q(1.99999984, 'rad / s')}
+
+    >>> v = {"r": 5, "theta": 3, "phi": 2.876553}  # unitless
+    >>> at = {"r": 3, "theta": 0.5, "phi": 0.5}  # unitless
+    >>> cxr.change_basis(v, cxc.sph3d, metric, cxr.phys_basis, cxr.coord_basis, at=at)
+    {'r': 5, 'theta': 1.0, 'phi': Array(1.99999984, dtype=float64, ...)}
+
+    """
+    # Check the metric is compatible with the chart
+    assert metric.ndim == chart.ndim  # noqa: S101
+    # Re-dispatch to metric-less version.
+    return cxrapi.change_basis(v, chart, from_basis, to_basis, at=at, usys=usys)  # ty: ignore[invalid-return-type]
+
+
+#####################################################################
+
+
+@plum.dispatch.multi(
+    (CDict, cxc.AbstractChart, Representation, Representation),
+    (CDict, cxc.AbstractChart, AbstractBasis, Representation),
+    (CDict, cxc.AbstractChart, Representation, AbstractBasis),
+)
+def change_basis(
+    v: CDict,
+    chart: cxc.AbstractChart,
+    from_rep: Representation,
+    to_rep: Representation,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> CDict:
+    """Change basis using source and/or target :class:`Representation` objects.
+
+    This is a convenience overload: the caller may pass full
+    :class:`Representation` objects for ``from_rep``/``to_rep`` instead of
+    bare :class:`AbstractBasis` instances.  The basis is extracted from each
+    argument and the appropriate :func:`change_basis` overload is called.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    Coordinate-basis displacement to physical-basis displacement in a
+    spherical chart, passing full :class:`Representation` objects:
+
+    >>> v = {"r": u.Q(5, "m/s"), "theta": u.Q(1, "rad/s"), "phi": u.Q(2, "rad/s")}
+    >>> at = {"r": u.Q(3, "m"), "theta": u.Q(0.5, "rad"), "phi": u.Q(0, "rad")}
+    >>> cxr.change_basis(v, cxc.sph3d, cxr.coord_disp, cxr.phys_disp, at=at)
+    {'r': Q(5, 'm / s'), 'theta': Q(3, 'm / s'), 'phi': Q(2.87655323, 'm / s')}
+
+    >>> v = {"r": 5, "theta": 1, "phi": 2}  # unitless
+    >>> at = {"r": 3, "theta": 0.5, "phi": 0}  # unitless
+    >>> cxr.change_basis(v, cxc.sph3d, cxr.coord_disp, cxr.phys_disp, at=at)
+    {'r': 5, 'theta': 3, 'phi': Array(2.87655323, dtype=float64, ...)}
+
+    """
+    if isinstance(from_rep, Representation) and not isinstance(
+        from_rep.geom_kind, TangentGeometry
+    ):
+        msg = "change_basis with Representation requires TangentGeometry for from_rep"
+        raise TypeError(msg)
+    if isinstance(to_rep, Representation) and not isinstance(
+        to_rep.geom_kind, TangentGeometry
+    ):
+        msg = "change_basis with Representation requires TangentGeometry for to_rep"
+        raise TypeError(msg)
+
+    # This multi-dispatch handles the case where the caller provides one or both
+    # of the representations instead of the bases. We just extract the bases and
+    # call the main dispatch.
+    from_basis = from_rep if isinstance(from_rep, AbstractBasis) else from_rep.basis
+    to_basis = to_rep if isinstance(to_rep, AbstractBasis) else to_rep.basis
+    # Re-dispatch to the main implementation.
+    return cxrapi.change_basis(v, chart, from_basis, to_basis, at=at, usys=usys)  # ty: ignore[invalid-return-type]

--- a/src/coordinax/representations/_src/core.py
+++ b/src/coordinax/representations/_src/core.py
@@ -13,7 +13,7 @@ import unxt.quantity as uq
 
 import coordinax.api.representations as cxrapi
 import coordinax.charts as cxc
-from .geom import PointGeometry
+from .geom import PointGeometry, TangentGeometry
 from .rep import Representation
 from coordinax.internal.custom_types import CDict, OptUSys
 
@@ -311,6 +311,68 @@ def cconvert(
     """
     return cxc.pt_map(
         x, from_chart, from_geom, from_rep, to_chart, to_geom, to_rep, usys=usys
+    )
+
+
+@plum.dispatch
+def cconvert(
+    x: Any,
+    # from-*
+    from_chart: cxc.AbstractChart,
+    from_geom: TangentGeometry,
+    from_rep: Representation,
+    # to-*
+    to_chart: cxc.AbstractChart,
+    to_geom: TangentGeometry,
+    to_rep: Representation,
+    /,
+    *,
+    at: CDict | None = None,
+    usys: OptUSys = None,
+) -> Any:
+    r"""Convert tangent data between basis conventions in the same chart.
+
+    Tangent conversions are basis changes when source and target charts are
+    identical. In this case, `cconvert` redispatches to `change_basis`.
+
+    Examples
+    --------
+    Convert tangent data between coordinate and physical basis in the same
+    chart:
+
+    >>> import jax.numpy as jnp
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> v = {"r": jnp.array(5.0), "theta": jnp.array(1.0), "phi": jnp.array(2.0)}
+    >>> at = {"r": jnp.array(3.0), "theta": jnp.array(0.5), "phi": jnp.array(0.0)}
+    >>> cxr.cconvert(v, cxc.sph3d, cxr.tangent_geom, cxr.coord_disp,
+    ...              cxc.sph3d, cxr.tangent_geom, cxr.phys_disp, at=at)
+    {'r': Array(5., dtype=float64, ...),
+     'theta': Array(3., dtype=float64, ...),
+     'phi': Array(..., dtype=float64, ...)}
+
+    Tangent conversion across different charts is not implemented by this
+    dispatch:
+
+    >>> cxr.cconvert(v, cxc.sph3d, cxr.tangent_geom, cxr.coord_disp,
+    ...              cxc.cart3d, cxr.tangent_geom, cxr.coord_disp, at=at)
+    Traceback (most recent call last):
+    ...
+    NotImplementedError: Tangent cconvert between different charts is not implemented;
+    use the same chart for basis changes.
+
+    """
+    del from_geom, to_geom  # represented by dispatch signature
+
+    if from_chart != to_chart:
+        msg = (
+            "Tangent cconvert between different charts is not implemented; "
+            "use the same chart for basis changes."
+        )
+        raise NotImplementedError(msg)
+
+    return cxrapi.change_basis(
+        x, from_chart, from_rep.basis, to_rep.basis, at=at, usys=usys
     )
 
 

--- a/tests/unit/representations/test_cconvert_tangent.py
+++ b/tests/unit/representations/test_cconvert_tangent.py
@@ -1,0 +1,122 @@
+"""Tests for tangent `cconvert` dispatch behavior."""
+
+from typing import cast
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import coordinax.charts as cxc
+import coordinax.representations as cxr
+
+
+class TestCConvertTangentDispatch:
+    """Dispatch behavior for tangent-geometry `cconvert` conversions."""
+
+    def test_same_chart_dispatches_to_change_basis(self):
+        v = {
+            "r": jnp.array(5.0),
+            "theta": jnp.array(1.0),
+            "phi": jnp.array(2.0),
+        }
+        at = {
+            "r": jnp.array(3.0),
+            "theta": jnp.array(0.5),
+            "phi": jnp.array(0.0),
+        }
+
+        out = cast(
+            "dict[str, object]",
+            cxr.cconvert(v, cxc.sph3d, cxr.coord_disp, cxc.sph3d, cxr.phys_disp, at=at),
+        )
+        expected = cast(
+            "dict[str, object]",
+            cxr.change_basis(v, cxc.sph3d, cxr.coord_basis, cxr.phys_basis, at=at),
+        )
+
+        np.testing.assert_allclose(np.asarray(out["r"]), np.asarray(expected["r"]))
+        np.testing.assert_allclose(
+            np.asarray(out["theta"]), np.asarray(expected["theta"])
+        )
+        np.testing.assert_allclose(np.asarray(out["phi"]), np.asarray(expected["phi"]))
+
+    def test_same_chart_cartesian_without_at(self):
+        v = {"x": jnp.array(1.0), "y": jnp.array(2.0)}
+
+        out = cast(
+            "dict[str, object]",
+            cxr.cconvert(v, cxc.cart2d, cxr.coord_disp, cxc.cart2d, cxr.phys_disp),
+        )
+
+        np.testing.assert_allclose(np.asarray(out["x"]), np.asarray(v["x"]))
+        np.testing.assert_allclose(np.asarray(out["y"]), np.asarray(v["y"]))
+
+    def test_different_chart_not_implemented(self):
+        v = {
+            "r": jnp.array(5.0),
+            "theta": jnp.array(1.0),
+            "phi": jnp.array(2.0),
+        }
+        at = {
+            "r": jnp.array(3.0),
+            "theta": jnp.array(0.5),
+            "phi": jnp.array(0.0),
+        }
+
+        with pytest.raises(NotImplementedError, match="different charts"):
+            cxr.cconvert(
+                v, cxc.sph3d, cxr.coord_disp, cxc.cart3d, cxr.coord_disp, at=at
+            )
+
+    def test_same_chart_non_cartesian_missing_at_raises(self):
+        v = {
+            "r": jnp.array(5.0),
+            "theta": jnp.array(1.0),
+            "phi": jnp.array(2.0),
+        }
+
+        with pytest.raises((TypeError, ValueError)):
+            cxr.cconvert(v, cxc.sph3d, cxr.coord_disp, cxc.sph3d, cxr.phys_disp)
+
+    def test_same_chart_respects_tangent_semantic_kind(self):
+        v = {
+            "r": jnp.array(5.0),
+            "theta": jnp.array(1.0),
+            "phi": jnp.array(2.0),
+        }
+        at = {
+            "r": jnp.array(3.0),
+            "theta": jnp.array(0.5),
+            "phi": jnp.array(0.0),
+        }
+
+        out_disp = cast(
+            "dict[str, object]",
+            cxr.cconvert(v, cxc.sph3d, cxr.coord_disp, cxc.sph3d, cxr.phys_disp, at=at),
+        )
+        out_vel = cast(
+            "dict[str, object]",
+            cxr.cconvert(v, cxc.sph3d, cxr.coord_vel, cxc.sph3d, cxr.phys_vel, at=at),
+        )
+
+        np.testing.assert_allclose(np.asarray(out_disp["r"]), np.asarray(out_vel["r"]))
+        np.testing.assert_allclose(
+            np.asarray(out_disp["theta"]), np.asarray(out_vel["theta"])
+        )
+        np.testing.assert_allclose(
+            np.asarray(out_disp["phi"]), np.asarray(out_vel["phi"])
+        )
+
+    def test_jit_same_chart_tangent(self):
+        v = {"x": jnp.array(1.0), "y": jnp.array(2.0)}
+
+        @jax.jit
+        def run(data):
+            return cxr.cconvert(
+                data, cxc.cart2d, cxr.coord_disp, cxc.cart2d, cxr.phys_disp
+            )
+
+        out = cast("dict[str, object]", run(v))
+        np.testing.assert_allclose(np.asarray(out["x"]), np.asarray(v["x"]))
+        np.testing.assert_allclose(np.asarray(out["y"]), np.asarray(v["y"]))

--- a/tests/unit/representations/test_change_basis.py
+++ b/tests/unit/representations/test_change_basis.py
@@ -1,0 +1,153 @@
+"""Tests for change_basis function."""
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.main as cx
+import coordinax.representations as cxr
+
+usys = u.unitsystems.si
+
+
+class TestChangeBasisExistence:
+    """Import-surface checks for the public API."""
+
+    def test_importable_from_representations(self):
+        assert hasattr(cxr, "change_basis")
+        assert callable(cxr.change_basis)
+
+    def test_importable_from_main(self):
+        assert hasattr(cx, "change_basis")
+        assert callable(cx.change_basis)
+
+
+class TestChangeBasisDispatch:
+    """Dispatch behavior for basis and representation overloads."""
+
+    def test_basis_overload_identity(self):
+        v = {"x": jnp.array(1.0), "y": jnp.array(2.0)}
+        at = {"x": jnp.array(0.0), "y": jnp.array(0.0)}
+        out = cxr.change_basis(v, cxc.cart2d, cxr.coord_basis, cxr.coord_basis, at=at)
+        assert out == v
+
+    def test_basis_overload_coord_to_phys_cartesian(self):
+        v = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
+
+        at = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
+        out = cxr.change_basis(v, cxc.cart2d, cxr.coord_basis, cxr.phys_basis, at=at)
+        np.testing.assert_allclose(out["x"], v["x"])
+        np.testing.assert_allclose(out["y"], v["y"])
+
+    def test_basis_overload_phys_to_coord_cartesian(self):
+        v = {"x": jnp.array(0.0), "y": jnp.array(2.0)}
+        at = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
+        out = cxr.change_basis(v, cxc.cart2d, cxr.phys_basis, cxr.coord_basis, at=at)
+        np.testing.assert_allclose(out["x"], v["x"])
+        np.testing.assert_allclose(out["y"], v["y"])
+
+    def test_rep_overload_identity(self):
+        v = {"x": jnp.array(1.0), "y": jnp.array(2.0)}
+        at = {"x": jnp.array(0.0), "y": jnp.array(0.0)}
+        rep = cxr.coord_disp
+        out = cxr.change_basis(v, cxc.cart2d, rep, rep, at=at)
+        assert out == v
+
+    def test_rep_overload_coord_to_phys(self):
+        v = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
+        at = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
+        rep_from = cxr.coord_disp
+        rep_to = cxr.phys_disp
+        out = cxr.change_basis(v, cxc.cart2d, rep_from, rep_to, at=at)
+        np.testing.assert_allclose(out["x"], v["x"])
+        np.testing.assert_allclose(out["y"], v["y"])
+
+    def test_rep_overload_phys_to_coord(self):
+        v = {"x": jnp.array(0.0), "y": jnp.array(2.0)}
+        at = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
+        rep_from = cxr.phys_disp
+        rep_to = cxr.coord_disp
+        out = cxr.change_basis(v, cxc.cart2d, rep_from, rep_to, at=at)
+        np.testing.assert_allclose(out["x"], v["x"])
+        np.testing.assert_allclose(out["y"], v["y"])
+
+    def test_round_trip_cartesian(self):
+        v = {"x": jnp.array(1.5), "y": jnp.array(-2.0)}
+        at = {"x": jnp.array(0.0), "y": jnp.array(0.0)}
+        v_phys = cxr.change_basis(v, cxc.cart2d, cxr.coord_basis, cxr.phys_basis, at=at)
+        v_back = cxr.change_basis(
+            v_phys, cxc.cart2d, cxr.phys_basis, cxr.coord_basis, at=at
+        )
+        np.testing.assert_allclose(v_back["x"], v["x"])
+        np.testing.assert_allclose(v_back["y"], v["y"])
+
+
+class TestChangeBasisErrors:
+    """Unsupported basis and representation cases."""
+
+    def test_no_basis_to_coord_is_identity(self):
+        v = {"x": jnp.array(1.0)}
+        at = {"x": jnp.array(0.0)}
+        out = cxr.change_basis(v, cxc.cart1d, cxr.no_basis, cxr.coord_basis, at=at)
+        np.testing.assert_allclose(out["x"], v["x"])
+
+    def test_no_basis_to_phys_is_identity_for_uniform_dimensions(self):
+        v = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "km/s")}
+        at = {"x": jnp.array(0.0), "y": jnp.array(0.0)}
+        out = cxr.change_basis(v, cxc.cart2d, cxr.no_basis, cxr.phys_basis, at=at)
+        np.testing.assert_allclose(u.ustrip("m/s", out["x"]), 1.0)
+        np.testing.assert_allclose(u.ustrip("km/s", out["y"]), 2.0)
+
+    def test_no_basis_to_phys_rejects_mixed_dimensions(self):
+        v = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m")}
+        at = {"x": jnp.array(0.0), "y": jnp.array(0.0)}
+        with pytest.raises(ValueError, match="same dimension"):
+            cxr.change_basis(v, cxc.cart2d, cxr.no_basis, cxr.phys_basis, at=at)
+
+    def test_point_rep_rejected(self):
+        v = {"x": jnp.array(1.0)}
+        at = {"x": jnp.array(0.0)}
+        with pytest.raises((TypeError, ValueError)):
+            cxr.change_basis(v, cxc.cart1d, cxr.point, cxr.coord_disp, at=at)
+
+    def test_missing_at_raises(self):
+        v = {"r": jnp.array(1.0), "theta": jnp.array(0.2), "phi": jnp.array(0.1)}
+        with pytest.raises((TypeError, ValueError)):
+            cxr.change_basis(v, cxc.sph3d, cxr.coord_basis, cxr.phys_basis)
+
+
+class TestChangeBasisJAX:
+    """JAX transformation compatibility for change_basis."""
+
+    def test_jit(self):
+        v = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
+        at = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
+
+        @jax.jit
+        def run(v, at):
+            return cxr.change_basis(
+                v, cxc.cart2d, cxr.coord_basis, cxr.phys_basis, at=at
+            )
+
+        out = run(v, at)
+        np.testing.assert_allclose(out["x"], v["x"])
+        np.testing.assert_allclose(out["y"], v["y"])
+
+    def test_vmap(self):
+        vs = {"x": jnp.ones(3), "y": jnp.zeros(3)}
+        ats = {"x": jnp.array([1.0, 2.0, 3.0]), "y": jnp.zeros(3)}
+
+        def single(v: dict[str, Any], at: dict[str, Any]) -> dict[str, Any]:
+            return cxr.change_basis(
+                v, cxc.cart2d, cxr.coord_basis, cxr.phys_basis, at=at
+            )
+
+        batched = jax.vmap(single)(vs, ats)
+        np.testing.assert_allclose(batched["x"], 1.0)
+        np.testing.assert_allclose(batched["y"], 0.0)

--- a/tests/unit/representations/test_change_basis.py
+++ b/tests/unit/representations/test_change_basis.py
@@ -11,9 +11,20 @@ import unxt as u
 
 import coordinax.charts as cxc
 import coordinax.main as cx
+import coordinax.manifolds as cxm
 import coordinax.representations as cxr
+from coordinax.internal import QuantityMatrix, UnitsMatrix
+from coordinax.representations._src.basis_change import _qm_triangular_solve
 
-usys = u.unitsystems.si
+
+def tree_equal(lhs: Any, rhs: Any) -> bool:
+    """Return True when two pytrees are elementwise equal."""
+    eq_tree = jax.tree_util.tree_map(lambda x, y: jnp.equal(x, y), lhs, rhs)
+    leaves = jax.tree_util.tree_leaves(eq_tree)
+    if not leaves:
+        return True
+    reduced = [jnp.all(jnp.asarray(leaf)) for leaf in leaves]
+    return bool(jnp.all(jnp.stack(reduced)))
 
 
 class TestChangeBasisExistence:
@@ -32,36 +43,36 @@ class TestChangeBasisDispatch:
     """Dispatch behavior for basis and representation overloads."""
 
     def test_basis_overload_identity(self):
-        v = {"x": jnp.array(1.0), "y": jnp.array(2.0)}
-        at = {"x": jnp.array(0.0), "y": jnp.array(0.0)}
+        v = {"x": jnp.array(1), "y": jnp.array(2)}
+        at = {"x": jnp.array(0), "y": jnp.array(0)}
         out = cxr.change_basis(v, cxc.cart2d, cxr.coord_basis, cxr.coord_basis, at=at)
-        assert out == v
+        assert tree_equal(out, v)
 
     def test_basis_overload_coord_to_phys_cartesian(self):
-        v = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
+        v = {"x": jnp.array(1), "y": jnp.array(0)}
 
-        at = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
+        at = {"x": jnp.array(1), "y": jnp.array(0)}
         out = cxr.change_basis(v, cxc.cart2d, cxr.coord_basis, cxr.phys_basis, at=at)
         np.testing.assert_allclose(out["x"], v["x"])
         np.testing.assert_allclose(out["y"], v["y"])
 
     def test_basis_overload_phys_to_coord_cartesian(self):
-        v = {"x": jnp.array(0.0), "y": jnp.array(2.0)}
-        at = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
+        v = {"x": jnp.array(0), "y": jnp.array(2)}
+        at = {"x": jnp.array(1), "y": jnp.array(0)}
         out = cxr.change_basis(v, cxc.cart2d, cxr.phys_basis, cxr.coord_basis, at=at)
         np.testing.assert_allclose(out["x"], v["x"])
         np.testing.assert_allclose(out["y"], v["y"])
 
     def test_rep_overload_identity(self):
-        v = {"x": jnp.array(1.0), "y": jnp.array(2.0)}
-        at = {"x": jnp.array(0.0), "y": jnp.array(0.0)}
+        v = {"x": jnp.array(1), "y": jnp.array(2)}
+        at = {"x": jnp.array(0), "y": jnp.array(0)}
         rep = cxr.coord_disp
         out = cxr.change_basis(v, cxc.cart2d, rep, rep, at=at)
-        assert out == v
+        assert tree_equal(out, v)
 
     def test_rep_overload_coord_to_phys(self):
-        v = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
-        at = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
+        v = {"x": jnp.array(1), "y": jnp.array(0)}
+        at = {"x": jnp.array(1), "y": jnp.array(0)}
         rep_from = cxr.coord_disp
         rep_to = cxr.phys_disp
         out = cxr.change_basis(v, cxc.cart2d, rep_from, rep_to, at=at)
@@ -69,8 +80,8 @@ class TestChangeBasisDispatch:
         np.testing.assert_allclose(out["y"], v["y"])
 
     def test_rep_overload_phys_to_coord(self):
-        v = {"x": jnp.array(0.0), "y": jnp.array(2.0)}
-        at = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
+        v = {"x": jnp.array(0), "y": jnp.array(2)}
+        at = {"x": jnp.array(1), "y": jnp.array(0)}
         rep_from = cxr.phys_disp
         rep_to = cxr.coord_disp
         out = cxr.change_basis(v, cxc.cart2d, rep_from, rep_to, at=at)
@@ -78,8 +89,8 @@ class TestChangeBasisDispatch:
         np.testing.assert_allclose(out["y"], v["y"])
 
     def test_round_trip_cartesian(self):
-        v = {"x": jnp.array(1.5), "y": jnp.array(-2.0)}
-        at = {"x": jnp.array(0.0), "y": jnp.array(0.0)}
+        v = {"x": jnp.array(1.5), "y": jnp.array(-2)}
+        at = {"x": jnp.array(0), "y": jnp.array(0)}
         v_phys = cxr.change_basis(v, cxc.cart2d, cxr.coord_basis, cxr.phys_basis, at=at)
         v_back = cxr.change_basis(
             v_phys, cxc.cart2d, cxr.phys_basis, cxr.coord_basis, at=at
@@ -87,37 +98,102 @@ class TestChangeBasisDispatch:
         np.testing.assert_allclose(v_back["x"], v["x"])
         np.testing.assert_allclose(v_back["y"], v["y"])
 
+    def test_round_trip_spherical_non_cartesian(self):
+        v = {"r": u.Q(5, "m/s"), "theta": u.Q(1, "rad/s"), "phi": u.Q(1, "rad/s")}
+        at = {"r": u.Q(2, "m"), "theta": u.Q(jnp.pi / 2, "rad"), "phi": u.Q(0, "rad")}
+
+        v_phys = cxr.change_basis(v, cxc.sph3d, cxr.coord_basis, cxr.phys_basis, at=at)
+        np.testing.assert_allclose(u.ustrip("m/s", v_phys["r"]), 5)
+        np.testing.assert_allclose(u.ustrip("m/s", v_phys["theta"]), 2)
+        np.testing.assert_allclose(u.ustrip("m/s", v_phys["phi"]), 2)
+
+        v_back = cxr.change_basis(
+            v_phys, cxc.sph3d, cxr.phys_basis, cxr.coord_basis, at=at
+        )
+        np.testing.assert_allclose(
+            u.ustrip("m/s", v_back["r"]), u.ustrip("m/s", v["r"])
+        )
+        np.testing.assert_allclose(
+            u.ustrip("rad/s", v_back["theta"]), u.ustrip("rad/s", v["theta"])
+        )
+        np.testing.assert_allclose(
+            u.ustrip("rad/s", v_back["phi"]), u.ustrip("rad/s", v["phi"])
+        )
+
+    def test_round_trip_diagonal_metric(self):
+        metric = cxm.EuclideanMetric(3)
+        v = {"r": u.Q(4, "m/s"), "theta": u.Q(0.5, "rad/s"), "phi": u.Q(0.25, "rad/s")}
+        at = {"r": u.Q(3, "m"), "theta": u.Q(0.5, "rad"), "phi": u.Q(0, "rad")}
+
+        v_phys = cxr.change_basis(
+            v, cxc.sph3d, metric, cxr.coord_basis, cxr.phys_basis, at=at
+        )
+        v_back = cxr.change_basis(
+            v_phys, cxc.sph3d, metric, cxr.phys_basis, cxr.coord_basis, at=at
+        )
+
+        np.testing.assert_allclose(
+            u.ustrip("m/s", v_back["r"]), u.ustrip("m/s", v["r"])
+        )
+        np.testing.assert_allclose(
+            u.ustrip("rad/s", v_back["theta"]), u.ustrip("rad/s", v["theta"])
+        )
+        np.testing.assert_allclose(
+            u.ustrip("rad/s", v_back["phi"]), u.ustrip("rad/s", v["phi"])
+        )
+
+    def test_round_trip_general_metric(self):
+        metric = cxm.InducedMetric(
+            cxm.TwoSphereIn3D(radius=u.Q(1, "km")), cxm.EuclideanMetric(3)
+        )
+        v = {"theta": u.Q(1, "rad/s"), "phi": u.Q(2, "rad/s")}
+        at = {"theta": u.Q(jnp.pi / 3, "rad"), "phi": u.Q(0, "rad")}
+
+        v_phys = cxr.change_basis(
+            v, cxc.sph2, metric, cxr.coord_basis, cxr.phys_basis, at=at
+        )
+        v_back = cxr.change_basis(
+            v_phys, cxc.sph2, metric, cxr.phys_basis, cxr.coord_basis, at=at
+        )
+
+        np.testing.assert_allclose(
+            u.ustrip("rad/s", v_back["theta"]), u.ustrip("rad/s", v["theta"])
+        )
+        np.testing.assert_allclose(
+            u.ustrip("rad/s", v_back["phi"]), u.ustrip("rad/s", v["phi"])
+        )
+
 
 class TestChangeBasisErrors:
     """Unsupported basis and representation cases."""
 
     def test_no_basis_to_coord_is_identity(self):
-        v = {"x": jnp.array(1.0)}
-        at = {"x": jnp.array(0.0)}
+        v = {"x": jnp.array(1)}
+        at = {"x": jnp.array(0)}
         out = cxr.change_basis(v, cxc.cart1d, cxr.no_basis, cxr.coord_basis, at=at)
         np.testing.assert_allclose(out["x"], v["x"])
 
     def test_no_basis_to_phys_is_identity_for_uniform_dimensions(self):
-        v = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "km/s")}
-        at = {"x": jnp.array(0.0), "y": jnp.array(0.0)}
+        v = {"x": u.Q(1, "m/s"), "y": u.Q(2, "km/s")}
+        at = {"x": jnp.array(0), "y": jnp.array(0)}
         out = cxr.change_basis(v, cxc.cart2d, cxr.no_basis, cxr.phys_basis, at=at)
-        np.testing.assert_allclose(u.ustrip("m/s", out["x"]), 1.0)
-        np.testing.assert_allclose(u.ustrip("km/s", out["y"]), 2.0)
+        np.testing.assert_allclose(u.ustrip("m/s", out["x"]), 1)
+        np.testing.assert_allclose(u.ustrip("km/s", out["y"]), 2)
 
     def test_no_basis_to_phys_rejects_mixed_dimensions(self):
-        v = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m")}
-        at = {"x": jnp.array(0.0), "y": jnp.array(0.0)}
+        v = {"x": u.Q(1, "m/s"), "y": u.Q(2, "m")}
+        at = {"x": jnp.array(0), "y": jnp.array(0)}
         with pytest.raises(ValueError, match="same dimension"):
             cxr.change_basis(v, cxc.cart2d, cxr.no_basis, cxr.phys_basis, at=at)
 
     def test_point_rep_rejected(self):
-        v = {"x": jnp.array(1.0)}
-        at = {"x": jnp.array(0.0)}
+        v = {"x": jnp.array(1)}
+        at = {"x": jnp.array(0)}
         with pytest.raises((TypeError, ValueError)):
             cxr.change_basis(v, cxc.cart1d, cxr.point, cxr.coord_disp, at=at)
 
     def test_missing_at_raises(self):
-        v = {"r": jnp.array(1.0), "theta": jnp.array(0.2), "phi": jnp.array(0.1)}
+        v = {"r": jnp.array(1), "theta": jnp.array(0.2), "phi": jnp.array(0.1)}
         with pytest.raises((TypeError, ValueError)):
             cxr.change_basis(v, cxc.sph3d, cxr.coord_basis, cxr.phys_basis)
 
@@ -126,8 +202,8 @@ class TestChangeBasisJAX:
     """JAX transformation compatibility for change_basis."""
 
     def test_jit(self):
-        v = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
-        at = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
+        v = {"x": jnp.array(1), "y": jnp.array(0)}
+        at = {"x": jnp.array(1), "y": jnp.array(0)}
 
         @jax.jit
         def run(v, at):
@@ -141,7 +217,7 @@ class TestChangeBasisJAX:
 
     def test_vmap(self):
         vs = {"x": jnp.ones(3), "y": jnp.zeros(3)}
-        ats = {"x": jnp.array([1.0, 2.0, 3.0]), "y": jnp.zeros(3)}
+        ats = {"x": jnp.array([1, 2, 3]), "y": jnp.zeros(3)}
 
         def single(v: dict[str, Any], at: dict[str, Any]) -> dict[str, Any]:
             return cxr.change_basis(
@@ -149,5 +225,29 @@ class TestChangeBasisJAX:
             )
 
         batched = jax.vmap(single)(vs, ats)
-        np.testing.assert_allclose(batched["x"], 1.0)
-        np.testing.assert_allclose(batched["y"], 0.0)
+        np.testing.assert_allclose(batched["x"], 1)
+        np.testing.assert_allclose(batched["y"], 0)
+
+
+class TestTriangularSolveBatching:
+    """Regression tests for batched triangular solves used by basis conversion."""
+
+    def test_qm_triangular_solve_batched_rows_scaled_correctly(self):
+        e_val = jnp.array([[[2, 1], [0, 4]], [[3, 2], [0, 5]]])
+        e_unit = UnitsMatrix(((u.unit("m"), u.unit("m")), (u.unit("m"), u.unit("m"))))
+        e = QuantityMatrix(e_val, unit=e_unit)
+
+        b_val = jnp.array([[5, 8], [7, 10]])
+        b_unit = UnitsMatrix((u.unit("m/s"), u.unit("m/s")))
+        b = QuantityMatrix(b_val, unit=b_unit)
+
+        out = _qm_triangular_solve(e, b)
+
+        expected = jnp.stack(
+            [
+                jax.scipy.linalg.solve_triangular(e_val[0], b_val[0], lower=False),
+                jax.scipy.linalg.solve_triangular(e_val[1], b_val[1], lower=False),
+            ]
+        )
+        np.testing.assert_allclose(out.value, expected)
+        assert out.unit == UnitsMatrix((u.unit("1 / s"), u.unit("1 / s")))


### PR DESCRIPTION
Implements the change_basis multi-dispatch function for converting vector components between coordinate basis and physical basis. Supports diagonal metrics (via scale factors), general metrics (via Cholesky vielbein), Cartesian charts (identity map), Spherical3D charts (closed-form), manifolds, NoBasis identity fallbacks, and convenience overloads accepting Representation objects. Includes docs updates (spec, API reference, guides, tutorials) and unit tests.