### PR TITLE
✨ feat: norm

### DIFF
--- a/docs/api/manifolds.md
+++ b/docs/api/manifolds.md
@@ -47,6 +47,7 @@ ang = cxm.angle_between(cxc.cart3d, uvec, vvec, at=at)
 - `guess_manifold`: infer a manifold from manifold/chart/data inputs
 - `scale_factors`: return the metric diagonal in a chart at a base point
 - `angle_between`: return the metric angle between two tangent-vector CDicts
+- `norm`: compute the Riemannian norm $\|v\|_g = \sqrt{g_p(v,v)}$ of a tangent vector in a chart
 - `pt_embed`: embed intrinsic coordinates into ambient coordinates
 - `pt_project`: project ambient coordinates back to intrinsic chart coordinates
 - `pt_map`: manifold-related re-export of point realization map

--- a/docs/guides/manifolds.md
+++ b/docs/guides/manifolds.md
@@ -318,10 +318,85 @@ Product manifolds combine independent factors and sum dimensions.
 3
 ```
 
+## Computing Vector Norms
+
+Manifold and metric objects expose a `norm` method that computes the Riemannian norm
+
+$$
+\|v\|_g = \sqrt{g_p(v, v)}
+$$
+
+where $g$ is the manifold metric and $p$ is the base point at which the metric is evaluated.
+
+Three equivalent call forms are available:
+
+- **Via manifold**: `manifold.norm(v, chart, at=at)` — uses the manifold's metric automatically.
+- **Via metric**: `metric.norm(v, chart, at=at)` — uses the metric object directly.
+- **Functional form**: `cxm.norm(v, metric_or_manifold, chart, at=at)`.
+
+The `at` keyword argument specifies the base point for position-dependent metrics (for example `HyperSphericalMetric`). For flat metrics such as `EuclideanMetric`, `at` is not always required by the interface and does not affect the result numerically.
+
+### Euclidean norms with Quantity components
+
+For CDict inputs whose values are quantities, `usys` is optional and a `Quantity` is returned:
+
+```{code-block} python
+>>> import jax.numpy as jnp
+>>> import unxt as u
+>>> import coordinax.charts as cxc
+>>> import coordinax.manifolds as cxm
+
+>>> M = cxm.EuclideanManifold(3)
+>>> chart = cxc.cart3d
+>>> at = {"x": jnp.array(0.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
+>>> v = {"x": u.Q(3.0, "m/s"), "y": u.Q(4.0, "m/s"), "z": u.Q(0.0, "m/s")}
+>>> M.norm(v, chart, at=at)
+Q(5., 'm / s')
+```
+
+### Euclidean norms with bare arrays
+
+When `v` contains bare `jax.Array` values a unit system must be supplied via `usys`:
+
+```{code-block} python
+>>> import jax.numpy as jnp
+>>> import unxt as u
+>>> import coordinax.charts as cxc
+>>> import coordinax.manifolds as cxm
+
+>>> M = cxm.EuclideanManifold(3)
+>>> chart = cxc.cart3d
+>>> at = {"x": jnp.array(0.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
+>>> v = jnp.array([3.0, 4.0, 0.0])
+>>> M.norm(v, chart, at=at, usys=u.unitsystems.si)
+Array(5., dtype=float64)
+```
+
+### Using the metric directly
+
+You can also call `norm` on a standalone metric object:
+
+```{code-block} python
+>>> import jax.numpy as jnp
+>>> import unxt as u
+>>> import coordinax.charts as cxc
+>>> import coordinax.manifolds as cxm
+
+>>> metric = cxm.EuclideanMetric(3)
+>>> chart = cxc.cart3d
+>>> at = {"x": jnp.array(0.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
+>>> v = {"x": u.Q(3.0, "m/s"), "y": u.Q(4.0, "m/s"), "z": u.Q(0.0, "m/s")}
+>>> metric.norm(v, chart, at=at)
+Q(5., 'm / s')
+```
+
+See [spec § norm](../spec.md#software-spec-norm) for the complete dispatch table and notes on curved-metric position dependence.
+
 ## Quick Reference
 
 - Need compatibility checks around chart transitions: manifold methods
 - Need manifold inference from data/charts: `guess_manifold`
+- Need to compute a Riemannian vector norm: `manifold.norm(...)` / `metric.norm(...)` / `cxm.norm(...)`
 - Need intrinsic-to-ambient conversion: `pt_embed` / `pt_project`
 - Need custom chart membership rules: `CustomAtlas` + `CustomManifold`
 - Need manifold products: `CartesianProductManifold`

--- a/docs/guides/manifolds.md
+++ b/docs/guides/manifolds.md
@@ -332,9 +332,9 @@ Three equivalent call forms are available:
 
 - **Via manifold**: `manifold.norm(v, chart, at=at)` — uses the manifold's metric automatically.
 - **Via metric**: `metric.norm(v, chart, at=at)` — uses the metric object directly.
-- **Functional form**: `cxm.norm(v, metric_or_manifold, chart, at=at)`.
+- **Functional form**: `cxm.norm(v, chart, at=at)`.
 
-The `at` keyword argument specifies the base point for position-dependent metrics (for example `HyperSphericalMetric`). For flat metrics such as `EuclideanMetric`, `at` is not always required by the interface and does not affect the result numerically.
+The `at` keyword argument specifies the base point for position-dependent metrics (for example `RoundMetric`), where it is required. For flat Euclidean Cartesian fast paths (`FlatMetric` with a `CartND` chart), `at` may be omitted because the metric is constant and does not depend on the base point.
 
 ### Euclidean norms with Quantity components
 

--- a/docs/guides/manifolds.md
+++ b/docs/guides/manifolds.md
@@ -382,7 +382,7 @@ You can also call `norm` on a standalone metric object:
 >>> import coordinax.charts as cxc
 >>> import coordinax.manifolds as cxm
 
->>> metric = cxm.EuclideanMetric(3)
+>>> metric = cxm.FlatMetric(3)
 >>> chart = cxc.cart3d
 >>> at = {"x": jnp.array(0.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
 >>> v = {"x": u.Q(3.0, "m/s"), "y": u.Q(4.0, "m/s"), "z": u.Q(0.0, "m/s")}

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2704,7 +2704,7 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
     **Signature:**
 
     ```
-    cxm.norm(v, chart, /, *, at, usys=None)
+    cxm.norm(v, chart, /, *, at=None, usys=None)
     ```
 
     Or via convenience wrappers on metric and manifold objects:
@@ -2720,9 +2720,8 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
       - `jax.Array` shaped `(ndim,)`: requires `usys` to interpret units.
       - `CDict` of bare `jax.Array` values: requires `usys`.
       - `CDict` of `unxt.AbstractQuantity` values: `usys` is optional.
-    - `metric_or_manifold`: an `AbstractMetric` instance (metric-level call) or an `AbstractManifold` instance (manifold-level call). When a manifold is passed, `norm` delegates to `manifold.metric`.
-    - `chart`: the coordinate chart in which `v` is expressed.
-    - `at` (keyword): the base point $p$ in chart coordinates at which the metric is evaluated.
+    - `chart`: the coordinate chart in which `v` is expressed. The chart carries its associated metric (`chart.M.metric`), so no separate metric argument is needed at the chart level.
+    - `at` (keyword, optional): the base point $p$ in chart coordinates at which the metric is evaluated. Optional for flat metrics (`FlatMetric` / `CartND`); required for curved metrics.
     - `usys` (keyword, optional): unit system; required when `v` contains bare arrays.
 
     **Return:**
@@ -2732,17 +2731,18 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
 
     **Dispatch table:**
 
-    | `v` type | `metric_or_manifold` type | `usys` | Result |
+    | `v` type | `at` | `usys` | Result |
     |---|---|---|---|
-    | `CDict[Quantity]` | `AbstractMetric` | optional | `Quantity` |
-    | `CDict[Array]` | `AbstractMetric` | required | `Array` |
-    | `jax.Array` | `AbstractMetric` | required | `Array` |
-    | Any of above | `AbstractManifold` | (as above) | (as above) |
+    | `CDict[Quantity]` (flat chart) | optional | optional | `Quantity` |
+    | `CDict[Quantity]` (curved chart) | required | optional | `Quantity` |
+    | `CDict[Array]` | required | required | `Array` |
+    | `jax.Array` (flat Cartesian) | optional | optional | `Array` |
+    | `jax.Array` (curved chart) | required | required | `Array` |
 
     **Position dependence:**
 
-    - For flat metrics (for example `EuclideanMetric`), the metric matrix is constant and `at` does not affect the result numerically, though it is still required by the API.
-    - For curved metrics (for example `HyperSphericalMetric`), the metric matrix depends on `at` and must be the correct base point.
+    - For flat metrics (e.g. `FlatMetric`), the metric matrix is constant; `at` is optional and ignored numerically.
+    - For curved metrics (e.g. `RoundMetric`), the metric matrix depends on `at`, which must be the correct base point.
 
     **Examples**
 
@@ -2754,23 +2754,22 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
 
     >>> M = cxm.EuclideanManifold(3)
     >>> chart = cxc.Cart3D(M=M)
-    >>> at = {"x": jnp.array(0.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
 
-    >>> # CDict of Quantities via manifold wrapper (usys optional):
+    >>> # CDict of Quantities via manifold wrapper (usys optional, at optional for flat):
     >>> v = {"x": u.Q(3.0, "m/s"), "y": u.Q(4.0, "m/s"), "z": u.Q(0.0, "m/s")}
-    >>> M.norm(v, chart, at=at)
+    >>> M.norm(v, chart, at={"x": jnp.array(0.0), "y": jnp.array(0.0), "z": jnp.array(0.0)})
     Q(5., 'm / s')
 
-    >>> cxm.norm(v, chart, at=at)
+    >>> cxm.norm(v, chart)
     Q(5., 'm / s')
 
     >>> # Stacked jax.Array (usys required):
-    >>> cxm.norm(jnp.array([3.0, 4.0, 0.0]), chart, at=at, usys=u.unitsystems.si)
+    >>> cxm.norm(jnp.array([3.0, 4.0, 0.0]), chart, usys=u.unitsystems.si)
     Array(5., dtype=float64)
 
     >>> # Via metric directly:
-    >>> metric = cxm.EuclideanMetric(3)
-    >>> metric.norm(v, chart, at=at)
+    >>> metric = cxm.FlatMetric(3)
+    >>> metric.norm(v, chart)
     Q(5., 'm / s')
     ```
 
@@ -2778,7 +2777,7 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
 
     - `AbstractMetric.norm` and `AbstractManifold.norm` are thin wrappers that delegate to `cxm.norm`.
     - Manifold-level calls resolve to `cxm.norm(v, manifold.metric, chart, at=at, usys=usys)`.
-    - An optimized Euclidean fast-path using `jnp.linalg.norm` is registered for `EuclideanMetric` with `CartND` charts.
+    - An optimized Euclidean fast-path using `jnp.linalg.norm` is registered for `FlatMetric` with `CartND` charts.
 
 (software-spec-angle-between)=
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2687,6 +2687,99 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
     (3,)
     ```
 
+(software-spec-norm)=
+
+!!! info `norm`
+
+    Compute the Riemannian norm of a tangent vector.
+
+    `norm` is a dispatched function that computes
+
+    $$
+    \|v\|_g = \sqrt{g_p(v, v)}
+    $$
+
+    where $g$ is the metric tensor and $p$ is the base point at which the metric is evaluated. It dispatches on the type of the second argument (either an `AbstractMetric` or an `AbstractManifold`) and on the type of `v`.
+
+    **Signature:**
+
+    ```
+    cxm.norm(v, chart, /, *, at, usys=None)
+    ```
+
+    Or via convenience wrappers on metric and manifold objects:
+
+    ```
+    metric.norm(v, chart, at=at, usys=usys)
+    manifold.norm(v, chart, at=at, usys=usys)
+    ```
+
+    **Arguments:**
+
+    - `v`: the tangent vector. Accepted forms:
+      - `jax.Array` shaped `(ndim,)`: requires `usys` to interpret units.
+      - `CDict` of bare `jax.Array` values: requires `usys`.
+      - `CDict` of `unxt.AbstractQuantity` values: `usys` is optional.
+    - `metric_or_manifold`: an `AbstractMetric` instance (metric-level call) or an `AbstractManifold` instance (manifold-level call). When a manifold is passed, `norm` delegates to `manifold.metric`.
+    - `chart`: the coordinate chart in which `v` is expressed.
+    - `at` (keyword): the base point $p$ in chart coordinates at which the metric is evaluated.
+    - `usys` (keyword, optional): unit system; required when `v` contains bare arrays.
+
+    **Return:**
+
+    - `Quantity` when `v` is quantity-valued.
+    - `jax.Array` when `v` is bare-array-valued and `usys` is provided.
+
+    **Dispatch table:**
+
+    | `v` type | `metric_or_manifold` type | `usys` | Result |
+    |---|---|---|---|
+    | `CDict[Quantity]` | `AbstractMetric` | optional | `Quantity` |
+    | `CDict[Array]` | `AbstractMetric` | required | `Array` |
+    | `jax.Array` | `AbstractMetric` | required | `Array` |
+    | Any of above | `AbstractManifold` | (as above) | (as above) |
+
+    **Position dependence:**
+
+    - For flat metrics (for example `EuclideanMetric`), the metric matrix is constant and `at` does not affect the result numerically, though it is still required by the API.
+    - For curved metrics (for example `HyperSphericalMetric`), the metric matrix depends on `at` and must be the correct base point.
+
+    **Examples**
+
+    ```pycon
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> M = cxm.EuclideanManifold(3)
+    >>> chart = cxc.Cart3D(M=M)
+    >>> at = {"x": jnp.array(0.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
+
+    >>> # CDict of Quantities via manifold wrapper (usys optional):
+    >>> v = {"x": u.Q(3.0, "m/s"), "y": u.Q(4.0, "m/s"), "z": u.Q(0.0, "m/s")}
+    >>> M.norm(v, chart, at=at)
+    Q(5., 'm / s')
+
+    >>> cxm.norm(v, chart, at=at)
+    Q(5., 'm / s')
+
+    >>> # Stacked jax.Array (usys required):
+    >>> cxm.norm(jnp.array([3.0, 4.0, 0.0]), chart, at=at, usys=u.unitsystems.si)
+    Array(5., dtype=float64)
+
+    >>> # Via metric directly:
+    >>> metric = cxm.EuclideanMetric(3)
+    >>> metric.norm(v, chart, at=at)
+    Q(5., 'm / s')
+    ```
+
+    **Notes:**
+
+    - `AbstractMetric.norm` and `AbstractManifold.norm` are thin wrappers that delegate to `cxm.norm`.
+    - Manifold-level calls resolve to `cxm.norm(v, manifold.metric, chart, at=at, usys=usys)`.
+    - An optimized Euclidean fast-path using `jnp.linalg.norm` is registered for `EuclideanMetric` with `CartND` charts.
+
 (software-spec-angle-between)=
 
 !!! info `angle_between`
@@ -2712,10 +2805,6 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
 
     **Signature:**
 
-    ```
-    cxm.angle_between(manifold, chart, u, v, /, *, at, usys=None)
-    ```
-    or
     ```
     cxm.angle_between(chart, u, v, /, *, at, usys=None)
     ```

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2699,12 +2699,13 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
     \|v\|_g = \sqrt{g_p(v, v)}
     $$
 
-    where $g$ is the metric tensor and $p$ is the base point at which the metric is evaluated. It dispatches on the type of the second argument (either an `AbstractMetric` or an `AbstractManifold`) and on the type of `v`.
+    where $g$ is the metric tensor and $p$ is the base point at which the metric is evaluated. It dispatches on the type of `v` and on whether the metric is supplied implicitly (via a `chart`, using its attached `chart.M.metric`) or explicitly (via an `AbstractMetric`).
 
-    **Signature:**
+    **Signatures:**
 
     ```
-    cxm.norm(v, chart, /, *, at=None, usys=None)
+    cxm.norm(v, chart, /, *, at=None, usys=None)          # chart-level: uses chart.M.metric
+    cxm.norm(v, metric, chart, /, *, at=None, usys=None)  # metric-level: explicit metric
     ```
 
     Or via convenience wrappers on metric and manifold objects:
@@ -2713,6 +2714,8 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
     metric.norm(v, chart, at=at, usys=usys)
     manifold.norm(v, chart, at=at, usys=usys)
     ```
+
+    There is no functional overload that takes an `AbstractManifold` as the second argument; norms with respect to a manifold are taken through the `manifold.norm(...)` wrapper, which delegates to the metric-level form using `manifold.metric`.
 
     **Arguments:**
 
@@ -2771,6 +2774,13 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
     >>> metric = cxm.FlatMetric(3)
     >>> metric.norm(v, chart)
     Q(5., 'm / s')
+
+    >>> # Metric-level functional form on a curved chart (at is required):
+    >>> rmetric = cxm.RoundMetric(2)
+    >>> at_eq = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0.0, "rad")}
+    >>> w = {"theta": u.Q(1.0, "rad/s"), "phi": u.Q(0.0, "rad/s")}
+    >>> cxm.norm(w, rmetric, cxc.sph2, at=at_eq)
+    Q(1., 'rad / s')
     ```
 
     **Notes:**

--- a/packages/coordinax.api/src/coordinax/api/manifolds.py
+++ b/packages/coordinax.api/src/coordinax/api/manifolds.py
@@ -9,6 +9,7 @@ __all__ = (
     "pt_embed",
     "pt_project",
     "pt_map",
+    "norm",
 )
 
 from typing import TYPE_CHECKING, Any
@@ -42,6 +43,16 @@ def guess_manifold(*args: Any, **kwargs: Any) -> "coordinax.manifolds.AbstractMa
     >>> cxm.guess_manifold(cxc.sph2)
     HyperSphericalManifold(ndim=2)
 
+    """
+    raise NotImplementedError  # pragma: no cover
+
+
+@plum.dispatch.abstract
+def norm(v: Any, metric: Any, /, *args: Any, **kwargs: Any) -> Any:
+    """Compute the Riemannian norm of a vector.
+
+    Dispatches on the type of the second argument (metric-related) and
+    the type of ``v``.
     """
     raise NotImplementedError  # pragma: no cover
 

--- a/packages/coordinax.astro/src/coordinax/astro/_src/register_constructors.py
+++ b/packages/coordinax.astro/src/coordinax/astro/_src/register_constructors.py
@@ -1,5 +1,7 @@
 """Register distance constructors."""
 
+__all__: tuple[str, ...] = ()
+
 from typing import Any
 
 import quaxed.numpy as jnp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,6 +324,15 @@ xfail_strict = true
 COORDINAX_ENABLE_RUNTIME_TYPECHECKING = "beartype.beartype"
 JAX_ENABLE_X64                        = "1"
 
+[tool.ty]
+environment.extra-paths = [
+  "packages/coordinax.api/src",
+  "packages/coordinax.astro/src",
+  "packages/coordinax.curveframes/src",
+  "packages/coordinax.hypothesis/src",
+  "packages/coordinax.interop.astropy/src",
+]
+
 [tool.ty.src]
 exclude = [
   "tests",

--- a/src/coordinax/_src/base/manifold.py
+++ b/src/coordinax/_src/base/manifold.py
@@ -223,6 +223,43 @@ class AbstractManifold(metaclass=abc.ABCMeta):
 
     # =====================================================
 
+    def norm(
+        self, v: Any, *args: Any, at: Any, usys: OptUSys = None, **kwargs: Any
+    ) -> Any:
+        r"""Compute the norm $\|v\|_g = \sqrt{g(v, v)}$.
+
+        Convenience wrapper that calls
+        ``cxmapi.norm(v, self.metric, chart, at=at, usys=usys)`` directly.
+        The ``chart`` must be passed as the second positional argument (after
+        ``v``).
+
+        Examples
+        --------
+        >>> import jax.numpy as jnp
+        >>> import unxt as u
+        >>> import coordinax.charts as cxc
+        >>> import coordinax.manifolds as cxm
+
+        >>> M = cxm.EuclideanManifold(3)
+        >>> chart = cxc.Cart3D(M=M)
+        >>> at = {"x": jnp.array(0.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
+
+        With a stacked ``jax.Array`` (usys required):
+
+        >>> usys = u.unitsystems.si
+        >>> v = jnp.array([3.0, 4.0, 0.0])
+        >>> M.norm(v, chart, at=at, usys=usys)
+        Array(5., dtype=float64)
+
+        With a CDict of quantities (usys optional):
+
+        >>> v = {"x": u.Q(3.0, "m/s"), "y": u.Q(4.0, "m/s"), "z": u.Q(0.0, "m/s")}
+        >>> M.norm(v, chart, at=at)
+        Q(5., 'm / s')
+
+        """
+        return cxmapi.norm(v, self.metric, *args, at=at, usys=usys, **kwargs)
+
     def angle_between(
         self,
         chart: "coordinax.charts.AbstractChart[Any, Any, Any]",

--- a/src/coordinax/_src/base/metric.py
+++ b/src/coordinax/_src/base/metric.py
@@ -4,7 +4,12 @@ __all__ = ("AbstractMetricField", "AbstractDiagonalMetricField")
 
 import abc
 
+from typing import Any
+
 import jax
+
+import coordinax.api.manifolds as cxmapi
+from coordinax._src.custom_types import OptUSys
 
 
 @jax.tree_util.register_static
@@ -60,6 +65,41 @@ class AbstractMetricField(metaclass=abc.ABCMeta):
     def signature(self) -> tuple[int, ...]:
         """Return the signature of the metric as a tuple of integers."""
         raise NotImplementedError  # pragma: no cover
+
+    def norm(
+        self, v: Any, *args: Any, at: Any, usys: OptUSys = None, **kwargs: Any
+    ) -> Any:
+        r"""Compute the norm $\|v\|_g = \sqrt{g(v, v)}$.
+
+        Convenience wrapper that calls
+        ``cxmapi.norm(v, self, chart, at=at, usys=usys)`` directly.  The
+        ``chart`` must be passed as the second positional argument (after
+        ``v``).
+
+        Examples
+        --------
+        >>> import jax.numpy as jnp
+        >>> import unxt as u
+        >>> import coordinax.charts as cxc
+        >>> import coordinax.manifolds as cxm
+
+        >>> metric = cxm.FlatMetric(3)
+        >>> at = {"x": jnp.array(0.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
+
+        With a CDict of quantities (usys optional):
+
+        >>> v = {"x": u.Q(3.0, "m/s"), "y": u.Q(4.0, "m/s"), "z": u.Q(0.0, "m/s")}
+        >>> metric.norm(v, cxc.cart3d, at=at)
+        Q(5., 'm / s')
+
+        With a stacked ``jax.Array`` (usys required):
+
+        >>> v = jnp.array([3.0, 4.0, 0.0])
+        >>> metric.norm(v, cxc.cart3d, at=at, usys=u.unitsystems.si)
+        Array(5., dtype=float64)
+
+        """
+        return cxmapi.norm(v, self, *args, at=at, usys=usys, **kwargs)
 
 
 class AbstractDiagonalMetricField(AbstractMetricField):

--- a/src/coordinax/_src/manifolds/__init__.py
+++ b/src/coordinax/_src/manifolds/__init__.py
@@ -1,5 +1,8 @@
 """Manifolds in coordinax."""
 
+__all__: tuple[str, ...] = ()
+
 from .angle_between import *
 from .guess import *
+from .norm import *
 from .scale_factors import *

--- a/src/coordinax/_src/manifolds/norm.py
+++ b/src/coordinax/_src/manifolds/norm.py
@@ -50,7 +50,7 @@ def norm(G: Array, v: Array, /) -> Array:
     return jnp.sqrt(jnp.einsum("...i,...ij,...j->...", v, G, v))
 
 
-array_norm = norm.invoke(Array, Array)
+array_norm = norm.invoke(Array, Array)  # ty: ignore[unresolved-attribute]
 
 
 @plum.dispatch
@@ -206,7 +206,7 @@ def norm(
 
     This was using the Euclidean metric, but it also works on curved metrics.
 
-    >>> metric = cxm.HyperSphericalMetric(2)
+    >>> metric = cxm.RoundMetric(2)
     >>> at = {"theta": u.Q(jnp.pi / 4, "rad"), "phi": u.Q(1.0, "rad")}
     >>> v = {"theta": u.Q(0.5, "rad/s"), "phi": u.Q(0.5, "rad/s")}
     >>> cxm.norm(v, metric, cxc.sph2, at=at)
@@ -214,7 +214,13 @@ def norm(
 
     """
     keys = chart.components
-    is_qty = any(map(is_any_quantity, v.values()))
+    qty_flags = [is_any_quantity(val) for val in v.values()]
+    if any(qty_flags) and not all(qty_flags):
+        raise TypeError(
+            "norm(): mixed CDict with both Quantity and bare Array values is not "
+            "supported. All components must be either all Quantity or all bare Array."
+        )
+    is_qty = all(qty_flags)
 
     if metric != chart.M.metric:
         raise ValueError("Metric-level dispatch: metric must match chart's metric")
@@ -227,10 +233,10 @@ def norm(
         )
 
     # Compute metric matrix; metric_matrix handles both bare and quantity at
-    G = metric.metric_matrix(chart, at=at, usys=usys)
+    G = metric.metric_matrix(chart, at=at, usys=usys)  # ty: ignore[unresolved-attribute]
 
-    if not is_qty:  # Bare arrays
-        v_vec = jnp.stack([jnp.asarray(v[k]) for k in keys])
+    if not is_qty:  # Bare arrays — stack on last axis for correct batch broadcasting
+        v_vec = jnp.stack([jnp.asarray(v[k]) for k in keys], axis=-1)
         return jnp.sqrt(jnp.einsum("...i,...ij,...j->...", v_vec, G, v_vec))
 
     # Pack CDict of quantities into a QMatrix, preserving per-component
@@ -321,7 +327,7 @@ def norm(
 
     Unit-sphere S²: ``v = (1, 0)`` at the equator has norm 1:
 
-    >>> M = cxm.HyperSphericalMetric(2)
+    >>> M = cxm.RoundMetric(2)
     >>> at_eq = {"theta": jnp.array(jnp.pi / 2), "phi": jnp.array(0.0)}
     >>> cxm.norm(jnp.array([1.0, 0.0]), M, cxc.sph2,
     ...          at=at_eq, usys=u.unitsystems.si)
@@ -334,8 +340,8 @@ def norm(
             "(no unit information). "
             "Example: pass `usys=unxt.unitsystems.si`."
         )
-    G = metric.metric_matrix(chart, at=at, usys=usys)
-    return cxmapi.norm(G, v)
+    G = metric.metric_matrix(chart, at=at, usys=usys)  # ty: ignore[unresolved-attribute]
+    return cxmapi.norm(G, v)  # ty: ignore[invalid-return-type]
 
 
 # ===========================================================================
@@ -343,14 +349,78 @@ def norm(
 
 
 @plum.dispatch
-def norm(v: CDict, chart: AbstractChart, /, *, at: CDict, usys: OptUSys = None) -> Any:
-    r"""Norm of a vector w.r.t. the chart.
+def norm(
+    v: CDict, chart: AbstractChart, /, *, at: CDict | None = None, usys: OptUSys = None
+) -> Any:
+    r"""Norm of a CDict vector w.r.t. the chart.
 
-    Dispatches to the metric-level overload, passing the chart's metric and the
-    chart itself.
+    Dispatches to the metric-level overload via the chart's attached metric.
+    For flat (Euclidean) charts ``at`` is optional; for curved metrics it is
+    required and passed through to ``metric.metric_matrix``.
 
     """
     return cxmapi.norm(v, chart.M.metric, chart, at=at, usys=usys)  # type: ignore[return-value]
+
+
+@plum.dispatch
+def norm(
+    v: Array, chart: AbstractChart, /, *, at: Any = None, usys: Any = None
+) -> Array:
+    r"""Norm of a packed ``jax.Array`` w.r.t. the chart.
+
+    Delegates to the metric-level ``norm(v, metric, chart, ...)`` overload via
+    the chart's attached metric.  For Euclidean Cartesian charts the fast-path
+    ``jnp.linalg.norm`` overload is picked automatically.  For curved charts
+    ``at`` and ``usys`` are required; missing ``usys`` raises ``TypeError``.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    Euclidean fast-path (no ``at`` needed):
+
+    >>> cxm.norm(jnp.array([3.0, 4.0, 0.0]), cxc.cart3d)
+    Array(5., dtype=float64)
+
+    Curved chart (``at`` and ``usys`` required):
+
+    >>> at = {"theta": jnp.array(jnp.pi / 2), "phi": jnp.array(0.0)}
+    >>> cxm.norm(jnp.array([1.0, 0.0]), cxc.sph2, at=at, usys=u.unitsystems.si)
+    Array(1., dtype=float64)
+
+    """
+    return cxmapi.norm(v, chart.M.metric, chart, at=at, usys=usys)  # ty: ignore[invalid-return-type]
+
+
+@plum.dispatch
+def norm(
+    v: u.AbstractQuantity, chart: AbstractChart, /, *, at: Any = None, usys: Any = None
+) -> u.AbstractQuantity:
+    r"""Norm of a single ``AbstractQuantity`` w.r.t. the chart.
+
+    Wraps the quantity in a one-element CDict keyed by the chart's first
+    component name, then delegates to the metric-level overload.  Primarily
+    useful for 1-D charts (``Cart1D``).
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> at = {"x": jnp.array(0.0)}
+    >>> cxm.norm(u.Q(5.0, "m/s"), cxc.cart1d, at=at)
+    Q(5., 'm / s')
+
+    >>> cxm.norm(u.Q(-3.0, "m"), cxc.cart1d, at=at)
+    Q(3., 'm')
+
+    """
+    return cxmapi.norm(v, chart.M.metric, chart, at=at, usys=usys)  # ty: ignore[invalid-return-type]
 
 
 # ===========================================================================

--- a/src/coordinax/_src/manifolds/norm.py
+++ b/src/coordinax/_src/manifolds/norm.py
@@ -1,0 +1,436 @@
+"""Dispatch implementations for `coordinax.api.manifolds.norm`."""
+
+__all__: tuple[str, ...] = ()
+
+from jaxtyping import Array
+from typing import Any
+
+import plum
+
+import quaxed.numpy as jnp
+import unxt as u
+from unxt.quantity import is_any_quantity
+
+import coordinax.api.charts as cxcapi
+import coordinax.api.manifolds as cxmapi
+from coordinax._src.base import AbstractChart, AbstractMetricField
+from coordinax._src.charts import Cart0D, Cart1D, Cart2D, Cart3D, CartND
+from coordinax._src.custom_types import CDict, OptUSys
+from coordinax._src.euclidean import FlatMetric
+from coordinax._src.internal import (
+    QMatrix,
+    pack_nonuniform_unit,
+    pack_uniform_unit,
+)
+
+# ===================================================================
+# Metric Matrix
+
+
+@plum.dispatch
+def norm(G: Array, v: Array, /) -> Array:
+    r"""Compute the norm of a vector using a general (possibly curved) metric.
+
+    This assumes ``G`` is evaluated at the correct chart and position, and
+    ``v`` components match the chart's ordering.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> from coordinax.manifolds import norm
+
+    Identity metric (Euclidean), 3-4-0 vector:
+
+    >>> G = jnp.eye(3)
+    >>> v = jnp.array([3, 4, 0])
+    >>> norm(G, v)
+    Array(5., dtype=float64)
+
+    """
+    return jnp.sqrt(jnp.einsum("...i,...ij,...j->...", v, G, v))
+
+
+array_norm = norm.invoke(Array, Array)
+
+
+@plum.dispatch
+def norm(G: Array, v: u.AbstractQuantity, /) -> u.AbstractQuantity:
+    r"""Compute the norm of a vector using a general (possibly curved) metric.
+
+    This assumes ``G`` is evaluated at the correct chart and position, and
+    ``v`` components match the chart's ordering.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from coordinax.manifolds import norm
+
+    Identity metric (Euclidean), quantity vector:
+
+    >>> G = jnp.eye(3)
+    >>> v = u.Q(jnp.array([3.0, 4.0, 0.0]), "m/s")
+    >>> norm(G, v)
+    Q(5., 'm / s')
+
+    """
+    unit = u.unit_of(v)
+    v_arr = u.ustrip(unit, v)
+    out = jnp.sqrt(jnp.einsum("...i,...ij,...j->...", v_arr, G, v_arr))
+    return u.Q(out, unit)
+
+
+@plum.dispatch
+def norm(G: QMatrix, v: u.AbstractQuantity, /) -> u.AbstractQuantity:
+    r"""Compute the norm of a vector using a general (possibly curved) metric.
+
+    This assumes ``G`` is evaluated at the correct chart and position, and
+    ``v`` components match the chart's ordering.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from coordinax.manifolds import norm
+
+    Identity metric (Euclidean), quantity vector:
+
+    >>> G = jnp.eye(3)
+    >>> v = u.Q(jnp.array([3.0, 4.0, 0.0]), "m/s")
+    >>> norm(G, v)
+    Q(5., 'm / s')
+
+    """
+    return jnp.sqrt(jnp.dot(v, jnp.matmul(G, v)))
+
+
+# TODO: sort out why jaxtyping double registers to restore "Real[Array, "n n"]""
+@plum.dispatch
+def norm(G: Array, v: CDict, /) -> Array | u.AbstractQuantity:
+    r"""Compute the norm of a vector using a general (possibly curved) metric.
+
+    This assumes ``G`` is evaluated at the correct chart and position, and
+    ``v`` components match the chart's ordering.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> from coordinax.manifolds import norm
+
+    Identity metric (Euclidean), CDict of quantities:
+
+    >>> G = jnp.eye(3)
+    >>> v = {"x": u.Q(3.0, "m/s"), "y": u.Q(4.0, "m/s"), "z": u.Q(0.0, "m/s")}
+    >>> norm(G, v)
+    Q(5., 'm / s')
+
+    """
+    # Pack CDict of quantities into a QMatrix, preserving per-component
+    # units.  Then compute v^T G v via QMatrix ops, which handle all unit
+    # conversions correctly (including mixed-unit components like m/s and 1/s).
+    v_vec, units = pack_nonuniform_unit(v, tuple(v.keys()))
+    v_qm = QMatrix(v_vec, unit=units)
+    return jnp.sqrt(jnp.dot(v_qm, jnp.matmul(G, v_qm)))
+
+    # # Pack vector components into a uniform array. This also checks that all
+    # # components have the same units.
+    # v_arr, unit = pack_uniform_unit(v, tuple(v.keys()))
+
+    # # Compute g_ij v^i v^j
+    # # For a vector v, the squared norm is v^T @ g @ v
+    # # Note: v_arr has shape (..., n) with components in the last dimension
+    # norm2 = jnp.einsum("...i,...ij,...j->...", v_arr, G, v_arr)
+
+    # # Return the norm, taking care of units if present
+    # return jnp.sqrt(norm2) if unit is None else u.Q(jnp.sqrt(norm2), unit)
+
+
+# ===========================================================================
+# Metric-level
+
+
+@plum.dispatch
+def norm(
+    v: CDict,
+    metric: AbstractMetricField,
+    chart: AbstractChart,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> Any:
+    r"""Norm of a vector w.r.t. the metric and chart.
+
+    * **Quantity values** (any unit combination): ``usys`` is optional.
+      The result is an ``AbstractQuantity`` whose unit reflects the physical
+      dimensions of the norm (e.g. ``m / s`` when components mix ``m/s``
+      and ``1/s``).  Mixed-unit components are handled correctly via
+      {class}`~coordinax.internal.QMatrix` arithmetic.
+    * **Bare jax.Array values**: ``usys`` is **required** (raises
+      ``TypeError`` if omitted); a plain ``jax.Array`` is returned.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> metric = cxm.FlatMetric(3)
+    >>> at = {"x": jnp.array(0.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
+
+    CDict of same-unit quantities — returns ``Quantity``:
+
+    >>> v = {"x": u.Q(3.0, "m/s"), "y": u.Q(4.0, "m/s"), "z": u.Q(0.0, "m/s")}
+    >>> cxm.norm(v, metric, cxc.cart3d, at=at)
+    Q(5., 'm / s')
+
+    CDict of mixed-unit quantities on a spherical chart — also returns
+    ``Quantity``.  At ``r = 5 m``, ``θ = π/2`` the metric is
+    ``G = diag(1, 25 m², 25 m²)``, so radial velocity ``(1 m/s, 0, 0)``
+    has norm ``1 m/s``:
+
+    >>> at_sph = {"r": u.Q(5.0, "m"), "theta": u.Q(jnp.pi / 2, "rad"),
+    ...           "phi": u.Q(0.0, "rad")}
+    >>> v_mixed = {"r": u.Q(1.0, "m/s"), "theta": u.Q(0.0, "rad/s"),
+    ...            "phi": u.Q(0.0, "rad/s")}
+    >>> cxm.norm(v_mixed, metric, cxc.sph3d, at=at_sph)
+    Q(1., 'm / s')
+
+    CDict of bare arrays (usys required) — returns bare ``Array``:
+
+    >>> v_bare = {"x": jnp.array(3.0), "y": jnp.array(4.0), "z": jnp.array(0.0)}
+    >>> cxm.norm(v_bare, metric, cxc.cart3d, at=at, usys=u.unitsystems.si)
+    Array(5., dtype=float64)
+
+    This was using the Euclidean metric, but it also works on curved metrics.
+
+    >>> metric = cxm.HyperSphericalMetric(2)
+    >>> at = {"theta": u.Q(jnp.pi / 4, "rad"), "phi": u.Q(1.0, "rad")}
+    >>> v = {"theta": u.Q(0.5, "rad/s"), "phi": u.Q(0.5, "rad/s")}
+    >>> cxm.norm(v, metric, cxc.sph2, at=at)
+    Q(0.61237244, 'rad / s')
+
+    """
+    keys = chart.components
+    is_qty = any(map(is_any_quantity, v.values()))
+
+    if metric != chart.M.metric:
+        raise ValueError("Metric-level dispatch: metric must match chart's metric")
+
+    if not is_qty and usys is None:
+        raise TypeError(
+            "norm(): `usys` is required when `v` is a CDict of bare arrays "
+            "(no unit information). "
+            "Example: pass `usys=unxt.unitsystems.si`."
+        )
+
+    # Compute metric matrix; metric_matrix handles both bare and quantity at
+    G = metric.metric_matrix(chart, at=at, usys=usys)
+
+    if not is_qty:  # Bare arrays
+        v_vec = jnp.stack([jnp.asarray(v[k]) for k in keys])
+        return jnp.sqrt(jnp.einsum("...i,...ij,...j->...", v_vec, G, v_vec))
+
+    # Pack CDict of quantities into a QMatrix, preserving per-component
+    # units.  Then compute v^T G v via QMatrix operations, which handle
+    # all unit conversions correctly (including mixed-unit components like m/s
+    # and 1/s).
+    v_vec, units = pack_nonuniform_unit(v, keys)
+    v_qm = QMatrix(v_vec, unit=units)
+    return jnp.sqrt(jnp.dot(v_qm, jnp.matmul(G, v_qm)))
+
+
+@plum.dispatch
+def norm(
+    v: u.AbstractQuantity,
+    metric: AbstractMetricField,
+    chart: AbstractChart,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> u.AbstractQuantity:
+    r"""Dispatch for a ``AbstractQuantity``.
+
+    The quantity is wrapped in a one-element CDict using the chart's first
+    (and only) component name, then the CDict overload is invoked.
+
+    This overload is primarily useful for 1-D manifolds (e.g.
+    ``EuclideanManifold(1)`` with a ``Cart1D`` chart).
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    Norm of a 1-D displacement on the real line:
+
+    >>> M = cxm.FlatMetric(1)
+    >>> at = {"x": jnp.array(0.0)}
+    >>> cxm.norm(u.Q(jnp.array([5.0]), "m/s"), M, cxc.cart1d, at=at)
+    Q(5., 'm / s')
+
+    """
+    v_dict = cxcapi.cdict(v, chart)
+    return cxmapi.norm(v_dict, metric, chart, at=at, usys=usys)  # ty: ignore[invalid-return-type]
+
+
+@plum.dispatch
+def norm(
+    v: Array,
+    metric: AbstractMetricField,
+    chart: AbstractChart,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> Array:
+    r"""Dispatch for a packed 1-D ``jax.Array`` (v first).
+
+    ``v`` is a stacked array whose entries correspond to the chart's
+    component ordering (``chart.components``).  Because the array carries
+    no unit information, ``usys`` is **required**; passing
+    ``usys=None`` (the default) raises ``TypeError``.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    3-4-0 triple in Cartesian 3-D:
+
+    >>> M = cxm.FlatMetric(3)
+    >>> at = {"x": jnp.array(0.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
+    >>> cxm.norm(jnp.array([3.0, 4.0, 0.0]), M, cxc.cart3d,
+    ...          at=at, usys=u.unitsystems.si)
+    Array(5., dtype=float64)
+
+    Missing ``usys`` raises ``TypeError``:
+
+    >>> try:
+    ...     cxm.norm(jnp.array([3.0, 4.0, 0.0]), M, cxc.sph3d, at=at)
+    ... except TypeError as e:
+    ...     print(e)
+    norm(): `usys` is required when `v` is a bare jax.Array ...
+
+    Unit-sphere S²: ``v = (1, 0)`` at the equator has norm 1:
+
+    >>> M = cxm.HyperSphericalMetric(2)
+    >>> at_eq = {"theta": jnp.array(jnp.pi / 2), "phi": jnp.array(0.0)}
+    >>> cxm.norm(jnp.array([1.0, 0.0]), M, cxc.sph2,
+    ...          at=at_eq, usys=u.unitsystems.si)
+    Array(1., dtype=float64)
+
+    """
+    if usys is None:
+        raise TypeError(
+            "norm(): `usys` is required when `v` is a bare jax.Array "
+            "(no unit information). "
+            "Example: pass `usys=unxt.unitsystems.si`."
+        )
+    G = metric.metric_matrix(chart, at=at, usys=usys)
+    return cxmapi.norm(G, v)
+
+
+# ===========================================================================
+# Chart-level
+
+
+@plum.dispatch
+def norm(v: CDict, chart: AbstractChart, /, *, at: CDict, usys: OptUSys = None) -> Any:
+    r"""Norm of a vector w.r.t. the chart.
+
+    Dispatches to the metric-level overload, passing the chart's metric and the
+    chart itself.
+
+    """
+    return cxmapi.norm(v, chart.M.metric, chart, at=at, usys=usys)  # type: ignore[return-value]
+
+
+# ===========================================================================
+# Euclidean Specializations
+
+
+@plum.dispatch
+def norm(
+    v: Array,
+    metric: FlatMetric,
+    chart: Cart0D | Cart1D | Cart2D | Cart3D | CartND,
+    /,
+    *,
+    at: Any = None,
+    usys: Any = None,
+) -> Array:
+    r"""Short-circuit: Euclidean Cartesian chart -> ``jnp.linalg.norm``.
+
+    When both the metric is flat (``FlatMetric``) and the chart is
+    Cartesian (``Cart3D``), the metric matrix is the 3x3 identity, so
+    ``‖v‖ = √(vᵀ I v) = ‖v‖₂``.  This overload skips the general matrix
+    computation and calls ``jnp.linalg.norm`` directly.  ``at`` and ``usys``
+    are ignored.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> M = cxm.FlatMetric(3)
+    >>> at = {"x": jnp.array(0.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
+
+    3-4-0 triple gives norm 5:
+
+    >>> cxm.norm(jnp.array([3.0, 4.0, 0.0]), M, cxc.cart3d, at=at)
+    Array(5., dtype=float64)
+
+    ``at`` and ``usys`` are unused and technically skippable in this fast path:
+
+    >>> cxm.norm(jnp.array([1.0, 0.0, 0.0]), M, cxc.cart3d)
+    Array(1., dtype=float64)
+
+    """
+    del metric, chart, at, usys  # Unused
+    return jnp.linalg.norm(v, axis=-1)
+
+
+@plum.dispatch
+def norm(
+    data: CDict,
+    metric: FlatMetric,
+    chart: Cart0D | Cart1D | Cart2D | Cart3D,
+    /,
+    *,
+    at: CDict | None = None,
+    usys: Any = None,
+) -> u.AbstractQuantity | Array:
+    r"""Compute the Euclidean norm of a vector.
+
+    Examples
+    --------
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+    >>> import unxt as u
+
+    >>> M = cxm.FlatMetric(3)
+    >>> v = {"x": u.Q(3, "m"), "y": u.Q(4, "m"), "z": u.Q(0, "m")}
+    >>> cxm.norm(v, M, cxc.cart3d)
+    Q(5., 'm')
+
+    Works in any dimension:
+
+    >>> M = cxm.FlatMetric(2)
+    >>> v2 = {"x": u.Q(3, "km"), "y": u.Q(4, "km")}
+    >>> cxm.norm(v2, M, cxc.cart2d)
+    Q(5., 'km')
+
+    """
+    del metric, at, usys
+    v, unit = pack_uniform_unit(data, chart.components)
+    vnorm = jnp.linalg.norm(v, axis=-1)
+    return u.Q(vnorm, unit) if unit is not None else vnorm

--- a/src/coordinax/_src/manifolds/norm.py
+++ b/src/coordinax/_src/manifolds/norm.py
@@ -75,8 +75,7 @@ def norm(G: Array, v: u.AbstractQuantity, /) -> u.AbstractQuantity:
 
     """
     unit = u.unit_of(v)
-    v_arr = u.ustrip(unit, v)
-    out = jnp.sqrt(jnp.einsum("...i,...ij,...j->...", v_arr, G, v_arr))
+    out = array_norm(G, u.ustrip(unit, v))
     return u.Q(out, unit)
 
 
@@ -125,25 +124,31 @@ def norm(G: Array, v: CDict, /) -> Array | u.AbstractQuantity:
     >>> norm(G, v)
     Q(5., 'm / s')
 
+    Identity metric (Euclidean), CDict of bare arrays — returns a bare ``Array``:
+
+    >>> v = {"x": jnp.array(3.0), "y": jnp.array(4.0), "z": jnp.array(0.0)}
+    >>> norm(G, v)
+    Array(5., dtype=float64)
+
     """
+    keys = tuple(v.keys())
+    qty_flags = [is_any_quantity(val) for val in v.values()]
+    if any(qty_flags) and not all(qty_flags):
+        raise TypeError(
+            "norm(): mixed CDict with both Quantity and bare Array values is not "
+            "supported. All components must be either all Quantity or all bare Array."
+        )
+
+    if not all(qty_flags):  # Bare arrays — stack on last axis and contract
+        v_vec = jnp.stack([jnp.asarray(v[k]) for k in keys], axis=-1)
+        return array_norm(G, v_vec)
+
     # Pack CDict of quantities into a QMatrix, preserving per-component
     # units.  Then compute v^T G v via QMatrix ops, which handle all unit
     # conversions correctly (including mixed-unit components like m/s and 1/s).
-    v_vec, units = pack_nonuniform_unit(v, tuple(v.keys()))
+    v_vec, units = pack_nonuniform_unit(v, keys)
     v_qm = QMatrix(v_vec, unit=units)
     return jnp.sqrt(jnp.dot(v_qm, jnp.matmul(G, v_qm)))
-
-    # # Pack vector components into a uniform array. This also checks that all
-    # # components have the same units.
-    # v_arr, unit = pack_uniform_unit(v, tuple(v.keys()))
-
-    # # Compute g_ij v^i v^j
-    # # For a vector v, the squared norm is v^T @ g @ v
-    # # Note: v_arr has shape (..., n) with components in the last dimension
-    # norm2 = jnp.einsum("...i,...ij,...j->...", v_arr, G, v_arr)
-
-    # # Return the norm, taking care of units if present
-    # return jnp.sqrt(norm2) if unit is None else u.Q(jnp.sqrt(norm2), unit)
 
 
 # ===========================================================================
@@ -232,20 +237,22 @@ def norm(
             "Example: pass `usys=unxt.unitsystems.si`."
         )
 
-    # Compute metric matrix; metric_matrix handles both bare and quantity at
-    G = metric.metric_matrix(chart, at=at, usys=usys)  # ty: ignore[unresolved-attribute]
+    # Evaluate the metric matrix at the base point.  ``metric_matrix`` returns a
+    # typed ``AbstractMetricMatrix`` (Diagonal/Dense) and handles both bare-array
+    # and Quantity ``at`` values; it needs no unit system.
+    mm = cxmapi.metric_matrix(chart.M, at, chart)
 
     if not is_qty:  # Bare arrays — stack on last axis for correct batch broadcasting
         v_vec = jnp.stack([jnp.asarray(v[k]) for k in keys], axis=-1)
-        return jnp.sqrt(jnp.einsum("...i,...ij,...j->...", v_vec, G, v_vec))
+        return array_norm(mm.to_dense().matrix, v_vec)  # ty: ignore[unresolved-attribute]
 
-    # Pack CDict of quantities into a QMatrix, preserving per-component
-    # units.  Then compute v^T G v via QMatrix operations, which handle
-    # all unit conversions correctly (including mixed-unit components like m/s
-    # and 1/s).
+    # Pack CDict of quantities into a QMatrix, preserving per-component units,
+    # then compute sqrt(vᵀ G v) via QMatrix/AbstractMetricMatrix arithmetic,
+    # which handles all unit conversions correctly (including mixed-unit
+    # components like m/s and rad/s).
     v_vec, units = pack_nonuniform_unit(v, keys)
     v_qm = QMatrix(v_vec, unit=units)
-    return jnp.sqrt(jnp.dot(v_qm, jnp.matmul(G, v_qm)))
+    return jnp.sqrt(v_qm @ (mm @ v_qm))
 
 
 @plum.dispatch
@@ -281,7 +288,14 @@ def norm(
     Q(5., 'm / s')
 
     """
-    v_dict = cxcapi.cdict(v, chart)
+    keys = chart.components
+    if len(keys) == 1:
+        # Single-component chart: wrap the (scalar or length-1) quantity in a
+        # one-element CDict, squeezing the trailing component axis if present.
+        v_dict = {keys[0]: v if v.ndim == 0 else v[..., 0]}
+    else:
+        # Multi-component chart: split the packed quantity across components.
+        v_dict = cxcapi.cdict(v, chart)
     return cxmapi.norm(v_dict, metric, chart, at=at, usys=usys)  # ty: ignore[invalid-return-type]
 
 
@@ -340,8 +354,8 @@ def norm(
             "(no unit information). "
             "Example: pass `usys=unxt.unitsystems.si`."
         )
-    G = metric.metric_matrix(chart, at=at, usys=usys)  # ty: ignore[unresolved-attribute]
-    return cxmapi.norm(G, v)  # ty: ignore[invalid-return-type]
+    mm = cxmapi.metric_matrix(chart.M, at, chart)
+    return array_norm(mm.to_dense().matrix, v)  # ty: ignore[unresolved-attribute]
 
 
 # ===========================================================================

--- a/src/coordinax/_src/spherical/embed.py
+++ b/src/coordinax/_src/spherical/embed.py
@@ -136,24 +136,22 @@ def embedded_twosphere(
 
     Default ambient (Spherical3D)::
 
-    >>> manifold = cxm.embedded_twosphere(radius=u.Q(2.0, "km"))
-    >>> manifold
+    >>> M = cxm.embedded_twosphere(radius=u.Q(2.0, "km"))
+    >>> M
     EmbeddedManifold(intrinsic=HyperSphericalManifold(...),
                      ambient=Rn(3),
                      embed_map=TwoSphereIn3D(radius=Q(2., 'km')))
 
     >>> p = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0.0, "rad")}
-    >>> sph = cxm.pt_embed(p, manifold)
+    >>> sph = cxm.pt_embed(p, M)
     >>> sph
     {'r': Q(2., 'km'), 'theta': Angle(1.57079633, 'rad'), 'phi': Angle(0., 'rad')}
 
     With Cartesian ambient::
 
-    >>> manifold = cxm.embedded_twosphere(
-    ...     radius=u.Q(2.0, "km"), ambient=cxc.cart3d,
-    ... )
-    >>> xyz = cxm.pt_embed(p, manifold)
-    >>> p3 = cxm.pt_project(xyz, manifold)
+    >>> M = cxm.embedded_twosphere(radius=u.Q(2.0, "km"), ambient=cxc.cart3d)
+    >>> xyz = cxm.pt_embed(p, M)
+    >>> p3 = cxm.pt_project(xyz, M)
     >>> p3
     {'theta': Angle(1.57079633, 'rad'), 'phi': Angle(0., 'rad')}
 

--- a/src/coordinax/main.py
+++ b/src/coordinax/main.py
@@ -175,7 +175,7 @@ from coordinax.vectors import Coordinate, Point, Tangent, ToUnitsOptions
 
 # Import interop modules to register conversions and chart transitions.
 with contextlib.suppress(ImportError):
-    import coordinax.interop.astropy as _  # noqa: F401  # ty: ignore[unresolved-import]
+    import coordinax.interop.astropy as _  # noqa: F401
 
 # Clean up namespace
 del contextlib

--- a/src/coordinax/manifolds.py
+++ b/src/coordinax/manifolds.py
@@ -10,6 +10,7 @@ __all__ = (
     "angle_between",
     "metric_matrix",
     "metric_representation",
+    "norm",
     # Abstract Manifold/Atlas/Metric
     "AbstractAtlas",
     "AbstractMetricField",
@@ -135,6 +136,7 @@ with install_import_hook("coordinax.manifolds"):
         guess_manifold,
         metric_matrix,
         metric_representation,
+        norm,
         pt_embed,
         pt_project,
         scale_factors,

--- a/src/coordinax/vectors/_src/base.py
+++ b/src/coordinax/vectors/_src/base.py
@@ -564,11 +564,6 @@ class AbstractVector(
         """
         return isinstance(obj, cls)
 
-    def norm(self, *args: "AbstractVector") -> u.AbstractQuantity:
-        msg = "TODO"
-        raise NotImplementedError(msg)
-        # return self.chart.norm(self.data, *args)
-
     # ===============================================================
     # Frame API
 

--- a/tests/unit/manifolds/test_custom.py
+++ b/tests/unit/manifolds/test_custom.py
@@ -53,25 +53,25 @@ class TestCustomManifold:
         atlas = cxm.CustomAtlas(
             charts=(cxc.Cart2D, cxc.Polar2D), chart_default=cxc.cart2d
         )
-        manifold = cxm.CustomManifold(atlas, metric=cxm.FlatMetric(2))
+        M = cxm.CustomManifold(atlas, metric=cxm.FlatMetric(2))
 
-        assert manifold.ndim == 2
-        assert manifold.default_chart() == cxc.cart2d
+        assert M.ndim == 2
+        assert M.default_chart() == cxc.cart2d
 
     def test_has_chart_and_check_chart(self) -> None:
         """Chart membership and validation are delegated to the atlas."""
         atlas = cxm.CustomAtlas(
             charts=(cxc.Cart2D, cxc.Polar2D), chart_default=cxc.cart2d
         )
-        manifold = cxm.CustomManifold(atlas, metric=cxm.FlatMetric(2))
+        M = cxm.CustomManifold(atlas, metric=cxm.FlatMetric(2))
 
-        assert manifold.has_chart(cxc.cart2d)
-        assert manifold.has_chart(cxc.polar2d)
-        assert not manifold.has_chart(cxc.cart3d)
+        assert M.has_chart(cxc.cart2d)
+        assert M.has_chart(cxc.polar2d)
+        assert not M.has_chart(cxc.cart3d)
 
-        manifold.check_chart(cxc.cart2d)
+        M.check_chart(cxc.cart2d)
         with pytest.raises(ValueError, match="is not supported"):
-            manifold.check_chart(cxc.cart3d)
+            M.check_chart(cxc.cart3d)
 
 
 @given(atlas=cxst.atlases(cxm.CustomAtlas))

--- a/tests/unit/manifolds/test_norm.py
+++ b/tests/unit/manifolds/test_norm.py
@@ -90,7 +90,7 @@ class TestNormSphere:
 
     def test_equator_equal_components(self):
         """At equator sin(theta)=1, norm = sqrt(1 + 1) = sqrt(2)."""
-        metric = cxm.HyperSphericalMetric(ndim=2)
+        metric = cxm.RoundMetric(ndim=2)
         p = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0, "rad")}
         v = {"theta": u.Q(1, "rad/s"), "phi": u.Q(1, "rad/s")}
         result = cxm.norm(v, metric, cxc.sph2, at=p)
@@ -98,7 +98,7 @@ class TestNormSphere:
 
     def test_near_pole_phi_vanishes(self):
         """Near north pole, phi contribution -> 0."""
-        metric = cxm.HyperSphericalMetric(ndim=2)
+        metric = cxm.RoundMetric(ndim=2)
         p = {"theta": u.Angle(0.001, "rad"), "phi": u.Angle(0, "rad")}
         v = {"theta": u.Q(0, "rad/s"), "phi": u.Q(1, "rad/s")}
         result = cxm.norm(v, metric, cxc.sph2, at=p)
@@ -106,7 +106,7 @@ class TestNormSphere:
 
     def test_theta_only_norm_is_one(self):
         """Pure theta motion has norm 1."""
-        metric = cxm.HyperSphericalMetric(ndim=2)
+        metric = cxm.RoundMetric(ndim=2)
         for theta_val in [0.1, jnp.pi / 4, jnp.pi / 2]:
             p = {"theta": u.Angle(theta_val, "rad"), "phi": u.Angle(0, "rad")}
             v = {"theta": u.Q(1, "rad/s"), "phi": u.Q(0, "rad/s")}
@@ -208,6 +208,16 @@ class TestNormBareCDict:
         assert jnp.allclose(result, 5)
         assert not isinstance(result, u.AbstractQuantity)
 
+    def test_curved_chart_bare_cdict_with_usys(self):
+        """Bare CDict on a curved chart with usys provided returns bare Array."""
+        metric = cxm.RoundMetric(ndim=2)
+        at = {"theta": jnp.array(jnp.pi / 2), "phi": jnp.array(0.0)}
+        v = {"theta": jnp.array(1.0), "phi": jnp.array(0.0)}
+        result = cxm.norm(v, metric, cxc.sph2, at=at, usys=u.unitsystems.si)
+        # v=(1,0) at equator: g_θθ=1, so norm = 1
+        assert jnp.allclose(result, 1.0, atol=1e-6)
+        assert not isinstance(result, u.AbstractQuantity)
+
 
 # =============================================================================
 # cxm.norm() with a single AbstractQuantity (1-D overload)
@@ -252,14 +262,14 @@ class TestNormMetricWrapper:
     """Tests for metric.norm() convenience method."""
 
     def test_euclidean_cdict_quantities(self):
-        metric = cxm.EuclideanMetric(3)
+        metric = cxm.FlatMetric(3)
         at = {"x": jnp.array(0), "y": jnp.array(0), "z": jnp.array(0)}
         v = {"x": u.Q(3, "m/s"), "y": u.Q(4, "m/s"), "z": u.Q(0, "m/s")}
         result = metric.norm(v, cxc.cart3d, at=at)
         assert qnp.allclose(result, u.Q(5, "m/s"), atol=u.Q(1e-5, "m/s"))
 
     def test_euclidean_bare_array_with_usys(self):
-        metric = cxm.EuclideanMetric(3)
+        metric = cxm.FlatMetric(3)
         at = {"x": jnp.array(0), "y": jnp.array(0), "z": jnp.array(0)}
         result = metric.norm(
             jnp.array([3, 4, 0]), cxc.cart3d, at=at, usys=u.unitsystems.si
@@ -267,7 +277,7 @@ class TestNormMetricWrapper:
         assert jnp.allclose(result, 5)
 
     def test_euclidean_bare_cdict_with_usys(self):
-        metric = cxm.EuclideanMetric(3)
+        metric = cxm.FlatMetric(3)
         at = {"x": jnp.array(0), "y": jnp.array(0), "z": jnp.array(0)}
         v = {"x": jnp.array(3), "y": jnp.array(4), "z": jnp.array(0)}
         result = metric.norm(v, cxc.cart3d, at=at, usys=u.unitsystems.si)
@@ -275,7 +285,7 @@ class TestNormMetricWrapper:
 
     def test_agrees_with_functional_api(self):
         """metric.norm(v, chart, at=at) == cxm.norm(v, metric, chart, at=at)."""
-        metric = cxm.EuclideanMetric(3)
+        metric = cxm.FlatMetric(3)
         at = {"x": jnp.array(0), "y": jnp.array(0), "z": jnp.array(0)}
         v = {"x": u.Q(3, "m"), "y": u.Q(4, "m"), "z": u.Q(0, "m")}
         result_wrapper = metric.norm(v, cxc.cart3d, at=at)
@@ -283,8 +293,8 @@ class TestNormMetricWrapper:
         assert qnp.allclose(result_wrapper, result_functional, atol=u.Q(1e-5, "m"))
 
     def test_spherical_metric_wrapper_matches_direct(self):
-        """HyperSphericalMetric.norm matches cxm.norm at S² equator."""
-        metric = cxm.HyperSphericalMetric(ndim=2)
+        """RoundMetric.norm matches cxm.norm at S² equator."""
+        metric = cxm.RoundMetric(ndim=2)
         at = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0, "rad")}
         v = {"theta": u.Q(1, "rad/s"), "phi": u.Q(0, "rad/s")}
         result_wrapper = metric.norm(v, cxc.sph2, at=at)
@@ -479,7 +489,7 @@ class TestNormErrors:
 
     def test_metric_mismatch_raises_value_error(self):
         """Passing a metric that doesn't belong to the chart raises ValueError."""
-        wrong_metric = cxm.EuclideanMetric(3)  # sph2 uses HyperSphericalMetric(ndim=2)
+        wrong_metric = cxm.FlatMetric(3)  # sph2 uses RoundMetric(ndim=2)
         at = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0, "rad")}
         v = {"theta": u.Q(1, "rad/s"), "phi": u.Q(0, "rad/s")}
         with pytest.raises(ValueError, match=r"[Mm]etric"):
@@ -492,10 +502,10 @@ class TestNormErrors:
 
 
 class TestNormJAXCompatSphere:
-    """JIT and vmap for norm() on the HyperSphericalMetric."""
+    """JIT and vmap for norm() on the RoundMetric."""
 
     def test_jit_sph2_cdict_quantities(self):
-        metric = cxm.HyperSphericalMetric(ndim=2)
+        metric = cxm.RoundMetric(ndim=2)
         p = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0, "rad")}
 
         @jax.jit
@@ -508,7 +518,7 @@ class TestNormJAXCompatSphere:
 
     def test_vmap_over_base_point_phi_norm_equals_sin_theta(self):
         """Norm of unit phi-velocity = sin(theta) on S²."""
-        metric = cxm.HyperSphericalMetric(ndim=2)
+        metric = cxm.RoundMetric(ndim=2)
         v = {"theta": u.Q(0, "rad/s"), "phi": u.Q(1, "rad/s")}
         thetas = jnp.array([jnp.pi / 6, jnp.pi / 4, jnp.pi / 2])
         expected = jnp.sin(thetas)  # g_φφ = sin²θ → norm = |sinθ|
@@ -523,7 +533,7 @@ class TestNormJAXCompatSphere:
 
     def test_vmap_over_vectors_at_fixed_point(self):
         """Norm scales linearly with vector magnitude."""
-        metric = cxm.HyperSphericalMetric(ndim=2)
+        metric = cxm.RoundMetric(ndim=2)
         at = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0, "rad")}
         magnitudes = jnp.array([1, 2, 3])
         v_batch = {
@@ -535,7 +545,7 @@ class TestNormJAXCompatSphere:
 
     def test_position_dependence_for_curved_metric(self):
         """Norm of phi-velocity differs at different latitudes on S²."""
-        metric = cxm.HyperSphericalMetric(ndim=2)
+        metric = cxm.RoundMetric(ndim=2)
         v = {"theta": u.Q(0, "rad/s"), "phi": u.Q(1, "rad/s")}
         at_equator = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0, "rad")}
         at_30deg = {"theta": u.Angle(jnp.pi / 6, "rad"), "phi": u.Angle(0, "rad")}

--- a/tests/unit/manifolds/test_norm.py
+++ b/tests/unit/manifolds/test_norm.py
@@ -1,0 +1,547 @@
+"""Tests for the norm() function and AbstractVector.norm() dispatch.
+
+Coverage includes Euclidean and spherical metric behavior, plus JIT/vmap usage.
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import quaxed.numpy as qnp
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+
+# =============================================================================
+# cxm.norm() standalone function
+# =============================================================================
+
+
+class TestNormEuclidean:
+    """Tests for cxm.norm() on Euclidean manifolds with Cartesian coordinates."""
+
+    @pytest.mark.parametrize(
+        ("v", "chart", "exp"),
+        [
+            (
+                {"x": u.Q(0, "m"), "y": u.Q(0, "m"), "z": u.Q(0, "m")},
+                cxc.cart3d,
+                u.Q(0, "m"),
+            ),
+            (
+                {"x": u.Q(3, "m"), "y": u.Q(4, "m"), "z": u.Q(0, "m")},
+                cxc.cart3d,
+                u.Q(5, "m"),
+            ),
+            (
+                {"x": u.Q(1, "m"), "y": u.Q(0, "m"), "z": u.Q(0, "m")},
+                cxc.cart3d,
+                u.Q(1, "m"),
+            ),
+            (
+                {"x": u.Q(1, "km"), "y": u.Q(1, "km"), "z": u.Q(1, "km")},
+                cxc.cart3d,
+                u.Q(jnp.sqrt(3), "km"),
+            ),
+            ({"x": u.Q(3, "m"), "y": u.Q(4, "m")}, cxc.cart2d, u.Q(5, "m")),
+            ({"x": u.Q(-5, "m")}, cxc.cart1d, u.Q(5, "m")),
+        ],
+    )
+    def test_known_cases(self, v, chart, exp):
+        """Known cases: Pythagorean triples, unit vectors, etc."""
+        got = cxm.norm(v, chart)
+        assert qnp.allclose(got, exp, atol=u.Q(1e-10, exp.unit))
+
+    def test_at_parameter_ignored_for_euclidean(self):
+        v = {"x": u.Q(3, "m"), "y": u.Q(4, "m"), "z": u.Q(0, "m")}
+        p = {"x": u.Q(100, "km"), "y": u.Q(200, "km"), "z": u.Q(300, "km")}
+        result = cxm.norm(v, cxc.cart3d, at=p)
+        assert qnp.allclose(result, u.Q(5, "m"), atol=u.Q(1e-5, "m"))
+
+    def test_velocity_units(self):
+        v = {"x": u.Q(3, "m/s"), "y": u.Q(4, "m/s"), "z": u.Q(0, "m/s")}
+        result = cxm.norm(v, cxc.cart3d)
+        assert qnp.allclose(result, u.Q(5, "m/s"), atol=u.Q(1e-5, "m/s"))
+
+    def test_jit(self):
+        @jax.jit
+        def compute(v):
+            return cxm.norm(v, cxc.cart3d)
+
+        v = {"x": u.Q(3, "m"), "y": u.Q(4, "m"), "z": u.Q(0, "m")}
+        result = compute(v)
+        assert qnp.allclose(result, u.Q(5, "m"), atol=u.Q(1e-5, "m"))
+
+    def test_batched(self):
+        """cxm.norm follows scalar-first design; use vmap for batched inputs."""
+        v_batch = {
+            "x": u.Q(jnp.array([3, 0, 1]), "m"),
+            "y": u.Q(jnp.array([4, 1, 0]), "m"),
+            "z": u.Q(jnp.array([0, 0, 0]), "m"),
+        }
+        result = jax.vmap(lambda v: cxm.norm(v, cxc.cart3d))(v_batch)
+        expected = jnp.array([5, 1, 1])
+        assert qnp.allclose(result, u.Q(expected, "m"), atol=u.Q(1e-5, "m"))
+
+
+class TestNormSphere:
+    """Tests for cxm.norm() on the 2-sphere with spherical coordinates."""
+
+    def test_equator_equal_components(self):
+        """At equator sin(theta)=1, norm = sqrt(1 + 1) = sqrt(2)."""
+        metric = cxm.HyperSphericalMetric(ndim=2)
+        p = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0, "rad")}
+        v = {"theta": u.Q(1, "rad/s"), "phi": u.Q(1, "rad/s")}
+        result = cxm.norm(v, metric, cxc.sph2, at=p)
+        assert qnp.allclose(result, u.Q(jnp.sqrt(2), "rad/s"), atol=u.Q(1e-5, "rad/s"))
+
+    def test_near_pole_phi_vanishes(self):
+        """Near north pole, phi contribution -> 0."""
+        metric = cxm.HyperSphericalMetric(ndim=2)
+        p = {"theta": u.Angle(0.001, "rad"), "phi": u.Angle(0, "rad")}
+        v = {"theta": u.Q(0, "rad/s"), "phi": u.Q(1, "rad/s")}
+        result = cxm.norm(v, metric, cxc.sph2, at=p)
+        assert u.ustrip("rad/s", result) < 0.01
+
+    def test_theta_only_norm_is_one(self):
+        """Pure theta motion has norm 1."""
+        metric = cxm.HyperSphericalMetric(ndim=2)
+        for theta_val in [0.1, jnp.pi / 4, jnp.pi / 2]:
+            p = {"theta": u.Angle(theta_val, "rad"), "phi": u.Angle(0, "rad")}
+            v = {"theta": u.Q(1, "rad/s"), "phi": u.Q(0, "rad/s")}
+            result = cxm.norm(v, metric, cxc.sph2, at=p)
+            assert qnp.allclose(result, u.Q(1, "rad/s"), atol=u.Q(1e-5, "rad/s"))
+
+
+# =============================================================================
+# cxm.norm() with a packed jnp.Array
+# =============================================================================
+
+
+class TestNormBareArray:
+    """Tests for cxm.norm() with a packed jnp.Array input."""
+
+    @pytest.mark.parametrize(
+        ("v", "chart", "exp"),
+        [
+            (jnp.array([3, 4, 0]), cxc.cart3d, 5),
+            (jnp.array([1, 0, 0]), cxc.cart3d, 1),
+            (jnp.array([3, 4]), cxc.cart2d, 5),
+            (jnp.array([5]), cxc.cart1d, 5),
+        ],
+    )
+    def test_euclidean_fast_path(self, v, chart, exp):
+        """Euclidean Cartesian fast-path accepts a bare Array without at/usys."""
+        result = cxm.norm(v, chart)
+        assert jnp.allclose(result, exp)
+
+    def test_euclidean_fast_path_returns_bare_array(self):
+        """Fast-path returns a bare jax.Array, not a Quantity."""
+        result = cxm.norm(jnp.array([1, 0, 0]), cxc.cart3d)
+        assert not isinstance(result, u.AbstractQuantity)
+
+    def test_spherical_chart_requires_usys(self):
+        """Non-Cartesian chart with bare Array raises TypeError when usys missing."""
+        at = {"theta": jnp.array(jnp.pi / 2), "phi": jnp.array(0)}
+        with pytest.raises(TypeError, match="usys"):
+            cxm.norm(jnp.array([1, 0]), cxc.sph2, at=at)
+
+    def test_sph2_equator_theta_unit_norm(self):
+        """On S², v=(1,0) at the equator has norm 1 (metric is identity there)."""
+        at = {"theta": jnp.array(jnp.pi / 2), "phi": jnp.array(0)}
+        result = cxm.norm(jnp.array([1, 0]), cxc.sph2, at=at, usys=u.unitsystems.si)
+        assert jnp.allclose(result, 1, atol=1e-6)
+
+    def test_sph2_near_pole_phi_component_suppressed(self):
+        """On S², pure phi velocity near the north pole has a tiny norm."""
+        at = {"theta": jnp.array(0.001), "phi": jnp.array(0)}
+        result = cxm.norm(jnp.array([0, 1]), cxc.sph2, at=at, usys=u.unitsystems.si)
+        assert float(result) < 0.01
+
+    def test_euclidean_fast_path_jit(self):
+        @jax.jit
+        def compute(v):
+            return cxm.norm(v, cxc.cart3d)
+
+        result = compute(jnp.array([3, 4, 0]))
+        assert jnp.allclose(result, 5)
+
+    def test_euclidean_fast_path_vmap(self):
+        """Vectorised norm over a batch of Euclidean vectors."""
+        v_batch = jnp.array([[3, 4, 0], [1, 0, 0], [0, 5, 0]])
+        result = jax.vmap(lambda v: cxm.norm(v, cxc.cart3d))(v_batch)
+        assert jnp.allclose(result, jnp.array([5, 1, 5]))
+
+
+# =============================================================================
+# cxm.norm() with CDict of bare jnp.Arrays
+# =============================================================================
+
+
+class TestNormBareCDict:
+    """Tests for cxm.norm() with a CDict of bare jnp.Arrays."""
+
+    def test_euclidean_cart3d_fast_path_no_usys(self):
+        """Euclidean Cartesian fast-path: bare CDict accepted without usys."""
+        v = {"x": jnp.array(3), "y": jnp.array(4), "z": jnp.array(0)}
+        result = cxm.norm(v, cxc.cart3d)
+        assert jnp.allclose(result, 5)
+
+    def test_euclidean_cart3d_returns_bare_array(self):
+        v = {"x": jnp.array(1), "y": jnp.array(0), "z": jnp.array(0)}
+        result = cxm.norm(v, cxc.cart3d)
+        assert not isinstance(result, u.AbstractQuantity)
+
+    def test_general_chart_requires_usys(self):
+        """CDict of raw arrays on a non-Cartesian chart raises TypeError w/out usys."""
+        v = {"theta": jnp.array(1), "phi": jnp.array(0)}
+        at = {"theta": jnp.array(jnp.pi / 2), "phi": jnp.array(0)}
+        with pytest.raises(TypeError, match="usys"):
+            cxm.norm(v, cxc.sph2, at=at)
+
+    def test_euclidean_with_explicit_usys(self):
+        """Usys is accepted and result still bare-array for Euclidean."""
+        v = {"x": jnp.array(3), "y": jnp.array(4), "z": jnp.array(0)}
+        at = {"x": jnp.array(0), "y": jnp.array(0), "z": jnp.array(0)}
+        result = cxm.norm(v, cxc.cart3d, at=at, usys=u.unitsystems.si)
+        assert jnp.allclose(result, 5)
+        assert not isinstance(result, u.AbstractQuantity)
+
+
+# =============================================================================
+# cxm.norm() with a single AbstractQuantity (1-D overload)
+# =============================================================================
+
+
+class TestNormSingleQuantity:
+    """Tests for cxm.norm() with a single AbstractQuantity (1-D chart overload)."""
+
+    def test_positive_value(self):
+        at = {"x": jnp.array(0)}
+        result = cxm.norm(u.Q(5, "m/s"), cxc.cart1d, at=at)
+        assert qnp.allclose(result, u.Q(5, "m/s"), atol=u.Q(1e-5, "m/s"))
+
+    def test_negative_value_gives_positive_norm(self):
+        at = {"x": jnp.array(0)}
+        result = cxm.norm(u.Q(-3, "m"), cxc.cart1d, at=at)
+        assert qnp.allclose(result, u.Q(3, "m"), atol=u.Q(1e-5, "m"))
+
+    def test_returns_quantity(self):
+        at = {"x": jnp.array(0)}
+        result = cxm.norm(u.Q(5, "m"), cxc.cart1d, at=at)
+        assert isinstance(result, u.AbstractQuantity)
+
+    def test_jit(self):
+        at = {"x": jnp.array(0)}
+
+        @jax.jit
+        def compute(v):
+            return cxm.norm(v, cxc.cart1d, at=at)
+
+        result = compute(u.Q(5, "m"))
+        assert qnp.allclose(result, u.Q(5, "m"), atol=u.Q(1e-5, "m"))
+
+
+# =============================================================================
+# AbstractMetric.norm() convenience wrapper
+# =============================================================================
+
+
+class TestNormMetricWrapper:
+    """Tests for metric.norm() convenience method."""
+
+    def test_euclidean_cdict_quantities(self):
+        metric = cxm.EuclideanMetric(3)
+        at = {"x": jnp.array(0), "y": jnp.array(0), "z": jnp.array(0)}
+        v = {"x": u.Q(3, "m/s"), "y": u.Q(4, "m/s"), "z": u.Q(0, "m/s")}
+        result = metric.norm(v, cxc.cart3d, at=at)
+        assert qnp.allclose(result, u.Q(5, "m/s"), atol=u.Q(1e-5, "m/s"))
+
+    def test_euclidean_bare_array_with_usys(self):
+        metric = cxm.EuclideanMetric(3)
+        at = {"x": jnp.array(0), "y": jnp.array(0), "z": jnp.array(0)}
+        result = metric.norm(
+            jnp.array([3, 4, 0]), cxc.cart3d, at=at, usys=u.unitsystems.si
+        )
+        assert jnp.allclose(result, 5)
+
+    def test_euclidean_bare_cdict_with_usys(self):
+        metric = cxm.EuclideanMetric(3)
+        at = {"x": jnp.array(0), "y": jnp.array(0), "z": jnp.array(0)}
+        v = {"x": jnp.array(3), "y": jnp.array(4), "z": jnp.array(0)}
+        result = metric.norm(v, cxc.cart3d, at=at, usys=u.unitsystems.si)
+        assert jnp.allclose(result, 5)
+
+    def test_agrees_with_functional_api(self):
+        """metric.norm(v, chart, at=at) == cxm.norm(v, metric, chart, at=at)."""
+        metric = cxm.EuclideanMetric(3)
+        at = {"x": jnp.array(0), "y": jnp.array(0), "z": jnp.array(0)}
+        v = {"x": u.Q(3, "m"), "y": u.Q(4, "m"), "z": u.Q(0, "m")}
+        result_wrapper = metric.norm(v, cxc.cart3d, at=at)
+        result_functional = cxm.norm(v, metric, cxc.cart3d, at=at)
+        assert qnp.allclose(result_wrapper, result_functional, atol=u.Q(1e-5, "m"))
+
+    def test_spherical_metric_wrapper_matches_direct(self):
+        """HyperSphericalMetric.norm matches cxm.norm at S² equator."""
+        metric = cxm.HyperSphericalMetric(ndim=2)
+        at = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0, "rad")}
+        v = {"theta": u.Q(1, "rad/s"), "phi": u.Q(0, "rad/s")}
+        result_wrapper = metric.norm(v, cxc.sph2, at=at)
+        result_direct = cxm.norm(v, metric, cxc.sph2, at=at)
+        assert qnp.allclose(result_wrapper, result_direct, atol=u.Q(1e-5, "rad/s"))
+
+
+# =============================================================================
+# AbstractManifold.norm() convenience wrapper
+# =============================================================================
+
+
+class TestNormManifoldWrapper:
+    """Tests for M.norm() convenience method."""
+
+    def test_euclidean_manifold_cdict_quantities(self):
+        M = cxm.EuclideanManifold(3)
+        chart = cxc.Cart3D(M=M)
+        at = {"x": jnp.array(0), "y": jnp.array(0), "z": jnp.array(0)}
+        v = {"x": u.Q(3, "m/s"), "y": u.Q(4, "m/s"), "z": u.Q(0, "m/s")}
+        result = M.norm(v, chart, at=at)
+        assert qnp.allclose(result, u.Q(5, "m/s"), atol=u.Q(1e-5, "m/s"))
+
+    def test_euclidean_manifold_bare_array_with_usys(self):
+        M = cxm.EuclideanManifold(3)
+        chart = cxc.Cart3D(M=M)
+        at = {"x": jnp.array(0), "y": jnp.array(0), "z": jnp.array(0)}
+        result = M.norm(jnp.array([3, 4, 0]), chart, at=at, usys=u.unitsystems.si)
+        assert jnp.allclose(result, 5)
+
+    def test_agrees_with_functional_api(self):
+        """M.norm(v, chart, at=at) == cxm.norm(v, M.metric, chart, at=at)."""
+        M = cxm.EuclideanManifold(3)
+        chart = cxc.Cart3D(M=M)
+        at = {"x": jnp.array(0), "y": jnp.array(0), "z": jnp.array(0)}
+        v = {"x": u.Q(1, "m"), "y": u.Q(1, "m"), "z": u.Q(1, "m")}
+        result_wrapper = M.norm(v, chart, at=at)
+        result_functional = cxm.norm(v, M.metric, chart, at=at)
+        assert qnp.allclose(result_wrapper, result_functional, atol=u.Q(1e-5, "m"))
+
+    def test_hyperspherical_manifold_predefined_chart(self):
+        """cxc.sph2.M.norm uses the manifold attached to the predefined chart."""
+        M = cxc.sph2.M  # HyperSphericalManifold(2)
+        at = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0, "rad")}
+        v = {"theta": u.Q(1, "rad/s"), "phi": u.Q(0, "rad/s")}
+        result = M.norm(v, cxc.sph2, at=at)
+        assert qnp.allclose(result, u.Q(1, "rad/s"), atol=u.Q(1e-5, "rad/s"))
+
+
+# =============================================================================
+# cxm.norm() on the full spherical 3D chart (mixed units)
+# =============================================================================
+
+
+class TestNormSph3D:
+    """Tests for cxm.norm() on sph3d (r, theta, phi) with mixed-unit vectors."""
+
+    def setup_method(self):
+        self.at = {
+            "r": u.Q(5, "m"),
+            "theta": u.Q(jnp.pi / 2, "rad"),
+            "phi": u.Q(0, "rad"),
+        }
+
+    def test_purely_radial_norm_equals_vr(self):
+        """Pure radial velocity: norm = |vr|, independent of position."""
+        v = {"r": u.Q(1, "m/s"), "theta": u.Q(0, "rad/s"), "phi": u.Q(0, "rad/s")}
+        result = cxm.norm(v, cxc.sph3d, at=self.at)
+        assert qnp.allclose(result, u.Q(1, "m/s"), atol=u.Q(1e-5, "m/s"))
+
+    def test_purely_theta_at_equator(self):
+        """Pure theta velocity at equator: norm = r * |vθ| = 5 m * 1 rad/s = 5 m/s."""
+        v = {"r": u.Q(0, "m/s"), "theta": u.Q(1, "rad/s"), "phi": u.Q(0, "rad/s")}
+        result = cxm.norm(v, cxc.sph3d, at=self.at)
+        # g_θθ = r² = 25 m² → norm = sqrt(25 m² * 1 rad²/s²) = 5 m/s
+        assert qnp.allclose(result, u.Q(5, "m/s"), atol=u.Q(1e-5, "m/s"))
+
+    def test_purely_phi_at_equator(self):
+        """Pure phi velocity at equator (sin θ = 1): norm = r * |vφ| = 5 m/s."""
+        v = {"r": u.Q(0, "m/s"), "theta": u.Q(0, "rad/s"), "phi": u.Q(1, "rad/s")}
+        result = cxm.norm(v, cxc.sph3d, at=self.at)
+        # g_φφ = r²sin²θ = 25 m² → norm = 5 m/s
+        assert qnp.allclose(result, u.Q(5, "m/s"), atol=u.Q(1e-5, "m/s"))
+
+    def test_zero_vector(self):
+        v = {"r": u.Q(0, "m/s"), "theta": u.Q(0, "rad/s"), "phi": u.Q(0, "rad/s")}
+        result = cxm.norm(v, cxc.sph3d, at=self.at)
+        assert qnp.allclose(result, u.Q(0, "m/s"), atol=u.Q(1e-5, "m/s"))
+
+    def test_returns_quantity(self):
+        v = {"r": u.Q(1, "m/s"), "theta": u.Q(0, "rad/s"), "phi": u.Q(0, "rad/s")}
+        result = cxm.norm(v, cxc.sph3d, at=self.at)
+        assert isinstance(result, u.AbstractQuantity)
+
+    def test_jit(self):
+        @jax.jit
+        def compute(v, at):
+            return cxm.norm(v, cxc.sph3d, at=at)
+
+        v = {"r": u.Q(1, "m/s"), "theta": u.Q(0, "rad/s"), "phi": u.Q(0, "rad/s")}
+        result = compute(v, self.at)
+        assert qnp.allclose(result, u.Q(1, "m/s"), atol=u.Q(1e-5, "m/s"))
+
+    def test_vmap_over_base_points(self):
+        """Vmap over r: purely radial norm equals |vr| regardless of r."""
+        at_batch = {
+            "r": u.Q(jnp.array([1, 5, 10]), "m"),
+            "theta": u.Q(jnp.full(3, jnp.pi / 2), "rad"),
+            "phi": u.Q(jnp.zeros(3), "rad"),
+        }
+        v = {
+            "r": u.Q(jnp.ones(3), "m/s"),
+            "theta": u.Q(jnp.zeros(3), "rad/s"),
+            "phi": u.Q(jnp.zeros(3), "rad/s"),
+        }
+        result = jax.vmap(lambda v, at: cxm.norm(v, cxc.sph3d, at=at))(v, at_batch)
+        assert qnp.allclose(result, u.Q(jnp.ones(3), "m/s"), atol=u.Q(1e-5, "m/s"))
+
+
+# =============================================================================
+# Low-level (metric_matrix, v) dispatch
+# =============================================================================
+
+
+class TestNormLowLevel:
+    """Tests for cxm.norm() with a precomputed metric matrix."""
+
+    def test_identity_matrix_bare_array(self):
+        G = jnp.eye(3)
+        v = jnp.array([3, 4, 0])
+        result = cxm.norm(G, v)
+        assert jnp.allclose(result, 5)
+
+    def test_identity_matrix_quantity(self):
+        G = jnp.eye(3)
+        v = u.Q(jnp.array([3, 4, 0]), "m/s")
+        result = cxm.norm(G, v)
+        assert qnp.allclose(result, u.Q(5, "m/s"), atol=u.Q(1e-5, "m/s"))
+
+    def test_identity_matrix_cdict_quantities(self):
+        G = jnp.eye(3)
+        v = {"x": u.Q(3, "m"), "y": u.Q(4, "m"), "z": u.Q(0, "m")}
+        result = cxm.norm(G, v)
+        assert qnp.allclose(result, u.Q(5, "m"), atol=u.Q(1e-5, "m"))
+
+    def test_identity_matrix_cdict_bare(self):
+        G = jnp.eye(3)
+        v = {"x": jnp.array(3), "y": jnp.array(4), "z": jnp.array(0)}
+        result = cxm.norm(G, v)
+        assert jnp.allclose(result, 5)
+
+    def test_scaled_metric(self):
+        """G = 4·I → norm = 2 · euclidean_norm."""
+        G = 4 * jnp.eye(3)
+        v = jnp.array([1, 0, 0])
+        result = cxm.norm(G, v)
+        assert jnp.allclose(result, 2)
+
+    def test_returns_bare_array_for_bare_v(self):
+        G = jnp.eye(2)
+        v = jnp.array([1, 0])
+        result = cxm.norm(G, v)
+        assert not isinstance(result, u.AbstractQuantity)
+
+    def test_returns_quantity_for_quantity_v(self):
+        G = jnp.eye(2)
+        v = u.Q(jnp.array([1, 0]), "m")
+        result = cxm.norm(G, v)
+        assert isinstance(result, u.AbstractQuantity)
+
+
+# =============================================================================
+# Error conditions
+# =============================================================================
+
+
+class TestNormErrors:
+    """Tests that norm() raises on invalid inputs."""
+
+    def test_bare_array_on_curved_chart_no_usys(self):
+        """Bare Array on a non-Cartesian chart requires usys."""
+        at = {"theta": jnp.array(jnp.pi / 2), "phi": jnp.array(0)}
+        with pytest.raises(TypeError, match="usys"):
+            cxm.norm(jnp.array([1, 0]), cxc.sph2, at=at)
+
+    def test_bare_cdict_on_curved_chart_no_usys(self):
+        """CDict of bare arrays on a non-Cartesian chart requires usys."""
+        v = {"theta": jnp.array(1), "phi": jnp.array(0)}
+        at = {"theta": jnp.array(jnp.pi / 2), "phi": jnp.array(0)}
+        with pytest.raises(TypeError, match="usys"):
+            cxm.norm(v, cxc.sph2, at=at)
+
+    def test_metric_mismatch_raises_value_error(self):
+        """Passing a metric that doesn't belong to the chart raises ValueError."""
+        wrong_metric = cxm.EuclideanMetric(3)  # sph2 uses HyperSphericalMetric(ndim=2)
+        at = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0, "rad")}
+        v = {"theta": u.Q(1, "rad/s"), "phi": u.Q(0, "rad/s")}
+        with pytest.raises(ValueError, match=r"[Mm]etric"):
+            cxm.norm(v, wrong_metric, cxc.sph2, at=at)
+
+
+# =============================================================================
+# JAX transformations on curved (spherical) manifolds
+# =============================================================================
+
+
+class TestNormJAXCompatSphere:
+    """JIT and vmap for norm() on the HyperSphericalMetric."""
+
+    def test_jit_sph2_cdict_quantities(self):
+        metric = cxm.HyperSphericalMetric(ndim=2)
+        p = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0, "rad")}
+
+        @jax.jit
+        def compute(v, at):
+            return cxm.norm(v, metric, cxc.sph2, at=at)
+
+        v = {"theta": u.Q(1, "rad/s"), "phi": u.Q(0, "rad/s")}
+        result = compute(v, p)
+        assert qnp.allclose(result, u.Q(1, "rad/s"), atol=u.Q(1e-5, "rad/s"))
+
+    def test_vmap_over_base_point_phi_norm_equals_sin_theta(self):
+        """Norm of unit phi-velocity = sin(theta) on S²."""
+        metric = cxm.HyperSphericalMetric(ndim=2)
+        v = {"theta": u.Q(0, "rad/s"), "phi": u.Q(1, "rad/s")}
+        thetas = jnp.array([jnp.pi / 6, jnp.pi / 4, jnp.pi / 2])
+        expected = jnp.sin(thetas)  # g_φφ = sin²θ → norm = |sinθ|
+
+        def at_theta(theta):
+            return {"theta": u.Angle(theta, "rad"), "phi": u.Angle(0, "rad")}
+
+        results = jax.vmap(lambda t: cxm.norm(v, metric, cxc.sph2, at=at_theta(t)))(
+            thetas
+        )
+        assert qnp.allclose(results, u.Q(expected, "rad/s"), atol=u.Q(1e-5, "rad/s"))
+
+    def test_vmap_over_vectors_at_fixed_point(self):
+        """Norm scales linearly with vector magnitude."""
+        metric = cxm.HyperSphericalMetric(ndim=2)
+        at = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0, "rad")}
+        magnitudes = jnp.array([1, 2, 3])
+        v_batch = {
+            "theta": u.Q(magnitudes, "rad/s"),
+            "phi": u.Q(jnp.zeros(3), "rad/s"),
+        }
+        results = jax.vmap(lambda v: cxm.norm(v, metric, cxc.sph2, at=at))(v_batch)
+        assert qnp.allclose(results, u.Q(magnitudes, "rad/s"), atol=u.Q(1e-5, "rad/s"))
+
+    def test_position_dependence_for_curved_metric(self):
+        """Norm of phi-velocity differs at different latitudes on S²."""
+        metric = cxm.HyperSphericalMetric(ndim=2)
+        v = {"theta": u.Q(0, "rad/s"), "phi": u.Q(1, "rad/s")}
+        at_equator = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0, "rad")}
+        at_30deg = {"theta": u.Angle(jnp.pi / 6, "rad"), "phi": u.Angle(0, "rad")}
+
+        norm_eq = cxm.norm(v, metric, cxc.sph2, at=at_equator)
+        norm_30 = cxm.norm(v, metric, cxc.sph2, at=at_30deg)
+
+        # sin(π/2) = 1 > sin(π/6) = 0.5
+        assert u.ustrip("rad/s", norm_eq) > u.ustrip("rad/s", norm_30)


### PR DESCRIPTION
## Summary

Adds a dispatched **`norm`** API to `coordinax.manifolds` for computing the Riemannian norm of a tangent vector,

$$\|v\|_g = \sqrt{g_p(v, v)},$$

with respect to a metric/chart, evaluated at a base point `p`. Works across Euclidean and curved (e.g. spherical) charts, supports mixed-unit components via `QMatrix` arithmetic, and is `jit`/`vmap`-compatible.

## API

Functional forms (dispatch on `type(v)` and on whether the metric is implicit via a chart or explicit):

```python
cxm.norm(v, chart, /, *, at=None, usys=None)          # chart-level: uses chart.M.metric
cxm.norm(v, metric, chart, /, *, at=None, usys=None)  # metric-level: explicit metric
cxm.norm(G, v)                                        # low-level: precomputed metric matrix
```

Convenience wrappers:

```python
metric.norm(v, chart, at=at, usys=usys)
manifold.norm(v, chart, at=at, usys=usys)
```

`v` may be a `CDict` of `Quantity` values (units carried, `usys` optional), a `CDict` of bare arrays (`usys` required), a packed `jax.Array` (`usys` required), or a single `Quantity` (1-D charts). `at` is optional for flat Euclidean Cartesian fast paths and required for curved metrics.

## Implementation notes

- Built on the standalone `cxmapi.metric_matrix(M, point, chart)` dispatch API, which returns a typed `AbstractMetricMatrix` (`DiagonalMetric`/`DenseMetric`); contraction mirrors the sibling `angle_between`, so mixed-unit components (e.g. `m/s` with `rad/s` on `sph3d`) are handled correctly.
- Euclidean Cartesian fast path short-circuits to `jnp.linalg.norm` (dispatched on `FlatMetric` + `Cart*` charts).
- Mixed `CDict`s (some `Quantity`, some bare) raise a clear `TypeError`; bare inputs without `usys` raise `TypeError`; metric/chart mismatch raises `ValueError`.

## Tests & docs

- New `tests/unit/manifolds/test_norm.py` covering Euclidean & spherical cases, the low-level matrix overload, bare/quantity/single-quantity inputs, error conditions, and `jit`/`vmap`.
- `docs/spec.md` normative `norm` section (dispatch table + call forms), user guide section in `docs/guides/manifolds.md`, and functional-API entry in `docs/api/manifolds.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)