### PR TITLE
✨ feat(vectors): add Tangent and Coordinate vector bundle types

### DIFF
--- a/docs/api/vectors.md
+++ b/docs/api/vectors.md
@@ -13,21 +13,30 @@ For design philosophy, practical patterns, and worked examples, see [Working Wit
 ```python
 import coordinax.main as cx
 import coordinax.charts as cxc
+import coordinax.representations as cxr
+import unxt as u
 
-# Construct and convert
-v = cx.Point.from_([1, 2, 3], "m")
-v_sph = cx.cconvert(v, cxc.sph3d)
+# ── Point ──────────────────────────────────────────────────
+p = cx.Point.from_([1, 2, 3], "m")
+p_sph = cx.cconvert(p, cxc.sph3d)
 
-# Arithmetic. Technically points are NOT displacements,
-# but for convenience we allow subtraction to yield a new point.
-v2 = cx.Point.from_([4, 5, 6], "m")
-difference = v - v2
+# ── Tangent ────────────────────────────────────────────────
+# A velocity vector — transforms by Jacobian pushforward
+v = cx.Tangent.from_(
+    {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+    cxc.cart3d,
+    cxr.coord_vel,
+)
+# Convert a Tangent — must supply the base Point via `at=`
+v_sph = v.cconvert(cxc.sph3d, at=p)
 
-# Inspect converted components
-components = cx.cdict(v_sph)
+# ── Coordinate ─────────────────────────────────────────────
+# Bundle: base Point + named Tangent fibre fields
+pv = cx.Coordinate(point=p, velocity=v)
+pv_sph = pv.cconvert(cxc.sph3d)  # converts point AND velocity together
 ```
 
-See [Working With Vectors](../guides/vectors.md#constructor-patterns) for all construction patterns and design rationale.
+See [Working With Vectors](../guides/vectors.md) and [Working With Tangent Vectors](../guides/tangents.md) for all construction patterns and design rationale.
 
 ## Functional API
 
@@ -60,14 +69,15 @@ Additional utilities:
 
 ## Available Objects
 
-- **`Point`**: the primary vector class storing data + chart + representation
+- **`Point`**: a geometric point storing data + chart + representation (always `PointGeometry`)
+- **`Tangent`**: a tangent-space vector with explicit basis and semantic kind (velocity, displacement, acceleration)
+- **`Coordinate`**: a vector bundle — a `Point` paired with named `Tangent` fibre fields anchored at that point
 - **`AbstractVector`**: base class defining the vector interface
-- **`Coordinate`**: a vector placed in a reference frame (see `coordinax.frames`)
 - **`ToUnitsOptions`**: configuration for unit conversion behavior
 
 ## Design & Integration
 
-For design philosophy, architecture, and immutability details, see [Working With Vectors](../guides/vectors.md#architecture--design-philosophy). For JAX integration patterns (PyTree, scalar-first design, vmap/jit/grad), see [Working With Vectors](../guides/vectors.md#jax-integration--scaling).
+For design philosophy, architecture, and immutability details, see [Working With Vectors](../guides/vectors.md#architecture--design-philosophy). For tangent-vector patterns (basis, semantic kind, Jacobian pushforward), see [Working With Tangent Vectors](../guides/tangents.md). For JAX integration patterns (PyTree, scalar-first design, vmap/jit/grad), see [Working With Vectors](../guides/vectors.md#jax-integration--scaling).
 
 ```{automodule} coordinax.vectors
 :members:

--- a/docs/guides/representations.md
+++ b/docs/guides/representations.md
@@ -27,7 +27,7 @@ A representation is a triple $R = (K, B, S)$:
 
 >>> rep = cxr.Representation(cxr.PointGeometry(), cxr.NoBasis(), cxr.Location())
 >>> rep
-Representation(geom_kind=PointGeometry(), basis=NoBasis(), semantic_kind=Location())
+point
 
 >>> rep == cxr.point
 True

--- a/docs/guides/tangents.md
+++ b/docs/guides/tangents.md
@@ -171,7 +171,9 @@ Converting a `Tangent` to a new chart requires knowing the **base point** at whi
 >>> # Convert to physical basis (all components in m/s)
 >>> vel_sph_phys = cxr.change_basis(vel_sph_coord, cxr.phys_basis, at=point_sph)
 >>> print(vel_sph_phys.rep)  # phys_vel
-Representation(geom_kind=TangentGeometry(), basis=PhysicalBasis(), semantic_kind=Velocity())
+Representation(
+    geom_kind=TangentGeometry(), basis=PhysicalBasis(), semantic_kind=Velocity()
+)
 ```
 
 ## Promoting a Point to a Displacement
@@ -195,7 +197,9 @@ You can also request the physical basis directly:
 ```{code-block} python
 >>> disp_phys = cxr.change_basis(pt, cxr.phys_basis)
 >>> print(disp_phys.rep)   # phys_disp
-Representation(geom_kind=TangentGeometry(), basis=PhysicalBasis(), semantic_kind=Displacement())
+Representation(
+    geom_kind=TangentGeometry(), basis=PhysicalBasis(), semantic_kind=Displacement()
+)
 ```
 
 The `at` and `usys` keyword arguments are accepted for API consistency but have no effect (no numerical transformation is performed).

--- a/docs/guides/tangents.md
+++ b/docs/guides/tangents.md
@@ -1,0 +1,250 @@
+# Working With Tangent Vectors
+
+This guide explains `Tangent` — coordinax's type for **tangent-space quantities** (velocities, displacements, accelerations). For bundling a `Tangent` with a base `Point`, see the [Coordinate guide](./vectors.md) and the [Coordinate tutorial](../tutorials/coordinate_objects.md). For API reference see [the vector module reference](../api/vectors.md).
+
+## Why Tangent Vectors?
+
+Points and tangent vectors look similar — both are dictionaries of components attached to a chart — but they **transform differently** when you change coordinate system:
+
+- **Point** `(r, θ, φ)`: transforms by the chart transition map $\varphi' \circ \varphi^{-1}$.
+- **Tangent** `(ṙ, θ̇, φ̇)`: transforms by the **Jacobian** $J^j{}_i = \partial \tilde{q}^j / \partial q^i$ evaluated at the base point.
+
+Getting this wrong produces incorrect physical results. `Tangent` encodes the correct transformation law, so `cconvert` always does the right thing automatically.
+
+Additionally, tangent vectors carry two extra pieces of metadata:
+
+- **basis**: are the components expressed in the _coordinate basis_ ($\partial/\partial q^i$) or the _physical (orthonormal) basis_ ($\hat{e}_i$)?
+- **semantic**: what physical quantity do the components represent — `vel` (velocity), `dpl` (displacement), or `acc` (acceleration)?
+
+## Basis And Semantic Kind
+
+### Basis
+
+| Object | Singleton | Meaning |
+| --- | --- | --- |
+| `CoordinateBasis` | `cxr.coord_basis` | components in coordinate (tangent) basis |
+| `PhysicalBasis` | `cxr.phys_basis` | components in orthonormal physical frame |
+
+For **Cartesian charts** these are identical. For **spherical/cylindrical** charts the coordinate basis has components with units like `m/s`, `rad/s`, `rad/s`, while the physical basis has all components in `m/s` (scaled by the metric's scale factors).
+
+### Semantic Kind
+
+| Object         | Singleton | Physical meaning                  |
+| -------------- | --------- | --------------------------------- |
+| `Displacement` | `cxr.dpl` | position displacement $\Delta q$  |
+| `Velocity`     | `cxr.vel` | time derivative $\dot{q}$         |
+| `Acceleration` | `cxr.acc` | second time derivative $\ddot{q}$ |
+
+### Pre-Built Representations
+
+The most common combinations are available as ready-made singletons:
+
+| Name             | `geom_kind`       | `basis`       | `semantic` |
+| ---------------- | ----------------- | ------------- | ---------- |
+| `cxr.coord_disp` | `TangentGeometry` | `coord_basis` | `dpl`      |
+| `cxr.coord_vel`  | `TangentGeometry` | `coord_basis` | `vel`      |
+| `cxr.coord_acc`  | `TangentGeometry` | `coord_basis` | `acc`      |
+| `cxr.phys_disp`  | `TangentGeometry` | `phys_basis`  | `dpl`      |
+| `cxr.phys_vel`   | `TangentGeometry` | `phys_basis`  | `vel`      |
+| `cxr.phys_acc`   | `TangentGeometry` | `phys_basis`  | `acc`      |
+
+## Constructing Tangent Vectors
+
+::::{tab-set}
+
+:::{tab-item} Dict + rep (most explicit)
+
+Name every component and supply the representation directly:
+
+```{code-block} python
+>>> import coordinax.main as cx
+>>> import coordinax.charts as cxc
+>>> import coordinax.representations as cxr
+>>> import unxt as u
+
+>>> vel = cx.Tangent.from_(
+...    {"x": u.Q(1, "m/s"), "y": u.Q(2, "m/s"), "z": u.Q(3, "m/s")},
+...    cxc.cart3d, cxr.coord_vel)
+>>> print(vel)
+<Tangent: chart=Cart3D (x, y, z) [m / s]
+    [1 2 3]>
+```
+
+:::
+
+:::{tab-item} Dict + basis + semantic
+
+Specify basis and semantic separately (equivalent to the above):
+
+```{code-block} python
+>>> vel = cx.Tangent.from_(
+...    {"x": u.Q(1, "m/s"), "y": u.Q(2, "m/s"), "z": u.Q(3, "m/s")},
+...    cxc.cart3d, cxr.coord_basis, cxr.vel)
+>>> print(vel)
+<Tangent: chart=Cart3D (x, y, z) [m / s]
+    [1 2 3]>
+```
+
+:::
+
+:::{tab-item} Array + unit
+
+Chart is inferred from the array length (3 → `cart3d`):
+
+```{code-block} python
+>>> vel = cx.Tangent.from_([1, 2, 3], "m/s")
+>>> print(vel.chart)  # Cart3D(M=Rn(3))
+Cart3D[('x', 'y', 'z'), ('length', 'length', 'length')](M=Rn(3))
+```
+
+:::
+
+:::{tab-item} Passthrough
+
+Passing an existing `Tangent` returns it unchanged:
+
+```{code-block} python
+>>> vel2 = cx.Tangent.from_(vel)
+>>> assert vel2 is vel
+```
+
+:::
+
+::::
+
+## Accessing Data
+
+```{code-block} python
+>>> vel = cx.Tangent.from_(
+...    {"x": u.Q(1, "m/s"), "y": u.Q(2, "m/s"), "z": u.Q(3, "m/s")},
+...    cxc.cart3d, cxr.coord_vel)
+
+>>> # Component access by name
+>>> print(vel["x"])  # Q(1., 'm / s')
+Q['speed'](Array(1, dtype=int64, weak_type=True), unit='m / s')
+
+# Metadata
+>>> print(vel.chart)  # Cart3D(M=Rn(3))
+Cart3D[('x', 'y', 'z'), ('length', 'length', 'length')](M=Rn(3))
+
+>>> print(vel.rep)  # coord_vel
+Representation(geom_kind=TangentGeometry(), basis=CoordinateBasis(), semantic_kind=Velocity())
+
+>>> print(vel.basis)  # coord_basis
+CoordinateBasis()
+
+>>> print(vel.semantic)  # vel
+Velocity()
+
+>>> print(vel.frame)  # NoFrame()
+NoFrame()
+```
+
+## Chart Conversion (Jacobian Pushforward)
+
+Converting a `Tangent` to a new chart requires knowing the **base point** at which the Jacobian is evaluated. Pass it via the `at=` argument:
+
+```{code-block} python
+>>> point = cx.Point.from_([1, 0, 0], "m") # Base point in Cartesian
+>>> vel_cart = cx.Tangent.from_(
+...     {"x": u.Q(1, "m/s"), "y": u.Q(0, "m/s"), "z": u.Q(0, "m/s")},
+...     cxc.cart3d, cxr.coord_vel)
+
+>>> # Convert to spherical — Jacobian is evaluated at `point`
+>>> vel_sph = vel_cart.cconvert(cxc.sph3d, at=point)
+>>> print(vel_sph)
+<Tangent: chart=Spherical3D (r[m / s], theta[rad / s], phi[rad / s])
+    [ 1. -0.  0.]>
+```
+
+**Key point**: the `at=` base point must be in the **same chart** as the tangent vector. To convert a point and its tangent field together in one call, bundle them into a `Coordinate` — see the [Coordinate tutorial](../tutorials/coordinate_objects.md).
+
+## Changing Basis
+
+`change_basis` converts between coordinate and physical bases for `Tangent` objects directly. Pass the tangent vector, the target basis, and the base `Point` at which scale factors are evaluated:
+
+```{code-block} python
+>>> # Velocity in coordinate basis at a spherical point
+>>> point_sph = cx.Point.from_(
+...     {"r": u.Q(1, "m"), "theta": u.Q(0.5, "rad"), "phi": u.Q(0, "rad")}, cxc.sph3d
+... )
+>>> vel_sph_coord = cx.Tangent.from_(
+...     {"r": u.Q(1, "m/s"), "theta": u.Q(0, "rad/s"), "phi": u.Q(0, "rad/s")},
+...     cxc.sph3d, cxr.coord_vel)
+>>> # Convert to physical basis (all components in m/s)
+>>> vel_sph_phys = cxr.change_basis(vel_sph_coord, cxr.phys_basis, at=point_sph)
+>>> print(vel_sph_phys.rep)  # phys_vel
+Representation(geom_kind=TangentGeometry(), basis=PhysicalBasis(), semantic_kind=Velocity())
+```
+
+## Promoting a Point to a Displacement
+
+`change_basis` has a second role: it can **promote a `Point` to a `Tangent` with `Displacement` semantics**. This is useful when you have a position vector that you want to reinterpret as a tangent-space displacement — for example, when computing offsets or feeding a position into an operation that expects a displacement.
+
+The component data is unchanged; only the geometric interpretation is recast from a manifold point (`PointGeometry`) to a tangent-space displacement (`TangentGeometry`, `Displacement`).
+
+```{code-block} python
+>>> pt = cx.Point.from_([1, 2, 3], "m")
+
+>>> # Promote to a coordinate-basis displacement
+>>> disp = cxr.change_basis(pt, cxr.coord_basis)
+>>> print(disp)
+<Tangent: chart=Cart3D (x, y, z) [m]
+    [1 2 3]>
+```
+
+You can also request the physical basis directly:
+
+```{code-block} python
+>>> disp_phys = cxr.change_basis(pt, cxr.phys_basis)
+>>> print(disp_phys.rep)   # phys_disp
+Representation(geom_kind=TangentGeometry(), basis=PhysicalBasis(), semantic_kind=Displacement())
+```
+
+The `at` and `usys` keyword arguments are accepted for API consistency but have no effect (no numerical transformation is performed).
+
+### JIT
+
+```{code-block} python
+>>> import jax
+>>> point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+>>> vel = cx.Tangent.from_(
+...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+...     cxc.cart3d, cxr.coord_vel)
+
+>>> convert_vel = jax.jit(lambda v, p: cx.cconvert(v, cxc.sph3d, at=p))
+>>> vel_sph = convert_vel(vel, point)
+>>> print(vel_sph.chart)  # Spherical3D(M=Rn(3))
+Spherical3D[('r', 'theta', 'phi'), ('length', 'angle', 'angle')](M=Rn(3))
+```
+
+### vmap
+
+Use scalar-first design and batch with `vmap`:
+
+```{code-block} python
+>>> import jax.numpy as jnp
+
+>>> # Build a batched Tangent by stacking scalar values per component
+>>> batch_vel = cx.Tangent(
+...     { "x": u.Q(jnp.array([1, 2, 3]), "m/s"),
+...       "y": u.Q(jnp.zeros(3), "m/s"), "z": u.Q(jnp.zeros(3), "m/s") },
+...     cxc.cart3d, cxr.coord_basis, cxr.vel)
+>>> batch_point = cx.Point(
+...     { "x": u.Q(jnp.ones(3), "m"), "y": u.Q(jnp.zeros(3), "m"),
+...       "z": u.Q(jnp.zeros(3), "m") }, cxc.cart3d)
+
+>>> vec_fn = jax.vmap(lambda v, p: cx.cconvert(v, cxc.sph3d, at=p))
+>>> vels_sph = vec_fn(batch_vel, batch_point)
+>>> print(vels_sph.data)  # Spherical3D(M=Rn(3))
+{'phi': Q([0., 0., 0.], 'rad / s'), 'r': Q([1., 2., 3.], 'm / s'), 'theta': Q([-0., -0., -0.], 'rad / s')}
+```
+
+## When To Use Tangent
+
+| You have | Use |
+| --- | --- |
+| Position only | `Point` — see [Point tutorial](../tutorials/point_objects.md) |
+| Velocity / displacement / acceleration only | `Tangent` (this guide) |
+| Position + tangent field(s) | `Coordinate` — see [Coordinate tutorial](../tutorials/coordinate_objects.md) |
+| Position to reinterpret as a displacement | `change_basis(pt, cxr.coord_basis)` → `Tangent[Displacement]` |

--- a/docs/guides/tangents.md
+++ b/docs/guides/tangents.md
@@ -127,9 +127,6 @@ Q['speed'](Array(1, dtype=int64, weak_type=True), unit='m / s')
 >>> print(vel.chart)  # Cart3D(M=Rn(3))
 Cart3D[('x', 'y', 'z'), ('length', 'length', 'length')](M=Rn(3))
 
->>> print(vel.rep)  # coord_vel
-Representation(geom_kind=TangentGeometry(), basis=CoordinateBasis(), semantic_kind=Velocity())
-
 >>> print(vel.basis)  # coord_basis
 CoordinateBasis()
 

--- a/docs/guides/vectors.md
+++ b/docs/guides/vectors.md
@@ -4,566 +4,204 @@ This guide provides a conceptual introduction to coordinax vectors and practical
 
 ## Motivation: Why A Separate Vector Class?
 
-In pure NumPy or JAX, coordinate data is just arrays. But astronomy and geometry demand more:
+In pure NumPy or JAX, coordinate data is just arrays. But geometry demands more:
 
 1. **Coordinate systems vary**: the same point is `(x, y, z)` in Cartesian but `(r, θ, φ)` in spherical. Which is it?
 2. **Units matter**: is `1.0` in meters, parsecs, or degrees? Silent unit confusion causes disasters.
-3. **Transformation laws differ**: point coordinates change by the chart transition; vector fields transform by the Jacobian. These rules cannot be implicit.
+3. **Transformation laws differ**: point coordinates change by the chart transition; velocity fields transform by the Jacobian. These rules cannot be implicit.
 4. **Type safety**: mixing spherical and Cartesian accidentally should be impossible, not silently wrong.
 
-Coordinax `Point` solves this by **making all three explicit**: chart (system), data (values), and representation (meaning).
+Coordinax solves this by attaching **chart** (coordinate system), **data** (component values), and **representation** (transformation law) to every vector, so every number carries its full mathematical context.
 
-## From Charts to Vectors
+## The Four Concepts
 
-If you have not yet read [Working With Charts](./charts.md), do so first. Charts define coordinate systems; vectors express data in those systems.
+| Concept | Type | What it is |
+| --- | --- | --- |
+| Chart | `AbstractChart` | coordinate system — defines component names and their dimensions |
+| Point | `Point` | position in a chart, with an optional reference frame |
+| Tangent | `Tangent` | tangent-space quantity (velocity, displacement, acceleration) at a base point |
+| Coordinate | `Coordinate` | bundle of a `Point` with named `Tangent` fibre fields |
 
-**Chart's job**: define component names and their physical dimensions.
+A **reference frame** (e.g., `Alice()`, `Alex()`) records the observer perspective. A `Point` without a frame defaults to `NoFrame()`.
 
-```python
-import coordinax.charts as cxc
+## From Charts to Points
 
-cart = cxc.cart3d  # Components: x, y, z (all length)
-sph = cxc.sph3d  # Components: r (length), theta (angle), phi (angle)
-```
-
-**Point's job**: store data _in a specific chart_ with an explicit transformation law.
+If you have not yet read [Working With Charts](./charts.md), do so first. Charts define coordinate systems; `Point` expresses data in those systems.
 
 ```python
 import coordinax.main as cx
+import coordinax.charts as cxc
 import unxt as u
 
-# A point in Cartesian space
-p_cart = cx.Point.from_(
-    {"x": u.Q(1, "m"), "y": u.Q(2, "m"), "z": u.Q(3, "m")}, cxc.cart3d, cx.point
+# Infer chart from array length (3 → cart3d)
+p = cx.Point.from_([1, 2, 3], "m")
+
+# Explicit: named components + chart
+p_sph = cx.Point.from_(
+    {"r": u.Q(1, "m"), "theta": u.Q(0.5, "rad"), "phi": u.Q(1.0, "rad")},
+    cxc.sph3d,
 )
 
-# Same point in spherical (after transformation)
-p_sph = cx.cconvert(p_cart, cxc.sph3d)
-print(p_sph.data)  # {"r": ..., "theta": ..., "phi": ...}
+# Chart is always accessible
+print(p.chart)  # Cart3D(M=Rn(3))
+print(p_sph.chart)  # Spherical3D(M=Rn(3))
 ```
 
-The chart and representation together ensure that:
+Shape inference for `from_([...], unit)`:
 
-- You know what the numbers mean
-- Transformations apply the correct mathematical laws
-- Mixing incompatible data is impossible
+| Array length | Inferred chart |
+| ------------ | -------------- |
+| 3            | `cart3d`       |
+| 2            | `cart2d`       |
+| 1            | `cart1d`       |
 
-## Constructor Patterns
+For a full walkthrough of all construction patterns, see the [Point & Coordinate tutorial](../tutorials/coordinate_objects.md).
 
-Vectors support flexible construction via `from_()`:
+## Converting Charts
 
-### 1. From Array + Unit (Simplest)
-
-```python
-import coordinax.main as cx
-
-# Shape infers chart (3 → cart3d, 2 → cart2d, etc.)
-v = cx.Point.from_([1, 2, 3], "m")
-```
-
-The chart is inferred from the array shape:
-
-- Shape `(3,)` → `cart3d`
-- Shape `(2,)` → `cart2d`
-- Shape `(1,)` → `cart1d`
-- Shape `()` → `cart0d`
-
-### 2. With Explicit Chart
+Use `cconvert()` to change the coordinate system. The geometric point is preserved; only the chart and component values change:
 
 ```python
-import coordinax.charts as cxc
-
-# Override inferred chart
-v = cx.Point.from_([1, 2, 3], "m", cxc.sph3d)
-```
-
-### 3. From Quantity
-
-```python
-import unxt as u
-
-# Quantity already has units
-q = u.Q([1, 2, 3], "m")
-v = cx.Point.from_(q)
-```
-
-### 4. From Component Dictionary
-
-```python
-import coordinax.charts as cxc
-import unxt as u
-
-# Most explicit: name each component
-v = cx.Point.from_({"x": u.Q(1, "m"), "y": u.Q(2, "m"), "z": u.Q(3, "m")}, cxc.cart3d)
-```
-
-This is the **most defensive** pattern: each component is named and units are explicit.
-
-### 5. Passthrough (Already a Point)
-
-```python
-v1 = cx.Point.from_([1, 2, 3], "m")
-v2 = cx.Point.from_(v1)  # Returns v1 unchanged
-```
-
-## Coordinate Transformations
-
-Use `cconvert()` to change coordinate systems while preserving the geometric point:
-
-```python
-import coordinax.main as cx
-import coordinax.charts as cxc
-import unxt as u
-
-# Start in Cartesian
 v_cart = cx.Point.from_([1, 2, 3], "m")
+v_sph = cx.cconvert(v_cart, cxc.sph3d)  # or v_cart.cconvert(cxc.sph3d)
 
-# Convert to spherical
-v_sph = cx.cconvert(v_cart, cxc.sph3d)
+print(v_sph.chart)  # Spherical3D(M=Rn(3))
 
-# Data is now in spherical coordinates
-print(v_sph.data)
-# {"r": Array(...), "theta": Array(...), "phi": Array(...)}
-
-# And back
-v_cart_again = cx.cconvert(v_sph, cxc.cart3d)
+# Round-trip
+v_back = cx.cconvert(v_sph, cxc.cart3d)
+print(v_back.chart)  # Cart3D(M=Rn(3))
 ```
 
-**Key point**: `cconvert` preserves the geometric meaning (same point), not the numbers. The chart _changes_; the point _stays_.
+## Converting Reference Frames
 
-## Unit Conversion
-
-Separate from chart conversion is unit conversion:
+Use `to_frame()` to change the observer. The chart is preserved; the component values are transformed into the new frame:
 
 ```python
-import coordinax.main as cx
-import unxt as u
+import coordinax.frames as cxf
 
-v = cx.Point.from_([1000, 2000, 3000], "m")
+p_alice = cx.Point.from_([1, 2, 3], "m", cxf.alice)
+p_alex = p_alice.to_frame(cxf.alex)
 
-# Convert to km (same chart, different units)
-v_km = u.uconvert({"x": "km", "y": "km", "z": "km"}, v)
-# Data is now [1, 2, 3] but in km
-
-# Can also convert per-component
-v_mixed = u.uconvert({"x": "km", "y": "km", "z": "m"}, v)
+print(p_alice.frame)  # Alice()
+print(p_alex.frame)  # Alex()
+print(p_alex.chart)  # Cart3D(M=Rn(3))  — unchanged
 ```
 
-## Coordinate Objects
+Identity frame changes are no-ops (same object returned):
 
-`Vector` answers: "what are the component values, chart, and representation?"
+```python
+assert p_alice.to_frame(cxf.alice) is p_alice
+```
 
-`Coordinate` answers: "what are the vector components **and** in which reference frame are they described?"
+For time-dependent frames, pass an optional evolution parameter:
 
-A coordinate is therefore:
+```python
+p_t = p_alice.to_frame(cxf.alex, t=u.Q(1.0, "s"))
+```
 
-- vector data (component values)
-- chart (coordinate system)
-- representation (transformation law)
-- frame (observer)
+## Tangent Fields and Coordinate Bundles
 
-### Choosing The Right Operation
+`Point` represents a location. To carry **tangent quantities** (velocities, displacements, accelerations) anchored at that location, use `Tangent` and bundle everything into a `Coordinate`.
 
-Use this decision table when transforming coordinate data:
+```python
+import coordinax.representations as cxr
 
-| Goal | API | What Changes | What Stays Invariant |
+point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+vel = cx.Tangent.from_(
+    {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+    cxc.cart3d,
+    cxr.coord_vel,
+)
+
+pv = cx.Coordinate(point=point, velocity=vel)
+
+# Convert the whole bundle — point by transition map, velocity by Jacobian
+pv_sph = pv.cconvert(cxc.sph3d)
+print(pv_sph.point.chart)  # Spherical3D(M=Rn(3))
+print(pv_sph["velocity"].chart)  # Spherical3D(M=Rn(3))
+```
+
+The **basis** controls how tangent components transform:
+
+- `coord_basis` — coordinate/tangent basis; components scale with the metric.
+- `phys_basis` — orthonormal physical frame; dimension-consistent components.
+
+For a full treatment of `Tangent`, basis kinds, and `Coordinate` bundles, see the [Tangent Vectors guide](./tangents.md) and the [Point & Coordinate tutorial](../tutorials/coordinate_objects.md).
+
+## Operations Decision Table
+
+| Goal | API | What changes | What stays invariant |
 | --- | --- | --- | --- |
-| Change observer/reference frame | `coord.to_frame(to_frame)` | `frame` (and usually component values) | represented geometric point |
-| Change coordinate system/chart | `coord.cconvert(to_chart)` | `chart` (and usually component values) | represented geometric point, `frame` |
-| Change both | chain both operations | both frame and chart | represented geometric point |
+| Change coordinate system | `p.cconvert(chart)` | chart, component values | geometric point, frame |
+| Change coordinate system + all tangents | `pv.cconvert(chart)` | chart of point + all fibres | geometric point, frame |
+| Change reference frame | `p.to_frame(frame)` | frame, component values | chart, geometric point |
+| Change frame of whole bundle | `pv.to_frame(frame)` | frame of point + all fibres | chart, geometric point |
+| Convert units | `u.uconvert(units_dict, v)` | component values | chart, frame, geometric point |
 
-### Constructing Coordinates
+## Combined Frame + Chart Pipelines
 
-`Coordinate.from_()` supports the same flexible input styles as `Vector.from_()`, with an additional frame argument.
-
-```python
-import coordinax.main as cx
-import coordinax.frames as cxf
-
-# 1) Array + unit + frame (common high-level pattern)
-coord1 = cx.Point.from_([1, 2, 3], "kpc", cxf.alice)
-
-# 2) Vector + frame
-vec = cx.Point.from_([1, 2, 3], "kpc")
-coord2 = cx.Point.from_(vec, cxf.alice)
-
-# 3) No explicit frame -> NoFrame()
-coord3 = cx.Point.from_([1, 2, 3], "kpc")
-print(coord3.frame)  # NoFrame()
-
-# 4) Passthrough
-coord4 = cx.Point.from_(coord1)
-```
-
-For explicit control, you can also pass chart/representation/manifold through constructor dispatches that mirror `Vector.from_()`.
-
-### Frame Transformations Of Coordinate Data
-
-Use `to_frame()` to apply the frame-transition operator associated with the new observer. Under the active convention, this moves the represented point data into the target frame.
+Operations chain naturally — each step is independent:
 
 ```python
-import coordinax.main as cx
-import coordinax.frames as cxf
+import coordinax.transforms as cxfm
 
-coord_a = cx.Point.from_([1, 2, 3], "m", cxf.alice)
-coord_b = coord_a.to_frame(cxf.alex)
+rot90z = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+rotated_frame = cxf.TransformedReferenceFrame(cxf.alice, rot90z)
 
-print(coord_a.frame)  # Alice()
-print(coord_b.frame)  # Alex()
+p_alice = cx.Point.from_([1, 2, 3], "m", cxf.alice)
+
+# Frame first, then chart
+result = p_alice.to_frame(rotated_frame).cconvert(cxc.sph3d)
+print(result.frame)  # TransformedReferenceFrame(...)
+print(result.chart)  # Spherical3D(M=Rn(3))
 ```
 
-Identity frame changes are cheap no-ops:
+## JAX Integration
+
+`Point`, `Tangent`, and `Coordinate` are all JAX PyTrees (via Equinox). They work with `jit`, `vmap`, and `grad` without special handling.
+
+### JIT Compilation
 
 ```python
-same = coord_a.to_frame(cxf.alice)
-print(same is coord_a)  # True
+import jax
+
+to_spherical = jax.jit(lambda v: cx.cconvert(v, cxc.sph3d))
+
+p = cx.Point.from_([1.0, 0.0, 0.0], "m")
+p_sph = to_spherical(p)
+print(p_sph.chart)  # Spherical3D(M=Rn(3))
 ```
 
-For evolving transforms, `to_frame()` accepts an optional evolution parameter `t` (a quantity):
+### Vectorisation With vmap
 
-```python
-import unxt as u
-
-coord_t = coord_a.to_frame(cxf.alex, t=u.Q(1.0, "s"))
-```
-
-You can also apply frame operators directly:
-
-```python
-op = cxf.frame_transition(cxf.alice, cxf.alex)
-coord_b2 = op(coord_a)
-```
-
-### Chart Transformations Of Coordinate Data
-
-Use `cconvert()` to change chart representation while preserving frame.
-
-```python
-import coordinax.charts as cxc
-
-coord_cart = cx.Point.from_([1, 2, 3], "m", cxf.alice)
-coord_sph = coord_cart.cconvert(cxc.sph3d)
-
-print(coord_cart.chart)  # Cart3D(M=Rn(3))
-print(coord_sph.chart)  # Spherical3D()
-
-print(coord_cart.frame)  # Alice()
-print(coord_sph.frame)  # Alice()  (unchanged)
-```
-
-Round-tripping charts preserves the represented point semantics:
-
-```python
-coord_cart_again = coord_sph.cconvert(cxc.cart3d)
-```
-
-### Combined Frame + Chart Pipelines
-
-Real workflows often require both transformations.
-
-```python
-import coordinax.charts as cxc
-import coordinax.frames as cxf
-import coordinax.main as cx
-
-coord = cx.Point.from_([10, 5, 2], "kpc", cxf.alice)
-
-# Pipeline A: frame first, then chart
-out_a = coord.to_frame(cxf.alex).cconvert(cxc.sph3d)
-
-# Pipeline B: chart first, then frame
-out_b = coord.cconvert(cxc.sph3d).to_frame(cxf.alex)
-
-print(out_a.frame, out_a.chart)  # Alex(), Spherical3D()
-print(out_b.frame, out_b.chart)  # Alex(), Spherical3D()
-```
-
-When reading a pipeline, track invariants explicitly:
-
-1. Frame operation changes observer metadata.
-2. Chart operation changes component schema/coordinate system.
-3. Both preserve the represented geometric point semantics.
-
-### Batch And JAX Patterns For Coordinates
-
-Use scalar-first functions, then batch with `vmap`.
-
-```python
-def to_alex_spherical(c):
-    return c.to_frame(cxf.alex).cconvert(cxc.sph3d)
-
-
-coords = [cx.Point.from_([i, i + 1, i + 2], "m", cxf.alice) for i in range(5)]
-coords_out = [to_alex_spherical(c) for c in coords]
-```
-
-### Astronomy-Oriented Pattern (Optional)
-
-If astronomy frames are available, Coordinate workflows are identical:
-
-```python
-# Optional: requires astro frame package/config in your environment
-# import coordinax.astro as cxastro
-# coord_icrs = cx.Point.from_([1, 2, 3], "kpc", cxastro.ICRS())
-# coord_gc = coord_icrs.to_frame(cxastro.Galactocentric())
-# coord_gc_sph = coord_gc.cconvert(cxc.sph3d)
-```
-
-This is the same pattern: first choose observer frame semantics, then choose the most useful chart for the analysis step.
-
-## Architecture & Design Philosophy
-
-The coordinax `Point` is built on a **"data + chart + representation" triple**. This design prevents silent coordinate errors and makes transformations explicit.
-
-### Why Combine Data + Chart + Representation?
-
-In raw NumPy/JAX, coordinates are just arrays. This creates problems:
+Design functions over scalar (single-point) objects, then batch with `vmap`:
 
 ```python
 import jax.numpy as jnp
 
-# BAD: What does this mean?
-x = jnp.array([1, 2, 3])
-# Is it Cartesian (x, y, z) or spherical (r, θ, φ)?
-# Are the units meters or degrees?
-# Should transformations apply the chart transition or Jacobian?
+# Scalar function
+to_sph = lambda v: cx.cconvert(v, cxc.sph3d)
+
+# Batch via vmap
+many = cx.Point.from_(jnp.ones((5, 3)), "m")
+many_sph = jax.vmap(to_sph)(many)
+print(many_sph.chart)  # Spherical3D(M=Rn(3))
 ```
 
-Coordinax solves this by making all three explicit:
+Chart, frame, and representation metadata are preserved through all JAX transformations — they are PyTree static fields, not array leaves.
+
+## Immutability
+
+Vectors are immutable. Use `equinox.tree_at` to create a modified copy:
 
 ```python
-# GOOD: Crystal clear
-v = cx.Point.from_({"x": u.Q(1, "m"), "y": u.Q(2, "m"), "z": u.Q(3, "m")}, cxc.cart3d)
-# → Chart says: components are (x, y, z) in meters
+import equinox as eqx
+
+v = cx.Point.from_({"x": u.Q(1, "m"), "y": u.Q(2, "m"), "z": u.Q(3, "m")})
+v2 = eqx.tree_at(lambda t: t.data["x"], v, u.Q(10, "m"))
+
+print(v.data["x"])  # Q(1, 'm')
+print(v2.data["x"])  # Q(10, 'm')
 ```
 
-**Benefits:**
-
-1. **Type Safety**: mixing `cart3d` and `sph3d` points is a type error, not silent garbage
-2. **Semantic Clarity**: each number has explicit meaning (system, units, transformation law)
-3. **Automatic Correctness**: transformations apply the right rules by construction
-
-### Immutability by Design
-
-Vectors are immutable. To modify a vector, use `dataclass.replace()`:
-
-```python
-import coordinax.main as cx
-from dataclasses import replace
-
-v = cx.Point.from_([1, 2, 3], "m")
-
-# Create a new point with modified data
-v_modified = replace(
-    v,
-    data={"x": u.Q(10, "m"), "y": u.Q(2, "m"), "z": u.Q(3, "m")},
-)
-
-# Original unchanged
-assert v.data["x"] != v_modified.data["x"]
-```
-
-Immutability enables:
-
-- **JAX safety**: no hidden mutations during transformations
-- **Functional composition**: pure functions chain reliably
-- **Caching**: same input always produces same result
-
-## Arithmetic & Operations
-
-Vectors support Quax-style arithmetic:
-
-```python
-import coordinax.main as cx
-
-v1 = cx.Point.from_([1, 2, 3], "m")
-v2 = cx.Point.from_([0.5, 0.5, 0.5], "m")
-
-# Example operations (availability may depend on branch state):
-# v_sum = v1 + v2
-# v_diff = v1 - v2
-# v_scaled = v1 * 2
-# dist = v_diff.norm()
-```
-
-**Implementation**: Operators use Quax dispatch on JAX primitives (`lax.add_p`, `lax.mul_p`, etc.), making them fully JAX-compatible. See [JAX Integration](#jax-integration--scaling) below.
-
-## Representations: Point vs Tangent (Future)
-
-Currently, vectors support the **point representation** (coordinates transform by chart change only).
-
-Future work will add:
-
-- **Tangent vectors**: transform by the Jacobian of the coordinate change
-- **Covectors**: transform inverse-transpose
-- **Densities**: transform with the determinant of the Jacobian
-
-For now, all vectors are points. The `rep` parameter is present for forward compatibility.
-
-## JAX Integration & Scaling
-
-Vectors are designed as JAX PyTrees and integrate seamlessly with JAX transformations. This section covers the implementation details and practical patterns.
-
-### Scalar-First Design
-
-Vectors are designed to operate on **scalar data** (individual points, not batches):
-
-```python
-import coordinax.main as cx
-
-# Scalar operation
-v = cx.Point.from_([1, 2, 3], "m")
-# Components are leaves: {"x": 1.0, "y": 2.0, "z": 3.0}
-
-# Don't design for: v = cx.Point.from_(np.array([[1, 2, 3], [4, 5, 6]]), "m")
-# (This would make components shaped, not scalar)
-```
-
-Instead, use **vmap** for batching:
-
-### PyTree Structure & Flattening
-
-Vectors are registered as JAX PyTrees via Equinox. This means:
-
-```python
-import jax
-import coordinax.main as cx
-
-v = cx.Point.from_([1, 2, 3], "m")
-
-# JAX sees Point as a pytree with:
-# - Children (leaves): the `data` dictionary components
-# - Metadata: chart, representation, other non-array attributes
-
-flat, treedef = jax.tree_util.tree_flatten(v)
-# flat = [1.0, 2.0, 3.0]  (the actual arrays)
-# treedef = <PyTreeDef with structure and metadata>
-
-# Reconstruct
-v_reconstructed = jax.tree_util.tree_unflatten(treedef, flat)
-```
-
-**Why this matters**:
-
-- `jit`, `vmap`, `grad` automatically traverse the tree correctly
-- Chart and representation metadata are preserved (not treated as data)
-- Transformations view vectors as a whole, not element-by-element
-
-### Quax Dispatch for Operators
-
-Vector operators (`+`, `-`, `*`, etc.) are implemented via **Quax multiple dispatch** on JAX primitives, not as Python magic methods. This enables JAX transformations to handle them correctly:
-
-```python
-# Point implements quax.ArrayValue interface
-# Operators are dispatched on lax primitives, e.g.:
-# @quax.register(lax.add_p)
-# def add_points(v1: Point, v2: Point, /) -> Point:
-#     new_data = {k: v1.data[k] + v2.data[k] for k in v1.data}
-#     return Point(new_data, chart=v1.chart)
-```
-
-**Why Quax (not Python magic methods)**:
-
-- `jnp.add(v1, v2)` decomposes to JAX primitives at JIT time
-- Static dispatch before JAX tracing preserves semantics
-- Works with `vmap`, `grad`, `jit` without modification
-
-### Vectorization via Vmap
-
-```python
-import coordinax.main as cx
-
-
-# Scalar operation: convert one vector to spherical
-def transform_one(v):
-    return cx.cconvert(v, cxc.sph3d)
-
-
-# Batch operation (doctest-safe example)
-many_vectors = [cx.Point.from_([i, i + 1, i + 2], "m") for i in range(5)]
-many_spherical = [transform_one(v) for v in many_vectors]
-```
-
-Vectors are JAX PyTrees, so they work with `jit`:
-
-```python
-# Example sketch (availability depends on branch state):
-# import jax
-#
-# @jax.jit
-# def compute_distances(v1, v2):
-#     diff = v1 - v2
-#     return diff.norm()
-#
-# result = compute_distances(vec1, vec2)
-```
-
-### Differentiation via Grad
-
-Compute gradients through vector operations:
-
-```python
-# Example sketch (availability depends on branch state):
-# @jax.grad
-# def loss(v):
-#     # Example: minimize norm
-#     return v.norm() ** 2
-#
-# grad_v = loss(vec)
-```
-
-## Common Pitfalls
-
-### 1. Silent Chart Mismatch (Prevented!)
-
-```python
-v_cart = cx.Point.from_([1, 2, 3], "m", cxc.cart3d)
-v_sph = cx.Point.from_([1, 2, 3], "m", cxc.sph3d)
-
-# This is caught by the type system (different charts)
-# v_sum = v_cart + v_sph  # ERROR: incompatible charts
-```
-
-### 2. Mutating Vectors (Not Allowed)
-
-```python
-v = cx.Point.from_([1, 2, 3], "m")
-
-# This is an error (immutable):
-# v.data["x"] = 10*u.m
-
-# Instead, use replace:
-from dataclasses import replace
-
-v = replace(v, data=v.data)
-```
-
-### 3. forgetting Units
-
-```python
-# WRONG: units are implicit
-# v = cx.Point.from_([1, 2, 3])  # ERROR: no unit specified
-
-# RIGHT: always specify units
-v = cx.Point.from_([1, 2, 3], "m")
-```
-
-### 4. Shape Inference Ambiguity
-
-```python
-# Shape (1,) could be 1D Cartesian or a scalar
-# Prefer explicit:
-v = cx.Point.from_([1.5], "m", cxc.cart1d)
-```
-
-## Summary: Workflow Pattern
-
-1. **Construct** from array, quantity, or dict
-2. **Inspect** data (print, check shape, extract components)
-3. **Convert** between charts if needed (cconvert)
-4. **Transform** units if needed (uconvert)
-5. **Operate** (arithmetic, norm, reshape)
-6. **Scale** with vmap/jit for batching and compilation
-7. **Differentiate** with grad if needed
-
-This workflow keeps coordinates clear, transformations correct, and code efficient.
+Immutability ensures no hidden mutations during JAX tracing and that pure functions compose reliably.

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ guides/charts.md
 guides/manifolds.md
 guides/representations.md
 guides/vectors.md
+guides/tangents.md
 guides/frames.md
 guides/transforms.md
 packages/coordinax.hypothesis/testing-guide

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2399,9 +2399,9 @@ Separating semantics from geometry provides two advantages:
     - A base **point** $q \in M$ (a `Point` instance).
     - A named collection of **fibre vectors** $\{v_i\}$ anchored at $q$ (each a `Tangent` with `TangentGeometry` rep).
 
-    On construction every fibre vector is automatically converted into the **reference frame of the base point** via `to_frame`. This guarantees internal consistency: after construction `pv["velocity"].frame` always equals `pv.point.frame`.
+    On construction every fibre vector is automatically converted into the **reference frame of the base point** via `to_frame`. This guarantees internal consistency: after construction `pv["velocity"].frame` always equals `pv.point.frame`. Fibre vectors are **not** chart-aligned on construction; each fibre retains the chart it was supplied with.
 
-    Coordinate conversion (chart change) propagates consistently: the base point converts via the chart transition map, and each fibre vector converts via the **Jacobian pushforward at the base point**.
+    Coordinate conversion (chart change) propagates consistently: the base point converts via the chart transition map, and each fibre vector converts via the **Jacobian pushforward at the base point** expressed in the fibre's current chart.
 
     **Fields:**
 
@@ -2416,6 +2416,7 @@ Separating semantics from geometry provides two advantages:
     - Every field value must be a `Tangent` instance; otherwise `TypeError`.
     - All shapes (point + fields) must be broadcastable; otherwise `ValueError`.
     - Every fibre vector whose `frame` differs from `point.frame` is **automatically converted** to `point.frame` before storage.
+    - Fibre charts are **not** altered on construction; each fibre retains its supplied chart.
 
     **Delegated properties** (forward to `self.point`):
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -78,7 +78,7 @@ are $C^\infty$ diffeomorphisms wherever chart domains overlap. The unique maxima
 
 A **point** is simply an element $p \in M$.
 
-Most of the important structures of smooth manifolds --- charts, atlases, transition maps, metrics, and embeddings --- are introduced in the sections that follow.
+Most of the important properties and structures associated with smooth manifolds --- such as coordinate systems, charts, atlases, and transition maps --- will be introduced and explained in subsequent sections.
 
 (math-spec-charts)=
 
@@ -968,7 +968,7 @@ A non-exhaustive table of exported objects are:
 | `coordinax.distances` | `AbstractDistance`, `Distance` |
 | `coordinax.charts` | `CartesianProductChart`, </br> `cartesian_chart`, `guess_chart`, `cdict`, `pt_map`, `jac_pt_map`, </br> `cart0d`, </br> `cart1d`, `radial1d`, `time1d`, </br> `cart2d`, `polar2d`, </br> `cart3d`, `cyl3d`, `sph3d`, `lonlat_sph3d`, `loncoslat_sph3d`, `math_sph3d`, </br> `cartnd`, </br> `spacetimect` |
 | `coordinax.representations` | `cconvert`, `change_basis`, `tangent_map`, </br> `Representation`, `point`, `coord_disp`, `coord_vel`, `coord_acc`, `phys_disp`, `phys_vel`, `phys_acc`, </br> `PointGeometry`, `point_geom`, `TangentGeometry`, `tangent_geom`, </br> `NoBasis`, `no_basis`, `CoordinateBasis`, `coord_basis`, `PhysicalBasis`, `phys_basis`, </br> `Location`, `loc`, `Displacement`, `dpl`, `Velocity`, `vel`, `Acceleration`, `acc`, </br> `guess_geometry_kind`, `guess_semantic_kind`, `guess_rep` |
-| `coordinax.vectors` | `Point`, `ToUnitsOptions` |
+| `coordinax.vectors` | `Point`, `Tangent`, `Coordinate`, `ToUnitsOptions` |
 | `coordinax.manifolds` | `guess_manifold`, `scale_factors`, `angle_between`, </br> `EuclideanManifold`, `Rn`, `EuclideanMetric`, `euclidean3d`, </br> `EmbeddedManifold`, `EmbeddedChart` </br> `twosphere`, `embedded_twosphere`, </br> `CustomManifold`,`CustomAtlas`, |
 | `coordinax.transforms` | `act`, `simplify`, `compose`, `materialize_transform`, </br> `AbstractTransform`, `Identity`, `Composed`, `Translate`, `Rotate`, `Reflect`, `Scale`, `Shear`, `identity`, </br> `AbstractTransformGroup`, `IdentityGroup`, `DiffeomorphismGroup`, `AffineGroup`, `EuclideanGroup`, `OrthogonalGroup`, `SpecialOrthogonalGroup`, `PoincareGroup`, `LorentzGroup`, `ProperOrthochronousLorentzGroup` |
 | `coordinax.frames` | `frame_transition`, </br> `AbstractReferenceFrame`, `FrameTransformError`, </br> `NoFrame`, `Alice`, `Alex`, `TransformedReferenceFrame` |
@@ -1787,6 +1787,8 @@ A representation is therefore **not** the same thing as a chart: the chart deter
 
     **Same-chart basis conversion:** `change_basis(v, chart, from_basis, to_basis, /, *, at)` changes tangent component conventions without changing charts. In v1 it is defined only for Cartesian charts and `CoordinateBasis` $
 
+    **Point-to-Displacement promotion:** `change_basis(v: Point, to_basis, /, *, at)` promotes a `Point` to a `Tangent` with `Displacement` semantics. The component data are unchanged; only the geometric interpretation is recast from a manifold point (affine, `PointGeometry`) to a tangent-space displacement vector (`TangentGeometry`, `Displacement`). The resulting `Tangent` carries the same chart as the input `Point`, and its basis is `to_basis`. This operation is the inverse of treating a displacement as an absolute position, and it respects the affine/tangent distinction enforced throughout the spec.
+
 </br>
 
 ### Geometric Kind
@@ -2280,6 +2282,218 @@ Separating semantics from geometry provides two advantages:
     - ``(obj, chart, frame) -> Point``
     - ``(obj, frame) -> Point``
     - ``(Array, unit, frame) -> Point``
+
+(software-spec-tangent)=
+
+!!! info `Tangent`
+
+    A `Tangent` is a **tangent-geometry vector** carrying explicit basis and semantic kind information alongside its coordinate data. It represents an element of the tangent space $T_p M$ at a base point $p$ — for example a velocity, displacement, or acceleration — expressed in a chosen chart and basis.
+
+    Unlike `Point`, whose representation is always the constant `cxr.point` (`PointGeometry / NoBasis / Location`), a `Tangent`'s representation is **computed** from its `basis` and `semantic` fields:
+
+    $$
+    \mathrm{rep} = \bigl(\mathrm{TangentGeometry},\; \mathrm{basis},\; \mathrm{semantic}\bigr).
+    $$
+
+    **Type parameters** (generic):
+
+    | Parameter   | Bound                         | Default                       |
+    |-------------|-------------------------------|-------------------------------|
+    | `ChartT`    | `AbstractChart`               | `AbstractChart`               |
+    | `BasisT`    | `AbstractLinearBasis`         | `AbstractLinearBasis`         |
+    | `SemanticT` | `AbstractTangentSemanticKind` | `AbstractTangentSemanticKind` |
+    | `V`         | `HasShape` (array-like)       | `unxt.Quantity`               |
+
+    **Fields:**
+
+    | Field      | Type                     | Notes                                  |
+    |------------|--------------------------|----------------------------------------|
+    | `data`     | `dict[str, V]`           | component name → scalar value          |
+    | `chart`    | `ChartT`                 | coordinate system; static (JAX-frozen) |
+    | `manifold` | `AbstractManifold`       | manifold the tangent lives in          |
+    | `basis`    | `BasisT`                 | linear basis; static                   |
+    | `semantic` | `SemanticT`              | physical interpretation; static        |
+    | `frame`    | `AbstractReferenceFrame` | defaults to `cxf.noframe`              |
+
+    **Post-init checks:**
+
+    - `manifold.has_chart(chart)` — chart must belong to the manifold's atlas.
+    - `chart.check_data(data, keys=True)` — data keys must match the chart's component schema.
+
+    **Methods & Properties:**
+
+    - `rep` (computed property) — returns `Representation(tangent_geom, basis, semantic)`. Never stored.
+    - `__getitem__(key)`:
+      - `str` key → returns the component leaf `data[key]`.
+      - integer/slice key → returns a batch-indexed `Tangent` with all components sliced at `key`.
+    - `shape` — broadcast shape of all component leaves.
+    - `aval()` — Quax API; returns `jax.core.ShapedArray` for JAX tracing.
+    - `cconvert(to_chart, *, at, usys)` — chart conversion via Jacobian pushforward at base point `at`.
+    - `to_frame(to_frame, t=None)` — frame transform; returns a new `Tangent` in `to_frame`.
+    - `uconvert(usys_or_units)` — unit conversion.
+    - `norm()` — Riemannian norm in the attached manifold.
+    - `__pdoc__()` — Wadler-Lindig repr.
+
+    **Coordinate transformation law:**
+
+    Tangent components transform via the **Jacobian pushforward** of the chart transition map. Given a base point `at` in `from_chart` coordinates and a target chart `to_chart`:
+
+    $$
+    \tilde{v}^j = J^j{}_i\, v^i, \qquad
+    J^j{}_i = \frac{\partial \tilde{q}^j}{\partial q^i}\bigg|_{\mathrm{at}}.
+    $$
+
+    For `PhysicalBasis` components the transform uses the orthonormal frame rotation matrix $R = B_{\mathrm{to}}^T B_{\mathrm{from}}$ instead of the raw Jacobian.
+
+    **`from_` Constructor Dispatches:**
+
+    | Signature | Behaviour |
+    |-----------|-----------|
+    | `(Tangent,)` | identity / fast-path if same type |
+    | `(obj, chart, basis, semantic, manifold)` | full explicit construction; manifold supplied |
+    | `(obj, chart, basis, semantic)` | manifold inferred via `cxm.guess_manifold(chart)` |
+    | `(obj, chart, rep)` | extracts `basis` and `semantic` from `rep`; raises `TypeError` if `rep.geom_kind` is not `TangentGeometry` |
+    | `(obj, chart)` | rep inferred via `cxr.guess_rep(data, chart)` |
+    | `(obj,)` | chart inferred via `cxc.guess_chart(obj)`, then cascades above |
+    | `(Array, unit)` | converts to `Quantity`, then cascades |
+    | `(Array, unit, chart)` | converts to `Quantity`, then `(Quantity, chart)` |
+    | `(Array, unit, chart, basis, semantic)` | converts to `Quantity`, then full dispatch |
+
+    **`cconvert` dispatches** (registered in `coordinax.vectors`):
+
+    - `cconvert(tangent, to_chart, *, at, usys)` — applies `tangent_map(tangent.data, tangent.chart, tangent.rep, to_chart, *, at=at.data)`. The `at` argument must be a `Point` in `tangent.chart`.
+
+    **Examples:**
+
+    ```pycon
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> v = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")},
+    ...     cxc.cart3d,
+    ...     cxr.coord_basis,
+    ...     cxr.vel,
+    ... )
+    >>> v.rep == cxr.coord_vel
+    True
+
+    >>> v.basis
+    coord_basis
+
+    >>> v.semantic
+    vel
+
+    >>> v["x"]
+    Q(1., 'm / s')
+    ```
+
+(software-spec-coordinate)=
+
+!!! info `Coordinate`
+
+    A `Coordinate` is a **vector bundle** anchored at a base `Point`. It stores:
+
+    - A base **point** $q \in M$ (a `Point` instance).
+    - A named collection of **fibre vectors** $\{v_i\}$ anchored at $q$ (each a `Tangent` with `TangentGeometry` rep).
+
+    On construction every fibre vector is automatically converted into the **reference frame of the base point** via `to_frame`. This guarantees internal consistency: after construction `pv["velocity"].frame` always equals `pv.point.frame`.
+
+    Coordinate conversion (chart change) propagates consistently: the base point converts via the chart transition map, and each fibre vector converts via the **Jacobian pushforward at the base point**.
+
+    **Fields:**
+
+    | Field   | Type                 | Notes                             |
+    |---------|----------------------|-----------------------------------|
+    | `point` | `Point`              | base point of the bundle          |
+    | `_data` | `dict[str, Tangent]` | fibre vectors; excluded from repr |
+
+    **Post-init invariants:**
+
+    - `point` must be a `Point` instance; otherwise `TypeError`.
+    - Every field value must be a `Tangent` instance; otherwise `TypeError`.
+    - All shapes (point + fields) must be broadcastable; otherwise `ValueError`.
+    - Every fibre vector whose `frame` differs from `point.frame` is **automatically converted** to `point.frame` before storage.
+
+    **Delegated properties** (forward to `self.point`):
+
+    - `data` — component data of the base point.
+    - `chart` — chart of the base point.
+    - `rep` — representation of the base point (always `PointGeometry`).
+    - `manifold` — manifold of the base point.
+    - `frame` — reference frame; always equals `point.frame`.
+    - `shape` — broadcast shape of base point and all fibre vectors.
+
+    **Mapping interface** (over fibre fields only, not including the base point):
+
+    - `keys()` — field names.
+    - `values()` — field `Tangent` objects.
+    - `items()` — `(name, Tangent)` pairs.
+    - `__len__()` — number of fibre fields.
+    - `__iter__()` — iterates over field names.
+
+    **`__getitem__(key)`:**
+
+    - `str` key → returns the named `Tangent` field.
+    - integer/slice key → batch-indexes the entire bundle (base point and all fields) and returns a new `Coordinate`.
+
+    **`cconvert(to_chart, *, field_charts=None, usys=None)`:**
+
+    Converts the whole bundle to `to_chart`:
+
+    1. Base point: plain chart transition map.
+    2. Each fibre field: Jacobian pushforward at `self.point`.
+
+    `field_charts` allows per-field target chart overrides (`dict[name, AbstractChart]`).
+
+    **`to_frame(to_frame, t=None) -> Coordinate`:**
+
+    Transforms the entire bundle (base point and all fibre fields) to `to_frame`.
+
+    **`from_` Constructor Dispatches:**
+
+    | Signature | Behaviour |
+    |-----------|-----------|
+    | `(Coordinate,)` | identity; returns the same object unchanged |
+    | `(Point,)` | wraps as a point-only bundle with no fibre fields |
+    | `(Mapping, *, point=None)` | reads `"point"` key from the mapping as base; explicit `point=` kwarg takes precedence |
+
+    **`cconvert` registration:**
+
+    `cconvert(coordinate, to_chart, ...)` delegates to `Coordinate.cconvert(to_chart, ...)`.
+
+    **Examples:**
+
+    ```pycon
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+    >>> vel = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+    ...     cxc.cart3d,
+    ...     cxr.coord_vel,
+    ... )
+    >>> pv = cx.Coordinate(point=point, velocity=vel)
+    >>> pv.point.chart
+    Cart3D()
+
+    >>> list(pv.keys())
+    ['velocity']
+
+    >>> pv["velocity"].semantic
+    vel
+
+    >>> pv_sph = pv.cconvert(cxc.sph3d)
+    >>> pv_sph.point.chart
+    Spherical3D()
+    >>> pv_sph["velocity"].chart
+    Spherical3D()
+    ```
 
 !!! info `ToUnitsOptions`
 

--- a/docs/tutorials/array_objects.md
+++ b/docs/tutorials/array_objects.md
@@ -19,7 +19,7 @@ more metadata. This tutorial covers the **bottom level** — plain arrays.
 | Level | Type | See tutorial |
 | --- | --- | --- |
 | Coordinate | `Coordinate` | [Coordinate tutorial](./coordinate_objects.md) |
-| Vector | `Vector` | [Vector tutorial](./vector_objects.md) |
+| Vector | `Vector` | [Point tutorial](./point_objects.md) |
 | CDict | `dict[str, Quantity]` | [CDict tutorial](./cdict_objects.md) |
 | Quantity | `unxt.Quantity` | [Quantity tutorial](./quantity_objects.md) |
 | **Array** | `jax.Array` | *this page* |

--- a/docs/tutorials/cdict_objects.md
+++ b/docs/tutorials/cdict_objects.md
@@ -21,7 +21,7 @@ more metadata. This tutorial covers `CDict`.
 | Level | Type | See tutorial |
 | --- | --- | --- |
 | Coordinate | `Coordinate` | [Coordinate tutorial](./coordinate_objects.md) |
-| Vector | `AbstractVector` | [Vector tutorial](./vector_objects.md) |
+| Vector | `AbstractVector` | [Point tutorial](./point_objects.md) |
 | **CDict** | `dict[str, Quantity]` | *this page* |
 | Quantity | `unxt.Quantity` | [Quantity tutorial](./quantity_objects.md) |
 | Array | `jax.Array` | [Array tutorial](./array_objects.md) |
@@ -284,6 +284,6 @@ Choose CDict when:
 - You need standard dict operations (iteration, merging, filtering).
 - You are inside a performance-sensitive inner loop where allocating `Point` objects is undesirable.
 
-**Trade-off**: CDicts require you to pass chart and representation explicitly to every function call. If you find yourself repeating `cxc.cart3d, cxr.point` everywhere, upgrade to `Point`. See the [Vector tutorial](./vector_objects.md).
+**Trade-off**: CDicts require you to pass chart and representation explicitly to every function call. If you find yourself repeating `cxc.cart3d, cxr.point` everywhere, upgrade to `Point`. See the [Point tutorial](./point_objects.md).
 
 If you want even less overhead and are willing to manage units externally, use a bare `Quantity`. See the [Quantity tutorial](./quantity_objects.md).

--- a/docs/tutorials/coordinate_objects.md
+++ b/docs/tutorials/coordinate_objects.md
@@ -166,7 +166,7 @@ NoFrame()
 >>> isinstance(pv["velocity"], cx.Tangent)
 True
 >>> pv["velocity"].semantic
-Velocity()
+vel
 ```
 
 ### Multiple Fibre Fields
@@ -183,7 +183,7 @@ A `Coordinate` can hold any number of named tangent fields:
 >>> sorted(pv2.keys())
 ['acceleration', 'velocity']
 >>> pv2["acceleration"].semantic
-Acceleration()
+acc
 ```
 
 ### Converting Charts (The Whole Bundle)

--- a/docs/tutorials/coordinate_objects.md
+++ b/docs/tutorials/coordinate_objects.md
@@ -1,34 +1,20 @@
-# Working With Points And Reference Frames
+# Working With Points And Coordinates
 
-This tutorial covers `Point` with a reference frame — coordinax's **richest** coordinate container. A `Point` stores data (components), a chart (coordinate system), a representation (transformation law), a manifold, and optionally a **reference frame**, giving every number full provenance: what it measures, in which system, and from whose perspective.
+This tutorial covers two linked types:
+
+- **`Point`** — a position carrying its chart and reference frame, so every number has full provenance: _what_, _where_, and _from whose perspective_.
+- **`Coordinate`** — a bundle of a `Point` with named `Tangent` fibre fields (velocities, displacements, accelerations). Chart conversion and frame changes propagate to all fields at once.
 
 You will learn how to:
 
-- Construct points with frames from multiple input forms
-- Change chart (coordinate system) with `cconvert`
-- Change reference frame with `to_frame`
-- Apply transforms directly with `act`
-- Inspect and convert units
-- Use frame-attached points with JAX `jit` and `vmap`
+- Construct `Point` objects with reference frames
+- Convert `Point` between charts and frames
+- Bundle a `Point` with `Tangent` fields into a `Coordinate`
+- Convert the whole bundle between charts in one call
+- Change reference frame for the whole bundle
+- Use both types with JAX `jit` and `vmap`
 
-**Prerequisites**: [Working With Vectors](../guides/vectors.md) and [Working With Frames](../guides/frames.md).
-
-```{admonition} Object Levels
-:class: tip
-
-Coordinax supports four levels of coordinate representation, each adding
-more metadata. This tutorial covers the **top level** — a `Point` with a reference frame.
-
-| Level | Type | See tutorial |
-| --- | --- | --- |
-| **Point (with frame)** | `Point` | *this page* |
-| Point (no frame) | `Point` | [Vector tutorial](./vector_objects.md) |
-| CDict | `dict[str, Quantity]` | [CDict tutorial](./cdict_objects.md) |
-| Quantity | `unxt.Quantity` | [Quantity tutorial](./quantity_objects.md) |
-| Array | `jax.Array` | [Array tutorial](./array_objects.md) |
-
-A `Point` always has a `frame` attribute. When constructed without one, it defaults to `NoFrame()`.
-```
+**Prerequisites**: [Working With Vectors](../guides/vectors.md), [Working With Tangent Vectors](./tangent_objects.md), and [Working With Frames](../guides/frames.md).
 
 ## Setup
 
@@ -43,283 +29,285 @@ A `Point` always has a `frame` attribute. When constructed without one, it defau
 >>> import jax
 ```
 
-## What Is A Point With Frame?
+## Part 1: Point — A Position With Frame
 
-A `Point` bundles five things together:
+A `Point` stores a position: component data, a chart (coordinate system), and optionally a **reference frame** — the observer from whose perspective the coordinates are expressed. A `Point` without a frame defaults to `NoFrame()`.
 
-```
-Point = data + chart + rep + manifold + frame
-```
-
-- **data**: component values (e.g. `{"x": Q(1, "km"), ...}`)
-- **chart**: the coordinate system (e.g. Cartesian, spherical)
-- **rep**: the transformation law (point, tangent, etc.)
-- **manifold**: the geometric space
-- **frame**: the reference observer — defaults to `NoFrame()` when omitted
-
-This ensures that **every number carries its full context**: the values, the coordinate system, the transformation law, the manifold, and the observer.
-
-## Constructing Points With Frames
-
-`Point.from_()` accepts an optional frame as the last argument.
-
-### From A Point And Frame
-
-Pass an existing `Point` and a frame — the frame is attached to it:
+### Constructing A Point
 
 ```{code-block} python
->>> vec = cx.Point.from_(
-...     {"x": u.Q(1, "km"), "y": u.Q(2, "km"), "z": u.Q(3, "km")}
-... )
+>>> p = cx.Point.from_([1.0, 2.0, 3.0], "km")
+>>> print(p)
+<Point: chart=Cart3D (x, y, z) [km]
+    [1. 2. 3.]>
+```
 
->>> coord = cx.Point.from_(vec, cxf.alice)
->>> coord.chart
-Cart3D(M=Rn(3))
->>> coord.frame
+Pass a frame as the last argument to attach it at construction:
+
+```{code-block} python
+>>> p_alice = cx.Point.from_([1.0, 2.0, 3.0], "km", cxf.alice)
+>>> p_alice.frame
 Alice()
 ```
 
-### From A Component Dictionary And Chart
-
-Pass a component dictionary, chart, and frame:
+Or attach a frame to an existing `Point`:
 
 ```{code-block} python
->>> coord = cx.Point.from_(
-...     {"x": u.Q(1, "km"), "y": u.Q(2, "km"), "z": u.Q(3, "km")},
-...     cxc.cart3d,
-...     cxf.alice,
-... )
->>> coord.chart
-Cart3D(M=Rn(3))
->>> coord.frame
+>>> p_alice2 = cx.Point.from_(p, cxf.alice)
+>>> p_alice2.frame
 Alice()
 ```
 
-### From An Array, Unit, And Frame
-
-The most compact form — the chart is inferred from the array shape (length 3 → `cart3d`):
+For the most explicit construction — specifying data, chart, and frame:
 
 ```{code-block} python
->>> coord = cx.Point.from_([1, 2, 3], "km", cxf.alice)
->>> coord.chart
+>>> p_explicit = cx.Point.from_(
+...     {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")},
+...     cxc.cart3d, cxf.alice)
+>>> p_explicit.chart
 Cart3D(M=Rn(3))
->>> coord.frame
+>>> p_explicit.frame
 Alice()
 ```
 
-### Full Specification (Dict + Chart + Rep + Frame)
+### Changing Chart
 
-When you need to control every aspect:
-
-```{code-block} python
->>> coord = cx.Point.from_(
-...     {"x": u.Q(1, "km"), "y": u.Q(2, "km"), "z": u.Q(3, "km")},
-...     cxc.cart3d, cxr.point, cxf.alice,
-... )
->>> coord.rep
-Representation(geom_kind=PointGeometry(), basis=NoBasis(), semantic_kind=Location())
-```
-
-### Default Frame
-
-If no frame is given, `NoFrame` is used:
+`cconvert` preserves the frame; only the chart and component values change:
 
 ```{code-block} python
->>> coord_noframe = cx.Point.from_(
-...     cx.Point.from_({"x": u.Q(1, "km"), "y": u.Q(2, "km"), "z": u.Q(3, "km")})
-... )
->>> coord_noframe.frame
-NoFrame()
-```
-
-### Passthrough
-
-Passing an existing point returns it unchanged:
-
-```{code-block} python
->>> same = cx.Point.from_(coord)
->>> same is coord
-True
-```
-
-## Inspecting Point Data
-
-Access the components, chart, frame, representation, and manifold directly:
-
-```{code-block} python
->>> coord = cx.Point.from_(
-...     {"x": u.Q(1, "km"), "y": u.Q(2, "km"), "z": u.Q(3, "km")},
-...     cxc.cart3d, cxf.alice,
-... )
-
->>> coord.chart
-Cart3D(M=Rn(3))
-
->>> coord.frame
-Alice()
-
->>> coord.rep
-Representation(geom_kind=PointGeometry(), basis=NoBasis(), semantic_kind=Location())
-
->>> coord.M
-Rn(3)
-
->>> isinstance(coord, cx.Point)
-True
-
->>> sorted(coord.data.keys())
-['x', 'y', 'z']
-```
-
-## Changing The Chart (Coordinate System)
-
-Use `cconvert()` to change the chart while preserving the frame and the geometric point:
-
-```{code-block} python
->>> coord_cart = cx.Point.from_(
-...     {"x": u.Q(1, "km"), "y": u.Q(2, "km"), "z": u.Q(3, "km")},
-...     cxc.cart3d, cxf.alice,
-... )
-
->>> coord_sph = coord_cart.cconvert(cxc.sph3d)
->>> coord_sph.chart
+>>> p_sph = p_alice.cconvert(cxc.sph3d)
+>>> p_sph.chart
 Spherical3D(M=Rn(3))
-
->>> coord_sph.frame  # unchanged
+>>> p_sph.frame
 Alice()
-
->>> sorted(coord_sph.data.keys())
-['phi', 'r', 'theta']
 ```
 
-Round-tripping preserves the geometric point:
+Round-tripping:
 
 ```{code-block} python
->>> coord_back = coord_sph.cconvert(cxc.cart3d)
->>> coord_back.chart
+>>> p_back = p_sph.cconvert(cxc.cart3d)
+>>> p_back.chart
 Cart3D(M=Rn(3))
 ```
 
-## Changing The Reference Frame
+### Changing Frame
 
-Use `to_frame()` to transform the point into a different observer's frame. First, build a frame that is rotated 90° about the z-axis relative to Alice:
+`to_frame` transforms the components into the new observer's frame. The chart is preserved:
 
 ```{code-block} python
->>> rot90z = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
->>> rotated_frame = cxf.TransformedReferenceFrame(cxf.alice, rot90z)
-
->>> coord_alice = cx.Point.from_(
-...     {"x": u.Q(1, "km"), "y": u.Q(0, "km"), "z": u.Q(0, "km")},
-...     cxc.cart3d, cxf.alice,
-... )
-
->>> coord_rotated = coord_alice.to_frame(rotated_frame)
->>> coord_rotated.frame
-TransformedReferenceFrame(base_frame=Alice(), xop=Rotate(R=f...[3,3]))
+>>> p_alex = p_alice.to_frame(cxf.alex)
+>>> p_alex.frame
+Alex()
+>>> p_alex.chart
+Cart3D(M=Rn(3))
 ```
 
 Identity frame changes are no-ops:
 
 ```{code-block} python
->>> same = coord_alice.to_frame(cxf.alice)
->>> same is coord_alice
+>>> p_alice.to_frame(cxf.alice) is p_alice
 True
 ```
 
-## Combined Pipeline: Frame + Chart
-
-Real workflows often require both frame and chart changes.
-
-```{code-block} python
->>> coord = cx.Point.from_(
-...     {"x": u.Q(1, "km"), "y": u.Q(2, "km"), "z": u.Q(3, "km")},
-...     cxc.cart3d, cxf.alice,
-... )
-
->>> rotated_frame = cxf.TransformedReferenceFrame(
-...     cxf.alice, cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
-... )
-
->>> # Pipeline: change frame, then chart
->>> result = coord.to_frame(rotated_frame).cconvert(cxc.sph3d)
->>> result.chart
-Spherical3D(M=Rn(3))
-
->>> result.frame
-TransformedReferenceFrame(base_frame=Alice(), xop=Rotate(R=f...[3,3]))
-```
-
-When reading a pipeline, each step preserves the geometric point but changes one metadata attribute:
-
-1. `to_frame(...)` changes the **frame** (and component values).
-2. `cconvert(...)` changes the **chart** (and component values).
-3. Both preserve the **represented geometric point**.
-
-## Applying Transforms Directly
-
-Use `cxfm.act()` to apply a transform directly to a point, without building a frame:
-
-```{code-block} python
->>> rot90z = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
-
->>> coord = cx.Point.from_(
-...     {"x": u.Q(1, "km"), "y": u.Q(0, "km"), "z": u.Q(0, "km")},
-...     cxc.cart3d, cxf.alice,
-... )
-
->>> rotated = cxfm.act(rot90z, None, coord)
->>> isinstance(rotated, cx.Point)
-True
-```
-
-The second argument (`None`) is the time parameter `tau` — pass `None` for time-independent transforms. For time-dependent transforms, see the [Time-Dependent Frames](./time_dependent_frames.md) tutorial.
-
-## Unit Conversion
-
-Convert component units with `u.uconvert()`:
-
-```{code-block} python
->>> coord_m = cx.Point.from_(
-...     {"x": u.Q(1000, "m"), "y": u.Q(2000, "m"), "z": u.Q(3000, "m")},
-...     cxc.cart3d, cxf.alice,
-... )
-
->>> coord_km = u.uconvert({"x": "km", "y": "km", "z": "km"}, coord_m)
->>> coord_km.data["x"]
-Q(1., 'km')
-```
-
-## JAX Integration
-
-Coordinates are JAX PyTrees by construction. They work with `jit` and `vmap`:
-
-### JIT Compilation
+To apply a rotation and then convert to spherical in one pipeline:
 
 ```{code-block} python
 >>> rot90z = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
 >>> rotated_frame = cxf.TransformedReferenceFrame(cxf.alice, rot90z)
 
->>> @jax.jit
-... def to_rotated_spherical(c):
-...     return c.to_frame(rotated_frame).cconvert(cxc.sph3d)
+>>> p_rotated_sph = p_alice.to_frame(rotated_frame).cconvert(cxc.sph3d)
+>>> p_rotated_sph.chart
+Spherical3D(M=Rn(3))
+>>> isinstance(p_rotated_sph.frame, cxf.TransformedReferenceFrame)
+True
+```
 
->>> coord = cx.Point.from_(
-...     {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")},
-...     cxc.cart3d, cxf.alice,
+See [point_objects.md](./point_objects.md) for a full walkthrough of `Point` including component dictionaries, applying transforms with `act`, unit conversion, and immutability.
+
+---
+
+## Part 2: Coordinate — Point With Tangent Fields
+
+A `Coordinate` is a **vector bundle**: a base `Point` together with named `Tangent` fibre fields anchored at it.
+
+```
+Coordinate = Point (base) + {name: Tangent} (fibres)
+```
+
+Chart conversion propagates consistently: the base `Point` converts by the chart transition map, and each `Tangent` converts by the **Jacobian pushforward** at the base. On construction, every fibre field whose frame differs from the base point's frame is **automatically converted** to match it, so `pv["velocity"].frame == pv.point.frame` always holds.
+
+### Constructing A Coordinate
+
+Pass a base `Point` and any number of named `Tangent` keyword arguments:
+
+```{code-block} python
+>>> point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+>>> vel = cx.Tangent.from_(
+...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+...     cxc.cart3d, cxr.coord_vel,
 ... )
 
->>> result = to_rotated_spherical(coord)
->>> result.chart
+>>> pv = cx.Coordinate(point=point, velocity=vel)
+>>> isinstance(pv, cx.Coordinate)
+True
+```
+
+### Accessing The Bundle
+
+Properties delegate to the base point; fibre fields are accessed by name:
+
+```{code-block} python
+>>> pv.chart        # delegates to pv.point.chart
+Cart3D(M=Rn(3))
+>>> pv.frame        # delegates to pv.point.frame
+NoFrame()
+>>> list(pv.keys())
+['velocity']
+>>> isinstance(pv["velocity"], cx.Tangent)
+True
+>>> pv["velocity"].semantic
+Velocity()
+```
+
+### Multiple Fibre Fields
+
+A `Coordinate` can hold any number of named tangent fields:
+
+```{code-block} python
+>>> acc = cx.Tangent.from_(
+...     {"x": u.Q(0.0, "m/s^2"), "y": u.Q(0.0, "m/s^2"), "z": u.Q(-9.8, "m/s^2")},
+...     cxc.cart3d, cxr.coord_acc,
+... )
+
+>>> pv2 = cx.Coordinate(point=point, velocity=vel, acceleration=acc)
+>>> sorted(pv2.keys())
+['acceleration', 'velocity']
+>>> pv2["acceleration"].semantic
+Acceleration()
+```
+
+### Converting Charts (The Whole Bundle)
+
+`cconvert` converts **all fields at once**:
+
+1. Base `Point` converts by the chart transition map.
+2. Each `Tangent` converts by the **Jacobian pushforward** at the base point.
+
+```{code-block} python
+>>> pv_sph = pv.cconvert(cxc.sph3d)
+>>> pv_sph.point.chart
+Spherical3D(M=Rn(3))
+>>> pv_sph["velocity"].chart
 Spherical3D(M=Rn(3))
 ```
 
-## When To Track Reference Frames
+Round-tripping:
 
-Attach a frame to a `Point` when you need **full provenance**:
+```{code-block} python
+>>> pv_back = pv_sph.cconvert(cxc.cart3d)
+>>> pv_back.point.chart
+Cart3D(M=Rn(3))
+```
 
-- You are tracking data from multiple observers and need to know which frame each measurement is in.
-- You want `to_frame()` semantics to transform between observers.
-- Your workflow chains frame transitions and chart conversions.
-- You are building an astronomy pipeline where frames like ICRS and Galactocentric are first-class concepts.
+Override the target chart for individual fields with `field_charts`:
 
-If you do not need frame tracking, omit the frame — a `Point` without one defaults to `NoFrame()` and is otherwise identical. See the [Vector tutorial](./vector_objects.md) for the frame-free workflow.
+```{code-block} python
+>>> pv_mixed = pv.cconvert(cxc.sph3d, field_charts={"velocity": cxc.cyl3d})
+>>> pv_mixed.point.chart
+Spherical3D(M=Rn(3))
+>>> pv_mixed["velocity"].chart
+Cylindrical3D(M=Rn(3))
+```
+
+### Changing Reference Frame
+
+`to_frame` moves **all fields** into the new frame. Construct the framed pieces first, then bundle:
+
+```{code-block} python
+>>> point_alice = cx.Point.from_([1.0, 0.0, 0.0], "m", cxf.alice)
+>>> vel_alice = cx.Tangent.from_(vel, cxf.alice)
+>>> pv_alice = cx.Coordinate(point=point_alice, velocity=vel_alice)
+
+>>> pv_alex = pv_alice.to_frame(cxf.alex)
+>>> pv_alex.frame
+Alex()
+>>> pv_alex["velocity"].frame
+Alex()
+```
+
+### Automatic Frame Alignment
+
+If a fibre field's frame differs from the base point's frame on construction, it is **automatically converted** to the base's frame. No manual conversion needed:
+
+```{code-block} python
+>>> vel_alex = cx.Tangent.from_(vel, cxf.alex)
+
+>>> # point is alice, vel is alex — vel is silently converted to alice
+>>> pv_auto = cx.Coordinate(point=point_alice, velocity=vel_alex)
+>>> pv_auto["velocity"].frame
+Alice()
+```
+
+### Combined Pipeline: Frame + Chart
+
+Frame changes and chart conversions can be chained:
+
+```{code-block} python
+>>> result = pv_alice.to_frame(rotated_frame).cconvert(cxc.sph3d)
+>>> result.point.chart
+Spherical3D(M=Rn(3))
+>>> isinstance(result.frame, cxf.TransformedReferenceFrame)
+True
+```
+
+### Indexing A Batched Coordinate
+
+Integer/slice indexing applies to the base point and all fibre fields together:
+
+```{code-block} python
+>>> pts = cx.Point.from_(jnp.ones((4, 3)), "m")
+>>> vels = cx.Tangent.from_(jnp.zeros((4, 3)), "m/s")
+>>> pv_batch = cx.Coordinate(point=pts, velocity=vels)
+
+>>> pv_0 = pv_batch[0]
+>>> pv_0.point.shape
+()
+```
+
+## JAX Integration
+
+Both `Point` and `Coordinate` are JAX PyTrees and work with all JAX transformations.
+
+### JIT Compilation
+
+```{code-block} python
+>>> to_spherical = jax.jit(lambda coord: coord.cconvert(cxc.sph3d))
+
+>>> result = to_spherical(pv)
+>>> result.point.chart
+Spherical3D(M=Rn(3))
+```
+
+### Vectorisation With vmap
+
+```{code-block} python
+>>> pts_batch = cx.Point.from_(
+...     jnp.stack([jnp.array([1.0, 0.0, 0.0]), jnp.array([0.0, 1.0, 0.0])]), "m"
+... )
+>>> vels_batch = cx.Tangent.from_(jnp.zeros((2, 3)), "m/s")
+>>> pv_batch2 = cx.Coordinate(point=pts_batch, velocity=vels_batch)
+
+>>> pv_sph_batch = jax.vmap(to_spherical)(pv_batch2)
+>>> pv_sph_batch.point.chart
+Spherical3D(M=Rn(3))
+```
+
+## When To Use
+
+| You have | Use |
+| --- | --- |
+| Position only | `Point` (Part 1 of this tutorial) |
+| Velocity / displacement / acceleration only | `Tangent` — see [Tangent tutorial](./tangent_objects.md) |
+| Position + tangent field(s) | `Coordinate` (Part 2 of this tutorial) |
+
+Use `Coordinate` when you need chart conversion to apply the correct transformation law to every field automatically, or when frame changes must propagate to all fields at once.

--- a/docs/tutorials/point_objects.md
+++ b/docs/tutorials/point_objects.md
@@ -16,13 +16,13 @@ You will learn how to:
 ```{admonition} Object Levels
 :class: tip
 
-Coordinax supports five levels of coordinate representation, each adding
-more metadata. This tutorial covers `Vector`.
+Coordinax supports a few levels of coordinate representation, each adding
+more metadata. This tutorial covers `Point`.
 
 | Level | Type | See tutorial |
 | --- | --- | --- |
-| Coordinate | `Coordinate` | [Coordinate tutorial](./coordinate_objects.md) |
-| **Vector** | `Vector` | *this page* |
+| Coordinate bundle | `Coordinate` | [Tangent tutorial](./tangent_objects.md) |
+| **Point** \& Tangent | `Point`, `Tangent` | *this page*, [Tangent tutorial](./tangent_objects.md) |
 | CDict | `dict[str, Quantity]` | [CDict tutorial](./cdict_objects.md) |
 | Quantity | `unxt.Quantity` | [Quantity tutorial](./quantity_objects.md) |
 | Array | `jax.Array` | [Array tutorial](./array_objects.md) |
@@ -293,7 +293,27 @@ Spherical3D(M=Rn(3))
 
 ## Upgrading To A Coordinate
 
-Attach a reference frame to promote a vector to a coordinate:
+A `Point` represents a location. If you also need to carry tangent quantities like velocity or acceleration **at** that point, bundle the `Point` with `Tangent` fields into a `Coordinate`:
+
+```{code-block} python
+>>> import coordinax.representations as cxr
+>>> import unxt as u
+
+>>> vel = cx.Tangent.from_(
+...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+...     cxc.cart3d, cxr.coord_vel,
+... )
+>>> pv = cx.Coordinate(point=cx.Point.from_([1.0, 0.0, 0.0], "m"), velocity=vel)
+>>> pv_sph = pv.cconvert(cxc.sph3d)
+>>> pv_sph["velocity"].chart
+Spherical3D(M=Rn(3))
+```
+
+See the [Coordinate tutorial](./coordinate_objects.md) for the full walkthrough.
+
+`Tangent` on its own is **not** an upgrade of `Point` — it is a separate type for tangent-space quantities that exist independently of a base location. See the [Tangent tutorial](./tangent_objects.md) if you need to work with tangent vectors directly.
+
+Attach a reference frame to a `Point` to track the observer:
 
 ```{code-block} python
 >>> v = cx.Point.from_({"x": u.Q(1, "km"), "y": u.Q(2, "km"), "z": u.Q(3, "km")})
@@ -304,15 +324,45 @@ Alice()
 Cart3D(M=Rn(3))
 ```
 
-## When To Use Vector
+## Promoting a Point to a Displacement
 
-Choose `Vector` when:
+Sometimes you have a `Point` whose component data you want to reinterpret as a tangent-space **displacement** rather than an absolute location — for example, when feeding a position offset into an operation that expects a `Tangent`.
+
+`change_basis` handles this in one call. The component data is **unchanged**; only the geometric type changes from `PointGeometry` to `TangentGeometry` with `Displacement` semantics:
+
+```{code-block} python
+>>> pt = cx.Point.from_([1.0, 2.0, 3.0], "m")
+>>> disp = cxr.change_basis(pt, cxr.coord_basis)
+>>> disp
+Tangent( {'x': Q(1., 'm'), 'y': Q(2., 'm'), 'z': Q(3., 'm')},
+         chart=Cart3D(M=Rn(3)), basis=coord_basis, semantic=dpl )
+```
+
+You can request the physical (orthonormal) basis instead:
+
+```{code-block} python
+>>> disp_phys = cxr.change_basis(pt, cxr.phys_basis)
+>>> disp_phys.rep
+Representation(geom_kind=TangentGeometry(), basis=PhysicalBasis(), semantic_kind=Displacement())
+```
+
+See the [Tangent guide](../guides/tangents.md) for more on basis and semantic kinds.
+
+## When To Use Point
+
+Choose `Point` when:
 
 - You need chart and representation metadata attached to your data.
 - You want `cconvert` and `act` to work without extra arguments.
 - You do not need reference-frame tracking (no `to_frame`).
 - You are doing geometry: chart conversions, transform pipelines, or building higher-level abstractions.
 
-If you need frame tracking, upgrade to `Coordinate`. See the [Coordinate tutorial](./coordinate_objects.md).
+If you need tangent fields (velocity, displacement, acceleration) bundled with the point, use `Coordinate`. See the [Coordinate tutorial](./coordinate_objects.md).
+
+If you need standalone tangent quantities (without a base point), use `Tangent`. See the [Tangent tutorial](./tangent_objects.md).
+
+If you want to reinterpret a `Point`'s data as a displacement, use `cxr.change_basis(pt, cxr.coord_basis)` to promote it to a `Tangent` with `Displacement` semantics.
+
+If you need frame tracking, attach a frame to a `Point`. See the [Coordinate tutorial](./coordinate_objects.md).
 
 If you want a lighter representation, use a component dictionary (`CDict`). See the [CDict tutorial](./cdict_objects.md).

--- a/docs/tutorials/point_objects.md
+++ b/docs/tutorials/point_objects.md
@@ -121,7 +121,7 @@ Spherical3D(M=Rn(3))
 ...     cxc.cart3d,
 ...     cxr.point,
 ... )
->>> v.rep
+>>> print(v.rep)
 Representation(geom_kind=PointGeometry(), basis=NoBasis(), semantic_kind=Location())
 ```
 
@@ -143,7 +143,7 @@ True
 Cart3D(M=Rn(3))
 
 >>> v.rep
-Representation(geom_kind=PointGeometry(), basis=NoBasis(), semantic_kind=Location())
+point
 
 >>> v.M
 Rn(3)
@@ -342,8 +342,10 @@ You can request the physical (orthonormal) basis instead:
 
 ```{code-block} python
 >>> disp_phys = cxr.change_basis(pt, cxr.phys_basis)
->>> disp_phys.rep
-Representation(geom_kind=TangentGeometry(), basis=PhysicalBasis(), semantic_kind=Displacement())
+>>> print(disp_phys.rep)
+Representation(
+    geom_kind=TangentGeometry(), basis=PhysicalBasis(), semantic_kind=Displacement()
+)
 ```
 
 See the [Tangent guide](../guides/tangents.md) for more on basis and semantic kinds.

--- a/docs/tutorials/quantity_objects.md
+++ b/docs/tutorials/quantity_objects.md
@@ -21,7 +21,7 @@ more metadata. This tutorial covers `Quantity`.
 | Level | Type | See tutorial |
 | --- | --- | --- |
 | Coordinate | `Coordinate` | [Coordinate tutorial](./coordinate_objects.md) |
-| Point | `Vector` | [Point tutorial](./point_objects.md) |
+| Point | `Point` | [Point tutorial](./point_objects.md) |
 | CDict | `dict[str, Quantity]` | [CDict tutorial](./cdict_objects.md) |
 | **Quantity** | `unxt.Quantity` | *this page* |
 | Array | `jax.Array` | [Array tutorial](./array_objects.md) |

--- a/docs/tutorials/quantity_objects.md
+++ b/docs/tutorials/quantity_objects.md
@@ -21,7 +21,7 @@ more metadata. This tutorial covers `Quantity`.
 | Level | Type | See tutorial |
 | --- | --- | --- |
 | Coordinate | `Coordinate` | [Coordinate tutorial](./coordinate_objects.md) |
-| Point | `Vector` | [Vector tutorial](./vector_objects.md) |
+| Point | `Vector` | [Point tutorial](./point_objects.md) |
 | CDict | `dict[str, Quantity]` | [CDict tutorial](./cdict_objects.md) |
 | **Quantity** | `unxt.Quantity` | *this page* |
 | Array | `jax.Array` | [Array tutorial](./array_objects.md) |
@@ -213,6 +213,6 @@ Choose `Quantity` when:
 - You are passing data to `act` and are happy with chart inference from the array shape.
 - You are working with existing unxt-based code and want coordinax transforms to "just work".
 
-**Trade-off**: Chart inference depends on array shape — it only works for trailing axis sizes 1, 2, or 3, and always assumes Cartesian. For non-Cartesian data or explicit chart control, decompose to a CDict or upgrade to a `Point`. See the [CDict tutorial](./cdict_objects.md) or the [Vector tutorial](./vector_objects.md).
+**Trade-off**: Chart inference depends on array shape — it only works for trailing axis sizes 1, 2, or 3, and always assumes Cartesian. For non-Cartesian data or explicit chart control, decompose to a CDict or upgrade to a `Point`. See the [CDict tutorial](./cdict_objects.md) or the [Point tutorial](./point_objects.md).
 
 If you need even less overhead and are willing to manage units yourself, use a bare array. See the [Array tutorial](./array_objects.md).

--- a/docs/tutorials/tangent_objects.md
+++ b/docs/tutorials/tangent_objects.md
@@ -1,0 +1,152 @@
+# Working With Tangent Vectors
+
+This tutorial covers `Tangent` — coordinax's type for **tangent-space quantities** (velocities, displacements, accelerations). Tangent vectors represent elements of the tangent space $T_p M$ and transform differently from points under chart conversion.
+
+You will learn how to:
+
+- Understand why tangent vectors need a different type from points
+- Construct `Tangent` objects from arrays, quantities, and dictionaries
+- Convert tangent vectors between charts using the Jacobian pushforward
+- Attach reference frames to tangent vectors
+- Use `Tangent` with JAX `jit` and `vmap`
+
+**Prerequisites**: [Working With Vectors](../guides/vectors.md). `Tangent` is one of several coordinate levels — for the full picture see the [Point](./point_objects.md) and [Coordinate](./coordinate_objects.md) tutorials.
+
+## Setup
+
+```{code-block} python
+>>> import coordinax.main as cx
+>>> import coordinax.charts as cxc
+>>> import coordinax.frames as cxf
+>>> import coordinax.representations as cxr
+>>> import unxt as u
+>>> import jax.numpy as jnp
+>>> import jax
+```
+
+## Why Tangent Vectors?
+
+Points and tangent vectors both store component dictionaries attached to a chart, but they follow **different transformation laws** under chart conversion:
+
+- A `Point` `(r, θ, φ)` transforms by the chart transition map.
+- A `Tangent` `(ṙ, θ̇, φ̇)` transforms by the **Jacobian** of that map, evaluated at the base point.
+
+Using the wrong law gives silently incorrect physics. `Tangent` encodes the correct transformation, so `cconvert` always does the right thing.
+
+Beyond the chart, each `Tangent` carries a **basis** and a **semantic kind**:
+
+- **basis** — `coord_basis` (coordinate/tangent basis, components scale with the metric) or `phys_basis` (orthonormal physical frame, dimension-consistent components).
+- **semantic** — `vel` (velocity), `dpl` (displacement), or `acc` (acceleration).
+
+Pre-built singletons combine these: `cxr.coord_vel`, `cxr.phys_vel`, `cxr.coord_acc`, etc.
+
+## Constructing Tangent Vectors
+
+### From A Component Dictionary (Primary)
+
+Pass a component dict, a chart, and a representation singleton:
+
+```{code-block} python
+>>> vel = cx.Tangent.from_(
+...     {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")},
+...     cxc.cart3d, cxr.coord_vel)
+>>> vel.chart
+Cart3D(M=Rn(3))
+>>> vel.rep == cxr.coord_vel
+True
+>>> vel["x"]
+Q(1., 'm / s')
+>>> vel.frame
+NoFrame()
+```
+
+### From An Array And Unit
+
+When the chart can be inferred from the array shape and unit, pass the array and unit directly:
+
+```{code-block} python
+>>> vel = cx.Tangent.from_([1.0, 2.0, 3.0], "m/s")
+>>> vel.chart
+Cart3D(M=Rn(3))
+```
+
+## Converting Charts — Jacobian Pushforward
+
+Converting a tangent vector to a new chart requires the **base point** at which the Jacobian is evaluated. Pass it via `at=`:
+
+```{code-block} python
+>>> point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+>>> vel_cart = cx.Tangent.from_(
+...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+...     cxc.cart3d, cxr.coord_vel)
+
+>>> vel_sph = vel_cart.cconvert(cxc.sph3d, at=point)
+>>> print(vel_sph)
+<Tangent: chart=Spherical3D (r[m / s], theta[rad / s], phi[rad / s])
+    [ 1. -0.  0.]>
+```
+
+The basis (`coord_basis`) and semantic (`vel`) are preserved across the conversion; only the chart and component values change.
+
+## Attaching A Reference Frame
+
+Construct a `Tangent` without a frame, then attach one:
+
+```{code-block} python
+>>> vel = cx.Tangent.from_(
+...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+...     cxc.cart3d, cxr.coord_vel)
+>>> vel_alice = cx.Tangent.from_(vel, cxf.alice)
+>>> vel_alice.frame
+Alice()
+
+>>> vel_alex = vel_alice.to_frame(cxf.alex)
+>>> vel_alex.frame
+Alex()
+```
+
+`cx.Tangent.from_(vel, frame)` replaces the frame without transforming components. `to_frame` applies the full frame transformation.
+
+## JAX Integration
+
+`Tangent` is a JAX PyTree and works with all JAX transformations.
+
+### JIT Compilation
+
+```{code-block} python
+>>> to_spherical = jax.jit(lambda v, pt: cx.cconvert(v, cxc.sph3d, at=pt))
+
+>>> point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+>>> vel = cx.Tangent.from_(
+...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+...     cxc.cart3d, cxr.coord_vel)
+
+>>> vel_sph = to_spherical(vel, point)
+>>> vel_sph.chart
+Spherical3D(M=Rn(3))
+```
+
+### Vectorisation With vmap
+
+```{code-block} python
+>>> to_sph_one = lambda v, pt: cx.cconvert(v, cxc.sph3d, at=pt)
+
+>>> pts = cx.Point.from_(jnp.ones((3, 3)), "m")
+>>> vels = cx.Tangent.from_(jnp.zeros((3, 3)), "m/s")
+
+>>> vels_sph = jax.vmap(to_sph_one)(vels, pts)
+>>> vels_sph.chart
+Spherical3D(M=Rn(3))
+>>> vels_sph.shape
+(3,)
+```
+
+## When To Use Tangent
+
+| You have | Use |
+| --- | --- |
+| Position only | `Point` — see [Point tutorial](./point_objects.md) |
+| Velocity / displacement / acceleration only | `Tangent` (this tutorial) |
+| Position + tangent field(s) | `Coordinate` — see [Coordinate tutorial](./coordinate_objects.md) |
+
+To bundle a `Tangent` with a base `Point`, use `Coordinate`. It handles chart conversion for the whole bundle — base point via the transition map, each fibre via the Jacobian — in a single call.

--- a/packages/coordinax.api/src/coordinax/api/representations.py
+++ b/packages/coordinax.api/src/coordinax/api/representations.py
@@ -90,7 +90,7 @@ def guess_basis_kind(*args: Any, **kwargs: Any) -> Any:
 
     >>> data = {"x": u.Q(1, "m"), "y": u.Q(2, "m"), "z": u.Q(3, "m")}
     >>> cxr.guess_basis_kind(data)
-    NoBasis()
+    no_basis
 
     """
     raise NotImplementedError  # pragma: no cover
@@ -110,7 +110,7 @@ def guess_geometry_kind(*args: Any, **kwargs: Any) -> Any:
 
     >>> data = {"x": u.Q(1, "m"), "y": u.Q(2, "m"), "z": u.Q(3, "m")}
     >>> cxr.guess_geometry_kind(data)
-    PointGeometry()
+    point_geom
 
     """
     raise NotImplementedError  # pragma: no cover
@@ -130,7 +130,7 @@ def guess_rep(*args: Any, **kwargs: Any) -> Any:
 
     >>> data = {"x": u.Q(1, "m"), "y": u.Q(2, "m"), "z": u.Q(3, "m")}
     >>> cxr.guess_rep(data)
-    Representation(geom_kind=PointGeometry(), basis=NoBasis(), semantic_kind=Location())
+    point
 
     """
     raise NotImplementedError  # pragma: no cover
@@ -150,7 +150,7 @@ def guess_semantic_kind(*args: Any, **kwargs: Any) -> Any:
 
     >>> data = {"x": u.Q(1, "m"), "y": u.Q(2, "m"), "z": u.Q(3, "m")}
     >>> cxr.guess_semantic_kind(data)
-    Location()
+    loc
     """
     raise NotImplementedError  # pragma: no cover
 

--- a/packages/coordinax.astro/src/coordinax/astro/_src/galactocentric.py
+++ b/packages/coordinax.astro/src/coordinax/astro/_src/galactocentric.py
@@ -21,7 +21,7 @@ from coordinax.distances import Distance
 ScalarAngle: TypeAlias = Shaped[u.Q["angle"] | u.Angle, ""]
 
 
-galcen_default = cxv.Point.from_(
+GALCEN_DEFAULT = cxv.Point.from_(
     {
         "lon": u.Angle(jnp.array(266.4051), "deg"),
         "lat": u.Angle(jnp.array(-28.936175), "degree"),
@@ -30,7 +30,7 @@ galcen_default = cxv.Point.from_(
     cxc.lonlat_sph3d,
     cxr.point,
 )
-# galcen_v_sun_default = cxv.Point.from_([12.9, 245.6, 7.78], "km/s")
+GALCEN_V_SUN_DEFAULT = cxv.Tangent.from_([12.9, 245.6, 7.78], "km/s")
 
 
 @final
@@ -53,7 +53,7 @@ class Galactocentric(AbstractSpaceFrame):
     #: distance: https://ui.adsabs.harvard.edu/abs/2018A%26A...615L..15G
     galcen: cxv.Point[cxc.LonLatSpherical3D, Any] = eqx.field(  # ty: ignore[invalid-assignment]
         converter=cxv.Point[cxc.LonLatSpherical3D, Any].from_,
-        default=galcen_default,
+        default=GALCEN_DEFAULT,
     )
 
     #: Rotation angle of the Galactic center from the ICRS x-axis.

--- a/packages/coordinax.curveframes/src/coordinax/curveframes/_src/base.py
+++ b/packages/coordinax.curveframes/src/coordinax/curveframes/_src/base.py
@@ -369,7 +369,7 @@ class AbstractParallelTransportTransform(cxt.AbstractCompositeTransform):
         - ``_is_forward = False``
         - All extra fields (e.g. Bishop's ``tau_0``, ``initial_normal``)
         """
-        ...
+        raise NotImplementedError  # pragma: no cover
 
     @abc.abstractmethod
     def _rebuild_forward(self) -> "AbstractParallelTransportTransform":
@@ -378,7 +378,7 @@ class AbstractParallelTransportTransform(cxt.AbstractCompositeTransform):
         Called when ``.inverse`` is invoked on an already-inverse instance,
         avoiding closure accumulation.
         """
-        ...
+        raise NotImplementedError  # pragma: no cover
 
     # ---------------------------------------------------------------
     # Inverse-building helpers (shared logic)

--- a/packages/coordinax.hypothesis/src/coordinax/hypothesis/charts/_src/chart_kwargs.py
+++ b/packages/coordinax.hypothesis/src/coordinax/hypothesis/charts/_src/chart_kwargs.py
@@ -109,8 +109,8 @@ def chart_init_kwargs(  # noqa: F811
     ...     assert chart.ndim == 3
 
     """
-    # Handle dimensionality alias and strategy
-    ndim = draw_if_strategy(draw, ndim)
+    # TODO: Handle dimensionality alias and strategy
+    # ndim = draw_if_strategy(draw, ndim)
 
     # Get a dictionary of all the required parameters for cls.__init__
     required_params = get_init_params(chart_class)

--- a/packages/coordinax.hypothesis/tests/unit/utils/annotations/test_get_all_subclasses.py
+++ b/packages/coordinax.hypothesis/tests/unit/utils/annotations/test_get_all_subclasses.py
@@ -31,7 +31,8 @@ class AbstractBase(abc.ABC):
     """Abstract base class for testing abstract exclusion."""
 
     @abc.abstractmethod
-    def method(self) -> None: ...
+    def method(self) -> None:
+        raise NotImplementedError  # pragma: no cover
 
 
 class ConcreteFromAbstract(AbstractBase):

--- a/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/distances.py
+++ b/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/distances.py
@@ -7,7 +7,7 @@ from plum import conversion_method
 
 from astropy.units import Quantity as AstropyQuantity
 
-import coordinax.astro as cxastro
+import coordinax.astro as cxastro  # ty: ignore[unresolved-import]
 import coordinax.distances as cxd
 
 # ============================================================================

--- a/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/frames.py
+++ b/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/frames.py
@@ -119,7 +119,8 @@ def from_(cls: type[cxastro.ICRS], obj: apyc.ICRS, /) -> cxastro.ICRS:
     ICRS()
 
     """
-    obj = eqx.error_if(obj, obj.has_data, "Astropy frame must not have data.")
+    if obj.has_data:
+        raise ValueError("Astropy frame must not have data.")
     return cls()
 
 

--- a/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/frames.py
+++ b/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/frames.py
@@ -63,7 +63,7 @@ import astropy.coordinates as apyc
 import astropy.units as apyu
 import unxt as u
 
-import coordinax.astro as cxastro
+import coordinax.astro as cxastro  # ty: ignore[unresolved-import]
 import coordinax.charts as cxc
 import coordinax.frames as cxf
 import coordinax.vectors as cxv
@@ -351,4 +351,4 @@ def astropy_galactocentric_to_coordinax_galactocentric(
     True
 
     """
-    return cxastro.Galactocentric.from_(frame)  # ty: ignore[invalid-return-type]
+    return cxastro.Galactocentric.from_(frame)

--- a/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/vec_constructors.py
+++ b/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/vec_constructors.py
@@ -7,7 +7,7 @@ import plum
 
 import astropy.coordinates as apyc
 
-import coordinax.astro as cxastro
+import coordinax.astro as cxastro  # ty: ignore[unresolved-import]
 import coordinax.charts as cxc
 import coordinax.frames as cxf
 import coordinax.vectors as cxv

--- a/packages/coordinax.interop.astropy/tests/test_distances.py
+++ b/packages/coordinax.interop.astropy/tests/test_distances.py
@@ -34,16 +34,6 @@ def float32s(
 # Distance
 
 
-def test_astropy_quantity_to_distance() -> None:
-    """Test converting AstropyQuantity to Distance."""
-    q = apyu.Quantity(1.0, "km")
-    dist = convert(q, Distance)
-
-    assert isinstance(dist, Distance)
-    assert dist.value == pytest.approx(1.0)
-    assert str(dist.unit) == "km"
-
-
 @given(unit=ust.units("length"))
 def test_astropy_quantity_to_distance(unit: str) -> None:
     """Test converting Astropy Quantity to Distance."""
@@ -85,16 +75,6 @@ def test_distance_roundtrip(dist: Distance) -> None:
 
 # =============================================================================
 # Parallax
-
-
-def test_astropy_quantity_to_parallax() -> None:
-    """Test converting AstropyQuantity to Parallax."""
-    q = AstropyQuantity(1.0, "mas")
-    plx = convert(q, Parallax)
-
-    assert isinstance(plx, Parallax)
-    assert plx.value == pytest.approx(1.0)
-    assert str(plx.unit) == "mas"
 
 
 @given(unit=ust.units("angle"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -454,6 +454,14 @@ invalid-argument-type = "ignore"
 [tool.ty.terminal]
 output-format = "concise"
 
+[tool.unxt]
+quantity.repr.named_unit     = false
+quantity.repr.short_arrays   = "compact"
+quantity.repr.use_short_name = true
+
+quantity.str.named_unit     = true
+quantity.str.short_arrays   = false
+quantity.str.use_short_name = true
 
 [tool.uv]
 # Temporary constraint to restrict JAX version
@@ -465,17 +473,6 @@ constraint-dependencies = ["numpy<2.4.0"]
 "coordinax.curveframes"     = { workspace = true }
 "coordinax.hypothesis"      = { workspace = true }
 "coordinax.interop.astropy" = { workspace = true }
-
-
-[tool.unxt]
-quantity.repr.named_unit     = false
-quantity.repr.short_arrays   = "compact"
-quantity.repr.use_short_name = true
-
-quantity.str.named_unit     = true
-quantity.str.short_arrays   = false
-quantity.str.use_short_name = true
-
 
 [tool.uv.workspace]
 members = ["packages/*"]

--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -113,13 +113,13 @@ class AbstractChart(Generic[Ks, Ds], metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def components(self) -> Ks:
         """The names of the components."""
-        ...
+        raise NotImplementedError  # pragma: no cover
 
     @property
     @abc.abstractmethod
     def coord_dimensions(self) -> Ds:
         """The dimensions of the components."""
-        ...
+        raise NotImplementedError  # pragma: no cover
 
     @property
     def ndim(self) -> int:

--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -965,6 +965,7 @@ def pt_map(
     return {"r": p["r"], "theta": p["phi"], "phi": p["theta"]}
 
 
+@plum.dispatch
 def pt_map(
     p: CDict,
     from_chart: ProlateSpheroidal3D,
@@ -997,12 +998,12 @@ def pt_map(
 
     >>> p = {"mu": u.Q(5.0, "m2"), "nu": u.Q(1.0, "m2"), "phi": u.Q(0, "rad")}
     >>> cxc.pt_map(p, prolatesph3d, cxc.cyl3d)
-    {'rho': Q(0.8660254, 'm'), 'phi': Q(0., 'rad'), 'z': Q(1.11803399, 'm')}
+    {'rho': Q(0.8660254, 'm'), 'phi': Q(0, 'rad'), 'z': Q(1.11803399, 'm')}
 
     >>> p = {"mu": 5.0, "nu": 1.0, "phi": 0}  # No units
     >>> usys = u.unitsystem("m", "rad")
     >>> cxc.pt_map(p, prolatesph3d, cxc.cyl3d, usys=usys)
-    {'rho': Array(0.8660254, dtype=float64), 'phi': Array(0., dtype=float64),
+    {'rho': Array(0.8660254, dtype=float64), 'phi': 0,
      'z': Array(1.11803399, dtype=float64)}
 
     """

--- a/src/coordinax/frames/_src/register_pfxm.py
+++ b/src/coordinax/frames/_src/register_pfxm.py
@@ -7,9 +7,31 @@ from typing import NoReturn
 
 import plum
 
+import coordinax.transforms as cxfm
 from .base import AbstractReferenceFrame
 from .errors import FrameTransformError
 from .null import NoFrame
+
+
+@plum.dispatch(precedence=2)  # ty: ignore[no-matching-overload]
+def frame_transition(from_frame: NoFrame, to_frame: NoFrame, /) -> cxfm.Identity:
+    """Null-to-null frame transition is always the identity.
+
+    When both source and target frames are :obj:`noframe` (i.e. the vector is
+    frame-agnostic) there is nothing to transform, so the result is the
+    identity operation.
+
+    Examples
+    --------
+    >>> import coordinax.frames as cxf
+    >>> import coordinax.transforms as cxfm
+
+    >>> op = cxf.frame_transition(cxf.noframe, cxf.noframe)
+    >>> isinstance(op, cxfm.Identity)
+    True
+
+    """
+    return cxfm.identity
 
 
 @plum.dispatch(precedence=1)  # ty: ignore[no-matching-overload]

--- a/src/coordinax/frames/_src/xfm.py
+++ b/src/coordinax/frames/_src/xfm.py
@@ -11,6 +11,7 @@ from typing_extensions import TypeVar
 import plum
 
 import coordinax.api.frames as cxfapi
+import coordinax.transforms as cxfm
 from .base import AbstractReferenceFrame
 from coordinax.transforms import AbstractTransform
 
@@ -202,6 +203,9 @@ def frame_transition(
 ) -> AbstractTransform:
     """Return a frame transform operator between two transformed frames.
 
+    When ``from_frame`` and ``to_frame`` are the same object the result is
+    the identity transform.
+
     Examples
     --------
     >>> import quaxed.numpy as jnp
@@ -212,6 +216,11 @@ def frame_transition(
 
     >>> R = cxfm.Rotate(jnp.asarray([[0., -1, 0], [1, 0, 0], [0, 0, 1]]))
     >>> frame1 = cxf.TransformedReferenceFrame(ICRS(), R)
+
+    Same frame → identity:
+
+    >>> cxf.frame_transition(frame1, frame1)
+    Identity()
 
     >>> shift = cxfm.Translate.from_([1, 0, 0], "kpc")
     >>> frame2 = cxf.TransformedReferenceFrame(frame1, shift)
@@ -225,6 +234,8 @@ def frame_transition(
         [ 1. -1.  0.]>
 
     """
+    if from_frame is to_frame:
+        return cxfm.identity
     return (
         from_frame.xop.inverse  # ty: ignore[unsupported-operator]
         | cxfapi.frame_transition(from_frame.base_frame, to_frame.base_frame)

--- a/src/coordinax/internal.py
+++ b/src/coordinax/internal.py
@@ -47,11 +47,15 @@ __all__ = (
     "pack_to_qmatrix",
     "pos_named_objs",
     "jax_scalar_handler",
+    # Types
+    "CDict",
+    "OptUSys",
 )
 
 from ._src.setup_package import install_import_hook
 
 with install_import_hook("coordinax.internal"):
+    from coordinax._src.custom_types import CDict, OptUSys
     from coordinax._src.internal import (
         QuantityMatrix,
         UnitsMatrix,

--- a/src/coordinax/main.py
+++ b/src/coordinax/main.py
@@ -88,6 +88,8 @@ __all__ = (  # distances
     "ToUnitsOptions",
 )
 
+import contextlib
+
 from coordinax.angles import Angle
 from coordinax.charts import (
     CartesianProductChart,
@@ -171,7 +173,9 @@ from coordinax.transforms import (
 )
 from coordinax.vectors import Coordinate, Point, Tangent, ToUnitsOptions
 
-try:  # noqa: SIM105
+# Import interop modules to register conversions and chart transitions.
+with contextlib.suppress(ImportError):
     import coordinax.interop.astropy as _  # noqa: F401  # ty: ignore[unresolved-import,unused-ignore-comment]
-except ImportError:
-    pass
+
+# Clean up namespace
+del contextlib

--- a/src/coordinax/main.py
+++ b/src/coordinax/main.py
@@ -83,6 +83,8 @@ __all__ = (  # distances
     "change_basis",
     # vectors
     "Point",
+    "Coordinate",
+    "Tangent",
     "ToUnitsOptions",
 )
 
@@ -167,9 +169,9 @@ from coordinax.transforms import (
     identity,
     simplify,
 )
-from coordinax.vectors import Point, ToUnitsOptions
+from coordinax.vectors import Coordinate, Point, Tangent, ToUnitsOptions
 
 try:  # noqa: SIM105
-    import coordinax.interop.astropy as _  # ty: ignore[unresolved-import,unused-ignore-comment]  # noqa: F401
+    import coordinax.interop.astropy as _  # noqa: F401  # ty: ignore[unresolved-import,unused-ignore-comment]
 except ImportError:
     pass

--- a/src/coordinax/main.py
+++ b/src/coordinax/main.py
@@ -175,7 +175,7 @@ from coordinax.vectors import Coordinate, Point, Tangent, ToUnitsOptions
 
 # Import interop modules to register conversions and chart transitions.
 with contextlib.suppress(ImportError):
-    import coordinax.interop.astropy as _  # noqa: F401  # ty: ignore[unresolved-import,unused-ignore-comment]
+    import coordinax.interop.astropy as _  # noqa: F401  # ty: ignore[unresolved-import]
 
 # Clean up namespace
 del contextlib

--- a/src/coordinax/representations/__init__.py
+++ b/src/coordinax/representations/__init__.py
@@ -53,7 +53,7 @@ Construct the canonical point representation explicitly:
 
 >>> rep = cxr.Representation(cxr.PointGeometry(), cxr.NoBasis(), cxr.Location())
 >>> rep
-Representation(geom_kind=PointGeometry(), basis=NoBasis(), semantic_kind=Location())
+point
 
 This is also provided as a convenient pre-defined instance.
 

--- a/src/coordinax/representations/_src/basis.py
+++ b/src/coordinax/representations/_src/basis.py
@@ -102,7 +102,7 @@ class AbstractBasis(metaclass=abc.ABCMeta):
     # ===============================================================
     # Wadler-Lindig API
 
-    def __pdoc__(self, *, canonical: bool = False, **kw: Any) -> wl.AbstractDoc:
+    def __pdoc__(self, *, canonical: bool = True, **kw: Any) -> wl.AbstractDoc:
         """Generate a Wadler-Lindig docstring for this Basis.
 
         Parameters
@@ -120,7 +120,7 @@ class AbstractBasis(metaclass=abc.ABCMeta):
         >>> import coordinax.representations as cxr
 
         >>> basis = cxr.NoBasis()
-        >>> wl.pprint(basis)
+        >>> wl.pprint(basis, canonical=False)
         NoBasis()
 
         >>> wl.pprint(basis, canonical=True)
@@ -138,9 +138,31 @@ class AbstractBasis(metaclass=abc.ABCMeta):
             indent=kw.get("indent", 4),
         )
 
+    def __repr__(self) -> str:
+        """Return the canonical string representation.
+
+        >>> import coordinax.representations as cxr
+        >>> repr(cxr.coord_basis)
+        'coord_basis'
+        >>> repr(cxr.CoordinateBasis())
+        'coord_basis'
+
+        """
+        return wl.pformat(self, canonical=True)
+
+    def __str__(self) -> str:
+        """Return the verbose string representation.
+
+        >>> import coordinax.representations as cxr
+        >>> str(cxr.coord_basis)
+        'CoordinateBasis()'
+
+        """
+        return wl.pformat(self, canonical=False)
+
 
 @final
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True, slots=True, repr=False)
 class NoBasis(AbstractBasis):
     r"""No-basis kind.
 
@@ -182,7 +204,7 @@ class NoBasis(AbstractBasis):
     The output `q` is still point data, but expressed in the target chart.
 
     >>> import wadler_lindig as wl
-    >>> wl.pprint(basis)
+    >>> wl.pprint(basis, canonical=False)
     NoBasis()
 
     >>> wl.pprint(basis, canonical=True)
@@ -227,7 +249,7 @@ class AbstractLinearBasis(AbstractBasis, metaclass=abc.ABCMeta):
 
 @final
 @jtu.register_static
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True, slots=True, repr=False)
 class CoordinateBasis(AbstractLinearBasis):
     r"""Coordinate basis kind.
 
@@ -277,7 +299,7 @@ coord_basis: Final = CoordinateBasis()
 
 @final
 @jtu.register_static
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True, slots=True, repr=False)
 class PhysicalBasis(AbstractLinearBasis):
     r"""Physical (orthonormal) basis kind.
 

--- a/src/coordinax/representations/_src/basis.py
+++ b/src/coordinax/representations/_src/basis.py
@@ -130,9 +130,10 @@ class AbstractBasis(metaclass=abc.ABCMeta):
         if canonical and self.canonical_name is not None:
             return wl.TextDoc(self.canonical_name)
 
+        items = field_items(self) if dataclasses.is_dataclass(self) else ()
         return wl.bracketed(
             begin=wl.TextDoc(f"{self.__class__.__name__}("),
-            docs=wl.named_objs(field_items(self), **kw),
+            docs=wl.named_objs(items, **kw),
             sep=wl.comma,
             end=wl.TextDoc(")"),
             indent=kw.get("indent", 4),

--- a/src/coordinax/representations/_src/core.py
+++ b/src/coordinax/representations/_src/core.py
@@ -62,8 +62,8 @@ def cmap(*fixed_args: Any, **fixed_kw: Any) -> Any:
     )
 
     """
-    return lambda x, *args, **kwargs: cxrapi.cconvert(
-        x, *fixed_args, *args, **fixed_kw, **kwargs
+    return lambda x, *args, **kw: cxrapi.cconvert(
+        x, *fixed_args, *args, **fixed_kw, **kw
     )
 
 

--- a/src/coordinax/representations/_src/geom.py
+++ b/src/coordinax/representations/_src/geom.py
@@ -121,9 +121,10 @@ class AbstractGeometry(metaclass=abc.ABCMeta):
         if canonical and self.canonical_name is not None:
             return wl.TextDoc(self.canonical_name)
 
+        items = field_items(self) if dataclasses.is_dataclass(self) else ()
         return wl.bracketed(
             begin=wl.TextDoc(f"{self.__class__.__name__}("),
-            docs=wl.named_objs(field_items(self), **kw),
+            docs=wl.named_objs(items, **kw),
             sep=wl.comma,
             end=wl.TextDoc(")"),
             indent=kw.get("indent", 4),

--- a/src/coordinax/representations/_src/geom.py
+++ b/src/coordinax/representations/_src/geom.py
@@ -93,7 +93,7 @@ class AbstractGeometry(metaclass=abc.ABCMeta):
     # ===============================================================
     # Wadler-Lindig API
 
-    def __pdoc__(self, *, canonical: bool = False, **kw: Any) -> wl.AbstractDoc:
+    def __pdoc__(self, *, canonical: bool = True, **kw: Any) -> wl.AbstractDoc:
         """Generate a Wadler-Lindig docstring for this Basis.
 
         Parameters
@@ -111,7 +111,7 @@ class AbstractGeometry(metaclass=abc.ABCMeta):
         >>> import coordinax.representations as cxr
 
         >>> geom = cxr.PointGeometry()
-        >>> wl.pprint(geom)
+        >>> wl.pprint(geom, canonical=False)
         PointGeometry()
 
         >>> wl.pprint(geom, canonical=True)
@@ -129,9 +129,33 @@ class AbstractGeometry(metaclass=abc.ABCMeta):
             indent=kw.get("indent", 4),
         )
 
+    def __repr__(self) -> str:
+        """Return the canonical string representation.
+
+        >>> import coordinax.representations as cxr
+        >>> repr(cxr.point_geom)
+        'point_geom'
+        >>> repr(cxr.PointGeometry())
+        'point_geom'
+
+        """
+        return wl.pformat(self, canonical=True)
+
+    def __str__(self) -> str:
+        """Return the verbose string representation.
+
+        >>> import coordinax.representations as cxr
+        >>> str(cxr.point_geom)
+        'PointGeometry()'
+        >>> str(cxr.PointGeometry())
+        'PointGeometry()'
+
+        """
+        return wl.pformat(self, canonical=False)
+
 
 @final
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True, slots=True, repr=False)
 class PointGeometry(AbstractGeometry):
     r"""Point geometric kind.
 
@@ -188,7 +212,7 @@ point_geom = PointGeometry()
 
 @final
 @jtu.register_static
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True, slots=True, repr=False)
 class TangentGeometry(AbstractGeometry):
     r"""Tangent-vector geometric kind.
 

--- a/src/coordinax/representations/_src/guess.py
+++ b/src/coordinax/representations/_src/guess.py
@@ -80,22 +80,22 @@ def guess_geometry_kind(
     >>> import coordinax.representations as cxr
 
     >>> cxr.guess_geometry_kind(u.dimension("length"))
-    PointGeometry()
+    point_geom
 
     >>> cxr.guess_geometry_kind((u.dimension("angle"), u.dimension("length")))
-    PointGeometry()
+    point_geom
 
     >>> cxr.guess_geometry_kind(u.dimension("speed"))
-    TangentGeometry()
+    tangent_geom
 
     >>> cxr.guess_geometry_kind(u.dimension("angular speed"))
-    TangentGeometry()
+    tangent_geom
 
     >>> cxr.guess_geometry_kind(u.dimension("acceleration"))
-    TangentGeometry()
+    tangent_geom
 
     >>> cxr.guess_geometry_kind(u.dimension("angular acceleration"))
-    TangentGeometry()
+    tangent_geom
 
     """
     try:
@@ -116,13 +116,13 @@ def guess_geometry_kind(obj: u.AbstractQuantity, /) -> AbstractGeometry:
     >>> import coordinax.representations as cxr
 
     >>> cxr.guess_geometry_kind(u.Q(1.0, "m"))
-    PointGeometry()
+    point_geom
 
     >>> cxr.guess_geometry_kind(u.Q(2.0, "m / s"))
-    TangentGeometry()
+    tangent_geom
 
     >>> cxr.guess_geometry_kind(u.Q(3.0, "m / s ** 2"))
-    TangentGeometry()
+    tangent_geom
 
     """
     dim = u.dimension_of(obj)
@@ -144,15 +144,15 @@ def guess_geometry_kind(obj: CDict, /) -> AbstractGeometry:
 
     >>> d1 = {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m")}
     >>> cxr.guess_geometry_kind(d1)
-    PointGeometry()
+    point_geom
 
     >>> d2 = {"lon": u.Q(1.0, "deg"), "lat": u.Q(2.0, "deg")}
     >>> cxr.guess_geometry_kind(d2)
-    PointGeometry()
+    point_geom
 
     >>> d3 = {"x": u.Q(1.0, "m / s"), "y": u.Q(2.0, "m / s")}
     >>> cxr.guess_geometry_kind(d3)
-    TangentGeometry()
+    tangent_geom
 
     """
     # Find the `dim` for determining the geometry kind
@@ -181,7 +181,7 @@ def guess_geometry_kind(obj: CDict, chart: cxc.AbstractChart, /) -> AbstractGeom
 
     >>> d = {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m")}
     >>> cxr.guess_geometry_kind(d, cxc.cart2d)
-    PointGeometry()
+    point_geom
 
     """  # noqa: E501
     # Confirm data is compatible with the chart (e.g., no "x" component for
@@ -206,7 +206,7 @@ def guess_geometry_kind(
     >>> d = {"mu": u.Q(1, "km2"), "nu": u.Q(0.5, "km2"), "phi": u.Q(1, "deg")}
     >>> chart = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(1.0, "km"))
     >>> cxr.guess_geometry_kind(d, chart)
-    PointGeometry()
+    point_geom
 
     """  # noqa: E501
     # Confirm data is compatible with the chart (e.g., no "x" component for
@@ -266,10 +266,10 @@ def guess_basis_kind(
     >>> import coordinax.representations as cxr
 
     >>> cxr.guess_basis_kind(u.dimension("length"))
-    NoBasis()
+    no_basis
 
     >>> cxr.guess_basis_kind((u.dimension("angle"), u.dimension("length")))
-    NoBasis()
+    no_basis
 
     """
     try:
@@ -290,7 +290,7 @@ def guess_basis_kind(obj: u.AbstractQuantity, /) -> AbstractBasis:
     >>> import coordinax.representations as cxr
 
     >>> cxr.guess_basis_kind(u.Q(1.0, "m"))
-    NoBasis()
+    no_basis
 
     """
     dim = u.dimension_of(obj)
@@ -309,11 +309,11 @@ def guess_basis_kind(obj: CDict, /) -> AbstractBasis:
 
     >>> d1 = {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m")}
     >>> cxr.guess_basis_kind(d1)
-    NoBasis()
+    no_basis
 
     >>> d2 = {"lon": u.Q(1.0, "deg"), "lat": u.Q(2.0, "deg")}
     >>> cxr.guess_basis_kind(d2)
-    NoBasis()
+    no_basis
 
     """
     dims = {u.dimension_of(v) for v in obj.values()}
@@ -376,22 +376,22 @@ def guess_semantic_kind(
     >>> import coordinax.representations as cxr
 
     >>> cxr.guess_semantic_kind(u.dimension("length"))
-    Location()
+    loc
 
     >>> cxr.guess_semantic_kind((u.dimension("angle"), u.dimension("length")))
-    Location()
+    loc
 
     >>> cxr.guess_semantic_kind(u.dimension("speed"))
-    Velocity()
+    vel
 
     >>> cxr.guess_semantic_kind(u.dimension("angular speed"))
-    Velocity()
+    vel
 
     >>> cxr.guess_semantic_kind(u.dimension("acceleration"))
-    Acceleration()
+    acc
 
     >>> cxr.guess_semantic_kind(u.dimension("angular acceleration"))
-    Acceleration()
+    acc
 
     """
     try:
@@ -412,7 +412,7 @@ def guess_semantic_kind(obj: u.AbstractQuantity, /) -> AbstractSemanticKind:
     >>> import coordinax.representations as cxr
 
     >>> cxr.guess_semantic_kind(u.Q(1.0, "m"))
-    Location()
+    loc
 
     """
     dim = u.dimension_of(obj)
@@ -431,11 +431,11 @@ def guess_semantic_kind(obj: CDict, /) -> AbstractSemanticKind:
 
     >>> d1 = {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m")}
     >>> cxr.guess_semantic_kind(d1)
-    Location()
+    loc
 
     >>> d2 = {"lon": u.Q(1.0, "deg"), "lat": u.Q(2.0, "deg")}
     >>> cxr.guess_semantic_kind(d2)
-    Location()
+    loc
 
     """
     # Find the `dim` for determining the semantic kind
@@ -481,7 +481,7 @@ def guess_rep(obj: PointGeometry, /) -> Representation:
 
     >>> geom = cxr.PointGeometry()
     >>> cxr.guess_rep(geom)
-    Representation(geom_kind=PointGeometry(), basis=NoBasis(), semantic_kind=Location())
+    point
 
     """
     return point  # ty: ignore[invalid-return-type]
@@ -505,7 +505,7 @@ def guess_rep(
 
     >>> rep = cxr.guess_rep(u.dimension("length"), cxr.point_geom)
     >>> rep
-    Representation(geom_kind=PointGeometry(), basis=NoBasis(), semantic_kind=Location())
+    point
 
     """
     return point  # ty: ignore[invalid-return-type]
@@ -529,15 +529,15 @@ def guess_rep(
 
     >>> rep = cxr.guess_rep(u.dimension("speed"), cxr.tangent_geom)
     >>> rep.geom_kind
-    TangentGeometry()
+    tangent_geom
     >>> rep.semantic_kind
-    Velocity()
+    vel
 
     >>> rep = cxr.guess_rep(u.dimension("acceleration"), cxr.tangent_geom)
     >>> rep.geom_kind
-    TangentGeometry()
+    tangent_geom
     >>> rep.semantic_kind
-    Acceleration()
+    acc
 
     """
     sem = cxrapi.guess_semantic_kind(obj)
@@ -561,29 +561,29 @@ def guess_rep(
 
     >>> rep = cxr.guess_rep(u.dimension("length"))
     >>> rep
-    Representation(geom_kind=PointGeometry(), basis=NoBasis(), semantic_kind=Location())
+    point
 
     >>> rep = cxr.guess_rep(u.Q(1.0, "m"))
     >>> rep
-    Representation(geom_kind=PointGeometry(), basis=NoBasis(), semantic_kind=Location())
+    point
 
     >>> rep = cxr.guess_rep(u.dimension("speed"))
     >>> rep.geom_kind
-    TangentGeometry()
+    tangent_geom
     >>> rep.semantic_kind
-    Velocity()
+    vel
 
     >>> rep = cxr.guess_rep(u.Q(1.0, "m / s"))
     >>> rep.geom_kind
-    TangentGeometry()
+    tangent_geom
     >>> rep.semantic_kind
-    Velocity()
+    vel
 
     >>> rep = cxr.guess_rep(u.dimension("acceleration"))
     >>> rep.geom_kind
-    TangentGeometry()
+    tangent_geom
     >>> rep.semantic_kind
-    Acceleration()
+    acc
 
     """
     geom = cxrapi.guess_geometry_kind(obj)
@@ -602,11 +602,11 @@ def guess_rep(obj: Any, chart: cxc.AbstractChart, /) -> Representation:
 
     >>> rep = cxr.guess_rep(u.dimension("length"))
     >>> rep
-    Representation(geom_kind=PointGeometry(), basis=NoBasis(), semantic_kind=Location())
+    point
 
     >>> rep = cxr.guess_rep(u.Q(1.0, "m"))
     >>> rep
-    Representation(geom_kind=PointGeometry(), basis=NoBasis(), semantic_kind=Location())
+    point
 
     """
     geom = cxrapi.guess_geometry_kind(obj, chart)
@@ -627,7 +627,7 @@ def guess_rep(
 
     >>> rep = cxr.guess_rep(u.Q(1.0, "m"), cxc.cart2d, point_geom)
     >>> rep
-    Representation(geom_kind=PointGeometry(), basis=NoBasis(), semantic_kind=Location())
+    point
 
     """
     return point  # ty: ignore[invalid-return-type]
@@ -649,16 +649,14 @@ def guess_rep(
 
     >>> rep = cxr.guess_rep(u.Q([1.0, 2.0], "m / s"), cxc.cart2d, cxr.TangentGeometry())
     >>> rep
-    Representation(geom_kind=TangentGeometry(), basis=CoordinateBasis(),
-                   semantic_kind=Velocity())
+    coord_vel
 
     Length dimensions would infer Location in general, but TangentGeometry
     requires a tangent semantic kind, so Displacement is returned instead:
 
     >>> rep = cxr.guess_rep(u.Q([1.0, 2.0], "m"), cxc.cart2d, cxr.TangentGeometry())
     >>> rep
-    Representation(geom_kind=TangentGeometry(), basis=CoordinateBasis(),
-                   semantic_kind=Displacement())
+    coord_disp
 
     """
     # Infer the semantic kind from the data.

--- a/src/coordinax/representations/_src/rep.py
+++ b/src/coordinax/representations/_src/rep.py
@@ -176,7 +176,8 @@ class Representation(Generic[GeomT, BasisT, SemanticT]):
             return wl.TextDoc(CANONICAL_REPRESENTATIONS[self])
 
         if field_names:
-            docs = wl.named_objs(field_items(self), canonical=canonical, **kw)
+            fi = field_items(self) if dataclasses.is_dataclass(self) else ()
+            docs = wl.named_objs(fi, canonical=canonical, **kw)
         else:
             fvals = cast("Iterable[Any]", field_values(self))
             docs = [wl.pdoc(v, canonical=canonical, **kw) for v in fvals]

--- a/src/coordinax/representations/_src/rep.py
+++ b/src/coordinax/representations/_src/rep.py
@@ -39,7 +39,7 @@ SemanticT = TypeVar(
 
 @jtu.register_static
 @final
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True, slots=True, repr=False)
 class Representation(Generic[GeomT, BasisT, SemanticT]):
     r"""Representation of geometric component data.
 
@@ -140,7 +140,7 @@ class Representation(Generic[GeomT, BasisT, SemanticT]):
     # Wadler-Lindig API
 
     def __pdoc__(
-        self, *, field_names: bool = True, canonical: bool = False, **kw: Any
+        self, *, field_names: bool = True, canonical: bool = True, **kw: Any
     ) -> wl.AbstractDoc:
         """Generate a Wadler-Lindig docstring for this representation.
 
@@ -161,15 +161,15 @@ class Representation(Generic[GeomT, BasisT, SemanticT]):
         >>> import coordinax.representations as cxr
 
         >>> rep = cxr.Representation(cxr.PointGeometry(), cxr.NoBasis(), cxr.Location())
-        >>> wl.pprint(rep)
+        >>> wl.pprint(rep, canonical=True)
+        point
+
+        >>> wl.pprint(rep, canonical=False)
         Representation(geom_kind=PointGeometry(), basis=NoBasis(),
                        semantic_kind=Location())
 
-        >>> wl.pprint(rep, field_names=False)
+        >>> wl.pprint(rep, canonical=False, field_names=False)
         Representation(PointGeometry(), NoBasis(), Location())
-
-        >>> wl.pprint(rep, canonical=True)
-        point
 
         """
         if canonical and self in CANONICAL_REPRESENTATIONS:
@@ -188,6 +188,29 @@ class Representation(Generic[GeomT, BasisT, SemanticT]):
             end=wl.TextDoc(")"),
             indent=kw.get("indent", 4),
         )
+
+    def __repr__(self) -> str:
+        """Return the canonical string representation.
+
+        >>> import coordinax.representations as cxr
+        >>> repr(cxr.point)
+        'point'
+        >>> repr(cxr.coord_vel)
+        'coord_vel'
+
+        """
+        return wl.pformat(self, canonical=True)
+
+    def __str__(self) -> str:
+        """Return the verbose string representation.
+
+        >>> import coordinax.representations as cxr
+        >>> print(cxr.point)
+        Representation(geom_kind=PointGeometry(), basis=NoBasis(),
+                       semantic_kind=Location())
+
+        """
+        return wl.pformat(self, canonical=False)
 
 
 point = Representation(point_geom, no_basis, loc)

--- a/src/coordinax/representations/_src/semantics.py
+++ b/src/coordinax/representations/_src/semantics.py
@@ -135,7 +135,7 @@ class AbstractSemanticKind(metaclass=abc.ABCMeta):
     # ===============================================================
     # Wadler-Lindig API
 
-    def __pdoc__(self, *, canonical: bool = False, **kw: Any) -> wl.AbstractDoc:
+    def __pdoc__(self, *, canonical: bool = True, **kw: Any) -> wl.AbstractDoc:
         """Generate a Wadler-Lindig docstring for this Basis.
 
         Parameters
@@ -153,7 +153,7 @@ class AbstractSemanticKind(metaclass=abc.ABCMeta):
         >>> import coordinax.representations as cxr
 
         >>> semantic = cxr.Location()
-        >>> wl.pprint(semantic)
+        >>> wl.pprint(semantic, canonical=False)
         Location()
 
         >>> wl.pprint(semantic, canonical=True)
@@ -171,13 +171,35 @@ class AbstractSemanticKind(metaclass=abc.ABCMeta):
             indent=kw.get("indent", 4),
         )
 
+    def __repr__(self) -> str:
+        """Return the canonical string representation.
+
+        >>> import coordinax.representations as cxr
+        >>> repr(cxr.vel)
+        'vel'
+        >>> repr(cxr.Velocity())
+        'vel'
+
+        """
+        return wl.pformat(self, canonical=True)
+
+    def __str__(self) -> str:
+        """Return the verbose string representation.
+
+        >>> import coordinax.representations as cxr
+        >>> str(cxr.vel)
+        'Velocity()'
+
+        """
+        return wl.pformat(self, canonical=False)
+
 
 # ===================================================================
 
 
 @final
 @jtu.register_static
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True, slots=True, repr=False)
 class Location(AbstractSemanticKind):
     r"""Location semantic kind.
 
@@ -480,9 +502,9 @@ class AbstractTangentSemanticKind(AbstractSemanticKind):
         --------
         >>> import coordinax.representations as cxr
         >>> cxr.Displacement().derivative()
-        Velocity()
+        vel
         >>> cxr.Velocity().derivative()
-        Acceleration()
+        acc
         >>> try:
         ...     cxr.Acceleration().derivative()   # no Jerk registered yet
         ... except ValueError as e:
@@ -519,9 +541,9 @@ class AbstractTangentSemanticKind(AbstractSemanticKind):
         --------
         >>> import coordinax.representations as cxr
         >>> cxr.Acceleration().antiderivative()
-        Velocity()
+        vel
         >>> cxr.Velocity().antiderivative()
-        Displacement()
+        dpl
         >>> try:
         ...     cxr.Displacement().antiderivative()   # no Absement registered yet
         ... except ValueError as e:
@@ -542,7 +564,7 @@ _TANGENT_TIME_ORDER_LADDER: Final[dict[int, type[AbstractTangentSemanticKind]]] 
 
 @final
 @jtu.register_static
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True, slots=True, repr=False)
 class Displacement(AbstractTangentSemanticKind):
     r"""Displacement semantic kind.
 
@@ -584,7 +606,7 @@ class Displacement(AbstractTangentSemanticKind):
         --------
         >>> import coordinax.representations as cxr
         >>> cxr.Displacement().derivative()
-        Velocity()
+        vel
 
         """
         return vel
@@ -596,7 +618,7 @@ dpl = Displacement()
 
 @final
 @jtu.register_static
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True, slots=True, repr=False)
 class Velocity(AbstractTangentSemanticKind):
     r"""Velocity semantic kind.
 
@@ -636,7 +658,7 @@ class Velocity(AbstractTangentSemanticKind):
         --------
         >>> import coordinax.representations as cxr
         >>> cxr.Velocity().derivative()
-        Acceleration()
+        acc
 
         """
         return acc
@@ -651,7 +673,7 @@ class Velocity(AbstractTangentSemanticKind):
         --------
         >>> import coordinax.representations as cxr
         >>> cxr.Velocity().antiderivative()
-        Displacement()
+        dpl
 
         """
         return dpl
@@ -663,7 +685,7 @@ vel = Velocity()
 
 @final
 @jtu.register_static
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True, slots=True, repr=False)
 class Acceleration(AbstractTangentSemanticKind):
     r"""Acceleration semantic kind.
 
@@ -703,7 +725,7 @@ class Acceleration(AbstractTangentSemanticKind):
         --------
         >>> import coordinax.representations as cxr
         >>> cxr.Acceleration().antiderivative()
-        Velocity()
+        vel
 
         """
         return vel

--- a/src/coordinax/representations/_src/semantics.py
+++ b/src/coordinax/representations/_src/semantics.py
@@ -329,7 +329,7 @@ def d_dt_dim(
 
 
 @jtu.register_static
-class AbstractTangentSemanticKind(AbstractSemanticKind, metaclass=abc.ABCMeta):
+class AbstractTangentSemanticKind(AbstractSemanticKind):
     r"""Abstract base class for tangent-vector semantic kinds.
 
     A tangent semantic kind specifies the **meaning** of a tangent-vector

--- a/src/coordinax/representations/_src/semantics.py
+++ b/src/coordinax/representations/_src/semantics.py
@@ -130,7 +130,7 @@ class AbstractSemanticKind(metaclass=abc.ABCMeta):
             dimensionless.
 
         """
-        ...
+        raise NotImplementedError  # pragma: no cover
 
     # ===============================================================
     # Wadler-Lindig API
@@ -163,9 +163,10 @@ class AbstractSemanticKind(metaclass=abc.ABCMeta):
         if canonical and self.canonical_name is not None:
             return wl.TextDoc(self.canonical_name)
 
+        items = field_items(self) if dataclasses.is_dataclass(self) else ()
         return wl.bracketed(
             begin=wl.TextDoc(f"{self.__class__.__name__}("),
-            docs=wl.named_objs(field_items(self), **kw),
+            docs=wl.named_objs(items, **kw),
             sep=wl.comma,
             end=wl.TextDoc(")"),
             indent=kw.get("indent", 4),

--- a/src/coordinax/transforms/_src/actions/base.py
+++ b/src/coordinax/transforms/_src/actions/base.py
@@ -77,7 +77,7 @@ class AbstractTransform(eqx.Module):
     @abc.abstractmethod
     def inverse(self) -> "AbstractTransform":
         """The inverse of the operator."""
-        ...
+        raise NotImplementedError  # pragma: no cover
 
     def simplify(self) -> "AbstractTransform":
         """Simplify the operator.

--- a/src/coordinax/transforms/_src/actions/composed.py
+++ b/src/coordinax/transforms/_src/actions/composed.py
@@ -288,9 +288,21 @@ def act(
     {'x': Q(1, 'km'), 'y': Q(2, 'km'), 'z': Q(3, 'km')}
 
     """
+    # 'at' tracks the evolving base point for tangent Jacobians: advance it
+    # after each sub-op so the next step evaluates at the correct anchor.
+    current_at = kw.get("at")
     result = x
     for sub_op in op.transforms:
-        result = cxfmapi.act(sub_op, tau, result, chart, rep, **kw)
+        result = cxfmapi.act(
+            sub_op,
+            tau,
+            result,
+            chart,
+            rep,
+            **({**kw, "at": current_at} if current_at is not None else kw),
+        )
+        if current_at is not None:
+            current_at = cxfmapi.act(sub_op, tau, current_at, chart, cxr.point)
     return cast("CDict", result)
 
 

--- a/src/coordinax/transforms/_src/actions/composed.py
+++ b/src/coordinax/transforms/_src/actions/composed.py
@@ -291,6 +291,7 @@ def act(
     # 'at' tracks the evolving base point for tangent Jacobians: advance it
     # after each sub-op so the next step evaluates at the correct anchor.
     current_at = kw.get("at")
+    kw_no_at = {k: v for k, v in kw.items() if k != "at"}
     result = x
     for sub_op in op.transforms:
         result = cxfmapi.act(
@@ -302,7 +303,9 @@ def act(
             **({**kw, "at": current_at} if current_at is not None else kw),
         )
         if current_at is not None:
-            current_at = cxfmapi.act(sub_op, tau, current_at, chart, cxr.point)
+            current_at = cxfmapi.act(
+                sub_op, tau, current_at, chart, cxr.point, **kw_no_at
+            )
     return cast("CDict", result)
 
 

--- a/src/coordinax/transforms/_src/actions/rotate.py
+++ b/src/coordinax/transforms/_src/actions/rotate.py
@@ -640,21 +640,25 @@ def act(
     rep: cxr.Representation,
     /,
     *,
+    at: CDict | None = None,
     usys: OptUSys = None,
     **kw: Any,
 ) -> CDict:
     """Apply a spatial rotation to a TangentGeometry coordinate dictionary.
 
-    Rotation is linear, so tangent vectors (for example velocity or
-    acceleration) transform with the same rotation matrix as point
-    coordinates.
+    Rotation acts on tangent vectors via the Jacobian pushforward, not as a
+    direct coordinate substitution.  The algorithm is:
 
-    The implementation:
+    1. Push ``x`` to the chart's canonical Cartesian chart via the Jacobian.
+    2. Pack Cartesian components to a common unit.
+    3. Apply ``R`` via ``einsum`` in a batch-safe way.
+    4. Pull the result back to the original chart via the inverse Jacobian
+       evaluated at the rotated base point.
 
-    1. Converts ``x`` to the chart canonical Cartesian chart.
-    2. Packs Cartesian components to a common unit.
-    3. Applies ``R`` via ``einsum`` in a batch-safe way.
-    4. Converts the rotated result back to the original chart.
+    For Cartesian charts the Jacobian is the identity, so steps 1 and 4 are
+    no-ops and ``at`` is not required.  For all other charts (e.g. spherical)
+    ``at`` **must** be supplied: it is the base point (in the original chart)
+    at which the Jacobian is evaluated.
 
     Examples
     --------
@@ -672,26 +676,54 @@ def act(
     >>> jnp.stack([out[c].to_value("m/s") for c in ("x", "y", "z")]).round(3)
     Array([0., 1., 0.], dtype=float64)
 
+    Rotate a spherical velocity at a given base point:
+
+    >>> import jax.numpy as jnp
+    >>> op = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+    >>> x = {"r": u.Q(1, "m/s"), "theta": u.Q(0, "rad/s"), "phi": u.Q(0, "rad/s")}
+    >>> at = {"r": u.Q(1, "m"), "theta": u.Q(jnp.pi / 2, "rad"), "phi": u.Q(0, "rad")}
+    >>> out = cxfm.act(op, None, x, cxc.sph3d, cxr.tangent_geom, cxr.coord_vel, at=at)
+    >>> round(float(out["r"].to_value("m/s")), 3)  # radial component preserved
+    1.0
+
     """
-    del geom, rep, kw  # Rotation acts identically on tangent vectors.
+    del geom, kw
 
     cart = chart.cartesian
-    comps_cart = cart.components
-
     op_eval = materialize_transform(op, tau)
     R = op_eval._get_R(cart)
 
-    # Convert to canonical Cartesian chart.
-    p_cart = cxc.pt_map(x, chart, cart, usys=usys)
+    if chart is cart:
+        # Cartesian chart: Jacobian is the identity — simple linear map.
+        p_cart = x
+    else:
+        # Non-Cartesian chart: push tangent forward via Jacobian.
+        if at is None:
+            msg = (
+                "act(Rotate, ..., TangentGeometry) on a non-Cartesian chart "
+                f"({chart!r}) requires 'at' (base point in chart coords) so "
+                "the Jacobian pushforward can be evaluated."
+            )
+            raise TypeError(msg)
+        at_cart = cxc.pt_map(at, chart, cart, usys=usys)
+        p_cart = cxr.tangent_map(x, chart, rep, cart, at=at, usys=usys)  # ty: ignore[missing-argument]
 
     # Pack -> rotate -> unpack (batch-safe)
-    v, unit = pack_uniform_unit(p_cart, keys=comps_cart)  # ty: ignore[no-matching-overload]
+    comps_cart = cart.components
+    v, unit = pack_uniform_unit(p_cart, keys=comps_cart)
     v_rot = jnp.einsum("ij,...j->...i", R, v)  # (..., n)
     p_cart_rot = cxc.cdict(v_rot, unit, comps_cart)
 
-    # Convert back to original chart.
-    out = cxc.pt_map(p_cart_rot, cart, chart, usys=usys)
-    return cast("CDict", out)
+    if chart is cart:
+        return p_cart_rot  # ty: ignore[invalid-return-type]
+
+    # Rotate the base point in Cartesian to anchor the inverse Jacobian.
+    at_cart_arr, at_unit = pack_uniform_unit(at_cart, keys=comps_cart)  # ty: ignore[no-matching-overload]
+    at_cart_rot_arr = jnp.einsum("ij,...j->...i", R, at_cart_arr)
+    at_cart_rot = cxc.cdict(at_cart_rot_arr, at_unit, comps_cart)
+
+    # Pull rotated tangent back to original chart via inverse Jacobian.
+    return cxr.tangent_map(p_cart_rot, cart, rep, chart, at=at_cart_rot, usys=usys)  # ty: ignore[missing-argument]
 
 
 # -----------------------------------------------

--- a/src/coordinax/transforms/_src/actions/translate.py
+++ b/src/coordinax/transforms/_src/actions/translate.py
@@ -297,12 +297,6 @@ def _act_translate_cdict(
     """Displacement-semantic translate: shifts points and displacement vectors."""
     op_eval = materialize_transform(op, tau)
 
-    # A vel/acc-semantic translate does not move position points.
-    # This check should never trigger here since dispatch selects on Displacement,
-    # but explicit for consistency with other overloads.
-    if rep == cxr.point and not isinstance(op.semantic_kind, cxr.Displacement):
-        return x
-
     if rep == cxr.point:
         # Translate in Cartesian space, then map back.
         cart = chart.cartesian

--- a/src/coordinax/transforms/_src/actions/translate.py
+++ b/src/coordinax/transforms/_src/actions/translate.py
@@ -150,11 +150,23 @@ def act(
     >>> cxfm.act(shift, None, x,  cxc.cart3d, cxr.point, usys=usys)
     Array([1000., 2000., 3000.], dtype=float64)
 
+    Velocity-semantic translate is identity on point arrays:
+
+    >>> import coordinax.representations as cxr
+    >>> from dataclassish import replace
+    >>> vel_shift = replace(shift, semantic_kind=cxr.vel)
+    >>> cxfm.act(vel_shift, None, x, cxc.cart3d, cxr.point, usys=usys)
+    Array([0., 0., 0.], dtype=float64)
+
     """
     del kw
 
     if rep != cxr.point:
         raise TypeError("Translate can only be applied to point representations")
+
+    # A vel/acc-semantic translate does not move position points.
+    if not isinstance(op.semantic_kind, cxr.Displacement):
+        return jnp.asarray(x)
 
     if usys is None:
         raise TypeError("Translate requires usys to convert delta to x's units")
@@ -202,6 +214,8 @@ def act(
     --------
     >>> import jax.numpy as jnp
     >>> import coordinax.transforms as cxfm
+    >>> import coordinax.representations as cxr
+    >>> from dataclassish import replace
     >>> import unxt as u
 
     >>> shift = cxfm.Translate.from_([1, 2, 3], "km")
@@ -209,9 +223,19 @@ def act(
     >>> cxfm.act(shift, None, x, cxc.cart3d, cxr.point)
     Q([1000., 2000., 3000.], 'm')
 
+    Velocity-semantic translate is identity on point quantities:
+
+    >>> vel_shift = replace(shift, semantic_kind=cxr.vel)
+    >>> cxfm.act(vel_shift, None, x, cxc.cart3d, cxr.point)
+    Q([0., 0., 0.], 'm')
+
     """
     if rep != cxr.point:
         raise TypeError("Translate can only be applied to point representations")
+
+    # A vel/acc-semantic translate does not move position points.
+    if not isinstance(op.semantic_kind, cxr.Displacement):
+        return x
 
     # Process Translation
     op_eval = materialize_transform(op, tau)
@@ -273,6 +297,12 @@ def _act_translate_cdict(
     """Displacement-semantic translate: shifts points and displacement vectors."""
     op_eval = materialize_transform(op, tau)
 
+    # A vel/acc-semantic translate does not move position points.
+    # This check should never trigger here since dispatch selects on Displacement,
+    # but explicit for consistency with other overloads.
+    if rep == cxr.point and not isinstance(op.semantic_kind, cxr.Displacement):
+        return x
+
     if rep == cxr.point:
         # Translate in Cartesian space, then map back.
         cart = chart.cartesian
@@ -327,6 +357,10 @@ def _act_translate_cdict(
 ) -> CDict:
     """Velocity/acceleration-semantic translate: shifts matching tangent vectors."""
     op_eval = materialize_transform(op, tau)
+
+    # A vel/acc-semantic translate does not move position points.
+    if rep == cxr.point:
+        return x
 
     if rep.semantic_kind == sk:
         return cast(

--- a/src/coordinax/transforms/_src/actions/translate.py
+++ b/src/coordinax/transforms/_src/actions/translate.py
@@ -331,6 +331,13 @@ def _act_translate_cdict(
 
     if isinstance(rep.semantic_kind, cxr.Displacement):
         # Shift displacement-valued tangent representations.
+        if op_eval.chart != chart:
+            msg = (
+                f"Translate.delta is defined in chart {op_eval.chart!r}, "
+                f"but the representation is in chart {chart!r}. "
+                "Convert delta to the target chart before constructing Translate."
+            )
+            raise ValueError(msg)
         return cast(
             "CDict",
             jtu.map(
@@ -363,6 +370,13 @@ def _act_translate_cdict(
         return x
 
     if rep.semantic_kind == sk:
+        if op_eval.chart != chart:
+            msg = (
+                f"Translate.delta is defined in chart {op_eval.chart!r}, "
+                f"but the representation is in chart {chart!r}. "
+                "Convert delta to the target chart before constructing Translate."
+            )
+            raise ValueError(msg)
         return cast(
             "CDict",
             jtu.map(

--- a/src/coordinax/transforms/_src/actions/translate.py
+++ b/src/coordinax/transforms/_src/actions/translate.py
@@ -3,7 +3,6 @@
 __all__ = ("Translate",)
 
 
-from collections.abc import Callable
 from jaxtyping import Array, ArrayLike
 from typing import Any, Union, cast, final
 
@@ -177,60 +176,6 @@ def act(
     return x_arr + delta if op_eval.right_add else delta + x_arr  # ty: ignore[unsupported-operator]
 
 
-def _require_tau_time(tau: Any, /) -> tuple[Array, u.AbstractUnit]:
-    """Return (tau_value, tau_unit), requiring tau to be a time quantity."""
-    # We require a Quantity-like tau with time dimension so we can form d/dtau.
-    tau = eqx.error_if(
-        tau,
-        not u.quantity.is_any_quantity(tau),
-        "Translate requires tau as a time Quantity when delta is time-dependent",
-    )
-    tau_unit = u.unit_of(tau)
-    tau = eqx.error_if(
-        tau,
-        u.dimension_of(tau_unit) != u.dimension_of(u.unit("s")),
-        "Translate requires tau to have time dimension",
-    )
-    # Differentiate with respect to the numeric tau in its own unit.
-    return jnp.asarray(u.ustrip(tau_unit, tau)), tau_unit  # ty: ignore[invalid-return-type]
-
-
-def _delta_values_fn(
-    delta_fn: Callable[[Any], Any],
-    chart: cxc.AbstractChart,
-    tau_unit: u.AbstractUnit,
-    /,
-) -> tuple[Callable[[Array], Array], u.AbstractUnit | None]:
-    """Build a pure-JAX function returning packed delta values.
-
-    Returns
-    -------
-    (f, unit)
-        f: tau_value -> Array[... , n] of delta values in `chart.components` order.
-        unit: common length unit returned by `pack_uniform_unit`.
-
-    Notes
-    -----
-    We wrap `tau_value` back into a Quantity with unit `tau_unit` before calling
-    the user-provided `delta_fn`.
-
-    """
-    keys = chart.components
-
-    def f(tau_value: Array) -> Array:
-        tau_q = u.Q(tau_value, tau_unit)
-        d = delta_fn(tau_q)
-        vals, _unit = pack_uniform_unit(d, keys=keys)
-        # Ensure an array output for JAX differentiation.
-        return jnp.asarray(vals)
-
-    # One eager call to learn the unit.
-    vals0, unit0 = pack_uniform_unit(delta_fn(u.Q(jnp.zeros(()), tau_unit)), keys=keys)
-    del vals0
-
-    return f, unit0
-
-
 # -----------------------------------------------
 # Special dispatches for Quantity.
 # These are interpreted as Cartesian coordinates in a Euclidean metric
@@ -294,19 +239,15 @@ def act(
 ) -> CDict:
     """Apply Translate to a Point-valued component dictionary.
 
-    Translation is performed in the canonical Cartesian chart of ``chart``:
-
-    1. Convert the point ``x`` to ``cart = chart.cartesian``.
-    2. Convert ``delta`` to the same ``cart`` using
-        ``api.phys_tangent_basis_change`` evaluated at the point being
-        translated (expressed in ``op.chart``).
-    3. Add in Cartesian components.
-    4. Convert the translated point back to ``chart``.
+    Dispatches on ``op.semantic_kind`` to determine which representations
+    are shifted.
 
     Examples
     --------
     >>> import coordinax.transforms as cxfm
     >>> import unxt as u
+
+    Default (displacement-semantic) translate shifts points:
 
     >>> shift = cxfm.Translate.from_([1, 2, 3], "km")
     >>> x = {"x": u.Q(0, "km"), "y": u.Q(0, "km"), "z": u.Q(0, "km")}
@@ -315,38 +256,87 @@ def act(
 
     """
     del kw
+    return _act_translate_cdict(op.semantic_kind, op, tau, x, chart, rep, usys=usys)
 
-    if rep != cxr.point:
-        raise TypeError("Translate can only be applied to point representations")
 
+@plum.dispatch
+def _act_translate_cdict(
+    sk: cxr.Displacement,
+    op: Translate,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+    usys: OptUSys = None,
+) -> CDict:
+    """Displacement-semantic translate: shifts points and displacement vectors."""
     op_eval = materialize_transform(op, tau)
 
-    # Shared canonical Cartesian chart for performing the translation.
-    cart = chart.cartesian
+    if rep == cxr.point:
+        # Translate in Cartesian space, then map back.
+        cart = chart.cartesian
+        x_cart = cxc.pt_map(x, chart, cart, usys=usys)
 
-    # Convert point to Cartesian.
-    x_cart = cxc.pt_map(x, chart, cart, usys=usys)
+        if op_eval.chart == cart:
+            delta_cart = op_eval.delta
+        else:
+            # Push delta through the Jacobian into Cartesian.
+            at_in_op_chart = cxc.pt_map(x_cart, cart, op_eval.chart, usys=usys)
+            delta_cart = cxr.tangent_map(  # ty: ignore[missing-argument]
+                op_eval.delta,
+                op_eval.chart,
+                cxr.coord_disp,
+                cart,
+                at=at_in_op_chart,
+                usys=usys,
+            )
 
-    # Convert delta to Cartesian (as a physical displacement).
-    if op_eval.chart == cart:
-        delta_cart = op_eval.delta
-    else:
-        raise NotImplementedError(
-            "Translation by a delta in a different chart is not implemented yet."
+        x_cart2 = jtu.map(
+            jnp.add,
+            *((x_cart, delta_cart) if op_eval.right_add else (delta_cart, x_cart)),
+            is_leaf=u.quantity.is_any_quantity,
         )
-        # # Base point expressed in the delta's chart.
-        # at_in_op_chart = cxc.pt_map(x, chart, op_eval.chart, usys=usys)
-        # delta_cart = cxtapi.phys_tangent_basis_change(
-        #     op_eval.delta, op_eval.chart, cart, at=at_in_op_chart, usys=usys
-        # )
+        return cast("CDict", cxc.pt_map(x_cart2, cart, chart, usys=usys))
 
-    # Add in Cartesian components (key-wise).
-    x_cart2 = jtu.map(
-        jnp.add,
-        *((x_cart, delta_cart) if op_eval.right_add else (delta_cart, x_cart)),
-        is_leaf=u.quantity.is_any_quantity,
-    )
+    if isinstance(rep.semantic_kind, cxr.Displacement):
+        # Shift displacement-valued tangent representations.
+        return cast(
+            "CDict",
+            jtu.map(
+                jnp.add,
+                *((x, op_eval.delta) if op_eval.right_add else (op_eval.delta, x)),
+                is_leaf=u.quantity.is_any_quantity,
+            ),
+        )
 
-    # Convert back to the input chart.
-    out = cxc.pt_map(x_cart2, cart, chart, usys=usys)
-    return cast("CDict", out)
+    # Identity for velocity, acceleration, and other representations.
+    return x
+
+
+@plum.dispatch
+def _act_translate_cdict(
+    sk: cxr.AbstractTangentSemanticKind,
+    op: Translate,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+    usys: OptUSys = None,
+) -> CDict:
+    """Velocity/acceleration-semantic translate: shifts matching tangent vectors."""
+    op_eval = materialize_transform(op, tau)
+
+    if rep.semantic_kind == sk:
+        return cast(
+            "CDict",
+            jtu.map(
+                jnp.add,
+                *((x, op_eval.delta) if op_eval.right_add else (op_eval.delta, x)),
+                is_leaf=u.quantity.is_any_quantity,
+            ),
+        )
+
+    # Identity for non-matching representations.
+    return x

--- a/src/coordinax/vectors/__init__.py
+++ b/src/coordinax/vectors/__init__.py
@@ -4,6 +4,8 @@ __all__ = (
     "cconvert",
     "AbstractVector",
     "Point",
+    "Coordinate",
+    "Tangent",
     "ToUnitsOptions",
 )
 
@@ -12,7 +14,9 @@ from ._setup_package import install_import_hook
 with install_import_hook("coordinax.vectors"):
     from ._src import (
         AbstractVector,
+        Coordinate,
         Point,
+        Tangent,
         ToUnitsOptions,
     )
     from coordinax.api.representations import cconvert

--- a/src/coordinax/vectors/_src/__init__.py
+++ b/src/coordinax/vectors/_src/__init__.py
@@ -2,6 +2,7 @@
 
 from .api import *
 from .base import *
+from .bundle import *
 from .constants import *
 from .custom_types import *
 from .mixins import *
@@ -10,4 +11,5 @@ from .register_cx import *
 from .register_dataclassish import *
 from .register_quax import *
 from .register_unxt import *
+from .tangent import *
 from .utils import *

--- a/src/coordinax/vectors/_src/base.py
+++ b/src/coordinax/vectors/_src/base.py
@@ -16,6 +16,7 @@ import quax_blocks
 import wadler_lindig as wl
 from quax import ArrayValue
 
+import dataclassish
 import quaxed.numpy as jnp
 import unxt as u
 from dataclassish import field_items
@@ -605,4 +606,4 @@ class AbstractVector(
 
         # Otherwise, apply the transformation and return a new point
         new = cxfm.act(op, t, self)
-        return dataclasses.replace(new, frame=toframe)
+        return dataclassish.replace(new, frame=toframe)  # ty: ignore[invalid-return-type]

--- a/src/coordinax/vectors/_src/base.py
+++ b/src/coordinax/vectors/_src/base.py
@@ -602,7 +602,14 @@ class AbstractVector(
 
         # Special case for identity operations (same frame)
         if isinstance(op, cxfm.Identity):
-            return self  # ty: ignore[invalid-return-type]
+            # Return self only when the frame object is already the target (fast
+            # path that preserves object identity).  When two distinct frame
+            # instances resolve to Identity – e.g. two separate NoFrame() values
+            # – we still rebind so that result.frame is literally toframe,
+            # matching the docstring guarantee of "frame=toframe".
+            if self.frame is toframe:
+                return self  # ty: ignore[invalid-return-type]
+            return dataclassish.replace(self, frame=toframe)  # ty: ignore[invalid-return-type]
 
         # Otherwise, apply the transformation and return a new point
         new = cxfm.act(op, t, self)

--- a/src/coordinax/vectors/_src/bundle.py
+++ b/src/coordinax/vectors/_src/bundle.py
@@ -47,27 +47,6 @@ def _broadcast_shapes(shapes: list[tuple[int, ...]]) -> tuple[int, ...]:
     return result
 
 
-def _frames_equal(
-    f1: cxf.AbstractReferenceFrame,
-    f2: cxf.AbstractReferenceFrame,
-) -> bool:
-    """Return True if two reference frames are structurally equal.
-
-    Uses identity check first (handles singletons like ``noframe``, ``alice``,
-    ``alex``), then falls back to Equinox structural equality for parametric
-    frames such as ``TransformedReferenceFrame``.
-    """
-    if f1 is f2:
-        return True
-    if type(f1) is not type(f2):
-        return False
-    # Same type — structural comparison (safe: same type → same pytree structure)
-    result = eqx.tree_equal(f1, f2)
-    if isinstance(result, bool):
-        return result
-    return bool(result)  # JAX boolean → concrete bool at init time
-
-
 def vectorform_pdoc(pv: "Coordinate", **kwargs: Any) -> wl.AbstractDoc:
     """Return the vector-form Wadler-Lindig document for a `Coordinate`."""
     kwargs.setdefault("canonical", True)
@@ -199,9 +178,9 @@ class Coordinate(AbstractVector):
                 raise TypeError(msg)
             vec: Tangent = val
 
-            # Convert to point's frame when frames differ
-            if not _frames_equal(vec.frame, target_frame):
-                vec = vec.to_frame(target_frame)  # ty: ignore[invalid-assignment]
+            # Always convert to point's frame (no-op when already equal;
+            # avoids materialising a JAX boolean which breaks under JIT).
+            vec = vec.to_frame(target_frame)  # ty: ignore[invalid-assignment]
 
             field_vecs[name] = vec
 

--- a/src/coordinax/vectors/_src/bundle.py
+++ b/src/coordinax/vectors/_src/bundle.py
@@ -14,7 +14,6 @@ from typing import Any, cast, final
 from typing_extensions import TypeVar, override
 
 import equinox as eqx
-import jax
 import jax.numpy as jnp
 import wadler_lindig as wl
 from jax.core import ShapedArray
@@ -279,21 +278,10 @@ class Coordinate(AbstractVector):
         if isinstance(key, str):
             return self._data[key]
 
-        # Batch-indexing: slice all arrays in point and all fields
-        nindex = len(key) if isinstance(key, tuple) else 1
-
-        def _index_leaf(x: Any) -> Any:
-            if not eqx.is_array(x):
-                return x
-            if getattr(x, "ndim", 0) < nindex:
-                return x
-            return x[key]
-
-        new_point = jax.tree.map(_index_leaf, self.point, is_leaf=eqx.is_array)
-        new_fields = {
-            k: jax.tree.map(_index_leaf, v, is_leaf=eqx.is_array)
-            for k, v in self._data.items()
-        }
+        # Batch-indexing: delegate to Point/Tangent indexing so invalid
+        # indices raise consistently instead of silently skipping.
+        new_point = self.point[key]
+        new_fields = {k: v[key] for k, v in self._data.items()}
         return Coordinate(point=new_point, **new_fields)
 
     def keys(self) -> KeysView[str]:

--- a/src/coordinax/vectors/_src/bundle.py
+++ b/src/coordinax/vectors/_src/bundle.py
@@ -1,0 +1,576 @@
+"""Coordinate: vector bundle anchored at a base point.
+
+A `Coordinate` stores a base `Point` and a named collection of fibre
+`Tangent`s (TangentGeometry rep) anchored at that point.  On construction,
+every fibre vector is automatically converted into the reference frame of the
+base point so the bundle is always internally consistent.
+"""
+
+__all__ = ("Coordinate",)
+
+
+from collections.abc import ItemsView, Iterator, KeysView, Mapping, ValuesView
+from typing import Any, cast, final
+from typing_extensions import TypeVar, override
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import wadler_lindig as wl
+from jax.core import ShapedArray
+
+import coordinax.charts as cxc
+import coordinax.frames as cxf
+import coordinax.manifolds as cxm
+import coordinax.representations as cxr
+from .base import AbstractVector
+from .point import Point, _vector_comps_unit_docs, _vector_values_str
+from .tangent import Tangent, _vectorform_pdoc as _vec_vectorform_pdoc
+from coordinax.internal import OptUSys
+
+ChartT = TypeVar(
+    "ChartT", bound=cxc.AbstractChart[Any, Any], default=cxc.AbstractChart[Any, Any]
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _broadcast_shapes(shapes: list[tuple[int, ...]]) -> tuple[int, ...]:
+    """Return the broadcast shape of a list of shapes."""
+    if not shapes:
+        return ()
+    result = shapes[0]
+    for s in shapes[1:]:
+        result = jnp.broadcast_shapes(result, s)
+    return result
+
+
+def _frames_equal(
+    f1: cxf.AbstractReferenceFrame,
+    f2: cxf.AbstractReferenceFrame,
+) -> bool:
+    """Return True if two reference frames are structurally equal.
+
+    Uses identity check first (handles singletons like ``noframe``, ``alice``,
+    ``alex``), then falls back to Equinox structural equality for parametric
+    frames such as ``TransformedReferenceFrame``.
+    """
+    if f1 is f2:
+        return True
+    if type(f1) is not type(f2):
+        return False
+    # Same type — structural comparison (safe: same type → same pytree structure)
+    result = eqx.tree_equal(f1, f2)
+    if isinstance(result, bool):
+        return result
+    return bool(result)  # JAX boolean → concrete bool at init time
+
+
+def vectorform_pdoc(pv: "Coordinate", **kwargs: Any) -> wl.AbstractDoc:
+    """Return the vector-form Wadler-Lindig document for a `Coordinate`."""
+    kwargs.setdefault("canonical", True)
+    chart_name = type(pv.point.chart).__name__
+    rep_name = wl.pformat(pv.point.rep, **kwargs)
+    comps_doc, unit_doc = _vector_comps_unit_docs(pv.point)
+    values_str = _vector_values_str(pv.point, **kwargs)
+
+    header = f"<Coordinate: chart={chart_name}, rep={rep_name} {comps_doc}"
+    if unit_doc:
+        header = f"{header} {unit_doc}"
+
+    if pv._data:
+
+        def _embedded_vectorform(vec: Tangent) -> str:
+            rendered = wl.pformat(_vec_vectorform_pdoc(vec, **kwargs))
+            if rendered.startswith("<") and rendered.endswith(">"):
+                return rendered[1:-1]
+            return rendered
+
+        field_lines = [
+            f"  {name}={_embedded_vectorform(vec)}" for name, vec in pv._data.items()
+        ]
+        return wl.TextDoc(header + values_str + "\n" + "\n".join(field_lines) + ">")
+    return wl.TextDoc(header + values_str + ">")
+
+
+# ---------------------------------------------------------------------------
+# Coordinate
+# ---------------------------------------------------------------------------
+
+
+@final
+class Coordinate(AbstractVector):
+    r"""A vector bundle anchored at a base point.
+
+    A `Coordinate` stores:
+
+    - A base **point** $q \in M$ (a `~coordinax.vectors.Point`).
+    - A collection of named **fibre vectors** $\{v_i\}$ anchored at $q$
+      (each a `~coordinax.vectors.Tangent` with ``TangentGeometry`` rep,
+      e.g. velocity, displacement, acceleration).
+
+    On construction every fibre vector is automatically converted into the
+    **reference frame of the base point** via
+    `~coordinax.vectors.AbstractVector.to_frame`.  This guarantees internal
+    consistency: after construction ``pv["velocity"].frame`` always equals
+    ``pv.point.frame``.
+
+    Coordinate conversion (chart change) is handled automatically: the base
+    converts as a point map, and each fibre vector converts via the Jacobian
+    pushforward at the base.
+
+    Parameters
+    ----------
+    point : Point
+        Base point. Must be an instance of `~coordinax.vectors.Point`.
+    **fields : Tangent
+        Named fibre vectors anchored at ``point``.  Must have
+        ``TangentGeometry`` representation (i.e. `~coordinax.vectors.Tangent`
+        instances).  Shapes must be broadcastable with ``point``.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+    >>> vel = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel)
+    >>> pv = cx.Coordinate(point=point, velocity=vel)
+    >>> pv.point.chart
+    Cart3D(M=Rn(3))
+
+    Convert to spherical — point converts as a point map, velocity via Jacobian:
+
+    >>> pv_sph = pv.cconvert(cxc.sph3d)
+    >>> pv_sph.point.chart
+    Spherical3D(M=Rn(3))
+    >>> pv_sph["velocity"].chart
+    Spherical3D(M=Rn(3))
+
+    """
+
+    point: Point
+    """Base point of the bundle. Must be a ``Point`` instance."""
+
+    _data: dict[str, Tangent] = eqx.field(repr=False)
+    """Fibre vectors (fields) anchored at the point. Excluded from repr."""
+
+    def __init__(
+        self,
+        /,
+        point: Any,  # Any so our isinstance check fires before beartype
+        **fields: Any,
+    ) -> None:
+        """Initialise a Coordinate.
+
+        Parameters
+        ----------
+        point : Point
+            Base point. Must be a ``Point`` instance.
+        **fields : Tangent
+            Named fibre vectors. Each must be a ``Tangent`` instance with
+            ``TangentGeometry`` representation.
+
+        """
+        # --- Validate: point must be a Point instance ---
+        if not isinstance(point, Point):
+            msg = (
+                "Coordinate: point must be a Point instance, "
+                f"got {type(point).__name__!r}"
+            )
+            raise TypeError(msg)
+
+        # --- Validate and (frame-align) fields ---
+        field_vecs: dict[str, Tangent] = {}
+        target_frame = point.frame
+        for name, val in fields.items():
+            # Fields must be Tangent (not Point or arbitrary objects)
+            if not isinstance(val, Tangent):
+                msg = (
+                    f"Coordinate: field '{name}' must be a Tangent instance, "
+                    f"got {type(val).__name__!r}"
+                )
+                raise TypeError(msg)
+            vec: Tangent = val
+
+            # Convert to point's frame when frames differ
+            if not _frames_equal(vec.frame, target_frame):
+                vec = vec.to_frame(target_frame)  # ty: ignore[invalid-assignment]
+
+            field_vecs[name] = vec
+
+        # --- Validate broadcastable shapes ---
+        all_shapes = [point.shape, *(v.shape for v in field_vecs.values())]
+        if len(all_shapes) > 1:
+            try:
+                jnp.broadcast_shapes(*all_shapes)
+            except Exception as exc:
+                msg = f"Coordinate: shapes {all_shapes} are not broadcastable: {exc}"
+                raise ValueError(msg) from exc
+
+        # Bypass equinox's immutable __setattr__
+        self.__dict__["point"] = point
+        self.__dict__["_data"] = field_vecs
+
+    # ===================================================================
+    # AbstractVector abstract attribute satisfaction (delegate to point)
+
+    @property
+    def data(self) -> Any:
+        """Component data of the base point."""
+        return self.point.data
+
+    @property
+    def chart(self) -> cxc.AbstractChart:
+        """Chart of the base point."""
+        return self.point.chart
+
+    @property
+    def rep(self) -> cxr.Representation:
+        """Representation of the base point (always PointGeometry)."""
+        return self.point.rep  # ty: ignore[invalid-return-type]
+
+    @property
+    def manifold(self) -> cxm.AbstractManifold:
+        """Manifold of the base point."""
+        return self.point.M
+
+    @property
+    def frame(self) -> cxf.AbstractReferenceFrame:
+        """Reference frame of the bundle — always equal to ``point.frame``."""
+        return self.point.frame
+
+    # ===================================================================
+    # Mapping interface (over fields only, not base)
+
+    @override
+    def __getitem__(self, key: Any) -> "Tangent | Coordinate":  # ty: ignore[invalid-method-override]
+        """Get a named field vector or batch-index the bundle.
+
+        Parameters
+        ----------
+        key : str or index
+            If ``str``, return the named field vector.
+            Otherwise, batch-index all component arrays (base + all fields).
+
+        Examples
+        --------
+        >>> import unxt as u
+        >>> import coordinax.main as cx
+        >>> import coordinax.charts as cxc
+        >>> import coordinax.representations as cxr
+
+        >>> base = cx.Point.from_([1.0, 0.0, 0.0], "m")
+        >>> vel = cx.Tangent.from_(
+        ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+        ...     cxc.cart3d, cxr.coord_vel)
+        >>> pv = cx.Coordinate(point=base, velocity=vel)
+        >>> isinstance(pv["velocity"], cx.Tangent)
+        True
+
+        """
+        if isinstance(key, str):
+            return self._data[key]
+
+        # Batch-indexing: slice all arrays in point and all fields
+        nindex = len(key) if isinstance(key, tuple) else 1
+
+        def _index_leaf(x: Any) -> Any:
+            if not eqx.is_array(x):
+                return x
+            if getattr(x, "ndim", 0) < nindex:
+                return x
+            return x[key]
+
+        new_point = jax.tree.map(_index_leaf, self.point, is_leaf=eqx.is_array)
+        new_fields = {
+            k: jax.tree.map(_index_leaf, v, is_leaf=eqx.is_array)
+            for k, v in self._data.items()
+        }
+        return Coordinate(point=new_point, **new_fields)
+
+    def keys(self) -> KeysView[str]:
+        """Return field names (excluding base point).
+
+        Examples
+        --------
+        >>> import unxt as u
+        >>> import coordinax.main as cx
+        >>> import coordinax.charts as cxc
+        >>> import coordinax.representations as cxr
+
+        >>> base = cx.Point.from_([1.0, 0.0, 0.0], "m")
+        >>> vel = cx.Tangent.from_(
+        ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+        ...     cxc.cart3d, cxr.coord_vel)
+        >>> pv = cx.Coordinate(point=base, velocity=vel)
+        >>> list(pv.keys())
+        ['velocity']
+
+        """
+        return self._data.keys()
+
+    def values(self) -> ValuesView[Tangent]:
+        """Return field vectors (excluding base point)."""
+        return self._data.values()
+
+    def items(self) -> ItemsView[str, Tangent]:
+        """Return ``(name, vector)`` pairs for fields (excluding base point)."""
+        return self._data.items()
+
+    def __len__(self) -> int:
+        """Return number of fibre field vectors."""
+        return len(self._data)
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over field names."""
+        return iter(self._data)
+
+    # ===================================================================
+    # Coordinate conversion
+
+    def cconvert(
+        self,
+        to_chart: cxc.AbstractChart,
+        /,
+        *,
+        field_charts: Mapping[str, cxc.AbstractChart] | None = None,
+        usys: OptUSys = None,
+    ) -> "Coordinate":
+        r"""Convert the bundle to a new coordinate chart.
+
+        Algorithm:
+
+        1. Convert base as a point map: ``new_point = cconvert(point, to_chart)``.
+        2. For each field vector, apply the tangent pushforward at ``point``
+           via ``cconvert(vec, field_to_chart, at=point)``.
+
+        Parameters
+        ----------
+        to_chart : AbstractChart
+            Target chart for the base and (by default) all fields.
+        field_charts : Mapping[str, AbstractChart], optional
+            Per-field target chart overrides.
+        usys : UnitSystem, optional
+            Unit system for the conversion.
+
+        Examples
+        --------
+        >>> import coordinax.main as cx
+        >>> import coordinax.charts as cxc
+        >>> import unxt as u
+        >>> import coordinax.representations as cxr
+
+        >>> point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+        >>> vel = cx.Tangent.from_(
+        ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+        ...     cxc.cart3d, cxr.coord_vel)
+        >>> pv = cx.Coordinate(point=point, velocity=vel)
+        >>> sph = pv.cconvert(cxc.sph3d)
+        >>> sph.point.chart
+        Spherical3D(M=Rn(3))
+        >>> sph["velocity"].chart
+        Spherical3D(M=Rn(3))
+
+        """
+        if field_charts is None:
+            field_charts = {}
+
+        # 1. Convert base point (pure point map — no Jacobian needed)
+        new_point = cast("Point", cxr.cconvert(self.point, to_chart, usys=usys))
+
+        # 2. Convert each field via tangent pushforward at self.point
+        new_fields: dict[str, Tangent] = {
+            name: cast(
+                "Tangent",
+                cxr.cconvert(
+                    vec, field_charts.get(name, to_chart), at=self.point, usys=usys
+                ),
+            )
+            for name, vec in self._data.items()
+        }
+
+        return Coordinate(point=new_point, **new_fields)
+
+    # ===================================================================
+    # AbstractVector — shape
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """Broadcast shape of base point and all field vectors.
+
+        Examples
+        --------
+        >>> import coordinax.main as cx
+        >>> pv = cx.Coordinate(point=cx.Point.from_([1.0, 2.0, 3.0], "m"))
+        >>> pv.shape
+        ()
+
+        """
+        all_shapes = [self.point.shape, *(v.shape for v in self._data.values())]
+        return _broadcast_shapes(all_shapes)
+
+    # ===================================================================
+    # Quax API
+
+    def aval(self) -> ShapedArray:
+        """Return abstract JAX array value for tracing."""
+        all_vecs = [self.point, *self._data.values()]
+        avals = [v.aval() for v in all_vecs]
+        dtype = jnp.result_type(*[a.dtype for a in avals])
+        return ShapedArray(self.shape, dtype)
+
+    # ===================================================================
+    # Wadler-Lindig API
+
+    def __pdoc__(self, *, vector_form: bool = False, **kwargs: Any) -> wl.AbstractDoc:
+        """Return the Wadler-Lindig document for a `Coordinate`.
+
+        Examples
+        --------
+        >>> import unxt as u
+        >>> import wadler_lindig as wl
+        >>> import coordinax.main as cx
+
+        >>> point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+        >>> vel = cx.Tangent.from_(
+        ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+        ...     cx.cart3d, cx.coord_vel,
+        ... )
+        >>> coord = cx.Coordinate(point=point, velocity=vel)
+
+        The standard document renders as a constructor-style representation:
+
+        >>> wl.pprint(coord)
+        Coordinate(
+          Point(
+            {'x': Q(f64[], 'm'), 'y': Q(f64[], 'm'), 'z': Q(f64[], 'm')},
+            chart=Cart3D(M=Rn(3))
+          ),
+          velocity=Tangent(
+            { 'x': Q(weak_f64[], 'm / s'), 'y': Q(weak_f64[], 'm / s'),
+              'z': Q(weak_f64[], 'm / s') },
+            chart=Cart3D(M=Rn(3)), basis=coord_basis, semantic=vel
+          )
+        )
+
+        The vector form renders as the compact angle-bracket representation:
+
+        >>> wl.pprint(coord, vector_form=True)
+        <Coordinate: chart=Cart3D, rep=point (x, y, z) [m]
+                [1. 0. 0.]
+            velocity=Tangent: chart=Cart3D (x, y, z) [m / s]
+                [1. 0. 0.]>
+
+        """
+        if vector_form:
+            return vectorform_pdoc(self, **kwargs)
+
+        kwargs.setdefault("use_short_name", True)
+        kwargs.setdefault("named_unit", False)
+        docs = [
+            wl.pdoc(self.point, **kwargs),
+            *wl.named_objs(self._data.items(), **kwargs),
+        ]
+        return wl.bracketed(
+            begin=wl.TextDoc("Coordinate("),
+            docs=docs,
+            sep=wl.comma,
+            end=wl.TextDoc(")"),
+            indent=kwargs.get("indent", 4),
+        )
+
+    def __repr__(self) -> str:
+        return wl.pformat(self, vector_form=False, short_arrays="compact")
+
+    def __str__(self) -> str:
+        return wl.pformat(self, vector_form=True, precision=3)
+
+
+# ===========================================================================
+# from_ dispatches
+# ===========================================================================
+
+
+@Coordinate.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(cls: type[Coordinate], pv: Coordinate, /) -> Coordinate:
+    """Identity: return the same Coordinate unchanged.
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> pv = cx.Coordinate(point=cx.Point.from_([1.0, 2.0, 3.0], "m"))
+    >>> cx.Coordinate.from_(pv) is pv
+    True
+
+    """
+    return pv
+
+
+@Coordinate.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(cls: type[Coordinate], p: Point, /) -> Coordinate:
+    """Wrap a single ``Point`` as a point-only bundle (no field vectors).
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> p = cx.Point.from_([1.0, 2.0, 3.0], "m")
+    >>> pv = cx.Coordinate.from_(p)
+    >>> pv.point is p
+    True
+
+    """
+    return cls(point=p)
+
+
+@Coordinate.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Coordinate],
+    data: Mapping[str, Any],
+    /,
+    *,
+    point: Point | None = None,
+) -> Coordinate:
+    """Create a ``Coordinate`` from a mapping of named objects.
+
+    The mapping may contain a ``"point"`` key for the base; the explicit
+    ``point`` keyword argument takes precedence if both are supplied.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> p = cx.Point.from_([1.0, 2.0, 3.0], "m")
+    >>> vel = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel)
+    >>> pv = cx.Coordinate.from_({"point": p, "velocity": vel})
+    >>> pv.point is p
+    True
+
+    """
+    data_dict = dict(data)
+
+    if point is None:
+        point = data_dict.pop("point", None)
+    else:
+        data_dict.pop("point", None)
+
+    if point is None:
+        msg = (
+            "Coordinate.from_: 'point' must be provided in the mapping "
+            "or as a keyword argument."
+        )
+        raise ValueError(msg)
+
+    return cls(point=point, **data_dict)

--- a/src/coordinax/vectors/_src/bundle.py
+++ b/src/coordinax/vectors/_src/bundle.py
@@ -93,16 +93,17 @@ class Coordinate(AbstractVector):
       (each a `~coordinax.vectors.Tangent` with ``TangentGeometry`` rep,
       e.g. velocity, displacement, acceleration).
 
-    On construction every fibre vector is automatically aligned to both the
-    **reference frame** and **chart** of the base point:
+    On construction every fibre vector is automatically frame-aligned to the
+    **reference frame** of the base point:
 
     1. Frame-alignment via `~coordinax.vectors.AbstractVector.to_frame`
        ensures ``pv["velocity"].frame == pv.point.frame``.
-    2. Chart-alignment via a Jacobian pushforward ensures
-       ``pv["velocity"].chart == pv.point.chart``, so that
-       `~coordinax.vectors.Coordinate.cconvert` can always pass
-       ``at=self.point`` to the tangent conversion without a chart-mismatch
-       error.
+
+    Fibre vectors are **not** chart-aligned on construction; each fibre
+    retains the chart it was supplied with.  Chart conversion is handled
+    lazily: `~coordinax.vectors.Coordinate.cconvert` pushes each fibre
+    forward using the Jacobian at the base point expressed in the fibre's
+    current chart.
 
     Coordinate conversion (chart change) is handled automatically: the base
     converts as a point map, and each fibre vector converts via the Jacobian
@@ -163,7 +164,8 @@ class Coordinate(AbstractVector):
         **fields : Tangent
             Named fibre vectors. Each must be a ``Tangent`` instance with
             ``TangentGeometry`` representation.  Each field is automatically
-            frame- and chart-aligned to ``point`` on construction.
+            frame-aligned to ``point`` on construction; the chart of each
+            fibre is preserved as supplied.
 
         """
         # --- Validate: point must be a Point instance ---
@@ -203,20 +205,6 @@ class Coordinate(AbstractVector):
                     cast("Tangent", cxfm.act(op, None, vec, at=at_point.data)),
                     frame=target_frame,
                 )  # ty: ignore[invalid-assignment]
-
-            # Chart-align: convert the field to the point's chart so that
-            # later Coordinate.cconvert() can safely pass `at=self.point`
-            # (which has `point.chart`) into Tangent.cconvert() without a
-            # chart-mismatch error.  The Jacobian needs a base point in the
-            # field's *source* chart, so we first convert `point` to that
-            # chart, push the tangent forward, and store the result in
-            # `point.chart`.
-            if vec.chart != point.chart:
-                at_in_field_chart = cast("Point", cxr.cconvert(point, vec.chart))
-                vec = cast(
-                    "Tangent",
-                    cxr.cconvert(vec, point.chart, at=at_in_field_chart),
-                )
 
             field_vecs[name] = vec
 
@@ -405,20 +393,24 @@ class Coordinate(AbstractVector):
         # 1. Convert base point (pure point map — no Jacobian needed)
         new_point = cast("Point", cxr.cconvert(self.point, to_chart, usys=usys))
 
-        # 2. Convert each field via tangent pushforward at self.point
-        new_fields: dict[str, Tangent] = {
-            name: cast(
-                "Tangent",
-                cxr.cconvert(
-                    vec, field_charts.get(name, to_chart), at=self.point, usys=usys
-                ),
+        # 2. Convert each field via tangent pushforward at self.point.
+        # Express self.point in each fibre's current chart for the Jacobian;
+        # this handles fibres that are in a different chart than self.point.
+        new_fields: dict[str, Tangent] = {}
+        for name, vec in self._data.items():
+            target = field_charts.get(name, to_chart)
+            at = (
+                self.point
+                if vec.chart == self.point.chart
+                else cast("Point", cxr.cconvert(self.point, vec.chart))
             )
-            for name, vec in self._data.items()
-        }
+            new_fields[name] = cast(
+                "Tangent",
+                cxr.cconvert(vec, target, at=at, usys=usys),
+            )
 
-        # Use _create_unchecked so that field_charts overrides (which may
-        # intentionally leave fields in a different chart than new_point)
-        # are not silently re-aligned by __init__.
+        # Use _create_unchecked to bypass frame re-alignment in __init__
+        # (the results are already in the correct frame).
         return Coordinate._create_unchecked(new_point, new_fields)
 
     # ===================================================================

--- a/src/coordinax/vectors/_src/bundle.py
+++ b/src/coordinax/vectors/_src/bundle.py
@@ -18,10 +18,13 @@ import jax.numpy as jnp
 import wadler_lindig as wl
 from jax.core import ShapedArray
 
+import dataclassish
+
 import coordinax.charts as cxc
 import coordinax.frames as cxf
 import coordinax.manifolds as cxm
 import coordinax.representations as cxr
+import coordinax.transforms as cxfm
 from .base import AbstractVector
 from .point import Point, _vector_comps_unit_docs, _vector_values_str
 from .tangent import Tangent, _vectorform_pdoc as _vec_vectorform_pdoc
@@ -90,11 +93,16 @@ class Coordinate(AbstractVector):
       (each a `~coordinax.vectors.Tangent` with ``TangentGeometry`` rep,
       e.g. velocity, displacement, acceleration).
 
-    On construction every fibre vector is automatically converted into the
-    **reference frame of the base point** via
-    `~coordinax.vectors.AbstractVector.to_frame`.  This guarantees internal
-    consistency: after construction ``pv["velocity"].frame`` always equals
-    ``pv.point.frame``.
+    On construction every fibre vector is automatically aligned to both the
+    **reference frame** and **chart** of the base point:
+
+    1. Frame-alignment via `~coordinax.vectors.AbstractVector.to_frame`
+       ensures ``pv["velocity"].frame == pv.point.frame``.
+    2. Chart-alignment via a Jacobian pushforward ensures
+       ``pv["velocity"].chart == pv.point.chart``, so that
+       `~coordinax.vectors.Coordinate.cconvert` can always pass
+       ``at=self.point`` to the tangent conversion without a chart-mismatch
+       error.
 
     Coordinate conversion (chart change) is handled automatically: the base
     converts as a point map, and each fibre vector converts via the Jacobian
@@ -154,7 +162,8 @@ class Coordinate(AbstractVector):
             Base point. Must be a ``Point`` instance.
         **fields : Tangent
             Named fibre vectors. Each must be a ``Tangent`` instance with
-            ``TangentGeometry`` representation.
+            ``TangentGeometry`` representation.  Each field is automatically
+            frame- and chart-aligned to ``point`` on construction.
 
         """
         # --- Validate: point must be a Point instance ---
@@ -178,9 +187,36 @@ class Coordinate(AbstractVector):
                 raise TypeError(msg)
             vec: Tangent = val
 
-            # Always convert to point's frame (no-op when already equal;
-            # avoids materialising a JAX boolean which breaks under JIT).
-            vec = vec.to_frame(target_frame)  # ty: ignore[invalid-assignment]
+            # Convert to point's frame using act() directly so we can supply
+            # the base-point anchor (at=) needed by non-Cartesian tangent
+            # frame transforms (e.g. Rotate on TangentGeometry requires 'at'
+            # to evaluate the Jacobian pushforward).  The Identity fast-path
+            # avoids any JAX tracing overhead when frames already match.
+            op = vec.frame.frame_transition(target_frame)
+            if not isinstance(op, cxfm.Identity):
+                # Express the base point in vec's current chart so that act()
+                # can evaluate the Jacobian at the correct location.
+                at_point = cast(
+                    "Point", cxr.cconvert(point.to_frame(vec.frame), vec.chart)
+                )
+                vec = dataclassish.replace(
+                    cast("Tangent", cxfm.act(op, None, vec, at=at_point.data)),
+                    frame=target_frame,
+                )  # ty: ignore[invalid-assignment]
+
+            # Chart-align: convert the field to the point's chart so that
+            # later Coordinate.cconvert() can safely pass `at=self.point`
+            # (which has `point.chart`) into Tangent.cconvert() without a
+            # chart-mismatch error.  The Jacobian needs a base point in the
+            # field's *source* chart, so we first convert `point` to that
+            # chart, push the tangent forward, and store the result in
+            # `point.chart`.
+            if vec.chart != point.chart:
+                at_in_field_chart = cast("Point", cxr.cconvert(point, vec.chart))
+                vec = cast(
+                    "Tangent",
+                    cxr.cconvert(vec, point.chart, at=at_in_field_chart),
+                )
 
             field_vecs[name] = vec
 
@@ -196,6 +232,22 @@ class Coordinate(AbstractVector):
         # Bypass equinox's immutable __setattr__
         self.__dict__["point"] = point
         self.__dict__["_data"] = field_vecs
+
+    @classmethod
+    def _create_unchecked(
+        cls,
+        point: Point,
+        fields: dict[str, Tangent],
+    ) -> "Coordinate":
+        """Create a ``Coordinate`` bypassing frame/chart alignment and validation.
+
+        For **internal use only**.  Callers must guarantee that ``point`` and
+        every value in ``fields`` already have consistent types and shapes.
+        """
+        obj: Coordinate = object.__new__(cls)
+        obj.__dict__["point"] = point
+        obj.__dict__["_data"] = fields
+        return obj
 
     # ===================================================================
     # AbstractVector abstract attribute satisfaction (delegate to point)
@@ -261,7 +313,7 @@ class Coordinate(AbstractVector):
         # indices raise consistently instead of silently skipping.
         new_point = self.point[key]
         new_fields = {k: v[key] for k, v in self._data.items()}
-        return Coordinate(point=new_point, **new_fields)
+        return Coordinate._create_unchecked(new_point, new_fields)
 
     def keys(self) -> KeysView[str]:
         """Return field names (excluding base point).
@@ -364,7 +416,10 @@ class Coordinate(AbstractVector):
             for name, vec in self._data.items()
         }
 
-        return Coordinate(point=new_point, **new_fields)
+        # Use _create_unchecked so that field_charts overrides (which may
+        # intentionally leave fields in a different chart than new_point)
+        # are not silently re-aligned by __init__.
+        return Coordinate._create_unchecked(new_point, new_fields)
 
     # ===================================================================
     # AbstractVector — shape
@@ -388,11 +443,45 @@ class Coordinate(AbstractVector):
     # Quax API
 
     def aval(self) -> ShapedArray:
-        """Return abstract JAX array value for tracing."""
+        """Return abstract JAX array value for tracing.
+
+        The shape is ``(*batch, total_components)`` where ``total_components``
+        is the sum of components across the base `Point` and every fibre
+        `Tangent`.  This is consistent with `Point.aval` / `Tangent.aval`
+        (which return ``(*batch, n_components)``) and reflects the full
+        flattened array that a ``Coordinate`` bundle conceptually represents.
+
+        The dtype is the promoted dtype across all held fields.
+
+        Examples
+        --------
+        >>> import coordinax.main as cx
+
+        >>> point = cx.Point.from_([1.0, 2.0, 3.0], "m")
+        >>> pv = cx.Coordinate(point=point)
+        >>> pv.aval()  # doctest: +ELLIPSIS
+        ShapedArray(float...[3])
+
+        A ``Coordinate`` with one velocity field (3 + 3 = 6 total components):
+
+        >>> import unxt as u
+        >>> import coordinax.charts as cxc
+        >>> import coordinax.representations as cxr
+        >>> vel = cx.Tangent.from_(
+        ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+        ...     cxc.cart3d, cxr.coord_vel,
+        ... )
+        >>> pv2 = cx.Coordinate(point=point, velocity=vel)
+        >>> pv2.aval()  # doctest: +ELLIPSIS
+        ShapedArray(float...[6])
+
+        """
         all_vecs = [self.point, *self._data.values()]
         avals = [v.aval() for v in all_vecs]
         dtype = jnp.result_type(*[a.dtype for a in avals])
-        return ShapedArray(self.shape, dtype)
+        batch = self.shape
+        total_components = sum(a.shape[-1] for a in avals)
+        return ShapedArray((*batch, total_components), dtype)
 
     # ===================================================================
     # Wadler-Lindig API

--- a/src/coordinax/vectors/_src/point.py
+++ b/src/coordinax/vectors/_src/point.py
@@ -143,9 +143,8 @@ class Point(
     )
     """The reference frame of the point. Defaults to ``cxf.noframe``."""
 
-    def _check_init(self) -> None:
-        # Pass a check to self.chart.check_data
-        self.M.has_chart(self.chart)
+    def __check_init__(self) -> None:
+        self.M.check_chart(self.chart)
         self.chart.check_data(self.data, keys=True)
 
     @property

--- a/src/coordinax/vectors/_src/point.py
+++ b/src/coordinax/vectors/_src/point.py
@@ -578,7 +578,7 @@ def from_(
     >>> p.chart
     Cart3D(M=Rn(3))
     >>> p.rep
-    Representation(geom_kind=PointGeometry(), basis=NoBasis(), semantic_kind=Location())
+    point
     >>> p.frame
     Alice()
 

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -487,10 +487,10 @@ def add(lhs: Tangent, rhs: Tangent, /) -> Tangent:
     """
     if lhs.rep != rhs.rep:
         msg = (
-            f"Cannot add tangent vectors with different representations: "
-            f"{lhs.rep} vs {rhs.rep}."
+            f"Cannot add Tangent vectors with different representations: "
+            f"{lhs.rep!r} vs {rhs.rep!r}."
         )
-        raise TypeError(msg)
+        raise ValueError(msg)
 
     data = jtu.map(jnp.add, lhs.data, rhs.data, is_leaf=uq.is_any_quantity)
     return replace(lhs, data=data)
@@ -526,10 +526,10 @@ def subtract(lhs: Tangent, rhs: Tangent, /) -> Tangent:
     """
     if lhs.rep != rhs.rep:
         msg = (
-            f"Cannot subtract tangent vectors with different representations: "
-            f"{lhs.rep} vs {rhs.rep}."
+            f"Cannot subtract Tangent vectors with different representations: "
+            f"{lhs.rep!r} vs {rhs.rep!r}."
         )
-        raise TypeError(msg)
+        raise ValueError(msg)
 
     data = jtu.map(jnp.subtract, lhs.data, rhs.data, is_leaf=uq.is_any_quantity)
     return replace(lhs, data=data)

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -283,7 +283,12 @@ def cconvert(
 
 @plum.dispatch
 def change_basis(
-    v: Tangent, to_basis: cxr.AbstractBasis, /, *, at: Any = None, usys: OptUSys = None
+    v: Tangent,
+    to_basis: cxr.AbstractLinearBasis,
+    /,
+    *,
+    at: Any = None,
+    usys: OptUSys = None,
 ) -> Tangent:
     """Change the basis of a `Tangent` vector.
 

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -6,9 +6,12 @@ from dataclasses import replace
 
 from typing import Any, cast
 
+import jax.tree as jtu
 import plum
 
 import dataclassish
+import quaxed.numpy as jnp
+import unxt.quantity as uq
 
 import coordinax.api.representations as cxrapi
 import coordinax.api.transforms as cxfmapi
@@ -454,6 +457,96 @@ def subtract(lhs: Point, rhs: Point, /) -> Point:
         lhs.data, lhs.chart, lhs.rep, rhs.data, rhs.chart, rhs.rep
     )
     return replace(lhs, data=result_data)
+
+
+@plum.dispatch
+def add(lhs: Tangent, rhs: Tangent, /) -> Tangent:
+    """Add two tangent vectors component-wise.
+
+    Tangent spaces are genuine vector spaces: addition is component-wise in
+    any chart basis (no Cartesian round-trip is needed or correct).  Both
+    operands must share the same representation (chart + basis + semantic).
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> v1 = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel,
+    ... )
+    >>> v2 = cx.Tangent.from_(
+    ...     {"x": u.Q(4.0, "m/s"), "y": u.Q(5.0, "m/s"), "z": u.Q(6.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel,
+    ... )
+    >>> result = cxr.add(v1, v2)
+    >>> result["x"]
+    Q(5., 'm / s')
+
+    """
+    if lhs.rep != rhs.rep:
+        msg = (
+            f"Cannot add tangent vectors with different representations: "
+            f"{lhs.rep} vs {rhs.rep}."
+        )
+        raise TypeError(msg)
+
+    data = jtu.map(
+        jnp.add,
+        jtu.leaves(lhs.data, is_leaf=uq.is_any_quantity),
+        jtu.leaves(rhs.data, is_leaf=uq.is_any_quantity),
+        is_leaf=uq.is_any_quantity,
+    )
+    keys = list(lhs.data.keys())
+    return replace(lhs, data=dict(zip(keys, data, strict=True)))
+
+
+@plum.dispatch
+def subtract(lhs: Tangent, rhs: Tangent, /) -> Tangent:
+    """Subtract two tangent vectors component-wise.
+
+    Tangent spaces are genuine vector spaces: subtraction is component-wise in
+    any chart basis (no Cartesian round-trip is needed or correct).  Both
+    operands must share the same representation (chart + basis + semantic).
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> v1 = cx.Tangent.from_(
+    ...     {"x": u.Q(4.0, "m/s"), "y": u.Q(5.0, "m/s"), "z": u.Q(6.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel,
+    ... )
+    >>> v2 = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel,
+    ... )
+    >>> result = cxr.subtract(v1, v2)
+    >>> result["x"]
+    Q(3., 'm / s')
+
+    """
+    if lhs.rep != rhs.rep:
+        msg = (
+            f"Cannot subtract tangent vectors with different representations: "
+            f"{lhs.rep} vs {rhs.rep}."
+        )
+        raise TypeError(msg)
+
+    data = jtu.map(
+        jnp.subtract,
+        jtu.leaves(lhs.data, is_leaf=uq.is_any_quantity),
+        jtu.leaves(rhs.data, is_leaf=uq.is_any_quantity),
+        is_leaf=uq.is_any_quantity,
+    )
+    keys = list(lhs.data.keys())
+    return replace(lhs, data=dict(zip(keys, data, strict=True)))
 
 
 # ===================================================================

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -8,17 +8,21 @@ from typing import Any, cast
 
 import plum
 
+import dataclassish
+
 import coordinax.api.transforms as cxfmapi
 import coordinax.charts as cxc
 import coordinax.representations as cxr
 import coordinax.transforms as cxfm
-from .custom_types import CDict, OptUSys
+from .bundle import Coordinate
 from .point import Point
+from .tangent import Tangent
+from coordinax.internal import CDict, OptUSys
 
 CHART_MSMTCH = "from_chart {0} does not match the point's chart {1.chart}"
 
 # ===================================================================
-# Vector conversion
+# Tangent conversion
 
 
 @plum.dispatch
@@ -156,6 +160,199 @@ def cdict(obj: Point, /) -> CDict:
     return obj.data
 
 
+@plum.dispatch
+def cdict(obj: Tangent, /) -> CDict:
+    """Extract component dictionary from a Tangent.
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.representations as cxr
+    >>> import unxt as u
+    >>> vec = cx.Tangent.from_(
+    ...     u.Q([1.0, 2.0, 3.0], "m/s"), "m/s", cx.cart3d, cxr.coord_basis, cxr.vel
+    ... )
+    >>> d = cx.cdict(vec)
+    >>> list(d.keys())
+    ['x', 'y', 'z']
+
+    """
+    return obj.data
+
+
+# ===================================================================
+# Tangent cconvert
+
+
+@plum.dispatch
+def cconvert(
+    from_vec: Tangent,
+    to_chart: cxc.AbstractChart,
+    /,
+    *,
+    at: Any = None,
+    usys: OptUSys = None,
+) -> Tangent:
+    """Convert a tangent Tangent from one chart to another.
+
+    The ``at`` parameter provides the base point at which the tangent map
+    (Jacobian pushforward) is evaluated. It may be a `Point` instance
+    (whose ``.data`` is used) or a raw ``CDict``.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> v = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_basis, cxr.vel,
+    ... )
+    >>> pt = cx.Point.from_([1.0, 0.0, 0.0], "m")
+    >>> v_sph = cx.cconvert(v, cxc.sph3d, at=pt)
+    >>> v_sph.chart
+    Spherical3D(M=Rn(3))
+
+    """
+    at_data: CDict | None = at.data if isinstance(at, Point) else at
+    p = cxr.cconvert(
+        from_vec.data,
+        from_vec.chart,
+        from_vec.rep,
+        to_chart,
+        **({"at": at_data} if at_data is not None else {}),
+        usys=usys,
+    )
+    return replace(from_vec, data=p, chart=to_chart)
+
+
+@plum.dispatch
+def cconvert(
+    from_vec: Tangent,
+    from_chart: cxc.AbstractChart,
+    to_chart: cxc.AbstractChart,
+    /,
+    *,
+    at: Any = None,
+    usys: OptUSys = None,
+) -> Tangent:
+    """Convert a tangent Tangent from one chart to another (explicit from-chart).
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> v = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_basis, cxr.vel,
+    ... )
+    >>> pt = cx.Point.from_([1.0, 0.0, 0.0], "m")
+    >>> v_sph = cx.cconvert(v, cxc.cart3d, cxc.sph3d, at=pt)
+    >>> v_sph.chart
+    Spherical3D(M=Rn(3))
+
+    """
+    if from_chart != from_vec.chart:
+        raise ValueError(CHART_MSMTCH.format(from_chart, from_vec))
+    return cxr.cconvert(from_vec, to_chart, at=at, usys=usys)  # ty: ignore[invalid-return-type]
+
+
+# ===================================================================
+# Basis change
+
+
+@plum.dispatch
+def change_basis(
+    v: Tangent, to_basis: cxr.AbstractBasis, /, *, at: Any = None, usys: OptUSys = None
+) -> Tangent:
+    """Change the basis of a `Tangent` vector.
+
+    Converts the component data from the current basis to ``to_basis`` using
+    the registered ``change_basis`` overload for dicts, then returns a new
+    `Tangent` with the updated data and basis.
+
+    The ``at`` parameter provides the base point at which the scale factors
+    are evaluated.  It may be a `Point` instance (whose ``.data`` is used) or
+    a raw ``CDict``.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    Convert a coordinate-basis spherical velocity to the physical basis:
+
+    >>> point = cx.Point.from_(
+    ...     {"r": u.Q(1.0, "m"), "theta": u.Q(0.5, "rad"), "phi": u.Q(0.0, "rad")},
+    ...     cxc.sph3d,
+    ... )
+    >>> vel = cx.Tangent.from_({"r": u.Q(1.0, "m/s"), "theta": u.Q(0.0, "rad/s"),
+    ...     "phi": u.Q(0.0, "rad/s")}, cxc.sph3d, cxr.coord_vel)
+    >>> vel_phys = cxr.change_basis(vel, cxr.phys_basis, at=point)
+    >>> vel_phys.basis
+    PhysicalBasis()
+    >>> vel_phys.rep
+    Representation(geom_kind=TangentGeometry(), basis=PhysicalBasis(),
+                   semantic_kind=Velocity())
+
+    """
+    at_data: CDict | None = at.data if isinstance(at, Point) else at
+    new_data = cxr.change_basis(
+        v.data,
+        v.chart,
+        v.basis,
+        to_basis,
+        **({"at": at_data} if at_data is not None else {}),
+        usys=usys,
+    )
+    return replace(v, data=new_data, basis=to_basis)
+
+
+@plum.dispatch
+def change_basis(
+    v: Point, to_basis: cxr.AbstractLinearBasis, /, *, at: Any = None, usys: Any = None
+) -> Tangent:
+    """Promote a `Point` to a `Tangent` with `Displacement` semantics.
+
+    The component data are unchanged; only the geometric interpretation is
+    recast from a manifold point (`PointGeometry`) to a tangent-space
+    displacement vector (`TangentGeometry`, `Displacement`).  The resulting
+    `Tangent` carries the same chart and frame as the input `Point`, and its
+    basis is ``to_basis``.
+
+    The ``at`` and ``usys`` parameters are accepted for API consistency but
+    are not used.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.representations as cxr
+
+    >>> pt = cx.Point.from_([1.0, 2.0, 3.0], "m")
+    >>> disp = cxr.change_basis(pt, cxr.coord_basis)
+    >>> disp.semantic
+    Displacement()
+    >>> disp.basis
+    CoordinateBasis()
+    >>> disp.chart == pt.chart
+    True
+
+    """
+    if at is not None:
+        raise ValueError("`at` parameter is not used for Point-to-Tangent promotion.")
+    return Tangent(  # ty: ignore[missing-argument]
+        data=v.data, chart=v.chart, basis=to_basis, semantic=cxr.dpl, frame=v.frame
+    )
+
+
 # ===================================================================
 # Add / Subtract
 
@@ -231,6 +428,33 @@ def subtract(lhs: Point, rhs: Point, /) -> Point:
 
 
 @plum.dispatch
+def act(op: cxfm.AbstractTransform, tau: Any, x: Tangent, /, **kw: Any) -> Tangent:
+    """Act a frame transform on a tangent Tangent.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.frames as cxf
+
+    >>> Rz = jnp.asarray([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
+    >>> op = cx.Rotate(Rz)
+    >>> v = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+    ...     cx.cart3d, cx.coord_vel,
+    ... )
+    >>> transformed = cx.act(op, None, v)
+    >>> print(transformed)
+    <Tangent: chart=Cart3D (x, y, z) [m / s]
+        [0. 1. 0.]>
+
+    """
+    data = cxfmapi.act(op, tau, x.data, x.chart, x.rep, **kw)
+    return replace(x, data=data)
+
+
+@plum.dispatch
 def act(op: cxfm.AbstractTransform, tau: Any, x: Point, /, **kw: Any) -> Point:
     """Act a frame transform on a Point.
 
@@ -256,3 +480,93 @@ def act(op: cxfm.AbstractTransform, tau: Any, x: Point, /, **kw: Any) -> Point:
     """
     data = cxfmapi.act(op, tau, x.data, x.chart, x.rep, **kw)
     return replace(x, data=data)
+
+
+@plum.dispatch
+def act(
+    op: cxfm.AbstractTransform, tau: Any, x: Coordinate, /, **kw: Any
+) -> Coordinate:
+    """Act a frame transform on a Coordinate (point + all fibres).
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.frames as cxf
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import unxt as u
+
+    >>> point = cx.Point.from_([1.0, 0.0, 0.0], "m", cxf.alice)
+    >>> vel = cx.Tangent(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_basis, cxr.vel, frame=cxf.alice,
+    ... )
+    >>> pv = cx.Coordinate(point=point, velocity=vel)
+    >>> pv_alex = pv.to_frame(cxf.alex)
+    >>> pv_alex.frame
+    Alex()
+    >>> pv_alex["velocity"].frame
+    Alex()
+
+    """
+    new_point = cxfm.act(op, tau, x.point, **kw)
+    new_fields = {
+        name: cxfm.act(op, tau, fibre, **kw) for name, fibre in x._data.items()
+    }
+    return Coordinate(point=new_point, **new_fields)
+
+
+@dataclassish.replace.dispatch  # type: ignore[attr-defined]
+def _replace_coordinate(coord: Coordinate, /, **kwargs: Any) -> Coordinate:
+    """Replace fields on a Coordinate, propagating ``frame`` to point and fibres.
+
+    When ``frame`` is supplied, it is forwarded to both the base ``point`` and
+    every fibre field so the bundle stays internally consistent.
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.frames as cxf
+
+    >>> point = cx.Point.from_([1.0, 0.0, 0.0], "m", cxf.alice)
+    >>> pv = cx.Coordinate(point=point)
+    >>> import dataclassish
+    >>> pv2 = dataclassish.replace(pv, frame=cxf.alex)
+    >>> pv2.frame
+    Alex()
+
+    """
+    frame = kwargs.pop("frame", None)
+    if frame is not None:
+        new_point = replace(coord.point, frame=frame)
+        new_fields = {name: replace(f, frame=frame) for name, f in coord._data.items()}
+        return Coordinate(point=new_point, **new_fields)
+    # No frame kwarg — only point-level replacement
+    return Coordinate(point=replace(coord.point, **kwargs), **coord._data)
+
+
+# ===================================================================
+# Coordinate conversion
+
+
+@plum.dispatch
+def cconvert(
+    pv: Coordinate, to_chart: cxc.AbstractChart, /, *, usys: OptUSys = None
+) -> Coordinate:
+    """Convert a Coordinate to a new chart.
+
+    Delegates to {meth}`Coordinate.cconvert`.
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+
+    >>> pt = cx.Point.from_([1.0, 0.0, 0.0], "m")
+    >>> pv = cx.Coordinate(point=pt)
+    >>> pv_sph = cx.cconvert(pv, cxc.sph3d)
+    >>> pv_sph.point.chart
+    Spherical3D(M=Rn(3))
+
+    """
+    return pv.cconvert(to_chart, usys=usys)

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -297,10 +297,9 @@ def change_basis(
     ...     "phi": u.Q(0.0, "rad/s")}, cxc.sph3d, cxr.coord_vel)
     >>> vel_phys = cxr.change_basis(vel, cxr.phys_basis, at=point)
     >>> vel_phys.basis
-    PhysicalBasis()
+    phys_basis
     >>> vel_phys.rep
-    Representation(geom_kind=TangentGeometry(), basis=PhysicalBasis(),
-                   semantic_kind=Velocity())
+    phys_vel
 
     """
     at_data: CDict | None = at.data if isinstance(at, Point) else at
@@ -339,9 +338,9 @@ def change_basis(
     >>> pt = cx.Point.from_([1.0, 2.0, 3.0], "m")
     >>> disp = cxr.change_basis(pt, cxr.coord_basis)
     >>> disp.semantic
-    Displacement()
+    dpl
     >>> disp.basis
-    CoordinateBasis()
+    coord_basis
     >>> disp.chart == pt.chart
     True
 

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -492,14 +492,8 @@ def add(lhs: Tangent, rhs: Tangent, /) -> Tangent:
         )
         raise TypeError(msg)
 
-    data = jtu.map(
-        jnp.add,
-        jtu.leaves(lhs.data, is_leaf=uq.is_any_quantity),
-        jtu.leaves(rhs.data, is_leaf=uq.is_any_quantity),
-        is_leaf=uq.is_any_quantity,
-    )
-    keys = list(lhs.data.keys())
-    return replace(lhs, data=dict(zip(keys, data, strict=True)))
+    data = jtu.map(jnp.add, lhs.data, rhs.data, is_leaf=uq.is_any_quantity)
+    return replace(lhs, data=data)
 
 
 @plum.dispatch
@@ -537,14 +531,8 @@ def subtract(lhs: Tangent, rhs: Tangent, /) -> Tangent:
         )
         raise TypeError(msg)
 
-    data = jtu.map(
-        jnp.subtract,
-        jtu.leaves(lhs.data, is_leaf=uq.is_any_quantity),
-        jtu.leaves(rhs.data, is_leaf=uq.is_any_quantity),
-        is_leaf=uq.is_any_quantity,
-    )
-    keys = list(lhs.data.keys())
-    return replace(lhs, data=dict(zip(keys, data, strict=True)))
+    data = jtu.map(jnp.subtract, lhs.data, rhs.data, is_leaf=uq.is_any_quantity)
+    return replace(lhs, data=data)
 
 
 # ===================================================================
@@ -637,11 +625,22 @@ def act(
     # Inject the base-point data as 'at' so non-Cartesian tangent dispatches
     # can evaluate the Jacobian at the correct location.  Callers may
     # override this by passing their own 'at' in **kw.
-    kw_fibre = dict(kw)
-    kw_fibre.setdefault("at", x.point.data)
-    new_fields = {
-        name: cxfm.act(op, tau, fibre, **kw_fibre) for name, fibre in x._data.items()
-    }
+    # 'at' is resolved per-fibre: if the fibre's chart differs from the
+    # point's chart (possible via _create_unchecked / cconvert with
+    # field_charts=), we convert the base point into the fibre's chart first
+    # so as not to violate Tangent's at-chart requirement.
+    kw_base = dict(kw)
+    new_fields: dict[str, Any] = {}
+    for name, fibre in x._data.items():
+        if "at" not in kw_base:
+            if fibre.chart == x.point.chart:
+                at_data = x.point.data
+            else:
+                at_data = cast("Point", cxr.cconvert(x.point, fibre.chart)).data
+            fibre_kw = {**kw_base, "at": at_data}
+        else:
+            fibre_kw = kw_base
+        new_fields[name] = cxfm.act(op, tau, fibre, **fibre_kw)
     return Coordinate(point=new_point, **new_fields)
 
 

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -543,8 +543,13 @@ def act(
 
     """
     new_point = cxfm.act(op, tau, x.point, **kw)
+    # Inject the base-point data as 'at' so non-Cartesian tangent dispatches
+    # can evaluate the Jacobian at the correct location.  Callers may
+    # override this by passing their own 'at' in **kw.
+    kw_fibre = dict(kw)
+    kw_fibre.setdefault("at", x.point.data)
     new_fields = {
-        name: cxfm.act(op, tau, fibre, **kw) for name, fibre in x._data.items()
+        name: cxfm.act(op, tau, fibre, **kw_fibre) for name, fibre in x._data.items()
     }
     return Coordinate(point=new_point, **new_fields)
 

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -216,6 +216,20 @@ def cconvert(
     Spherical3D(M=Rn(3))
 
     """
+    if from_vec.chart != to_chart:
+        if at is None:
+            msg = (
+                f"'at' is required when converting a Tangent between different charts "
+                f"({from_vec.chart!r} -> {to_chart!r}): "
+                "the Jacobian pushforward needs a base point."
+            )
+            raise TypeError(msg)
+        if isinstance(at, Point) and at.chart != from_vec.chart:
+            msg = (
+                f"'at' chart {at.chart!r} does not match "
+                f"the source chart {from_vec.chart!r}."
+            )
+            raise ValueError(msg)
     at_data: CDict | None = at.data if isinstance(at, Point) else at
     p = cxr.cconvert(
         from_vec.data,
@@ -302,6 +316,20 @@ def change_basis(
     phys_vel
 
     """
+    if v.basis != to_basis:
+        if at is None:
+            msg = (
+                f"'at' is required when changing the basis of a Tangent "
+                f"({v.basis!r} -> {to_basis!r}): "
+                "scale factors need a base point."
+            )
+            raise TypeError(msg)
+        if isinstance(at, Point) and at.chart != v.chart:
+            msg = (
+                f"'at' chart {at.chart!r} does not match "
+                f"the vector's chart {v.chart!r}."
+            )
+            raise ValueError(msg)
     at_data: CDict | None = at.data if isinstance(at, Point) else at
     new_data = cxr.change_basis(
         v.data,

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -10,6 +10,7 @@ import plum
 
 import dataclassish
 
+import coordinax.api.representations as cxrapi
 import coordinax.api.transforms as cxfmapi
 import coordinax.charts as cxc
 import coordinax.representations as cxr
@@ -273,7 +274,7 @@ def cconvert(
     """
     if from_chart != from_vec.chart:
         raise ValueError(CHART_MSMTCH.format(from_chart, from_vec))
-    return cxr.cconvert(from_vec, to_chart, at=at, usys=usys)  # ty: ignore[invalid-return-type]
+    return cxrapi.cconvert(from_vec, to_chart, at=at, usys=usys)  # ty: ignore[invalid-return-type]
 
 
 # ===================================================================
@@ -545,10 +546,13 @@ def act(
 
 @dataclassish.replace.dispatch  # type: ignore[attr-defined]
 def _replace_coordinate(coord: Coordinate, /, **kwargs: Any) -> Coordinate:
-    """Replace fields on a Coordinate, propagating ``frame`` to point and fibres.
+    """Replace fields on a Coordinate.
 
+    Supports replacing ``point``, any named fibre field, or ``frame``.
     When ``frame`` is supplied, it is forwarded to both the base ``point`` and
     every fibre field so the bundle stays internally consistent.
+
+    Unknown keys are rejected with a ``TypeError``.
 
     Examples
     --------
@@ -558,18 +562,42 @@ def _replace_coordinate(coord: Coordinate, /, **kwargs: Any) -> Coordinate:
     >>> point = cx.Point.from_([1.0, 0.0, 0.0], "m", cxf.alice)
     >>> pv = cx.Coordinate(point=point)
     >>> import dataclassish
+
+    Replace the frame (propagates to point and all fibres):
+
     >>> pv2 = dataclassish.replace(pv, frame=cxf.alex)
     >>> pv2.frame
     Alex()
 
+    Replace the base point directly:
+
+    >>> point2 = cx.Point.from_([2.0, 0.0, 0.0], "m", cxf.alice)
+    >>> pv3 = dataclassish.replace(pv, point=point2)
+    >>> pv3.point is point2
+    True
+
     """
+    # Validate: reject unknown keys up front
+    valid_keys = {"frame", "point"} | coord._data.keys()
+    unknown = set(kwargs) - valid_keys
+    if unknown:
+        msg = (
+            f"dataclassish.replace(Coordinate, ...): unknown field(s) {unknown!r}. "
+            f"Valid fields are: {sorted(valid_keys)!r}."
+        )
+        raise TypeError(msg)
+
     frame = kwargs.pop("frame", None)
+    new_point = kwargs.pop("point", coord.point)
+    # Remaining kwargs are fibre-field replacements
+    new_fields = dict(coord._data)
+    new_fields.update(kwargs)
+
     if frame is not None:
-        new_point = replace(coord.point, frame=frame)
-        new_fields = {name: replace(f, frame=frame) for name, f in coord._data.items()}
-        return Coordinate(point=new_point, **new_fields)
-    # No frame kwarg — only point-level replacement
-    return Coordinate(point=replace(coord.point, **kwargs), **coord._data)
+        new_point = replace(new_point, frame=frame)
+        new_fields = {name: replace(f, frame=frame) for name, f in new_fields.items()}
+
+    return Coordinate(point=new_point, **new_fields)
 
 
 # ===================================================================

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -382,8 +382,6 @@ def change_basis(
     True
 
     """
-    if at is not None:
-        raise ValueError("`at` parameter is not used for Point-to-Tangent promotion.")
     return Tangent(  # ty: ignore[missing-argument]
         data=v.data, chart=v.chart, basis=to_basis, semantic=cxr.dpl, frame=v.frame
     )

--- a/src/coordinax/vectors/_src/register_dataclassish.py
+++ b/src/coordinax/vectors/_src/register_dataclassish.py
@@ -35,12 +35,13 @@ def replace(obj: Point, /, **kwargs: Any) -> Point:
     # Get all the kwarg fields that are part of Point, reserving the rest to
     # pass to the constructor.
     keys = obj.__dataclass_fields__.keys()
-    fs = {k: kwargs.pop(k) for k in kwargs if k in keys}
+    fs = {k: v for k, v in kwargs.items() if k in keys}
+    component_kwargs = {k: v for k, v in kwargs.items() if k not in keys}
     # If any of the kwargs are also in the data, that's an error (ambiguous).
-    if "data" in fs and kwargs:
+    if "data" in fs and component_kwargs:
         raise ValueError("Cannot pass both data and non-field kwargs.")
     # If any of the kwargs are in the data, merge them with the existing data.
-    if kwargs:
-        fs["data"] = {**obj.data, **kwargs}
+    if component_kwargs:
+        fs["data"] = {**obj.data, **component_kwargs}
     # Replace the fields using dataclasses.replace.
     return dataclasses.replace(obj, **fs)

--- a/src/coordinax/vectors/_src/register_quax.py
+++ b/src/coordinax/vectors/_src/register_quax.py
@@ -450,7 +450,7 @@ def convert_element_type_p_coordinate(operand: Coordinate, /, **kw: Any) -> Coor
     >>> pv.point["x"].dtype
     dtype('int64')
 
-    >>> qlax.convert_element_type(pv, float).point["x"].value.dtype
+    >>> qlax.convert_element_type(pv, float).point["x"].dtype
     dtype('float64')
 
     """

--- a/src/coordinax/vectors/_src/register_quax.py
+++ b/src/coordinax/vectors/_src/register_quax.py
@@ -1,4 +1,4 @@
-"""Register `quax` with `Point`."""
+"""Register `quax` with `Point`, `Tangent`, and `Coordinate`."""
 
 __all__: tuple[str, ...] = ()
 
@@ -17,8 +17,10 @@ import unxt.quantity as uq
 
 import coordinax.charts as cxc
 import coordinax.representations as cxr
+from .bundle import Coordinate
 from .custom_types import Shape
 from .point import Point
+from .tangent import Tangent
 
 ##############################################################################
 # Primitives
@@ -191,7 +193,7 @@ def mul_p_vecs(lhs: Point, rhs: int | float | Array, /, **kw: Any) -> Point:
 
 
 @quax.register(jax.lax.div_p)
-def div_p_absvecs(lhs: int | float | Array, rhs: Point, /, **kw: Any) -> Point:
+def div_p_scalar_point(lhs: int | float | Array, rhs: Point, /, **kw: Any) -> Point:
     """Element-wise division of a scalar by a point."""
     data = jtu.map(lambda v: jnp.divide(lhs, v), rhs.data, is_leaf=uq.is_any_quantity)
     return replace(rhs, data=data)
@@ -202,3 +204,296 @@ def div_p_vecs(lhs: Point, rhs: int | float | Array, /, **kw: Any) -> Point:
     """Element-wise division of a point by a scalar."""
     data = jtu.map(lambda v: jnp.divide(v, rhs), lhs.data, is_leaf=uq.is_any_quantity)
     return replace(lhs, data=data)
+
+
+##############################################################################
+# Tangent primitives
+#
+# Tangent vectors live in a genuine linear (vector) space T_p M.  All
+# operations are component-wise — no Cartesian round-trip is needed or correct.
+##############################################################################
+
+
+@quax.register(jax.lax.broadcast_in_dim_p)
+def broadcast_in_dim_p_tangent(
+    operand: Tangent, /, *, shape: Shape, **kw: Any
+) -> Tangent:
+    """Broadcast a Tangent to a new shape.
+
+    >>> import quaxed.numpy as jnp
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import unxt as u
+
+    >>> v = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel,
+    ... )
+    >>> result = jnp.broadcast_to(v, (2, 3))
+    >>> result["x"].shape
+    (2,)
+
+    """
+    c_shape = shape[:-1]
+    return replace(
+        operand,
+        data=jtu.map(lambda v: jnp.broadcast_to(v, c_shape), operand.data),
+    )
+
+
+@quax.register(jax.lax.convert_element_type_p)
+def convert_element_type_p_tangent(operand: Tangent, /, **kw: Any) -> Tangent:
+    """Convert the element type of all components in a Tangent.
+
+    >>> import quaxed.lax as qlax
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import unxt as u
+
+    >>> v = cx.Tangent.from_(
+    ...     {"x": u.Q(1, "m/s"), "y": u.Q(2, "m/s"), "z": u.Q(3, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel,
+    ... )
+    >>> v["x"].dtype
+    dtype('int64')
+
+    >>> qlax.convert_element_type(v, float)["x"].dtype
+    dtype('float64')
+
+    """
+    convert_p = quax.quaxify(jax.lax.convert_element_type_p.bind)
+    data = jtu.map(lambda v: convert_p(v, **kw), operand.data)
+    return replace(operand, data=data)
+
+
+@quax.register(jax.lax.eq_p)
+def eq_p_tangents(lhs: Tangent, rhs: Tangent, /) -> Bool[Array, "..."]:
+    """Element-wise equality of two Tangent vectors."""
+    comp_tree = jtu.map(
+        jnp.equal,
+        jtu.leaves(lhs.data, is_leaf=uq.is_any_quantity),
+        jtu.leaves(rhs.data, is_leaf=uq.is_any_quantity),
+        is_leaf=uq.is_any_quantity,
+    )
+    return jax.tree.reduce(jnp.logical_and, comp_tree)
+
+
+@quax.register(jax.lax.neg_p)
+def neg_p_tangent(operand: Tangent, /) -> Tangent:
+    """Component-wise negation of a Tangent.
+
+    Tangent spaces are vector spaces so negation is always component-wise,
+    regardless of chart.
+
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import unxt as u
+
+    >>> v = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel,
+    ... )
+    >>> (-v)["x"]
+    Q(-1., 'm / s')
+
+    """
+    return replace(
+        operand,
+        data=jtu.map(lambda v: -v, operand.data, is_leaf=uq.is_any_quantity),
+    )
+
+
+@quax.register(jax.lax.add_p)
+def add_p_tangents(lhs: Tangent, rhs: Tangent, /, **kw: Any) -> Tangent:
+    """Component-wise addition of two Tangent vectors.
+
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import unxt as u
+
+    >>> v1 = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel,
+    ... )
+    >>> v2 = cx.Tangent.from_(
+    ...     {"x": u.Q(4.0, "m/s"), "y": u.Q(5.0, "m/s"), "z": u.Q(6.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel,
+    ... )
+    >>> (v1 + v2)["x"]
+    Q(5., 'm / s')
+
+    """
+    return cast("Tangent", cxr.add(lhs, rhs))
+
+
+@quax.register(jax.lax.sub_p)
+def sub_p_tangents(lhs: Tangent, rhs: Tangent, /, **kw: Any) -> Tangent:
+    """Component-wise subtraction of two Tangent vectors.
+
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import unxt as u
+
+    >>> v1 = cx.Tangent.from_(
+    ...     {"x": u.Q(4.0, "m/s"), "y": u.Q(5.0, "m/s"), "z": u.Q(6.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel,
+    ... )
+    >>> v2 = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel,
+    ... )
+    >>> (v1 - v2)["x"]
+    Q(3., 'm / s')
+
+    """
+    return cast("Tangent", cxr.subtract(lhs, rhs))
+
+
+@quax.register(jax.lax.mul_p)
+def mul_p_scalar_tangent(
+    lhs: int | float | Array, rhs: Tangent, /, **kw: Any
+) -> Tangent:
+    """Scalar * Tangent — scale all components."""
+    data = jtu.map(lambda v: jnp.multiply(lhs, v), rhs.data, is_leaf=uq.is_any_quantity)
+    return replace(rhs, data=data)
+
+
+@quax.register(jax.lax.mul_p)
+def mul_p_tangent_scalar(
+    lhs: Tangent, rhs: int | float | Array, /, **kw: Any
+) -> Tangent:
+    """Tangent * scalar — scale all components."""
+    data = jtu.map(lambda v: jnp.multiply(v, rhs), lhs.data, is_leaf=uq.is_any_quantity)
+    return replace(lhs, data=data)
+
+
+@quax.register(jax.lax.div_p)
+def div_p_tangent_scalar(
+    lhs: Tangent, rhs: int | float | Array, /, **kw: Any
+) -> Tangent:
+    """Tangent / scalar — divide all components."""
+    data = jtu.map(lambda v: jnp.divide(v, rhs), lhs.data, is_leaf=uq.is_any_quantity)
+    return replace(lhs, data=data)
+
+
+##############################################################################
+# Coordinate primitives
+#
+# Coordinate is a bundle (Point + named Tangents).  The JAX infrastructure
+# primitives (broadcast_in_dim, convert_element_type) must propagate to both
+# the base point and every fibre Tangent so that jit/vmap work correctly.
+##############################################################################
+
+
+@quax.register(jax.lax.broadcast_in_dim_p)
+def broadcast_in_dim_p_coordinate(
+    operand: Coordinate, /, *, shape: Shape, **kw: Any
+) -> Coordinate:
+    """Broadcast a Coordinate (base point + all fibre tangents) to a new shape.
+
+    >>> import quaxed.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+    >>> vel = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel,
+    ... )
+    >>> pv = cx.Coordinate(point=point, velocity=vel)
+    >>> result = jnp.broadcast_to(pv, (2, 3))
+    >>> result.point["x"].shape
+    (2,)
+
+    """
+    # broadcast_in_dim is called by quax with the full batch+component shape;
+    # the last axis is the component axis inside each vector — strip it.
+    c_shape = shape[:-1]
+
+    new_point = replace(
+        operand.point,
+        data=jtu.map(lambda v: jnp.broadcast_to(v, c_shape), operand.point.data),
+    )
+    new_fields = {
+        name: replace(
+            vec,
+            data=jtu.map(lambda v: jnp.broadcast_to(v, c_shape), vec.data),
+        )
+        for name, vec in operand.items()
+    }
+    return Coordinate(point=new_point, **new_fields)
+
+
+@quax.register(jax.lax.convert_element_type_p)
+def convert_element_type_p_coordinate(operand: Coordinate, /, **kw: Any) -> Coordinate:
+    """Convert element type for all components in a Coordinate bundle.
+
+    >>> import quaxed.lax as qlax
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> point = cx.Point.from_([1, 0, 0], "m")
+    >>> vel = cx.Tangent.from_(
+    ...     {"x": u.Q(1, "m/s"), "y": u.Q(0, "m/s"), "z": u.Q(0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel,
+    ... )
+    >>> pv = cx.Coordinate(point=point, velocity=vel)
+    >>> pv.point["x"].dtype
+    dtype('int64')
+
+    >>> qlax.convert_element_type(pv, float).point["x"].value.dtype
+    dtype('float64')
+
+    """
+    convert_p = quax.quaxify(jax.lax.convert_element_type_p.bind)
+
+    new_point = replace(
+        operand.point,
+        data=jtu.map(lambda v: convert_p(v, **kw), operand.point.data),
+    )
+    new_fields = {
+        name: replace(vec, data=jtu.map(lambda v: convert_p(v, **kw), vec.data))
+        for name, vec in operand.items()
+    }
+    return Coordinate(point=new_point, **new_fields)
+
+
+@quax.register(jax.lax.eq_p)
+def eq_p_coordinates(lhs: Coordinate, rhs: Coordinate, /) -> Bool[Array, "..."]:
+    """Element-wise equality of two Coordinate bundles.
+
+    Returns True only if the base point and every named tangent fibre are
+    component-wise equal.
+
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import unxt as u
+
+    >>> point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+    >>> vel = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_vel,
+    ... )
+    >>> pv = cx.Coordinate(point=point, velocity=vel)
+    >>> bool(pv == pv)
+    True
+
+    """
+    # Check point equality
+    point_eq = eq_p_absvecs(lhs.point, rhs.point)
+    # Check equality for every fibre tangent
+    fibre_eqs = [
+        eq_p_tangents(lhs_v, rhs_v)
+        for lhs_v, rhs_v in zip(lhs.values(), rhs.values(), strict=True)
+    ]
+    return jax.tree.reduce(jnp.logical_and, [point_eq, *fibre_eqs])

--- a/src/coordinax/vectors/_src/register_quax.py
+++ b/src/coordinax/vectors/_src/register_quax.py
@@ -327,6 +327,12 @@ def add_p_tangents(lhs: Tangent, rhs: Tangent, /, **kw: Any) -> Tangent:
     Q(5., 'm / s')
 
     """
+    if lhs.rep != rhs.rep:
+        msg = (
+            f"Cannot add Tangent vectors with different representations: "
+            f"{lhs.rep!r} vs {rhs.rep!r}."
+        )
+        raise ValueError(msg)
     return cast("Tangent", cxr.add(lhs, rhs))
 
 
@@ -489,11 +495,11 @@ def eq_p_coordinates(lhs: Coordinate, rhs: Coordinate, /) -> Bool[Array, "..."]:
     True
 
     """
+    # Ensure the same set of fibre names; if not, return False
+    if set(lhs.keys()) != set(rhs.keys()):
+        return jnp.asarray(value=False)
     # Check point equality
     point_eq = eq_p_absvecs(lhs.point, rhs.point)
-    # Check equality for every fibre tangent
-    fibre_eqs = [
-        eq_p_tangents(lhs_v, rhs_v)
-        for lhs_v, rhs_v in zip(lhs.values(), rhs.values(), strict=True)
-    ]
+    # Check equality for every fibre tangent, matched by name
+    fibre_eqs = [eq_p_tangents(lhs[name], rhs[name]) for name in lhs]
     return jax.tree.reduce(jnp.logical_and, [point_eq, *fibre_eqs])

--- a/src/coordinax/vectors/_src/register_quax.py
+++ b/src/coordinax/vectors/_src/register_quax.py
@@ -327,12 +327,6 @@ def add_p_tangents(lhs: Tangent, rhs: Tangent, /, **kw: Any) -> Tangent:
     Q(5., 'm / s')
 
     """
-    if lhs.rep != rhs.rep:
-        msg = (
-            f"Cannot add Tangent vectors with different representations: "
-            f"{lhs.rep!r} vs {rhs.rep!r}."
-        )
-        raise ValueError(msg)
     return cast("Tangent", cxr.add(lhs, rhs))
 
 
@@ -357,12 +351,6 @@ def sub_p_tangents(lhs: Tangent, rhs: Tangent, /, **kw: Any) -> Tangent:
     Q(3., 'm / s')
 
     """
-    if lhs.rep != rhs.rep:
-        msg = (
-            f"Cannot subtract Tangent vectors with different representations: "
-            f"{lhs.rep!r} vs {rhs.rep!r}."
-        )
-        raise ValueError(msg)
     return cast("Tangent", cxr.subtract(lhs, rhs))
 
 

--- a/src/coordinax/vectors/_src/register_quax.py
+++ b/src/coordinax/vectors/_src/register_quax.py
@@ -440,7 +440,7 @@ def broadcast_in_dim_p_coordinate(
         )
         for name, vec in operand.items()
     }
-    return Coordinate(point=new_point, **new_fields)
+    return Coordinate._create_unchecked(new_point, new_fields)
 
 
 @quax.register(jax.lax.convert_element_type_p)
@@ -476,7 +476,7 @@ def convert_element_type_p_coordinate(operand: Coordinate, /, **kw: Any) -> Coor
         name: replace(vec, data=jtu.map(lambda v: convert_p(v, **kw), vec.data))
         for name, vec in operand.items()
     }
-    return Coordinate(point=new_point, **new_fields)
+    return Coordinate._create_unchecked(new_point, new_fields)
 
 
 @quax.register(jax.lax.eq_p)

--- a/src/coordinax/vectors/_src/register_quax.py
+++ b/src/coordinax/vectors/_src/register_quax.py
@@ -497,7 +497,7 @@ def eq_p_coordinates(lhs: Coordinate, rhs: Coordinate, /) -> Bool[Array, "..."]:
     """
     # Ensure the same set of fibre names; if not, return False
     if set(lhs.keys()) != set(rhs.keys()):
-        return jnp.asarray(value=False)
+        return jnp.asarray(False)  # noqa: FBT003
     # Check point equality
     point_eq = eq_p_absvecs(lhs.point, rhs.point)
     # Check equality for every fibre tangent, matched by name

--- a/src/coordinax/vectors/_src/register_quax.py
+++ b/src/coordinax/vectors/_src/register_quax.py
@@ -408,7 +408,7 @@ def broadcast_in_dim_p_coordinate(
     ...     cxc.cart3d, cxr.coord_vel,
     ... )
     >>> pv = cx.Coordinate(point=point, velocity=vel)
-    >>> result = jnp.broadcast_to(pv, (2, 3))
+    >>> result = jnp.broadcast_to(pv, (2, 6))
     >>> result.point["x"].shape
     (2,)
 

--- a/src/coordinax/vectors/_src/register_quax.py
+++ b/src/coordinax/vectors/_src/register_quax.py
@@ -332,7 +332,7 @@ def add_p_tangents(lhs: Tangent, rhs: Tangent, /, **kw: Any) -> Tangent:
             f"Cannot add Tangent vectors with different representations: "
             f"{lhs.rep!r} vs {rhs.rep!r}."
         )
-        raise ValueError(msg)
+        raise TypeError(msg)
     return cast("Tangent", cxr.add(lhs, rhs))
 
 
@@ -357,6 +357,12 @@ def sub_p_tangents(lhs: Tangent, rhs: Tangent, /, **kw: Any) -> Tangent:
     Q(3., 'm / s')
 
     """
+    if lhs.rep != rhs.rep:
+        msg = (
+            f"Cannot subtract Tangent vectors with different representations: "
+            f"{lhs.rep!r} vs {rhs.rep!r}."
+        )
+        raise TypeError(msg)
     return cast("Tangent", cxr.subtract(lhs, rhs))
 
 

--- a/src/coordinax/vectors/_src/register_quax.py
+++ b/src/coordinax/vectors/_src/register_quax.py
@@ -332,7 +332,7 @@ def add_p_tangents(lhs: Tangent, rhs: Tangent, /, **kw: Any) -> Tangent:
             f"Cannot add Tangent vectors with different representations: "
             f"{lhs.rep!r} vs {rhs.rep!r}."
         )
-        raise TypeError(msg)
+        raise ValueError(msg)
     return cast("Tangent", cxr.add(lhs, rhs))
 
 
@@ -362,7 +362,7 @@ def sub_p_tangents(lhs: Tangent, rhs: Tangent, /, **kw: Any) -> Tangent:
             f"Cannot subtract Tangent vectors with different representations: "
             f"{lhs.rep!r} vs {rhs.rep!r}."
         )
-        raise TypeError(msg)
+        raise ValueError(msg)
     return cast("Tangent", cxr.subtract(lhs, rhs))
 
 

--- a/src/coordinax/vectors/_src/register_quax.py
+++ b/src/coordinax/vectors/_src/register_quax.py
@@ -77,11 +77,11 @@ def eq_p_absvecs(lhs: Point, rhs: Point, /) -> Bool[Array, "..."]:
     See `Point.__eq__` for examples.
 
     """
-    # Map the equality over the leaves, which are Quantities.
+    # Map the equality over the dict values, matching by key.
     comp_tree = jtu.map(
         jnp.equal,
-        jtu.leaves(lhs.data, is_leaf=uq.is_any_quantity),
-        jtu.leaves(rhs.data, is_leaf=uq.is_any_quantity),
+        lhs.data,
+        rhs.data,
         is_leaf=uq.is_any_quantity,
     )
 
@@ -273,8 +273,8 @@ def eq_p_tangents(lhs: Tangent, rhs: Tangent, /) -> Bool[Array, "..."]:
     """Element-wise equality of two Tangent vectors."""
     comp_tree = jtu.map(
         jnp.equal,
-        jtu.leaves(lhs.data, is_leaf=uq.is_any_quantity),
-        jtu.leaves(rhs.data, is_leaf=uq.is_any_quantity),
+        lhs.data,
+        rhs.data,
         is_leaf=uq.is_any_quantity,
     )
     return jax.tree.reduce(jnp.logical_and, comp_tree)

--- a/src/coordinax/vectors/_src/tangent.py
+++ b/src/coordinax/vectors/_src/tangent.py
@@ -133,7 +133,8 @@ class Tangent(
     )
     """The reference frame. Defaults to ``cxf.noframe``."""
 
-    def _check_init(self) -> None:
+    def __check_init__(self) -> None:
+        self.M.check_chart(self.chart)
         self.chart.check_data(self.data, keys=True)
 
     @property
@@ -288,7 +289,7 @@ def from_(
     """Construct a Tangent from data, chart, and a tangent Representation.
 
     Extracts ``basis`` and ``semantic`` from the representation. Raises
-    ``ValueError`` if the representation's geometry kind is not
+    ``TypeError`` if the representation's geometry kind is not
     ``TangentGeometry``.
 
     Examples

--- a/src/coordinax/vectors/_src/tangent.py
+++ b/src/coordinax/vectors/_src/tangent.py
@@ -363,6 +363,63 @@ def from_(cls: type[Tangent], obj: Any, /) -> Tangent:
     return cls.from_(data, chart, rep)  # ty: ignore[invalid-return-type]
 
 
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Tangent],
+    obj: list[Any],
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+) -> Tangent:
+    """Construct a Tangent from a Python list, chart, and Representation.
+
+    Converts the list to a JAX array before dispatching. The values are
+    treated as dimensionless; use the ``(list, unit, chart, ...)`` overloads
+    when physical units are needed.
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> v = cx.Tangent.from_([10, 20, 30], cxc.cart3d, cxr.coord_vel)
+    >>> isinstance(v, cx.Tangent)
+    True
+
+    """
+    return cls.from_(jnp.asarray(obj), chart, rep)  # ty: ignore[invalid-return-type]
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Tangent],
+    obj: list[Any],
+    chart: cxc.AbstractChart,
+    basis: cxr.AbstractLinearBasis,
+    semantic: cxr.AbstractTangentSemanticKind,
+    /,
+) -> Tangent:
+    """Construct a Tangent from a Python list, chart, basis, and semantic kind.
+
+    Converts the list to a JAX array before dispatching. The values are
+    treated as dimensionless; use the ``(list, unit, chart, ...)`` overloads
+    when physical units are needed.
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> v = cx.Tangent.from_([10, 20, 30], cxc.cart3d, cxr.coord_basis, cxr.vel)
+    >>> isinstance(v, cx.Tangent)
+    True
+
+    """
+    return cls.from_(jnp.asarray(obj), chart, basis, semantic)  # ty: ignore[invalid-return-type]
+
+
 # -----------------------------------------
 # Array-like constructors
 

--- a/src/coordinax/vectors/_src/tangent.py
+++ b/src/coordinax/vectors/_src/tangent.py
@@ -1,0 +1,610 @@
+"""Tangent."""
+
+__all__ = ("Tangent",)
+
+
+from dataclasses import replace
+
+from jaxtyping import ArrayLike
+from typing import TYPE_CHECKING, Any, Generic, cast, final
+from typing_extensions import TypeVar, override
+
+import equinox as eqx
+import quax_blocks
+import wadler_lindig as wl
+from jax.core import ShapedArray
+
+import dataclassish
+import quaxed.numpy as jnp
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.frames as cxf
+import coordinax.representations as cxr
+from .base import AbstractVector
+from .custom_types import CKey, HasShape
+from .mixins import AstropyRepresentationAPIMixin
+from .point import _frame_converter, _vector_comps_unit_docs, _vector_values_str
+from coordinax.internal import pos_named_objs
+
+if TYPE_CHECKING:
+    from coordinax.internal import CDict
+
+ChartT = TypeVar(
+    "ChartT", bound=cxc.AbstractChart[Any, Any], default=cxc.AbstractChart[Any, Any]
+)
+BasisT = TypeVar(
+    "BasisT",
+    bound=cxr.AbstractLinearBasis,
+    default=cxr.AbstractLinearBasis,
+)
+SemanticT = TypeVar(
+    "SemanticT",
+    bound=cxr.AbstractTangentSemanticKind,
+    default=cxr.AbstractTangentSemanticKind,
+)
+V = TypeVar("V", bound=HasShape, default=u.Q)
+
+
+@final
+class Tangent(
+    AstropyRepresentationAPIMixin,
+    quax_blocks.NumpyInvertMixin[Any],
+    quax_blocks.LaxLenMixin,
+    AbstractVector[ChartT, cxr.TangentGeometry, BasisT, SemanticT, V],
+    Generic[ChartT, BasisT, SemanticT, V],
+):
+    r"""A tangent-geometry vector with explicit basis and semantic kind.
+
+    A `Tangent` stores four pieces of information:
+
+    - **data**: a mapping from component name to scalar-like value (typically
+      `unxt.Quantity`),
+    - **chart**: a chart object describing the coordinate system and component
+      schema,
+    - **basis**: an `~coordinax.representations.AbstractLinearBasis` specifying
+      the basis in which tangent components are expressed
+      (e.g. `~coordinax.representations.CoordinateBasis` or
+      `~coordinax.representations.PhysicalBasis`), and
+    - **semantic**: an `~coordinax.representations.AbstractTangentSemanticKind`
+      giving the physical interpretation of the tangent vector
+      (e.g. `~coordinax.representations.Velocity`,
+      `~coordinax.representations.Displacement`).
+
+    The **representation** is computed from these, always with
+    `~coordinax.representations.TangentGeometry` as the geometry kind:
+
+    .. math::
+
+        \mathrm{rep} = (
+            \mathrm{TangentGeometry},\, \mathrm{basis},\, \mathrm{semantic}
+        ).
+
+    This is contrast to `~coordinax.vectors.Point`, which stores a fixed
+    `~coordinax.representations.PointGeometry`-flavoured rep and a concrete
+    location on the manifold.
+
+    Parameters
+    ----------
+    data
+        Mapping from chart component name to scalar value.
+    chart
+        A chart instance (e.g. `cxc.cart3d`) that defines the coordinate
+        system.
+    basis
+        The linear basis in which the tangent components are expressed.
+    semantic
+        The semantic kind of the tangent vector (velocity, displacement, etc.).
+    frame
+        The reference frame. Defaults to ``cxf.noframe``.
+
+    Examples
+    --------
+    Construct a **coordinate-basis velocity** in Cartesian 3D:
+
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import unxt as u
+
+    >>> v = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_basis, cxr.vel,
+    ... )
+    >>> v.rep == cxr.coord_vel
+    True
+
+    """
+
+    data: dict[CKey, V]
+    """The data for each component."""
+
+    chart: ChartT = eqx.field(static=True)
+    """The chart of the vector, e.g. `cxc.cart3d`."""
+
+    basis: BasisT = eqx.field(static=True)
+    """The linear basis for tangent components."""
+
+    semantic: SemanticT = eqx.field(static=True)
+    """The semantic kind of the tangent vector."""
+
+    frame: cxf.AbstractReferenceFrame = eqx.field(
+        default=cxf.noframe, converter=_frame_converter
+    )
+    """The reference frame. Defaults to ``cxf.noframe``."""
+
+    def _check_init(self) -> None:
+        self.chart.check_data(self.data, keys=True)
+
+    @property
+    def rep(self) -> cxr.Representation:
+        """The representation, computed from basis and semantic."""
+        return cxr.Representation(cxr.tangent_geom, self.basis, self.semantic)
+
+    @override
+    def __getitem__(self, key: Any) -> "V | Tangent":  # ty: ignore[invalid-method-override]
+        if isinstance(key, str):
+            return self.data[key]
+        return replace(self, data={k: v[key] for k, v in self.data.items()})  # ty: ignore[invalid-return-type,not-subscriptable]
+
+    # ===============================================================
+    # Quax API
+
+    def aval(self) -> ShapedArray:
+        """Return the vector as a JAX abstract array."""
+        fvs = self.data.values()
+        shape = (*jnp.broadcast_shapes(*map(jnp.shape, fvs)), len(fvs))
+        dtype = jnp.result_type(*map(jnp.dtype, fvs))
+        return ShapedArray(shape, dtype)
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        """Return the batch shape of the vector."""
+        shapes = [v.shape for v in self.data.values()]
+        return jnp.broadcast_shapes(*shapes)
+
+    # ===============================================================
+    # Wadler-Lindig API
+
+    def __pdoc__(self, *, vector_form: bool = False, **kw: Any) -> wl.AbstractDoc:
+        """Return the Wadler-Lindig docstring for the vector.
+
+        Parameters
+        ----------
+        vector_form
+            If True, return the compact vector-form representation.
+        **kw
+            Additional keyword arguments forwarded to the formatter.
+
+        """
+        if vector_form:
+            return _vectorform_pdoc(self, **kw)
+
+        kw.setdefault("use_short_name", True)
+        kw.setdefault("named_unit", False)
+        kw.setdefault("include_params", False)
+        kw.setdefault("canonical", True)
+
+        docs = pos_named_objs(
+            dataclassish.field_items(self), ["data"], self.__dataclass_fields__, **kw
+        )
+        return wl.bracketed(
+            begin=wl.TextDoc(f"{self.__class__.__name__}("),
+            docs=docs,
+            sep=wl.comma,
+            end=wl.TextDoc(")"),
+            indent=kw.get("indent", 4),
+        )
+
+
+def _vectorform_pdoc(
+    vector: Tangent[Any, Any, Any, Any],
+    *,
+    class_name: str | None = None,
+    **kwargs: Any,
+) -> wl.AbstractDoc:
+    """Return the compact vector-form docstring for a Tangent."""
+    kwargs.setdefault("canonical", True)
+    cls_name = class_name if class_name is not None else vector.__class__.__name__
+    chart_name = type(vector.chart).__name__
+    # Reuse Point's helper (works on any object with .chart and .data)
+    comps_doc, unit_doc = _vector_comps_unit_docs(vector)
+    values_str = _vector_values_str(vector, **kwargs)
+
+    header = f"<{cls_name}: chart={chart_name} {comps_doc}"
+    if unit_doc:
+        header = f"{header} {unit_doc}"
+
+    return wl.TextDoc(header + values_str + ">")
+
+
+# ===================================================================
+# Constructors
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(cls: type[Tangent], obj: Tangent, /) -> Tangent:
+    """Construct a Tangent from another Tangent (identity / fast path).
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import unxt as u
+
+    >>> v = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_basis, cxr.vel,
+    ... )
+    >>> v2 = cx.Tangent.from_(v)
+    >>> v2 is v
+    True
+
+    """
+    if type(obj) is cls:  # pylint: disable=unidiomatic-typecheck
+        return obj  # fast path for same type
+    return cls.from_(obj.data, obj.chart, obj.basis, obj.semantic)
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Tangent],
+    obj: Any,
+    chart: cxc.AbstractChart,
+    basis: cxr.AbstractLinearBasis,
+    semantic: cxr.AbstractTangentSemanticKind,
+    /,
+) -> Tangent:
+    """Construct a Tangent from data, chart, basis, and semantic.
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import unxt as u
+
+    >>> d = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")}
+    >>> v = cx.Tangent.from_(d, cxc.cart3d, cxr.coord_basis, cxr.vel)
+    >>> v.chart
+    Cart3D(M=Rn(3))
+
+    """
+    data = cast("CDict", cxc.cdict(obj, chart))
+    return Tangent(  # ty: ignore[missing-argument]
+        data=data, chart=chart, basis=basis, semantic=semantic
+    )
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Tangent],
+    obj: Any,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+) -> Tangent:
+    """Construct a Tangent from data, chart, and a tangent Representation.
+
+    Extracts ``basis`` and ``semantic`` from the representation. Raises
+    ``ValueError`` if the representation's geometry kind is not
+    ``TangentGeometry``.
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import unxt as u
+
+    >>> d = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")}
+    >>> v = cx.Tangent.from_(d, cxc.cart3d, cxr.coord_vel)
+    >>> v.basis == cxr.coord_basis
+    True
+    >>> v.semantic == cxr.vel
+    True
+
+    """
+    if not isinstance(rep.geom_kind, cxr.TangentGeometry):
+        raise TypeError(
+            f"Tangent requires a TangentGeometry representation, got {rep.geom_kind!r}."
+        )
+    if not isinstance(rep.basis, cxr.AbstractLinearBasis):
+        raise TypeError(f"Tangent requires an AbstractLinearBasis, got {rep.basis!r}.")
+    if not isinstance(rep.semantic_kind, cxr.AbstractTangentSemanticKind):
+        raise TypeError(
+            f"Tangent requires an AbstractTangentSemanticKind,"
+            f" got {rep.semantic_kind!r}."
+        )
+    return cls.from_(obj, chart, rep.basis, rep.semantic_kind)  # ty: ignore[invalid-return-type]
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(cls: type[Tangent], obj: Any, chart: cxc.AbstractChart, /) -> Tangent:
+    """Construct a Tangent from data and chart (rep inferred from data).
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import unxt as u
+
+    >>> d = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")}
+    >>> v = cx.Tangent.from_(d, cxc.cart3d)
+    >>> isinstance(v, cx.Tangent)
+    True
+
+    """
+    data = cast("CDict", cxc.cdict(obj, chart))
+    rep = cxr.guess_rep(data, chart)
+    return cls.from_(obj, chart, rep)  # ty: ignore[invalid-return-type]
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(cls: type[Tangent], obj: Any, /) -> Tangent:
+    """Construct a Tangent from data alone (chart and rep inferred).
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import unxt as u
+
+    >>> d = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")}
+    >>> v = cx.Tangent.from_(d)
+    >>> isinstance(v, cx.Tangent)
+    True
+
+    """
+    chart = cxc.guess_chart(obj)
+    data = cast("CDict", cxc.cdict(obj, chart))
+    rep = cxr.guess_rep(data, chart)
+    return cls.from_(data, chart, rep)  # ty: ignore[invalid-return-type]
+
+
+# -----------------------------------------
+# Array-like constructors
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Tangent],
+    obj: ArrayLike | list[Any],
+    unit: u.AbstractUnit | str,
+    /,
+) -> Tangent:
+    """Construct a Tangent from an array and unit (chart inferred).
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+
+    >>> v = cx.Tangent.from_([1.0, 2.0, 3.0], "m/s")
+    >>> isinstance(v, cx.Tangent)
+    True
+
+    """
+    return cls.from_(u.Q(obj, u.unit(unit)))  # ty: ignore[invalid-return-type]
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Tangent],
+    obj: ArrayLike | list[Any],
+    unit: u.AbstractUnit | str,
+    chart: cxc.AbstractChart,
+    /,
+) -> Tangent:
+    """Construct a Tangent from an array, unit, and chart.
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+
+    >>> v = cx.Tangent.from_([1.0, 2.0, 3.0], "m/s", cxc.cart3d)
+    >>> isinstance(v, cx.Tangent)
+    True
+
+    """
+    return cls.from_(u.Q(obj, u.unit(unit)), chart)  # ty: ignore[invalid-return-type]
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Tangent],
+    obj: ArrayLike | list[Any],
+    unit: u.AbstractUnit | str,
+    chart: cxc.AbstractChart,
+    basis: cxr.AbstractLinearBasis,
+    semantic: cxr.AbstractTangentSemanticKind,
+    /,
+) -> Tangent:
+    """Construct a Tangent from array, unit, chart, basis, and semantic.
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> v = cx.Tangent.from_(
+    ...     [1.0, 2.0, 3.0], "m/s", cxc.cart3d, cxr.coord_basis, cxr.vel
+    ... )
+    >>> v.basis == cxr.coord_basis
+    True
+
+    """
+    return cls.from_(u.Q(obj, u.unit(unit)), chart, basis, semantic)  # ty: ignore[invalid-return-type]
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Tangent],
+    obj: u.AbstractQuantity,
+    unit: u.AbstractUnit | str,
+    chart: cxc.AbstractChart,
+    basis: cxr.AbstractLinearBasis,
+    semantic: cxr.AbstractTangentSemanticKind,
+    /,
+) -> Tangent:
+    """Construct a Tangent from a Quantity, unit, chart, basis, and semantic.
+
+    The Quantity is converted to the given unit before construction.
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import unxt as u
+
+    >>> v = cx.Tangent.from_(
+    ...     u.Q([1.0, 2.0, 3.0], "m/s"), "m/s", cxc.cart3d, cxr.coord_basis, cxr.vel
+    ... )
+    >>> v.basis == cxr.coord_basis
+    True
+
+    """
+    return cls.from_(  # ty: ignore[invalid-return-type]
+        u.uconvert(u.unit(unit), obj), chart, basis, semantic
+    )
+
+
+# -----------------------------------------
+# Frame-aware constructors
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Tangent],
+    obj: Tangent,
+    frame: cxf.AbstractReferenceFrame,
+    /,
+) -> Tangent:
+    """Construct a Tangent from another Tangent, replacing its frame.
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import coordinax.frames as cxf
+    >>> import unxt as u
+
+    >>> v = cx.Tangent.from_(
+    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")},
+    ...     cxc.cart3d, cxr.coord_basis, cxr.vel,
+    ... )
+    >>> v2 = cx.Tangent.from_(v, cxf.alice)
+    >>> v2.frame
+    Alice()
+
+    """
+    return replace(obj, frame=frame)
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Tangent],
+    obj: Any,
+    frame: cxf.AbstractReferenceFrame,
+    /,
+) -> Tangent:
+    """Construct a Tangent from data with a frame (chart and rep inferred).
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.frames as cxf
+    >>> import unxt as u
+
+    >>> d = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")}
+    >>> v = cx.Tangent.from_(d, cxf.alice)
+    >>> v.frame
+    Alice()
+
+    """
+    v = cls.from_(obj)
+    return replace(v, frame=frame)
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Tangent],
+    obj: Any,
+    chart: cxc.AbstractChart,
+    frame: cxf.AbstractReferenceFrame,
+    /,
+) -> Tangent:
+    """Construct a Tangent from data, chart, and frame (basis/semantic inferred).
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.frames as cxf
+    >>> import unxt as u
+
+    >>> d = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")}
+    >>> v = cx.Tangent.from_(d, cxc.cart3d, cxf.alice)
+    >>> v.frame
+    Alice()
+
+    """
+    v = cls.from_(obj, chart)
+    return replace(v, frame=frame)
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Tangent],
+    obj: Any,
+    chart: cxc.AbstractChart,
+    basis: cxr.AbstractLinearBasis,
+    semantic: cxr.AbstractTangentSemanticKind,
+    frame: cxf.AbstractReferenceFrame,
+    /,
+) -> Tangent:
+    """Construct a Tangent from data, chart, basis, semantic, and frame.
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import coordinax.frames as cxf
+    >>> import unxt as u
+
+    >>> d = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")}
+    >>> v = cx.Tangent.from_(d, cxc.cart3d, cxr.coord_basis, cxr.vel, cxf.alice)
+    >>> v.frame
+    Alice()
+
+    """
+    v = cls.from_(obj, chart, basis, semantic)
+    return replace(v, frame=frame)
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Tangent],
+    obj: ArrayLike | list[Any],
+    unit: u.AbstractUnit | str,
+    frame: cxf.AbstractReferenceFrame,
+    /,
+) -> Tangent:
+    """Construct a Tangent from an array, unit, and frame.
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.frames as cxf
+
+    >>> v = cx.Tangent.from_([1.0, 2.0, 3.0], "m/s", cxf.alice)
+    >>> v.frame
+    Alice()
+
+    """
+    v = cls.from_(obj, unit)
+    return replace(v, frame=frame)

--- a/src/coordinax/vectors/_src/tangent.py
+++ b/src/coordinax/vectors/_src/tangent.py
@@ -363,63 +363,6 @@ def from_(cls: type[Tangent], obj: Any, /) -> Tangent:
     return cls.from_(data, chart, rep)  # ty: ignore[invalid-return-type]
 
 
-@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
-def from_(
-    cls: type[Tangent],
-    obj: list[Any],
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-) -> Tangent:
-    """Construct a Tangent from a Python list, chart, and Representation.
-
-    Converts the list to a JAX array before dispatching. The values are
-    treated as dimensionless; use the ``(list, unit, chart, ...)`` overloads
-    when physical units are needed.
-
-    Examples
-    --------
-    >>> import coordinax.main as cx
-    >>> import coordinax.charts as cxc
-    >>> import coordinax.representations as cxr
-
-    >>> v = cx.Tangent.from_([10, 20, 30], cxc.cart3d, cxr.coord_vel)
-    >>> isinstance(v, cx.Tangent)
-    True
-
-    """
-    return cls.from_(jnp.asarray(obj), chart, rep)  # ty: ignore[invalid-return-type]
-
-
-@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
-def from_(
-    cls: type[Tangent],
-    obj: list[Any],
-    chart: cxc.AbstractChart,
-    basis: cxr.AbstractLinearBasis,
-    semantic: cxr.AbstractTangentSemanticKind,
-    /,
-) -> Tangent:
-    """Construct a Tangent from a Python list, chart, basis, and semantic kind.
-
-    Converts the list to a JAX array before dispatching. The values are
-    treated as dimensionless; use the ``(list, unit, chart, ...)`` overloads
-    when physical units are needed.
-
-    Examples
-    --------
-    >>> import coordinax.main as cx
-    >>> import coordinax.charts as cxc
-    >>> import coordinax.representations as cxr
-
-    >>> v = cx.Tangent.from_([10, 20, 30], cxc.cart3d, cxr.coord_basis, cxr.vel)
-    >>> isinstance(v, cx.Tangent)
-    True
-
-    """
-    return cls.from_(jnp.asarray(obj), chart, basis, semantic)  # ty: ignore[invalid-return-type]
-
-
 # -----------------------------------------
 # Array-like constructors
 
@@ -466,6 +409,31 @@ def from_(
 
     """
     return cls.from_(u.Q(obj, u.unit(unit)), chart)  # ty: ignore[invalid-return-type]
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Tangent],
+    obj: ArrayLike | list[Any],
+    unit: u.AbstractUnit | str,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+) -> Tangent:
+    """Construct a Tangent from an array, unit, chart, and Representation.
+
+    Examples
+    --------
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> v = cx.Tangent.from_([1.0, 2.0, 3.0], "m/s", cxc.cart3d, cxr.coord_vel)
+    >>> v.basis == cxr.coord_basis
+    True
+
+    """
+    return cls.from_(u.Q(obj, u.unit(unit)), chart, rep)  # ty: ignore[invalid-return-type]
 
 
 @Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]

--- a/src/coordinax/vectors/_src/tangent.py
+++ b/src/coordinax/vectors/_src/tangent.py
@@ -34,9 +34,7 @@ ChartT = TypeVar(
     "ChartT", bound=cxc.AbstractChart[Any, Any], default=cxc.AbstractChart[Any, Any]
 )
 BasisT = TypeVar(
-    "BasisT",
-    bound=cxr.AbstractLinearBasis,
-    default=cxr.AbstractLinearBasis,
+    "BasisT", bound=cxr.AbstractLinearBasis, default=cxr.AbstractLinearBasis
 )
 SemanticT = TypeVar(
     "SemanticT",
@@ -197,10 +195,7 @@ class Tangent(
 
 
 def _vectorform_pdoc(
-    vector: Tangent[Any, Any, Any, Any],
-    *,
-    class_name: str | None = None,
-    **kwargs: Any,
+    vector: Tangent[Any, Any, Any, Any], *, class_name: str | None = None, **kwargs: Any
 ) -> wl.AbstractDoc:
     """Return the compact vector-form docstring for a Tangent."""
     kwargs.setdefault("canonical", True)
@@ -274,11 +269,7 @@ def from_(
 
 @Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
 def from_(
-    cls: type[Tangent],
-    obj: Any,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
+    cls: type[Tangent], obj: Any, chart: cxc.AbstractChart, rep: cxr.Representation, /
 ) -> Tangent:
     """Construct a Tangent from data, chart, and a tangent Representation.
 
@@ -357,10 +348,7 @@ def from_(cls: type[Tangent], obj: Any, /) -> Tangent:
 
 @Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
 def from_(
-    cls: type[Tangent],
-    obj: ArrayLike | list[Any],
-    unit: u.AbstractUnit | str,
-    /,
+    cls: type[Tangent], obj: ArrayLike | list[Any], unit: u.AbstractUnit | str, /
 ) -> Tangent:
     """Construct a Tangent from an array and unit (chart inferred).
 
@@ -444,7 +432,7 @@ def from_(
     Alice()
 
     """
-    v = cls.from_(u.Q(obj, u.unit(unit)), chart, rep)  # ty: ignore[invalid-return-type]
+    v = cls.from_(u.Q(obj, u.unit(unit)), chart, rep)
     return replace(v, frame=frame)
 
 
@@ -511,10 +499,7 @@ def from_(
 
 @Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
 def from_(
-    cls: type[Tangent],
-    obj: Tangent,
-    frame: cxf.AbstractReferenceFrame,
-    /,
+    cls: type[Tangent], obj: Tangent, frame: cxf.AbstractReferenceFrame, /
 ) -> Tangent:
     """Construct a Tangent from another Tangent, replacing its frame.
 
@@ -538,10 +523,7 @@ def from_(
 
 @Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
 def from_(
-    cls: type[Tangent],
-    obj: Any,
-    frame: cxf.AbstractReferenceFrame,
-    /,
+    cls: type[Tangent], obj: Any, frame: cxf.AbstractReferenceFrame, /
 ) -> Tangent:
     """Construct a Tangent from data with a frame (chart and rep inferred).
 

--- a/src/coordinax/vectors/_src/tangent.py
+++ b/src/coordinax/vectors/_src/tangent.py
@@ -98,8 +98,6 @@ class Tangent(
     frame
         The reference frame. Defaults to ``cxf.noframe``.
 
-    Examples
-    --------
     Construct a **coordinate-basis velocity** in Cartesian 3D:
 
     >>> import coordinax.main as cx
@@ -227,8 +225,6 @@ def _vectorform_pdoc(
 def from_(cls: type[Tangent], obj: Tangent, /) -> Tangent:
     """Construct a Tangent from another Tangent (identity / fast path).
 
-    Examples
-    --------
     >>> import coordinax.main as cx
     >>> import coordinax.charts as cxc
     >>> import coordinax.representations as cxr
@@ -259,8 +255,6 @@ def from_(
 ) -> Tangent:
     """Construct a Tangent from data, chart, basis, and semantic.
 
-    Examples
-    --------
     >>> import coordinax.main as cx
     >>> import coordinax.charts as cxc
     >>> import coordinax.representations as cxr
@@ -292,8 +286,6 @@ def from_(
     ``TypeError`` if the representation's geometry kind is not
     ``TangentGeometry``.
 
-    Examples
-    --------
     >>> import coordinax.main as cx
     >>> import coordinax.charts as cxc
     >>> import coordinax.representations as cxr
@@ -325,8 +317,6 @@ def from_(
 def from_(cls: type[Tangent], obj: Any, chart: cxc.AbstractChart, /) -> Tangent:
     """Construct a Tangent from data and chart (rep inferred from data).
 
-    Examples
-    --------
     >>> import coordinax.main as cx
     >>> import coordinax.charts as cxc
     >>> import unxt as u
@@ -346,8 +336,6 @@ def from_(cls: type[Tangent], obj: Any, chart: cxc.AbstractChart, /) -> Tangent:
 def from_(cls: type[Tangent], obj: Any, /) -> Tangent:
     """Construct a Tangent from data alone (chart and rep inferred).
 
-    Examples
-    --------
     >>> import coordinax.main as cx
     >>> import unxt as u
 
@@ -376,8 +364,6 @@ def from_(
 ) -> Tangent:
     """Construct a Tangent from an array and unit (chart inferred).
 
-    Examples
-    --------
     >>> import coordinax.main as cx
 
     >>> v = cx.Tangent.from_([1.0, 2.0, 3.0], "m/s")
@@ -398,8 +384,6 @@ def from_(
 ) -> Tangent:
     """Construct a Tangent from an array, unit, and chart.
 
-    Examples
-    --------
     >>> import coordinax.main as cx
     >>> import coordinax.charts as cxc
 
@@ -422,8 +406,6 @@ def from_(
 ) -> Tangent:
     """Construct a Tangent from an array, unit, chart, and Representation.
 
-    Examples
-    --------
     >>> import coordinax.main as cx
     >>> import coordinax.charts as cxc
     >>> import coordinax.representations as cxr
@@ -442,14 +424,42 @@ def from_(
     obj: ArrayLike | list[Any],
     unit: u.AbstractUnit | str,
     chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    frame: cxf.AbstractReferenceFrame,
+    /,
+) -> Tangent:
+    """Construct a Tangent from an array, unit, chart, Representation, and frame.
+
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import coordinax.frames as cxf
+
+    >>> v = cx.Tangent.from_(
+    ...     [1.0, 2.0, 3.0], "m/s", cxc.cart3d, cxr.coord_vel, cxf.alice
+    ... )
+    >>> v.basis == cxr.coord_basis
+    True
+    >>> v.frame
+    Alice()
+
+    """
+    v = cls.from_(u.Q(obj, u.unit(unit)), chart, rep)  # ty: ignore[invalid-return-type]
+    return replace(v, frame=frame)
+
+
+@Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(
+    cls: type[Tangent],
+    obj: ArrayLike | list[Any],
+    unit: u.AbstractUnit | str,
+    chart: cxc.AbstractChart,
     basis: cxr.AbstractLinearBasis,
     semantic: cxr.AbstractTangentSemanticKind,
     /,
 ) -> Tangent:
     """Construct a Tangent from array, unit, chart, basis, and semantic.
 
-    Examples
-    --------
     >>> import coordinax.main as cx
     >>> import coordinax.charts as cxc
     >>> import coordinax.representations as cxr
@@ -478,8 +488,6 @@ def from_(
 
     The Quantity is converted to the given unit before construction.
 
-    Examples
-    --------
     >>> import coordinax.main as cx
     >>> import coordinax.charts as cxc
     >>> import coordinax.representations as cxr
@@ -510,8 +518,6 @@ def from_(
 ) -> Tangent:
     """Construct a Tangent from another Tangent, replacing its frame.
 
-    Examples
-    --------
     >>> import coordinax.main as cx
     >>> import coordinax.charts as cxc
     >>> import coordinax.representations as cxr
@@ -539,8 +545,6 @@ def from_(
 ) -> Tangent:
     """Construct a Tangent from data with a frame (chart and rep inferred).
 
-    Examples
-    --------
     >>> import coordinax.main as cx
     >>> import coordinax.frames as cxf
     >>> import unxt as u
@@ -565,8 +569,6 @@ def from_(
 ) -> Tangent:
     """Construct a Tangent from data, chart, and frame (basis/semantic inferred).
 
-    Examples
-    --------
     >>> import coordinax.main as cx
     >>> import coordinax.charts as cxc
     >>> import coordinax.frames as cxf
@@ -594,8 +596,6 @@ def from_(
 ) -> Tangent:
     """Construct a Tangent from data, chart, basis, semantic, and frame.
 
-    Examples
-    --------
     >>> import coordinax.main as cx
     >>> import coordinax.charts as cxc
     >>> import coordinax.representations as cxr
@@ -622,8 +622,6 @@ def from_(
 ) -> Tangent:
     """Construct a Tangent from an array, unit, and frame.
 
-    Examples
-    --------
     >>> import coordinax.main as cx
     >>> import coordinax.frames as cxf
 

--- a/tests/integration/angles/test_quax.py
+++ b/tests/integration/angles/test_quax.py
@@ -34,15 +34,13 @@ import coordinax.hypothesis.main as cxst
 # Bounded to [-3, 3] rad — covers more than a full turn without overflowing
 # trig functions
 _angle_rad = cxst.angles(
-    unit="rad",
-    elements=st.floats(min_value=-3.0, max_value=3.0, width=32),
+    unit="rad", elements=st.floats(min_value=-3, max_value=3, width=32)
 )
 
 # Narrower range for grad tests where we compare with cos(x): avoids
 # cancellation near ±π/2
 _angle_rad_trig = cxst.angles(
-    unit="rad",
-    elements=st.floats(min_value=-1.0, max_value=1.0, width=32),
+    unit="rad", elements=st.floats(min_value=-1, max_value=1, width=32)
 )
 
 
@@ -57,9 +55,9 @@ class TestQuaxedUnary:
             (1.5, qnp.abs, 1.5),  # positive → unchanged
             (-1.5, qnp.abs, 1.5),  # negative → flipped
             (1.5, qnp.negative, -1.5),
-            (1.7, qnp.floor, 1.0),
-            (1.2, qnp.ceil, 2.0),
-            (1.6, qnp.round, 2.0),
+            (1.7, qnp.floor, 1),
+            (1.2, qnp.ceil, 2),
+            (1.6, qnp.round, 2),
         ],
     )
     def test_known_value(self, value: float, fn: object, expected: float) -> None:
@@ -91,7 +89,7 @@ class TestQuaxedTrig:
     # in one parametrized test so we avoid duplicating the fixture setup.
     @pytest.mark.parametrize(
         ("fn", "angle_val", "expected"),
-        [(qnp.sin, jnp.pi / 2, 1.0), (qnp.cos, 0.0, 1.0), (qnp.tan, jnp.pi / 4, 1.0)],
+        [(qnp.sin, jnp.pi / 2, 1), (qnp.cos, 0, 1), (qnp.tan, jnp.pi / 4, 1)],
     )
     def test_trig_known_value_and_type(
         self, fn: object, angle_val: float, expected: float
@@ -107,7 +105,7 @@ class TestQuaxedTrig:
         """sin²(x) + cos²(x) == 1 for all angles (numerical sanity check)."""
         s2 = qnp.sin(angle).value ** 2
         c2 = qnp.cos(angle).value ** 2
-        assert jnp.allclose(s2 + c2, 1.0, atol=1e-5)
+        assert jnp.allclose(s2 + c2, 1, atol=1e-5)
 
 
 class TestQuaxedBinary:
@@ -115,7 +113,7 @@ class TestQuaxedBinary:
 
     @pytest.mark.parametrize(
         ("a_val", "b_val", "fn", "expected"),
-        [(1.0, 0.5, qnp.add, 1.5), (1.5, 0.5, qnp.subtract, 1.0)],
+        [(1, 0.5, qnp.add, 1.5), (1.5, 0.5, qnp.subtract, 1)],
     )
     def test_known_value(
         self, a_val: float, b_val: float, fn: object, expected: float
@@ -126,16 +124,16 @@ class TestQuaxedBinary:
 
     def test_multiply_by_scalar(self) -> None:
         """Multiplying an Angle by a plain scalar returns an Angle."""
-        result = qnp.multiply(cxa.Angle(1.5, "rad"), 2.0)
+        result = qnp.multiply(cxa.Angle(1.5, "rad"), 2)
         assert isinstance(result, cxa.Angle)
-        assert jnp.allclose(result.value, 3.0)
+        assert jnp.allclose(result.value, 3)
 
     @given(
         a=cxst.angles(
-            unit="rad", elements=st.floats(min_value=0.0, max_value=3.0, width=32)
+            unit="rad", elements=st.floats(min_value=0, max_value=3, width=32)
         ),
         b=cxst.angles(
-            unit="rad", elements=st.floats(min_value=0.0, max_value=3.0, width=32)
+            unit="rad", elements=st.floats(min_value=0, max_value=3, width=32)
         ),
     )
     def test_add_commutativity(self, a: cxa.Angle, b: cxa.Angle) -> None:
@@ -153,10 +151,10 @@ class TestQuaxedReductions:
     @pytest.mark.parametrize(
         ("values", "fn", "expected"),
         [
-            ([1.0, 2.0, 3.0], qnp.sum, 6.0),
-            ([0.0, 2.0, 4.0], qnp.mean, 2.0),
-            ([3.0, 1.0, 2.0], qnp.min, 1.0),
-            ([3.0, 1.0, 2.0], qnp.max, 3.0),
+            ([1, 2, 3], qnp.sum, 6),
+            ([0, 2, 4], qnp.mean, 2),
+            ([3, 1, 2], qnp.min, 1),
+            ([3, 1, 2], qnp.max, 3),
         ],
     )
     def test_known_value(
@@ -178,26 +176,24 @@ class TestQuaxedArrayOps:
 
     def test_stack(self) -> None:
         """Stack creates an Angle array from scalar Angles."""
-        result = qnp.stack([cxa.Angle(1.0, "rad"), cxa.Angle(2.0, "rad")])
+        result = qnp.stack([cxa.Angle(1, "rad"), cxa.Angle(2, "rad")])
         assert isinstance(result, cxa.Angle)
         assert result.shape == (2,)
-        assert jnp.allclose(result.value, jnp.array([1.0, 2.0]))
+        assert jnp.allclose(result.value, jnp.array([1, 2]))
 
     def test_concatenate(self) -> None:
-        result = qnp.concatenate(
-            [cxa.Angle([1.0, 2.0], "rad"), cxa.Angle([3.0, 4.0], "rad")]
-        )
+        result = qnp.concatenate([cxa.Angle([1, 2], "rad"), cxa.Angle([3, 4], "rad")])
         assert isinstance(result, cxa.Angle)
         assert result.shape == (4,)
-        assert jnp.allclose(result.value, jnp.array([1.0, 2.0, 3.0, 4.0]))
+        assert jnp.allclose(result.value, jnp.array([1, 2, 3, 4]))
 
     def test_sort(self) -> None:
-        result = qnp.sort(cxa.Angle([3.0, 1.0, 2.0], "rad"))
+        result = qnp.sort(cxa.Angle([3, 1, 2], "rad"))
         assert isinstance(result, cxa.Angle)
-        assert jnp.allclose(result.value, jnp.array([1.0, 2.0, 3.0]))
+        assert jnp.allclose(result.value, jnp.array([1, 2, 3]))
 
     def test_reshape(self) -> None:
-        result = qnp.reshape(cxa.Angle([[1.0, 2.0], [3.0, 4.0]], "deg"), (4,))
+        result = qnp.reshape(cxa.Angle([[1, 2], [3, 4]], "deg"), (4,))
         assert isinstance(result, cxa.Angle)
         assert result.shape == (4,)
 
@@ -208,10 +204,10 @@ class TestQuaxedArrayOps:
         assert jnp.all(result.value == 1.5)
 
     def test_diff(self) -> None:
-        result = qnp.diff(cxa.Angle([1.0, 3.0, 6.0], "deg"))
+        result = qnp.diff(cxa.Angle([1, 3, 6], "deg"))
         assert isinstance(result, cxa.Angle)
         assert result.shape == (2,)
-        assert jnp.allclose(result.value, jnp.array([2.0, 3.0]))
+        assert jnp.allclose(result.value, jnp.array([2, 3]))
 
     @pytest.mark.parametrize(
         ("cond", "a_val", "b_val", "expected"),
@@ -234,11 +230,11 @@ class TestQuaxedArrayOps:
         """Where with a boolean array selects element-wise."""
         result = qnp.where(
             jnp.array([True, False, True]),
-            cxa.Angle([1.0, 2.0, 3.0], "rad"),
-            cxa.Angle([4.0, 5.0, 6.0], "rad"),
+            cxa.Angle([1, 2, 3], "rad"),
+            cxa.Angle([4, 5, 6], "rad"),
         )
         assert isinstance(result, cxa.Angle)
-        assert jnp.allclose(result.value, jnp.array([1.0, 5.0, 3.0]))
+        assert jnp.allclose(result.value, jnp.array([1, 5, 3]))
 
 
 class TestQuaxQuaxify:
@@ -256,7 +252,7 @@ class TestQuaxQuaxify:
 
     @pytest.mark.parametrize(
         ("fn", "angle_val", "expected"),
-        [(jax.numpy.sin, jnp.pi / 2, 1.0), (jax.numpy.cos, 0.0, 1.0)],
+        [(jax.numpy.sin, jnp.pi / 2, 1), (jax.numpy.cos, 0, 1)],
     )
     def test_quaxify_trig_known_value(
         self, fn: object, angle_val: float, expected: float
@@ -268,9 +264,7 @@ class TestQuaxQuaxify:
 
     def test_quaxify_add_preserves_angle_type(self) -> None:
         """quaxify(jax.numpy.add) on two Angles returns an Angle."""
-        result = quax.quaxify(jax.numpy.add)(
-            cxa.Angle(1.0, "rad"), cxa.Angle(0.5, "rad")
-        )
+        result = quax.quaxify(jax.numpy.add)(cxa.Angle(1, "rad"), cxa.Angle(0.5, "rad"))
         assert isinstance(result, cxa.Angle)
         assert jnp.allclose(result.value, 1.5)
 
@@ -280,30 +274,30 @@ class TestQuaxQuaxify:
         def double(x):
             return jax.numpy.add(x, x)
 
-        result = quax.quaxify(double)(cxa.Angle(1.0, "rad"))
+        result = quax.quaxify(double)(cxa.Angle(1, "rad"))
         assert isinstance(result, cxa.Angle)
-        assert jnp.allclose(result.value, 2.0)
+        assert jnp.allclose(result.value, 2)
 
     def test_quaxify_jit(self) -> None:
         """jax.jit(quaxify(fn)) works on an Angle."""
         result = jax.jit(quax.quaxify(jax.numpy.sin))(cxa.Angle(jnp.pi / 2, "rad"))
         assert isinstance(result, u.AbstractQuantity)
-        assert jnp.allclose(result.value, 1.0, atol=1e-6)
+        assert jnp.allclose(result.value, 1, atol=1e-6)
 
     def test_quaxify_vmap(self) -> None:
         """jax.vmap(quaxify(fn)) maps over an Angle array."""
-        arr = cxa.Angle([0.0, jnp.pi / 6, jnp.pi / 2], "rad")
+        arr = cxa.Angle([0, jnp.pi / 6, jnp.pi / 2], "rad")
         result = jax.vmap(quax.quaxify(jax.numpy.sin))(arr)
         assert isinstance(result, u.AbstractQuantity)
         assert result.value.shape == (3,)
-        assert jnp.allclose(result.value[2], 1.0, atol=1e-5)
+        assert jnp.allclose(result.value[2], 1, atol=1e-5)
 
     @given(angle=_angle_rad)
     def test_quaxify_pythagorean_identity(self, angle: cxa.Angle) -> None:
         """sin²+cos² == 1 via quaxified raw jax.numpy functions."""
         s = quax.quaxify(jax.numpy.sin)(angle)
         c = quax.quaxify(jax.numpy.cos)(angle)
-        assert jnp.allclose(s.value**2 + c.value**2, 1.0, atol=1e-5)
+        assert jnp.allclose(s.value**2 + c.value**2, 1, atol=1e-5)
 
 
 class TestJAXTransformsWithQuaxed:
@@ -312,10 +306,8 @@ class TestJAXTransformsWithQuaxed:
     @pytest.mark.parametrize(
         ("loss_fn", "angle_val", "expected_grad"),
         [
-            # d/dx sin(x) = cos(x)
-            (lambda x: qnp.sin(x).value, 1.0, jnp.cos(1.0)),
-            # d/dx cos(x) = -sin(x)
-            (lambda x: qnp.cos(x).value, 1.0, -jnp.sin(1.0)),
+            (lambda x: qnp.sin(x).value, 1.0, jnp.cos(1.0)),  # d/dx sin(x) = cos(x)
+            (lambda x: qnp.cos(x).value, 1.0, -jnp.sin(1.0)),  # d/dx cos(x) = -sin(x)
         ],
     )
     def test_grad_known_value(
@@ -337,8 +329,8 @@ class TestJAXTransformsWithQuaxed:
     @pytest.mark.parametrize(
         ("fn", "angle_val", "expected_type", "expected_val"),
         [
-            (lambda x: qnp.sin(x), jnp.pi / 2, u.AbstractQuantity, 1.0),
-            (lambda x: qnp.add(x, x), 1.0, cxa.Angle, 2.0),
+            (qnp.sin, jnp.pi / 2, u.AbstractQuantity, 1),
+            (lambda x: qnp.add(x, x), 1, cxa.Angle, 2),
         ],
     )
     def test_jit(
@@ -362,7 +354,7 @@ class TestJAXTransformsWithQuaxed:
         angle=cxst.angles(
             unit="rad",
             shape=(4,),
-            elements=st.floats(min_value=-2.0, max_value=2.0, width=32),
+            elements=st.floats(min_value=-2, max_value=2, width=32),
         )
     )
     @settings(deadline=None)

--- a/tests/unit/charts/test_cdict.py
+++ b/tests/unit/charts/test_cdict.py
@@ -64,7 +64,8 @@ def test_cdict_from_quantity_and_chart(data, chart):
 def test_cdict_from_array_and_chart(data, chart):
     """cdict(array, chart) should return a CDict with correct keys and values."""
     ndim = len(chart.components)
-    q = data.draw(xps.arrays(xps.real_dtypes(), shape=(ndim,)))
+    dtype = data.draw(st.sampled_from([jnp.float32, jnp.float64]))
+    q = data.draw(xps.arrays(dtype, shape=(ndim,)))
 
     got = cxc.cdict(q, chart)
 

--- a/tests/unit/charts/test_cdict.py
+++ b/tests/unit/charts/test_cdict.py
@@ -11,7 +11,7 @@ import unxt_hypothesis as ust
 import coordinax.charts as cxc
 import coordinax.hypothesis.main as cxst
 from .conftest import shapes_ending_in_123, xps
-from coordinax._src.custom_types import CDict
+from coordinax.internal import CDict
 
 
 @given(cxst.cdicts(cxst.charts()))

--- a/tests/unit/charts/test_fixedcompcharts.py
+++ b/tests/unit/charts/test_fixedcompcharts.py
@@ -1,7 +1,7 @@
 """Tests for AbstractFixedComponentsChart."""
 
 import hypothesis.strategies as st
-from hypothesis import given
+from hypothesis import given, settings
 
 import coordinax.charts as cxc
 import coordinax.hypothesis.main as cxst
@@ -19,6 +19,7 @@ _fixedcharts = cxst.charts(filter=cxc.AbstractFixedComponentsChart)
 class TestFixedComponentsChart:
     """Behavior of charts with fixed components."""
 
+    @settings(deadline=None)
     @given(data=st.data(), chart_class=_fixedchart_classes)
     def test_instances_from_same_class_have_same_component_schema(
         self, data, chart_class

--- a/tests/unit/representations/test_change_basis.py
+++ b/tests/unit/representations/test_change_basis.py
@@ -19,7 +19,7 @@ from coordinax.representations._src.basis_change import _qm_triangular_solve
 
 def tree_equal(lhs: Any, rhs: Any) -> bool:
     """Return True when two pytrees are elementwise equal."""
-    eq_tree = jax.tree_util.tree_map(lambda x, y: jnp.equal(x, y), lhs, rhs)
+    eq_tree = jax.tree_util.tree_map(jnp.equal, lhs, rhs)
     leaves = jax.tree_util.tree_leaves(eq_tree)
     if not leaves:
         return True

--- a/tests/unit/transforms/test_act.py
+++ b/tests/unit/transforms/test_act.py
@@ -16,6 +16,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 import unxt as u
 
@@ -565,3 +566,200 @@ class TestTransformCallable:
     def test_identity_call_coordinate(self, identity_op, coord_3d):
         result = identity_op(coord_3d)
         _assert_close(_extract_xyz(result), EXPECTED_IDENTITY)
+
+
+# ===================================================================
+# Tangent geometry on non-Cartesian charts (Jacobian pushforward)
+# ===================================================================
+
+
+class TestRotateTangentGeometryNonCartesian:
+    """Verify that act(Rotate, TangentGeometry, sph3d) uses the Jacobian.
+
+    The key invariant:
+        cart(rotate(v, at_sph)) == R * cart(v, at_sph)
+
+    where cart(*) denotes the tangent_map pushforward to Cartesian coords.
+    """
+
+    @pytest.fixture
+    def rot90z(self):
+        return cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+
+    @pytest.fixture
+    def at_sph(self):
+        """Base point at the equator phi=0; Cartesian (1,0,0)."""
+        return {
+            "r": u.Q(1.0, "m"),
+            "theta": u.Q(jnp.pi / 2, "rad"),
+            "phi": u.Q(0.0, "rad"),
+        }
+
+    @pytest.fixture
+    def v_radial_sph(self):
+        """Purely radial velocity in spherical coord-basis."""
+        return {
+            "r": u.Q(1.0, "m/s"),
+            "theta": u.Q(0.0, "rad/s"),
+            "phi": u.Q(0.0, "rad/s"),
+        }
+
+    def test_cart_consistency(self, rot90z, at_sph, v_radial_sph):
+        """cart(R*v at R*p) == R * cart(v at p)."""
+        # Rotate tangent via Jacobian path
+        v_rot_sph = cxfm.act(
+            rot90z,
+            None,
+            v_radial_sph,
+            cxc.sph3d,
+            cxr.tangent_geom,
+            cxr.coord_vel,
+            at=at_sph,
+        )
+        # Rotated base point in spherical (phi: 0 -> pi/2)
+        at_sph_rot = {
+            "r": u.Q(1.0, "m"),
+            "theta": u.Q(jnp.pi / 2, "rad"),
+            "phi": u.Q(jnp.pi / 2, "rad"),
+        }
+        # Push rotated tangent to Cartesian
+        v_rot_cart = cxr.tangent_map(
+            v_rot_sph, cxc.sph3d, cxr.coord_vel, cxc.cart3d, at=at_sph_rot
+        )
+        # Directly compute R * cart(v)
+        v_cart = cxr.tangent_map(
+            v_radial_sph, cxc.sph3d, cxr.coord_vel, cxc.cart3d, at=at_sph
+        )
+        R = rot90z._get_R(cxc.cart3d)
+        v_arr = jnp.stack([v_cart["x"].value, v_cart["y"].value, v_cart["z"].value])
+        v_expected = R @ v_arr
+
+        assert abs(float(v_rot_cart["x"].value) - float(v_expected[0])) < ATOL
+        assert abs(float(v_rot_cart["y"].value) - float(v_expected[1])) < ATOL
+        assert abs(float(v_rot_cart["z"].value) - float(v_expected[2])) < ATOL
+
+    def test_round_trip(self, rot90z, at_sph, v_radial_sph):
+        """R⁻¹(R(v, at), R(at)) == v."""
+        v_rot_sph = cxfm.act(
+            rot90z,
+            None,
+            v_radial_sph,
+            cxc.sph3d,
+            cxr.tangent_geom,
+            cxr.coord_vel,
+            at=at_sph,
+        )
+        at_sph_rot = {
+            "r": u.Q(1.0, "m"),
+            "theta": u.Q(jnp.pi / 2, "rad"),
+            "phi": u.Q(jnp.pi / 2, "rad"),
+        }
+        inv_op = cxfm.Rotate.from_euler("z", u.Q(-90, "deg"))
+        v_recovered = cxfm.act(
+            inv_op,
+            None,
+            v_rot_sph,
+            cxc.sph3d,
+            cxr.tangent_geom,
+            cxr.coord_vel,
+            at=at_sph_rot,
+        )
+        assert abs(float(v_recovered["r"].to_value("m/s")) - 1.0) < ATOL
+        assert abs(float(v_recovered["theta"].to_value("rad/s"))) < ATOL
+        assert abs(float(v_recovered["phi"].to_value("rad/s"))) < ATOL
+
+    def test_raises_without_at(self, rot90z, v_radial_sph):
+        """act(Rotate, sph3d, TangentGeometry) raises TypeError without at=."""
+        with pytest.raises(TypeError, match="requires 'at'"):
+            cxfm.act(
+                rot90z,
+                None,
+                v_radial_sph,
+                cxc.sph3d,
+                cxr.tangent_geom,
+                cxr.coord_vel,
+            )
+
+    def test_jit(self, rot90z, at_sph, v_radial_sph):
+        """act(Rotate, sph3d, TangentGeometry) is JIT-compatible."""
+        result = eqx.filter_jit(
+            lambda v: cxfm.act(
+                rot90z,
+                None,
+                v,
+                cxc.sph3d,
+                cxr.tangent_geom,
+                cxr.coord_vel,
+                at=at_sph,
+            )
+        )(v_radial_sph)
+        assert abs(float(result["r"].to_value("m/s")) - 1.0) < ATOL
+
+
+# ===================================================================
+# Coordinate.to_frame with non-Cartesian velocity
+# ===================================================================
+
+
+class TestCoordinateToFrameNonCartesianTangent:
+    """Verify Coordinate.to_frame injects 'at' correctly for tangent fibres."""
+
+    def test_cart3d_velocity_to_rotated_frame(self):
+        """Coordinate with Cartesian velocity transforms correctly via to_frame."""
+        rot = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+        rotated_frame = cxf.TransformedReferenceFrame(cxf.alice, rot)
+
+        point = cx.Point.from_([1.0, 0.0, 0.0], "m", cxf.alice)
+        vel = cx.Tangent(
+            {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+            cxc.cart3d,
+            cxr.coord_basis,
+            cxr.vel,
+            frame=cxf.alice,
+        )
+        coord = cx.Coordinate(point=point, velocity=vel)
+        result = coord.to_frame(rotated_frame)
+
+        # Point (1,0,0) rotated 90° about z -> (0,1,0)
+        _assert_close(
+            (
+                float(result.point.data["x"].to_value("m")),
+                float(result.point.data["y"].to_value("m")),
+                float(result.point.data["z"].to_value("m")),
+            ),
+            (0.0, 1.0, 0.0),
+        )
+        # Velocity (1,0,0) m/s rotated -> (0,1,0) m/s
+        _assert_close(
+            (
+                float(result["velocity"].data["x"].to_value("m/s")),
+                float(result["velocity"].data["y"].to_value("m/s")),
+                float(result["velocity"].data["z"].to_value("m/s")),
+            ),
+            (0.0, 1.0, 0.0),
+        )
+
+    def test_coordinate_to_frame_then_cconvert_sph(self):
+        """Coordinate.to_frame followed by .cconvert(sph3d) works correctly."""
+        rot = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+        rotated_frame = cxf.TransformedReferenceFrame(cxf.alice, rot)
+
+        point = cx.Point.from_([1.0, 0.0, 0.0], "m", cxf.alice)
+        vel = cx.Tangent(
+            {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+            cxc.cart3d,
+            cxr.coord_basis,
+            cxr.vel,
+            frame=cxf.alice,
+        )
+        coord = cx.Coordinate(point=point, velocity=vel)
+        result = coord.to_frame(rotated_frame).cconvert(cxc.sph3d)
+
+        # Point should land at (r=1, theta=pi/2, phi=pi/2)
+        assert abs(float(result.point.data["r"].to_value("m")) - 1.0) < ATOL
+        assert (
+            abs(float(result.point.data["theta"].to_value("rad")) - jnp.pi / 2) < ATOL
+        )
+        assert abs(float(result.point.data["phi"].to_value("rad")) - jnp.pi / 2) < ATOL
+        # Velocity should be purely radial (ṙ≈1, θ̇≈0, φ̇≈0)
+        assert abs(float(result["velocity"].data["r"].to_value("m/s")) - 1.0) < ATOL

--- a/tests/unit/transforms/test_act.py
+++ b/tests/unit/transforms/test_act.py
@@ -626,17 +626,17 @@ class TestRotateTangentGeometryNonCartesian:
         v_rot_cart = cxr.tangent_map(
             v_rot_sph, cxc.sph3d, cxr.coord_vel, cxc.cart3d, at=at_sph_rot
         )
-        # Directly compute R * cart(v)
+        # Directly compute R * cart(v) via public act on the Cartesian tangent
         v_cart = cxr.tangent_map(
             v_radial_sph, cxc.sph3d, cxr.coord_vel, cxc.cart3d, at=at_sph
         )
-        R = rot90z._get_R(cxc.cart3d)
-        v_arr = jnp.stack([v_cart["x"].value, v_cart["y"].value, v_cart["z"].value])
-        v_expected = R @ v_arr
+        v_expected = cxfm.act(
+            rot90z, None, v_cart, cxc.cart3d, cxr.tangent_geom, cxr.coord_vel
+        )
 
-        assert abs(float(v_rot_cart["x"].value) - float(v_expected[0])) < ATOL
-        assert abs(float(v_rot_cart["y"].value) - float(v_expected[1])) < ATOL
-        assert abs(float(v_rot_cart["z"].value) - float(v_expected[2])) < ATOL
+        assert abs(float(v_rot_cart["x"].value) - float(v_expected["x"].value)) < ATOL
+        assert abs(float(v_rot_cart["y"].value) - float(v_expected["y"].value)) < ATOL
+        assert abs(float(v_rot_cart["z"].value) - float(v_expected["z"].value)) < ATOL
 
     def test_round_trip(self, rot90z, at_sph, v_radial_sph):
         """R⁻¹(R(v, at), R(at)) == v."""

--- a/tests/unit/transforms/test_translate.py
+++ b/tests/unit/transforms/test_translate.py
@@ -1,0 +1,296 @@
+"""Tests for Translate operator with semantic_kind field."""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.representations as cxr
+import coordinax.transforms as cxfm
+from coordinax.internal import CDict
+
+
+@pytest.fixture
+def cart_delta() -> CDict:
+    """A sample delta vector in Cartesian coordinates."""
+    return {"x": jnp.array(1.0), "y": jnp.array(2.0), "z": jnp.array(3.0)}
+
+
+@pytest.fixture
+def translate_dpl(cart_delta) -> cxfm.Translate:
+    """A Translate with default semantic_kind (displacement)."""
+    return cxfm.Translate(cart_delta, chart=cxc.cart3d)
+
+
+@pytest.fixture
+def translate_vel(cart_delta) -> cxfm.Translate:
+    """A Translate with semantic_kind=velocity."""
+    return cxfm.Translate(cart_delta, chart=cxc.cart3d, semantic_kind=cxr.vel)
+
+
+@pytest.fixture
+def translate_acc(cart_delta) -> cxfm.Translate:
+    """A Translate with semantic_kind=acceleration."""
+    return cxfm.Translate(cart_delta, chart=cxc.cart3d, semantic_kind=cxr.acc)
+
+
+@pytest.fixture
+def point_cdict() -> CDict:
+    """A sample point in Cartesian coordinates."""
+    return {"x": jnp.array(0.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
+
+
+@pytest.fixture
+def vel_cdict() -> CDict:
+    """A sample velocity vector in Cartesian coordinates."""
+    return {"x": jnp.array(10.0), "y": jnp.array(20.0), "z": jnp.array(30.0)}
+
+
+@pytest.fixture
+def disp_cdict() -> CDict:
+    """A sample displacement vector in Cartesian coordinates."""
+    return {"x": jnp.array(5.0), "y": jnp.array(6.0), "z": jnp.array(7.0)}
+
+
+@pytest.fixture
+def acc_cdict() -> CDict:
+    """A sample acceleration vector in Cartesian coordinates."""
+    return {"x": jnp.array(0.1), "y": jnp.array(0.2), "z": jnp.array(0.3)}
+
+
+# ============================================================================
+
+
+class TestTranslateSemanticKindField:
+    """Tests for the semantic_kind field of Translate."""
+
+    def test_default_is_displacement(self, translate_dpl):
+        assert isinstance(translate_dpl.semantic_kind, cxr.Displacement)
+        assert translate_dpl.semantic_kind == cxr.dpl
+
+    def test_velocity_semantic_kind(self, translate_vel):
+        assert isinstance(translate_vel.semantic_kind, cxr.Velocity)
+        assert translate_vel.semantic_kind == cxr.vel
+
+    def test_acceleration_semantic_kind(self, translate_acc):
+        assert isinstance(translate_acc.semantic_kind, cxr.Acceleration)
+        assert translate_acc.semantic_kind == cxr.acc
+
+    def test_default_repr_hides_semantic_kind(self, translate_dpl):
+        r = repr(translate_dpl)
+        # Default semantic_kind=dpl should NOT appear (it equals the default)
+        assert "semantic_kind" not in r
+
+    def test_non_default_repr_shows_semantic_kind(self, translate_vel):
+        r = repr(translate_vel)
+        assert "semantic_kind" in r
+
+    def test_inverse_preserves_semantic_kind(self, translate_vel):
+        inv = translate_vel.inverse
+        assert isinstance(inv, cxfm.Translate)
+        assert inv.semantic_kind == cxr.vel
+
+
+# ============================================================================
+
+
+class TestTranslateDisplacementSemantic:
+    """Translate with semantic_kind=dpl (default) acts on points and displacements."""
+
+    def test_shifts_point(self, translate_dpl, point_cdict, cart_delta):
+        result = cxfm.act(translate_dpl, None, point_cdict, cxc.cart3d, cxr.point)
+        for k in point_cdict:
+            assert jnp.allclose(result[k], point_cdict[k] + cart_delta[k])
+
+    def test_shifts_coord_disp(self, translate_dpl, disp_cdict, cart_delta):
+        result = cxfm.act(translate_dpl, None, disp_cdict, cxc.cart3d, cxr.coord_disp)
+        for k in disp_cdict:
+            assert jnp.allclose(result[k], disp_cdict[k] + cart_delta[k])
+
+    def test_shifts_phys_disp(self, translate_dpl, disp_cdict, cart_delta):
+        result = cxfm.act(translate_dpl, None, disp_cdict, cxc.cart3d, cxr.phys_disp)
+        for k in disp_cdict:
+            assert jnp.allclose(result[k], disp_cdict[k] + cart_delta[k])
+
+    def test_identity_for_velocity(self, translate_dpl, vel_cdict):
+        result = cxfm.act(translate_dpl, None, vel_cdict, cxc.cart3d, cxr.coord_vel)
+        for k in vel_cdict:
+            assert jnp.allclose(result[k], vel_cdict[k])
+
+    def test_identity_for_acceleration(self, translate_dpl, acc_cdict):
+        result = cxfm.act(translate_dpl, None, acc_cdict, cxc.cart3d, cxr.coord_acc)
+        for k in acc_cdict:
+            assert jnp.allclose(result[k], acc_cdict[k])
+
+
+# ============================================================================
+
+
+class TestTranslateVelocitySemantic:
+    """Translate with semantic_kind=vel acts only on velocity vectors."""
+
+    def test_identity_for_point(self, translate_vel, point_cdict):
+        result = cxfm.act(translate_vel, None, point_cdict, cxc.cart3d, cxr.point)
+        for k in point_cdict:
+            assert jnp.allclose(result[k], point_cdict[k])
+
+    def test_identity_for_displacement(self, translate_vel, disp_cdict):
+        result = cxfm.act(translate_vel, None, disp_cdict, cxc.cart3d, cxr.coord_disp)
+        for k in disp_cdict:
+            assert jnp.allclose(result[k], disp_cdict[k])
+
+    def test_shifts_coord_vel(self, translate_vel, vel_cdict, cart_delta):
+        result = cxfm.act(translate_vel, None, vel_cdict, cxc.cart3d, cxr.coord_vel)
+        for k in vel_cdict:
+            assert jnp.allclose(result[k], vel_cdict[k] + cart_delta[k])
+
+    def test_shifts_phys_vel(self, translate_vel, vel_cdict, cart_delta):
+        result = cxfm.act(translate_vel, None, vel_cdict, cxc.cart3d, cxr.phys_vel)
+        for k in vel_cdict:
+            assert jnp.allclose(result[k], vel_cdict[k] + cart_delta[k])
+
+    def test_identity_for_acceleration(self, translate_vel, acc_cdict):
+        result = cxfm.act(translate_vel, None, acc_cdict, cxc.cart3d, cxr.coord_acc)
+        for k in acc_cdict:
+            assert jnp.allclose(result[k], acc_cdict[k])
+
+
+# ============================================================================
+
+
+class TestTranslateAccelerationSemantic:
+    """Translate with semantic_kind=acc acts only on acceleration vectors."""
+
+    def test_identity_for_point(self, translate_acc, point_cdict):
+        result = cxfm.act(translate_acc, None, point_cdict, cxc.cart3d, cxr.point)
+        for k in point_cdict:
+            assert jnp.allclose(result[k], point_cdict[k])
+
+    def test_identity_for_displacement(self, translate_acc, disp_cdict):
+        result = cxfm.act(translate_acc, None, disp_cdict, cxc.cart3d, cxr.coord_disp)
+        for k in disp_cdict:
+            assert jnp.allclose(result[k], disp_cdict[k])
+
+    def test_identity_for_velocity(self, translate_acc, vel_cdict):
+        result = cxfm.act(translate_acc, None, vel_cdict, cxc.cart3d, cxr.coord_vel)
+        for k in vel_cdict:
+            assert jnp.allclose(result[k], vel_cdict[k])
+
+    def test_shifts_coord_acc(self, translate_acc, acc_cdict, cart_delta):
+        result = cxfm.act(translate_acc, None, acc_cdict, cxc.cart3d, cxr.coord_acc)
+        for k in acc_cdict:
+            assert jnp.allclose(result[k], acc_cdict[k] + cart_delta[k])
+
+
+# ============================================================================
+
+
+class TestTranslateVelJAXCompatibility:
+    """Tests Translate(kind=vel) is compatible with JAX transformations."""
+
+    def test_jit_velocity_semantic(self, translate_vel, vel_cdict):
+        result = jax.jit(
+            lambda v: cxfm.act(translate_vel, None, v, cxc.cart3d, cxr.coord_vel)
+        )(vel_cdict)
+        for k in vel_cdict:
+            assert jnp.allclose(result[k], vel_cdict[k] + translate_vel.delta[k])
+
+    def test_vmap_velocity_semantic(self, translate_vel):
+        batch = {
+            "x": jnp.ones(4) * 10.0,
+            "y": jnp.ones(4) * 20.0,
+            "z": jnp.ones(4) * 30.0,
+        }
+        result = jax.vmap(
+            lambda v: cxfm.act(translate_vel, None, v, cxc.cart3d, cxr.coord_vel)
+        )(batch)
+        assert result["x"].shape == (4,)
+        assert jnp.allclose(result["x"], batch["x"] + translate_vel.delta["x"])
+
+
+# ============================================================================
+
+
+class TestTranslateVelRoundtrip:
+    """Tests roundtripping translate velocity vector."""
+
+    def test_vel_roundtrip(self, translate_vel, vel_cdict):
+        shifted = cxfm.act(translate_vel, None, vel_cdict, cxc.cart3d, cxr.coord_vel)
+        restored = cxfm.act(
+            translate_vel.inverse, None, shifted, cxc.cart3d, cxr.coord_vel
+        )
+        for k in vel_cdict:
+            assert jnp.allclose(restored[k], vel_cdict[k], atol=1e-6)
+
+    def test_point_roundtrip_with_quantity(self):
+        shift = cxfm.Translate.from_([1, 2, 3], "km")
+        x = {"x": u.Q(0.0, "km"), "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")}
+        shifted = cxfm.act(shift, None, x, cxc.cart3d, cxr.point)
+        restored = cxfm.act(shift.inverse, None, shifted, cxc.cart3d, cxr.point)
+        for k, v in x.items():
+            assert jnp.allclose(
+                u.ustrip(u.unit("km"), restored[k]),
+                u.ustrip(u.unit("km"), v),
+                atol=1e-6,
+            )
+
+
+# ============================================================================
+
+
+class TestTranslateAddPreservesSemanticKind:
+    """Tests adding Translates with the same semantic_kind gives a Translate."""
+
+    def test_add_dpl_dpl(self, translate_dpl):
+        result = translate_dpl + translate_dpl
+        assert isinstance(result, cxfm.Translate)
+        assert result.semantic_kind == cxr.dpl
+
+    def test_add_vel_vel(self, translate_vel):
+        result = translate_vel + translate_vel
+        assert isinstance(result, cxfm.Translate)
+        assert result.semantic_kind == cxr.vel
+
+    def test_add_acc_acc(self, translate_acc):
+        result = translate_acc + translate_acc
+        assert isinstance(result, cxfm.Translate)
+        assert result.semantic_kind == cxr.acc
+
+    def test_add_different_types_gives_composed(self, translate_dpl, translate_vel):
+        result = translate_dpl + translate_vel
+        assert isinstance(result, cxfm.Composed)
+
+    def test_vel_add_combined_delta(self, translate_vel, cart_delta, vel_cdict):
+        combined = translate_vel + translate_vel
+        result = cxfm.act(combined, None, vel_cdict, cxc.cart3d, cxr.coord_vel)
+        for k in vel_cdict:
+            assert jnp.allclose(result[k], vel_cdict[k] + 2 * cart_delta[k])
+
+
+# ============================================================================
+
+
+class TestTranslateDisplacementNonCartesianDelta:
+    """Translate with delta in non-Cartesian chart uses tangent_map Jacobian."""
+
+    def test_non_cartesian_delta_with_usys(self):
+        """Translate with delta in spherical chart works when usys is provided."""
+        usys = u.unitsystems.si
+
+        # delta expressed in spherical 3d chart (with units)
+        sph_delta = {
+            "r": u.Q(1.0, "km"),
+            "theta": u.Q(0.0, "rad"),
+            "phi": u.Q(0.0, "rad"),
+        }
+        t = cxfm.Translate(sph_delta, chart=cxc.sph3d)
+
+        # Apply to a Cartesian point (with units)
+        x = {"x": u.Q(1.0, "km"), "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")}
+        # Previously raised NotImplementedError; now uses tangent_map Jacobian
+        result = cxfm.act(t, None, x, cxc.cart3d, cxr.point, usys=usys)
+        assert "x" in result
+        assert "y" in result
+        assert "z" in result

--- a/tests/unit/vectors/test_arithmetic.py
+++ b/tests/unit/vectors/test_arithmetic.py
@@ -416,7 +416,7 @@ class TestTangentMismatchedRep:
             cxc.cart3d,
             cxr.coord_acc,
         )
-        with pytest.raises((TypeError, Exception)):
+        with pytest.raises(ValueError, match="Cannot add Tangent vectors"):
             _ = vel + acc
 
 

--- a/tests/unit/vectors/test_arithmetic.py
+++ b/tests/unit/vectors/test_arithmetic.py
@@ -407,17 +407,26 @@ class TestTangentScalarDiv:
 
 
 class TestTangentMismatchedRep:
-    """Adding Tangents with different reps raises TypeError."""
+    """Adding/subtracting Tangents with different reps raises TypeError."""
 
-    def test_add_different_semantic_raises(self) -> None:
+    def _vel_acc(self) -> tuple:
         vel = _cart_tangent(1.0, 2.0, 3.0)  # coord_vel semantic
         acc = cx.Tangent.from_(
             {"x": u.Q(1.0, "m/s2"), "y": u.Q(0.0, "m/s2"), "z": u.Q(0.0, "m/s2")},
             cxc.cart3d,
             cxr.coord_acc,
         )
+        return vel, acc
+
+    def test_add_different_semantic_raises(self) -> None:
+        vel, acc = self._vel_acc()
         with pytest.raises(ValueError, match="Cannot add Tangent vectors"):
             _ = vel + acc
+
+    def test_sub_different_semantic_raises(self) -> None:
+        vel, acc = self._vel_acc()
+        with pytest.raises(ValueError, match="Cannot subtract Tangent vectors"):
+            _ = vel - acc
 
 
 # ===================================================================

--- a/tests/unit/vectors/test_arithmetic.py
+++ b/tests/unit/vectors/test_arithmetic.py
@@ -1,10 +1,12 @@
-"""Tests for Point add/subtract arithmetic."""
+"""Tests for Point, Tangent, and Coordinate arithmetic via Quax primitives."""
 
 __all__: tuple[str, ...] = ()
 
 import jax
 import pytest
 
+import quaxed.lax as qlax
+import quaxed.numpy as jnp
 import unxt as u
 
 import coordinax.charts as cxc
@@ -205,3 +207,272 @@ class TestMismatchedRep:
     @pytest.mark.skip(reason="Only one rep type (point) currently exists")
     def test_different_rep_raises(self) -> None:
         pass
+
+
+# ===================================================================
+# Helpers for Tangent tests
+# ===================================================================
+
+
+def _cart_tangent(*xyz: float, unit: str = "m/s") -> cx.Tangent:
+    """Create a Cartesian coord-basis velocity Tangent."""
+    return cx.Tangent.from_(
+        {"x": u.Q(xyz[0], unit), "y": u.Q(xyz[1], unit), "z": u.Q(xyz[2], unit)},
+        cxc.cart3d,
+        cxr.coord_vel,
+    )
+
+
+# ===================================================================
+# Tangent add
+# ===================================================================
+
+
+class TestTangentAdd:
+    """Tangent + Tangent: component-wise (linear space, no round-trip)."""
+
+    def test_basic(self) -> None:
+        v1 = _cart_tangent(1.0, 2.0, 3.0)
+        v2 = _cart_tangent(4.0, 5.0, 6.0)
+        result = v1 + v2
+        assert result["x"] == u.Q(5.0, "m/s")
+        assert result["y"] == u.Q(7.0, "m/s")
+        assert result["z"] == u.Q(9.0, "m/s")
+
+    def test_chart_preserved(self) -> None:
+        result = _cart_tangent(1.0, 2.0, 3.0) + _cart_tangent(4.0, 5.0, 6.0)
+        assert result.chart == cxc.cart3d
+
+    def test_rep_preserved(self) -> None:
+        result = _cart_tangent(1.0, 2.0, 3.0) + _cart_tangent(4.0, 5.0, 6.0)
+        assert result.rep == cxr.coord_vel
+
+    def test_jit(self) -> None:
+        f = jax.jit(lambda a, b: a + b)
+        result = f(_cart_tangent(1.0, 2.0, 3.0), _cart_tangent(4.0, 5.0, 6.0))
+        assert result["x"] == u.Q(5.0, "m/s")
+
+    def test_cx_add(self) -> None:
+        v1 = _cart_tangent(1.0, 2.0, 3.0)
+        v2 = _cart_tangent(4.0, 5.0, 6.0)
+        result = cxr.add(v1, v2)
+        assert result["x"] == u.Q(5.0, "m/s")
+
+
+# ===================================================================
+# Tangent subtract
+# ===================================================================
+
+
+class TestTangentSubtract:
+    """Tangent - Tangent: component-wise (linear space)."""
+
+    def test_basic(self) -> None:
+        v1 = _cart_tangent(4.0, 5.0, 6.0)
+        v2 = _cart_tangent(1.0, 2.0, 3.0)
+        result = v1 - v2
+        assert result["x"] == u.Q(3.0, "m/s")
+        assert result["y"] == u.Q(3.0, "m/s")
+        assert result["z"] == u.Q(3.0, "m/s")
+
+    def test_subtract_self_is_zero(self) -> None:
+        v = _cart_tangent(1.0, 2.0, 3.0)
+        result = v - v
+        assert result["x"] == u.Q(0.0, "m/s")
+        assert result["y"] == u.Q(0.0, "m/s")
+        assert result["z"] == u.Q(0.0, "m/s")
+
+    def test_chart_preserved(self) -> None:
+        result = _cart_tangent(4.0, 5.0, 6.0) - _cart_tangent(1.0, 2.0, 3.0)
+        assert result.chart == cxc.cart3d
+
+    def test_rep_preserved(self) -> None:
+        result = _cart_tangent(4.0, 5.0, 6.0) - _cart_tangent(1.0, 2.0, 3.0)
+        assert result.rep == cxr.coord_vel
+
+    def test_jit(self) -> None:
+        f = jax.jit(lambda a, b: a - b)
+        result = f(_cart_tangent(4.0, 5.0, 6.0), _cart_tangent(1.0, 2.0, 3.0))
+        assert result["x"] == u.Q(3.0, "m/s")
+
+    def test_cx_subtract(self) -> None:
+        v1 = _cart_tangent(4.0, 5.0, 6.0)
+        v2 = _cart_tangent(1.0, 2.0, 3.0)
+        result = cxr.subtract(v1, v2)
+        assert result["x"] == u.Q(3.0, "m/s")
+
+
+# ===================================================================
+# Tangent negation
+# ===================================================================
+
+
+class TestTangentNeg:
+    """Unary negation of a Tangent is component-wise."""
+
+    def test_basic(self) -> None:
+        v = _cart_tangent(1.0, 2.0, 3.0)
+        result = -v
+        assert result["x"] == u.Q(-1.0, "m/s")
+        assert result["y"] == u.Q(-2.0, "m/s")
+        assert result["z"] == u.Q(-3.0, "m/s")
+
+    def test_chart_preserved(self) -> None:
+        result = -_cart_tangent(1.0, 2.0, 3.0)
+        assert result.chart == cxc.cart3d
+
+    def test_rep_preserved(self) -> None:
+        result = -_cart_tangent(1.0, 2.0, 3.0)
+        assert result.rep == cxr.coord_vel
+
+    def test_double_neg_identity(self) -> None:
+        v = _cart_tangent(1.0, 2.0, 3.0)
+        neg_v = -v
+        assert (-neg_v)["x"] == v["x"]
+
+    def test_jit(self) -> None:
+        f = jax.jit(lambda a: -a)
+        result = f(_cart_tangent(1.0, 2.0, 3.0))
+        assert result["x"] == u.Q(-1.0, "m/s")
+
+
+# ===================================================================
+# Tangent scalar multiplication / division
+# ===================================================================
+
+
+class TestTangentScalarMul:
+    """Scalar * Tangent and Tangent * scalar."""
+
+    def test_scalar_times_tangent(self) -> None:
+        v = _cart_tangent(1.0, 2.0, 3.0)
+        result = 2.0 * v
+        assert result["x"] == u.Q(2.0, "m/s")
+        assert result["y"] == u.Q(4.0, "m/s")
+        assert result["z"] == u.Q(6.0, "m/s")
+
+    def test_tangent_times_scalar(self) -> None:
+        v = _cart_tangent(1.0, 2.0, 3.0)
+        result = v * 3.0
+        assert result["x"] == u.Q(3.0, "m/s")
+        assert result["y"] == u.Q(6.0, "m/s")
+        assert result["z"] == u.Q(9.0, "m/s")
+
+    def test_chart_preserved(self) -> None:
+        result = 2.0 * _cart_tangent(1.0, 2.0, 3.0)
+        assert result.chart == cxc.cart3d
+
+    def test_rep_preserved(self) -> None:
+        result = 2.0 * _cart_tangent(1.0, 2.0, 3.0)
+        assert result.rep == cxr.coord_vel
+
+    def test_jit_scalar_times_tangent(self) -> None:
+        f = jax.jit(lambda s, v: s * v)
+        result = f(2.0, _cart_tangent(1.0, 2.0, 3.0))
+        assert result["x"] == u.Q(2.0, "m/s")
+
+    def test_jit_tangent_times_scalar(self) -> None:
+        f = jax.jit(lambda v, s: v * s)
+        result = f(_cart_tangent(1.0, 2.0, 3.0), 3.0)
+        assert result["x"] == u.Q(3.0, "m/s")
+
+
+class TestTangentScalarDiv:
+    """Tangent / scalar."""
+
+    def test_basic(self) -> None:
+        v = _cart_tangent(2.0, 4.0, 6.0)
+        result = v / 2.0
+        assert result["x"] == u.Q(1.0, "m/s")
+        assert result["y"] == u.Q(2.0, "m/s")
+        assert result["z"] == u.Q(3.0, "m/s")
+
+    def test_chart_preserved(self) -> None:
+        result = _cart_tangent(2.0, 4.0, 6.0) / 2.0
+        assert result.chart == cxc.cart3d
+
+    def test_rep_preserved(self) -> None:
+        result = _cart_tangent(2.0, 4.0, 6.0) / 2.0
+        assert result.rep == cxr.coord_vel
+
+    def test_jit(self) -> None:
+        f = jax.jit(lambda v, s: v / s)
+        result = f(_cart_tangent(2.0, 4.0, 6.0), 2.0)
+        assert result["x"] == u.Q(1.0, "m/s")
+
+
+# ===================================================================
+# Tangent mismatched rep → error
+# ===================================================================
+
+
+class TestTangentMismatchedRep:
+    """Adding Tangents with different reps raises TypeError."""
+
+    def test_add_different_semantic_raises(self) -> None:
+        vel = _cart_tangent(1.0, 2.0, 3.0)  # coord_vel semantic
+        acc = cx.Tangent.from_(
+            {"x": u.Q(1.0, "m/s2"), "y": u.Q(0.0, "m/s2"), "z": u.Q(0.0, "m/s2")},
+            cxc.cart3d,
+            cxr.coord_acc,
+        )
+        with pytest.raises((TypeError, Exception)):
+            _ = vel + acc
+
+
+# ===================================================================
+# Coordinate broadcast / convert (required for JAX JIT / vmap)
+# ===================================================================
+
+
+class TestCoordinateBroadcast:
+    """broadcast_in_dim on Coordinate must propagate to point and all tangents."""
+
+    def _make_coord(self) -> cx.Coordinate:
+        point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+        vel = cx.Tangent.from_(
+            {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+            cxc.cart3d,
+            cxr.coord_vel,
+        )
+        return cx.Coordinate(point=point, velocity=vel)
+
+    def test_broadcast_to_batch(self) -> None:
+        pv = self._make_coord()
+        # broadcast_to(pv, (2, 6)) — the '6' is the total component axis
+        # (3 for point + 3 for velocity) so each individual component gets
+        # batch shape (2,).
+        result = jnp.broadcast_to(pv, (2, 6))
+        assert result.point["x"].shape == (2,)
+        assert result["velocity"]["x"].shape == (2,)
+
+    def test_jit_identity(self) -> None:
+        """JIT over a Coordinate requires broadcast_in_dim to succeed."""
+        pv = self._make_coord()
+        f = jax.jit(lambda x: x)
+        result = f(pv)
+        assert result.point["x"] == u.Q(1.0, "m")
+
+
+class TestCoordinateConvertElementType:
+    """convert_element_type on Coordinate must propagate to point and all tangents."""
+
+    def _make_coord(self) -> cx.Coordinate:
+        point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+        vel = cx.Tangent.from_(
+            {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+            cxc.cart3d,
+            cxr.coord_vel,
+        )
+        return cx.Coordinate(point=point, velocity=vel)
+
+    def test_convert_to_float(self) -> None:
+        pv = self._make_coord()
+        result = qlax.convert_element_type(pv, float)
+        assert result.point["x"].value.dtype == float
+
+    def test_jit_with_float_input(self) -> None:
+        pv = self._make_coord()
+        f = jax.jit(lambda x: x)
+        result = f(pv)
+        assert result.point["x"] == u.Q(1.0, "m")

--- a/tests/unit/vectors/test_arithmetic.py
+++ b/tests/unit/vectors/test_arithmetic.py
@@ -488,7 +488,7 @@ class TestCoordinateConvertElementType:
     def test_convert_to_float(self) -> None:
         pv = self._make_coord()
         result = qlax.convert_element_type(pv, float)
-        assert result.point["x"].value.dtype == float
+        assert result.point["x"].dtype == float
 
     def test_jit_with_float_input(self) -> None:
         pv = self._make_coord()

--- a/tests/unit/vectors/test_arithmetic.py
+++ b/tests/unit/vectors/test_arithmetic.py
@@ -407,7 +407,7 @@ class TestTangentScalarDiv:
 
 
 class TestTangentMismatchedRep:
-    """Adding/subtracting Tangents with different reps raises TypeError."""
+    """Adding/subtracting Tangents with different reps raises ValueError."""
 
     def _vel_acc(self) -> tuple:
         vel = _cart_tangent(1.0, 2.0, 3.0)  # coord_vel semantic
@@ -427,6 +427,16 @@ class TestTangentMismatchedRep:
         vel, acc = self._vel_acc()
         with pytest.raises(ValueError, match="Cannot subtract Tangent vectors"):
             _ = vel - acc
+
+    def test_cx_add_different_semantic_raises(self) -> None:
+        vel, acc = self._vel_acc()
+        with pytest.raises(ValueError, match="Cannot add Tangent vectors"):
+            cxr.add(vel, acc)
+
+    def test_cx_subtract_different_semantic_raises(self) -> None:
+        vel, acc = self._vel_acc()
+        with pytest.raises(ValueError, match="Cannot subtract Tangent vectors"):
+            cxr.subtract(vel, acc)
 
 
 # ===================================================================

--- a/tests/unit/vectors/test_coordinate.py
+++ b/tests/unit/vectors/test_coordinate.py
@@ -1,0 +1,523 @@
+"""Tests for Coordinate.
+
+Per the spec, a Coordinate stores:
+  - a base ``Point`` (PointGeometry),
+  - a named collection of fibre ``Tangent``s (TangentGeometry),
+and on construction automatically converts every fibre vector into the
+reference frame of the base point.
+"""
+
+__all__: tuple[str, ...] = ()
+
+from dataclasses import replace
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.frames as cxf
+import coordinax.main as cx
+import coordinax.manifolds as cxm
+import coordinax.representations as cxr
+from coordinax.vectors import Coordinate, Point, Tangent
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_point(
+    *xyz: float, unit: str = "m", frame: cxf.AbstractReferenceFrame = cxf.noframe
+) -> Point:
+    """Cartesian position point."""
+    p = cx.Point.from_(list(xyz), unit)
+    return replace(p, frame=frame)
+
+
+def _make_vel(
+    *xyz: float, unit: str = "m/s", frame: cxf.AbstractReferenceFrame = cxf.noframe
+) -> Tangent:
+    """Cartesian velocity vector."""
+    data = {"x": u.Q(xyz[0], unit), "y": u.Q(xyz[1], unit), "z": u.Q(xyz[2], unit)}
+    v = cx.Tangent.from_(data, cxc.cart3d, cxr.coord_vel)
+    return replace(v, frame=frame)
+
+
+# ---------------------------------------------------------------------------
+# TestConstruction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    """Test basic construction and type validation."""
+
+    def test_base_only(self) -> None:
+        """Coordinate with only a base point, no field vectors."""
+        base = _make_point(1, 2, 3)
+        pv = Coordinate(point=base)
+        assert pv.point is base
+        assert len(list(pv.keys())) == 0
+
+    def test_base_with_one_field(self) -> None:
+        """Coordinate with base point + one field vector."""
+        base = _make_point(1, 2, 3)
+        vel = _make_vel(10, 20, 30)
+        pv = Coordinate(point=base, velocity=vel)
+        assert pv.point is base
+        assert "velocity" in list(pv.keys())
+
+    def test_base_with_multiple_fields(self) -> None:
+        """Coordinate with base + two field vectors."""
+        base = _make_point(1, 2, 3)
+        vel = _make_vel(10, 20, 30)
+        acc = cx.Tangent.from_(
+            {"x": u.Q(0.1, "m/s^2"), "y": u.Q(0.2, "m/s^2"), "z": u.Q(0.3, "m/s^2")},
+            cxc.cart3d,
+            cxr.coord_acc,
+        )
+        pv = Coordinate(point=base, velocity=vel, acceleration=acc)
+        assert "velocity" in list(pv.keys())
+        assert "acceleration" in list(pv.keys())
+
+    def test_point_must_be_Point(self) -> None:
+        """Passing a bare Tangent (not Point) as point must raise TypeError."""
+        vel = _make_vel(1, 2, 3)  # this is a Tangent, not a Point
+        with pytest.raises(TypeError, match="point must be a Point"):
+            Coordinate(point=vel)
+
+    def test_field_must_not_be_Point(self) -> None:
+        """Passing a Point as a field vector must raise TypeError."""
+        base = _make_point(1, 2, 3)
+        another_pos = _make_point(4, 5, 6)  # also a Point (PointGeometry)
+        with pytest.raises(TypeError, match="must be a Tangent"):
+            Coordinate(point=base, second_pos=another_pos)
+
+
+# ---------------------------------------------------------------------------
+# TestFrameAlignment
+# ---------------------------------------------------------------------------
+
+
+class TestFrameAlignment:
+    """Test automatic frame alignment of field vectors on construction."""
+
+    def test_noframe_noframe_no_conversion(self) -> None:
+        """Field with noframe when point has noframe: no conversion (identity)."""
+        base = _make_point(1, 0, 0)  # noframe
+        vel = _make_vel(1, 0, 0)  # noframe
+        pv = Coordinate(point=base, velocity=vel)
+        # Same frame — no conversion, same object returned
+        assert pv["velocity"] is vel
+
+    def test_same_real_frame_no_conversion(self) -> None:
+        """Field with same real frame as point: no conversion needed."""
+        base = _make_point(1, 0, 0, frame=cxf.alice)
+        vel = _make_vel(1, 0, 0, frame=cxf.alice)
+        pv = Coordinate(point=base, velocity=vel)
+        assert pv["velocity"].frame is cxf.alice
+
+    def test_different_frame_converts(self) -> None:
+        """Field in different frame is converted to point's frame."""
+        base = _make_point(1, 0, 0, frame=cxf.alice)
+        vel = _make_vel(1, 0, 0, frame=cxf.alex)  # alex != alice
+        pv = Coordinate(point=base, velocity=vel)
+        # After construction, velocity must be in alice's frame
+        assert pv["velocity"].frame is cxf.alice
+
+    def test_frame_property_is_point_frame(self) -> None:
+        """pv.frame is always equal to point.frame."""
+        base = _make_point(1, 0, 0, frame=cxf.alice)
+        pv = Coordinate(point=base)
+        assert pv.frame is cxf.alice
+
+    def test_multiple_fields_all_converted(self) -> None:
+        """All field vectors are converted to point's frame."""
+        base = _make_point(1, 0, 0, frame=cxf.alice)
+        vel = _make_vel(1, 0, 0, frame=cxf.alex)
+        acc_data = {
+            "x": u.Q(0.1, "m/s^2"),
+            "y": u.Q(0.0, "m/s^2"),
+            "z": u.Q(0.0, "m/s^2"),
+        }
+        acc = replace(
+            cx.Tangent.from_(acc_data, cxc.cart3d, cxr.coord_acc),
+            frame=cxf.alex,
+        )
+        pv = Coordinate(point=base, velocity=vel, acceleration=acc)
+        assert pv["velocity"].frame is cxf.alice
+        assert pv["acceleration"].frame is cxf.alice
+
+
+# ---------------------------------------------------------------------------
+# TestMappingAPI
+# ---------------------------------------------------------------------------
+
+
+class TestMappingAPI:
+    """Test Mapping-like interface (fields only, not base point)."""
+
+    @pytest.fixture
+    def pv(self) -> Coordinate:
+        base = _make_point(1, 2, 3)
+        vel = _make_vel(10, 20, 30)
+        return Coordinate(point=base, velocity=vel)
+
+    def test_getitem_field_by_name(self, pv: Coordinate) -> None:
+        assert isinstance(pv["velocity"], Tangent)
+
+    def test_getitem_unknown_key_raises(self, pv: Coordinate) -> None:
+        with pytest.raises((KeyError, Exception)):
+            _ = pv["nonexistent"]
+
+    def test_keys_contains_fields(self, pv: Coordinate) -> None:
+        assert "velocity" in list(pv.keys())
+
+    def test_keys_excludes_point(self, pv: Coordinate) -> None:
+        assert "point" not in list(pv.keys())
+
+    def test_values(self, pv: Coordinate) -> None:
+        vals = list(pv.values())
+        assert len(vals) == 1
+        assert isinstance(vals[0], Tangent)
+
+    def test_items(self, pv: Coordinate) -> None:
+        items = list(pv.items())
+        assert len(items) == 1
+        name, vec = items[0]
+        assert name == "velocity"
+        assert isinstance(vec, Tangent)
+
+    def test_len_counts_fields_only(self, pv: Coordinate) -> None:
+        assert len(pv) == 1  # one field vector, not counting point
+
+    def test_iter_yields_field_names(self, pv: Coordinate) -> None:
+        assert list(iter(pv)) == ["velocity"]
+
+
+# ---------------------------------------------------------------------------
+# TestProperties
+# ---------------------------------------------------------------------------
+
+
+class TestProperties:
+    """Test properties that delegate to the base point."""
+
+    def test_chart_delegates_to_point(self) -> None:
+        base = _make_point(1, 2, 3)
+        pv = Coordinate(point=base)
+        assert pv.chart == cxc.cart3d
+
+    def test_rep_delegates_to_point(self) -> None:
+        base = _make_point(1, 2, 3)
+        pv = Coordinate(point=base)
+        assert pv.rep == cxr.point
+
+    def test_manifold_delegates_to_point(self) -> None:
+        base = _make_point(1, 2, 3)
+        pv = Coordinate(point=base)
+        assert isinstance(pv.manifold, cxm.AbstractManifold)
+
+    def test_frame_delegates_to_point(self) -> None:
+        base = _make_point(1, 2, 3, frame=cxf.alice)
+        pv = Coordinate(point=base)
+        assert pv.frame is cxf.alice
+
+    def test_shape_scalar(self) -> None:
+        base = _make_point(1, 2, 3)
+        vel = _make_vel(10, 20, 30)
+        pv = Coordinate(point=base, velocity=vel)
+        assert pv.shape == ()
+
+    def test_shape_batched_base(self) -> None:
+        base = cx.Point.from_(jnp.ones((2, 3)), "m")
+        pv = Coordinate(point=base)
+        assert pv.shape == (2,)
+
+    def test_shape_broadcast(self) -> None:
+        """Batched base (2,) and scalar velocity () broadcast to (2,)."""
+        base = cx.Point.from_(jnp.ones((2, 3)), "m")
+        vel = _make_vel(10, 20, 30)  # scalar shape ()
+        pv = Coordinate(point=base, velocity=vel)
+        assert pv.shape == (2,)
+
+
+# ---------------------------------------------------------------------------
+# TestCconvert
+# ---------------------------------------------------------------------------
+
+
+class TestCconvert:
+    """Test chart conversion of Coordinate."""
+
+    def test_base_only_cart_to_sph(self) -> None:
+        """Base-only bundle converts base as a point map."""
+        base = _make_point(1, 0, 0)
+        pv = Coordinate(point=base)
+        pv_sph = pv.cconvert(cxc.sph3d)
+        assert pv_sph.point.chart == cxc.sph3d
+
+    def test_base_cart_to_sph_values(self) -> None:
+        """[1,0,0] in Cartesian → [r=1, theta=π/2, phi=0] in Spherical."""
+        base = _make_point(1.0, 0.0, 0.0)
+        pv = Coordinate(point=base)
+        pv_sph = pv.cconvert(cxc.sph3d)
+        assert jnp.allclose(pv_sph.point["r"].value, jnp.array(1.0), atol=1e-6)
+        assert jnp.allclose(
+            pv_sph.point["theta"].value, jnp.array(jnp.pi / 2), atol=1e-6
+        )
+        assert jnp.allclose(pv_sph.point["phi"].value, jnp.array(0.0), atol=1e-6)
+
+    def test_velocity_uses_tangent_map(self) -> None:
+        """Velocity at [1,0,0] in Cartesian converts via Jacobian to Spherical."""
+        base = _make_point(1.0, 0.0, 0.0)
+        vel = _make_vel(1.0, 0.0, 0.0)  # radial velocity in Cartesian
+        pv = Coordinate(point=base, velocity=vel)
+        pv_sph = pv.cconvert(cxc.sph3d)
+        assert pv_sph.point.chart == cxc.sph3d
+        assert pv_sph["velocity"].chart == cxc.sph3d
+        # Radial velocity [1,0,0] at [1,0,0] → [vr=1, vθ=0, vφ=0] in spherical
+        assert jnp.allclose(pv_sph["velocity"]["r"].value, jnp.array(1.0), atol=1e-6)
+
+    def test_round_trip(self) -> None:
+        """Cart → sph → cart should recover original base values."""
+        base = _make_point(1.0, 2.0, 0.0)
+        pv = Coordinate(point=base)
+        pv_rt = pv.cconvert(cxc.sph3d).cconvert(cxc.cart3d)
+        assert jnp.allclose(pv_rt.point["x"].value, base["x"].value, atol=1e-6)
+        assert jnp.allclose(pv_rt.point["y"].value, base["y"].value, atol=1e-6)
+
+    def test_identity_same_chart(self) -> None:
+        """Converting to the same chart returns equivalent values."""
+        base = _make_point(1.0, 2.0, 3.0)
+        vel = _make_vel(4.0, 5.0, 6.0)
+        pv = Coordinate(point=base, velocity=vel)
+        pv_same = pv.cconvert(cxc.cart3d)
+        assert jnp.allclose(pv_same.point["x"].value, base["x"].value, atol=1e-6)
+        assert jnp.allclose(pv_same["velocity"]["x"].value, vel["x"].value, atol=1e-6)
+
+    def test_pv_method_agrees_with_cx_function(self) -> None:
+        """pv.cconvert(chart) and cx.cconvert(pv, chart) agree."""
+        base = _make_point(1.0, 0.0, 0.0)
+        pv = Coordinate(point=base)
+        via_method = pv.cconvert(cxc.sph3d)
+        via_func = cx.cconvert(pv, cxc.sph3d)
+        assert via_method.point.chart == via_func.point.chart
+
+
+# ---------------------------------------------------------------------------
+# TestFromDispatches
+# ---------------------------------------------------------------------------
+
+
+class TestFromDispatches:
+    """Test Coordinate.from_ constructor dispatches."""
+
+    def test_from_pointed_vector_is_identity(self) -> None:
+        """Coordinate.from_(pv) returns the same object."""
+        base = _make_point(1, 2, 3)
+        pv = Coordinate(point=base)
+        pv2 = Coordinate.from_(pv)
+        assert pv2 is pv
+
+    def test_from_point_wraps(self) -> None:
+        """Coordinate.from_(Point) wraps it as a point-only bundle."""
+        base = _make_point(1, 2, 3)
+        pv = Coordinate.from_(base)
+        assert isinstance(pv, Coordinate)
+        assert pv.point is base
+        assert len(list(pv.keys())) == 0
+
+    def test_from_mapping_with_point_key(self) -> None:
+        """Coordinate.from_(mapping) detects 'point' key for base."""
+        base = _make_point(1, 2, 3)
+        vel = _make_vel(4, 5, 6)
+        pv = Coordinate.from_({"point": base, "velocity": vel})
+        assert isinstance(pv, Coordinate)
+        assert "velocity" in list(pv.keys())
+
+    def test_from_mapping_explicit_point_kwarg(self) -> None:
+        """Coordinate.from_(mapping, point=...) uses explicit base."""
+        base = _make_point(1, 2, 3)
+        vel = _make_vel(4, 5, 6)
+        pv = Coordinate.from_({"velocity": vel}, point=base)
+        assert pv.point is base
+
+
+# ---------------------------------------------------------------------------
+# TestJAXCompat
+# ---------------------------------------------------------------------------
+
+
+class TestJAXCompat:
+    """Test JAX compatibility: pytree, jit, batch indexing."""
+
+    def test_pytree_flatten_unflatten(self) -> None:
+        """Pytree round-trip preserves structure."""
+        base = _make_point(1.0, 2.0, 3.0)
+        vel = _make_vel(4.0, 5.0, 6.0)
+        pv = Coordinate(point=base, velocity=vel)
+        leaves, treedef = jax.tree.flatten(pv)
+        pv2 = jax.tree.unflatten(treedef, leaves)
+        assert pv2.point.chart == pv.point.chart
+        assert "velocity" in list(pv2.keys())
+
+    def test_jit_cconvert(self) -> None:
+        """Cconvert works under jax.jit."""
+        base = _make_point(1.0, 0.0, 0.0)
+        pv = Coordinate(point=base)
+
+        @jax.jit
+        def convert(p: Coordinate) -> Coordinate:
+            return p.cconvert(cxc.sph3d)
+
+        result = convert(pv)
+        assert result.point.chart == cxc.sph3d
+
+    def test_batch_indexing(self) -> None:
+        """pv[0] returns a Coordinate sliced along the batch axis."""
+        base = cx.Point.from_(jnp.ones((2, 3)), "m")
+        vel_data = {
+            "x": u.Q(jnp.ones((2,)), "m/s"),
+            "y": u.Q(jnp.ones((2,)), "m/s"),
+            "z": u.Q(jnp.ones((2,)), "m/s"),
+        }
+        vel = cx.Tangent.from_(vel_data, cxc.cart3d, cxr.coord_vel)
+        pv = Coordinate(point=base, velocity=vel)
+        pv0 = pv[0]
+        assert isinstance(pv0, Coordinate)
+        assert pv0.shape == ()
+
+    def test_vmap_cconvert(self) -> None:
+        """Vmap over a Coordinate converts correctly."""
+        base = cx.Point.from_(jnp.ones((2, 3)), "m")
+        vel_data = {
+            "x": u.Q(jnp.ones((2,)), "m/s"),
+            "y": u.Q(jnp.zeros((2,)), "m/s"),
+            "z": u.Q(jnp.zeros((2,)), "m/s"),
+        }
+        vel = cx.Tangent.from_(vel_data, cxc.cart3d, cxr.coord_vel)
+        pv = Coordinate(point=base, velocity=vel)
+
+        def convert_one(p: Coordinate) -> Coordinate:
+            return p.cconvert(cxc.sph3d)
+
+        result = jax.vmap(convert_one)(pv)
+        assert result.point.chart == cxc.sph3d
+        assert result["velocity"].chart == cxc.sph3d
+
+    def test_jit_with_fields(self) -> None:
+        """Jit with velocity field runs correctly."""
+        base = _make_point(1.0, 0.0, 0.0)
+        vel = _make_vel(1.0, 0.0, 0.0)
+        pv = Coordinate(point=base, velocity=vel)
+
+        @jax.jit
+        def convert(p: Coordinate) -> Coordinate:
+            return p.cconvert(cxc.sph3d)
+
+        result = convert(pv)
+        assert result.point.chart == cxc.sph3d
+        assert result["velocity"].chart == cxc.sph3d
+
+
+# ---------------------------------------------------------------------------
+# TestFieldCharts
+# ---------------------------------------------------------------------------
+
+
+class TestFieldCharts:
+    """Test field_charts kwarg in cconvert."""
+
+    def test_field_charts_override(self) -> None:
+        """field_charts allows velocity to convert to a different chart than base."""
+        base = _make_point(1.0, 0.0, 0.0)
+        vel = _make_vel(1.0, 0.0, 0.0)
+        pv = Coordinate(point=base, velocity=vel)
+        pv_mixed = pv.cconvert(cxc.sph3d, field_charts={"velocity": cxc.cart3d})
+        assert pv_mixed.point.chart == cxc.sph3d
+        assert pv_mixed["velocity"].chart == cxc.cart3d
+
+    def test_field_charts_empty_uses_default(self) -> None:
+        """Empty field_charts dict behaves as default (all fields use to_chart)."""
+        base = _make_point(1.0, 0.0, 0.0)
+        vel = _make_vel(1.0, 0.0, 0.0)
+        pv = Coordinate(point=base, velocity=vel)
+        pv_a = pv.cconvert(cxc.sph3d, field_charts={})
+        pv_b = pv.cconvert(cxc.sph3d)
+        assert pv_a["velocity"].chart == pv_b["velocity"].chart
+
+
+# ---------------------------------------------------------------------------
+# TestFromErrors
+# ---------------------------------------------------------------------------
+
+
+class TestFromErrors:
+    """Test Coordinate.from_ error cases."""
+
+    def test_from_mapping_no_point_raises(self) -> None:
+        """from_(mapping) without a 'point' key or kwarg raises ValueError."""
+        vel = _make_vel(1, 2, 3)
+        with pytest.raises(ValueError, match="point"):
+            Coordinate.from_({"velocity": vel})
+
+    def test_from_mapping_explicit_point_kwarg_takes_precedence(self) -> None:
+        """Explicit point= kwarg wins over 'point' key in the mapping."""
+        base1 = _make_point(1, 2, 3)
+        base2 = _make_point(4, 5, 6)
+        vel = _make_vel(1, 0, 0)
+        pv = Coordinate.from_({"point": base1, "velocity": vel}, point=base2)
+        assert pv.point is base2
+
+
+# ---------------------------------------------------------------------------
+# TestReprStr
+# ---------------------------------------------------------------------------
+
+
+class TestReprStr:
+    """Test __repr__ and __str__ output."""
+
+    def test_repr_contains_coordinate(self) -> None:
+        base = _make_point(1, 2, 3)
+        pv = Coordinate(point=base)
+        assert "Coordinate" in repr(pv)
+
+    def test_repr_contains_point(self) -> None:
+        base = _make_point(1, 2, 3)
+        pv = Coordinate(point=base)
+        assert "Point" in repr(pv)
+
+    def test_str_nonempty(self) -> None:
+        base = _make_point(1, 2, 3)
+        vel = _make_vel(4, 5, 6)
+        pv = Coordinate(point=base, velocity=vel)
+        assert str(pv)
+
+    def test_repr_with_fields_contains_field_name(self) -> None:
+        base = _make_point(1, 2, 3)
+        vel = _make_vel(4, 5, 6)
+        pv = Coordinate(point=base, velocity=vel)
+        assert "velocity" in repr(pv)
+
+
+# ---------------------------------------------------------------------------
+# TestManifoldProperty
+# ---------------------------------------------------------------------------
+
+
+class TestManifoldProperty:
+    """Test Coordinate.manifold delegates to point.M."""
+
+    def test_manifold_is_abstract_manifold(self) -> None:
+        base = _make_point(1, 2, 3)
+        pv = Coordinate(point=base)
+        assert isinstance(pv.manifold, cxm.AbstractManifold)
+
+    def test_manifold_matches_point_M(self) -> None:
+        base = _make_point(1, 2, 3)
+        pv = Coordinate(point=base)
+        assert pv.manifold == base.M

--- a/tests/unit/vectors/test_coordinate.py
+++ b/tests/unit/vectors/test_coordinate.py
@@ -26,20 +26,6 @@ import coordinax.vectors as cxv
 from coordinax.vectors import Coordinate, Tangent
 
 # ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_vel(
-    *xyz: float, unit: str = "m/s", frame: cxf.AbstractReferenceFrame = cxf.noframe
-) -> Tangent:
-    """Cartesian velocity vector."""
-    data = {"x": u.Q(xyz[0], unit), "y": u.Q(xyz[1], unit), "z": u.Q(xyz[2], unit)}
-    v = cx.Tangent.from_(data, cxc.cart3d, cxr.coord_vel)
-    return replace(v, frame=frame)
-
-
-# ---------------------------------------------------------------------------
 # TestConstruction
 # ---------------------------------------------------------------------------
 
@@ -57,7 +43,7 @@ class TestConstruction:
     def test_base_with_one_field(self) -> None:
         """Coordinate with base point + one field vector."""
         base = cxv.Point.from_([1, 2, 3], "m")
-        vel = cx.Tangent.from_([10, 20, 30], cxc.cart3d, cxr.coord_vel)
+        vel = cx.Tangent.from_([10, 20, 30], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
         assert pv.point is base
         assert "velocity" in list(pv.keys())
@@ -65,19 +51,15 @@ class TestConstruction:
     def test_base_with_multiple_fields(self) -> None:
         """Coordinate with base + two field vectors."""
         base = cxv.Point.from_([1, 2, 3], "m")
-        vel = _make_vel(10, 20, 30)
-        acc = cx.Tangent.from_(
-            {"x": u.Q(0.1, "m/s^2"), "y": u.Q(0.2, "m/s^2"), "z": u.Q(0.3, "m/s^2")},
-            cxc.cart3d,
-            cxr.coord_acc,
-        )
+        vel = cx.Tangent.from_([10, 20, 30], "m/s", cxc.cart3d, cxr.coord_vel)
+        acc = cx.Tangent.from_([0.1, 0.2, 0.3], "m/s^2", cxc.cart3d, cxr.coord_acc)
         pv = Coordinate(point=base, velocity=vel, acceleration=acc)
         assert "velocity" in list(pv.keys())
         assert "acceleration" in list(pv.keys())
 
     def test_point_must_be_Point(self) -> None:
         """Passing a bare Tangent (not Point) as point must raise TypeError."""
-        vel = _make_vel(1, 2, 3)  # this is a Tangent, not a Point
+        vel = cxv.Tangent.from_([1, 2, 3], "m/s", cxc.cart3d, cxr.coord_vel)
         with pytest.raises(TypeError, match="point must be a Point"):
             Coordinate(point=vel)
 
@@ -100,7 +82,7 @@ class TestFrameAlignment:
     def test_noframe_noframe_no_conversion(self) -> None:
         """Field with noframe when point has noframe: no conversion (identity)."""
         base = cxv.Point.from_([1, 0, 0], "m")  # noframe
-        vel = _make_vel(1, 0, 0)  # noframe
+        vel = cxv.Tangent.from_([1, 0, 0], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
         # Same frame — no conversion, same object returned
         assert pv["velocity"] is vel
@@ -108,14 +90,14 @@ class TestFrameAlignment:
     def test_same_real_frame_no_conversion(self) -> None:
         """Field with same real frame as point: no conversion needed."""
         base = cxv.Point.from_([1, 0, 0], "m", cxf.alice)
-        vel = _make_vel(1, 0, 0, frame=cxf.alice)
+        vel = cxv.Tangent.from_([1, 0, 0], "m/s", cxc.cart3d, cxr.coord_vel, cxf.alice)
         pv = Coordinate(point=base, velocity=vel)
         assert pv["velocity"].frame is cxf.alice
 
     def test_different_frame_converts(self) -> None:
         """Field in different frame is converted to point's frame."""
         base = cxv.Point.from_([1, 0, 0], "m", cxf.alice)
-        vel = _make_vel(1, 0, 0, frame=cxf.alex)  # alex != alice
+        vel = cxv.Tangent.from_([1, 0, 0], "m/s", cxc.cart3d, cxr.coord_vel, cxf.alex)
         pv = Coordinate(point=base, velocity=vel)
         # After construction, velocity must be in alice's frame
         assert pv["velocity"].frame is cxf.alice
@@ -129,7 +111,7 @@ class TestFrameAlignment:
     def test_multiple_fields_all_converted(self) -> None:
         """All field vectors are converted to point's frame."""
         base = cxv.Point.from_([1, 0, 0], "m", cxf.alice)
-        vel = _make_vel(1, 0, 0, frame=cxf.alex)
+        vel = cxv.Tangent.from_([1, 0, 0], "m/s", cxc.cart3d, cxr.coord_vel, cxf.alex)
         acc_data = {
             "x": u.Q(0.1, "m/s^2"),
             "y": u.Q(0.0, "m/s^2"),
@@ -154,11 +136,7 @@ def _make_sph_vel(r: float, theta: float, phi: float) -> Tangent:
 
     r component in m/s, theta and phi components in rad/s.
     """
-    data = {
-        "r": u.Q(r, "m/s"),
-        "theta": u.Q(theta, "rad/s"),
-        "phi": u.Q(phi, "rad/s"),
-    }
+    data = {"r": u.Q(r, "m/s"), "theta": u.Q(theta, "rad/s"), "phi": u.Q(phi, "rad/s")}
     return cx.Tangent.from_(data, cxc.sph3d, cxr.coord_vel)
 
 
@@ -172,7 +150,7 @@ class TestChartAlignment:
 
     def test_mismatched_chart_field_is_converted(self) -> None:
         """Field supplied in sph3d is converted to point's cart3d chart."""
-        base = cxv.Point.from_([1.0, 0.0, 0.0], "m")  # cart3d
+        base = cxv.Point.from_([1, 0, 0], "m")  # cart3d
         # velocity given in spherical coords at (r=1, θ=π/2, φ=0) — same point
         vel_sph = _make_sph_vel(1.0, 0.0, 0.0)
         pv = Coordinate(point=base, velocity=vel_sph)
@@ -180,16 +158,16 @@ class TestChartAlignment:
 
     def test_same_chart_no_change(self) -> None:
         """Field already in point's chart is left unchanged."""
-        base = cxv.Point.from_([1.0, 0.0, 0.0], "m")  # cart3d
-        vel = _make_vel(1.0, 0.0, 0.0)  # also cart3d
+        base = cxv.Point.from_([1, 0, 0], "m")  # cart3d
+        vel = cxv.Tangent.from_([1, 0, 0], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
         # same chart — object is the same instance (no conversion occurred)
         assert pv["velocity"] is vel
 
     def test_mismatched_chart_numerically_correct(self) -> None:
         """Value after chart-alignment equals value pre-converted manually."""
-        base = cxv.Point.from_([1.0, 0.0, 0.0], "m")  # cart3d, at (1,0,0)
-        vel_sph = _make_sph_vel(1.0, 0.0, 0.0)  # radial unit velocity in sph3d
+        base = cxv.Point.from_([1, 0, 0], "m")  # cart3d, at (1,0,0)
+        vel_sph = _make_sph_vel(1, 0, 0)  # radial unit velocity in sph3d
 
         # Pre-convert manually: get sph3d representation of the same base point,
         # then push the tangent forward to cart3d.
@@ -211,8 +189,8 @@ class TestChartAlignment:
 
     def test_cconvert_after_mismatched_chart_init_succeeds(self) -> None:
         """Cconvert must not raise after constructing with a mismatched-chart field."""
-        base = cxv.Point.from_([1.0, 0.0, 0.0], "m")  # cart3d
-        vel_sph = _make_sph_vel(1.0, 0.0, 0.0)
+        base = cxv.Point.from_([1, 0, 0], "m")  # cart3d
+        vel_sph = _make_sph_vel(1, 0, 0)
         pv = Coordinate(point=base, velocity=vel_sph)
         # This must not raise (original bug: would raise chart-mismatch ValueError)
         pv_sph = pv.cconvert(cxc.sph3d)
@@ -221,8 +199,8 @@ class TestChartAlignment:
 
     def test_multiple_fields_different_charts(self) -> None:
         """Multiple fields with different charts are all converted to point.chart."""
-        base = cxv.Point.from_([1.0, 0.0, 0.0], "m")  # cart3d
-        vel_sph = _make_sph_vel(1.0, 0.0, 0.0)
+        base = cxv.Point.from_([1, 0, 0], "m")  # cart3d
+        vel_sph = _make_sph_vel(1, 0, 0)
         acc_sph = cx.Tangent.from_(
             {
                 "r": u.Q(0.1, "m/s^2"),
@@ -248,7 +226,7 @@ class TestMappingAPI:
     @pytest.fixture
     def pv(self) -> Coordinate:
         base = cxv.Point.from_([1, 2, 3], "m")
-        vel = _make_vel(10, 20, 30)
+        vel = cxv.Tangent.from_([10, 20, 30], "m/s", cxc.cart3d, cxr.coord_vel)
         return Coordinate(point=base, velocity=vel)
 
     def test_getitem_field_by_name(self, pv: Coordinate) -> None:
@@ -313,7 +291,7 @@ class TestProperties:
 
     def test_shape_scalar(self) -> None:
         base = cxv.Point.from_([1, 2, 3], "m")
-        vel = _make_vel(10, 20, 30)
+        vel = cxv.Tangent.from_([10, 20, 30], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
         assert pv.shape == ()
 
@@ -325,7 +303,7 @@ class TestProperties:
     def test_shape_broadcast(self) -> None:
         """Batched base (2,) and scalar velocity () broadcast to (2,)."""
         base = cxv.Point.from_(jnp.ones((2, 3)), "m")
-        vel = _make_vel(10, 20, 30)  # scalar shape ()
+        vel = cxv.Tangent.from_([10, 20, 30], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
         assert pv.shape == (2,)
 
@@ -358,8 +336,8 @@ class TestCconvert:
 
     def test_velocity_uses_tangent_map(self) -> None:
         """Velocity at [1,0,0] in Cartesian converts via Jacobian to Spherical."""
-        base = cxv.Point.from_([1.0, 0.0, 0.0], "m")
-        vel = _make_vel(1.0, 0.0, 0.0)  # radial velocity in Cartesian
+        base = cxv.Point.from_([1, 0, 0], "m")
+        vel = cxv.Tangent.from_([1, 0, 0], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
         pv_sph = pv.cconvert(cxc.sph3d)
         assert pv_sph.point.chart == cxc.sph3d
@@ -369,7 +347,7 @@ class TestCconvert:
 
     def test_round_trip(self) -> None:
         """Cart → sph → cart should recover original base values."""
-        base = cxv.Point.from_([1.0, 2.0, 0.0], "m")  # cart3d
+        base = cxv.Point.from_([1, 2, 0], "m")  # cart3d
         pv = Coordinate(point=base)
         pv_rt = pv.cconvert(cxc.sph3d).cconvert(cxc.cart3d)
         assert jnp.allclose(pv_rt.point["x"].value, base["x"].value, atol=1e-6)
@@ -377,8 +355,8 @@ class TestCconvert:
 
     def test_identity_same_chart(self) -> None:
         """Converting to the same chart returns equivalent values."""
-        base = cxv.Point.from_([1.0, 2.0, 3.0], "m")  # cart3d
-        vel = _make_vel(4.0, 5.0, 6.0)
+        base = cxv.Point.from_([1, 2, 3], "m")  # cart3d
+        vel = cxv.Tangent.from_([4, 5, 6], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
         pv_same = pv.cconvert(cxc.cart3d)
         assert jnp.allclose(pv_same.point["x"].value, base["x"].value, atol=1e-6)
@@ -386,7 +364,7 @@ class TestCconvert:
 
     def test_pv_method_agrees_with_cx_function(self) -> None:
         """pv.cconvert(chart) and cx.cconvert(pv, chart) agree."""
-        base = cxv.Point.from_([1.0, 0.0, 0.0], "m")  # cart3d
+        base = cxv.Point.from_([1, 0, 0], "m")  # cart3d
         pv = Coordinate(point=base)
         via_method = pv.cconvert(cxc.sph3d)
         via_func = cx.cconvert(pv, cxc.sph3d)
@@ -419,7 +397,7 @@ class TestFromDispatches:
     def test_from_mapping_with_point_key(self) -> None:
         """Coordinate.from_(mapping) detects 'point' key for base."""
         base = cxv.Point.from_([1, 2, 3], "m")
-        vel = _make_vel(4, 5, 6)
+        vel = cxv.Tangent.from_([4, 5, 6], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate.from_({"point": base, "velocity": vel})
         assert isinstance(pv, Coordinate)
         assert "velocity" in list(pv.keys())
@@ -427,7 +405,7 @@ class TestFromDispatches:
     def test_from_mapping_explicit_point_kwarg(self) -> None:
         """Coordinate.from_(mapping, point=...) uses explicit base."""
         base = cxv.Point.from_([1, 2, 3], "m")
-        vel = _make_vel(4, 5, 6)
+        vel = cxv.Tangent.from_([4, 5, 6], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate.from_({"velocity": vel}, point=base)
         assert pv.point is base
 
@@ -443,7 +421,7 @@ class TestJAXCompat:
     def test_pytree_flatten_unflatten(self) -> None:
         """Pytree round-trip preserves structure."""
         base = cxv.Point.from_([1, 2, 3], "m")
-        vel = _make_vel(4, 5, 6)
+        vel = cxv.Tangent.from_([4, 5, 6], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
         leaves, treedef = jax.tree.flatten(pv)
         pv2 = jax.tree.unflatten(treedef, leaves)
@@ -497,7 +475,7 @@ class TestJAXCompat:
     def test_jit_with_fields(self) -> None:
         """Jit with velocity field runs correctly."""
         base = cxv.Point.from_([1, 0, 0], "m")
-        vel = _make_vel(1, 0, 0)
+        vel = cxv.Tangent.from_([1, 0, 0], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
 
         @jax.jit
@@ -520,7 +498,7 @@ class TestFieldCharts:
     def test_field_charts_override(self) -> None:
         """field_charts allows velocity to convert to a different chart than base."""
         base = cxv.Point.from_([1, 0, 0], "m")
-        vel = _make_vel(1, 0, 0)
+        vel = cxv.Tangent.from_([1, 0, 0], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
         pv_mixed = pv.cconvert(cxc.sph3d, field_charts={"velocity": cxc.cart3d})
         assert pv_mixed.point.chart == cxc.sph3d
@@ -529,7 +507,7 @@ class TestFieldCharts:
     def test_field_charts_empty_uses_default(self) -> None:
         """Empty field_charts dict behaves as default (all fields use to_chart)."""
         base = cxv.Point.from_([1, 0, 0], "m")
-        vel = _make_vel(1, 0, 0)
+        vel = cxv.Tangent.from_([1, 0, 0], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
         pv_a = pv.cconvert(cxc.sph3d, field_charts={})
         pv_b = pv.cconvert(cxc.sph3d)
@@ -546,7 +524,7 @@ class TestFromErrors:
 
     def test_from_mapping_no_point_raises(self) -> None:
         """from_(mapping) without a 'point' key or kwarg raises ValueError."""
-        vel = _make_vel(1, 2, 3)
+        vel = cxv.Tangent.from_([1, 2, 3], "m/s", cxc.cart3d, cxr.coord_vel)
         with pytest.raises(ValueError, match="point"):
             Coordinate.from_({"velocity": vel})
 
@@ -554,7 +532,7 @@ class TestFromErrors:
         """Explicit point= kwarg wins over 'point' key in the mapping."""
         base1 = cxv.Point.from_([1, 2, 3], "m")
         base2 = cxv.Point.from_([4, 5, 6], "m")
-        vel = _make_vel(1, 0, 0)
+        vel = cxv.Tangent.from_([1, 0, 0], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate.from_({"point": base1, "velocity": vel}, point=base2)
         assert pv.point is base2
 
@@ -579,13 +557,13 @@ class TestReprStr:
 
     def test_str_nonempty(self) -> None:
         base = cxv.Point.from_([1, 2, 3], "m")
-        vel = _make_vel(4, 5, 6)
+        vel = cxv.Tangent.from_([4, 5, 6], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
         assert str(pv)
 
     def test_repr_with_fields_contains_field_name(self) -> None:
         base = cxv.Point.from_([1, 2, 3], "m")
-        vel = _make_vel(4, 5, 6)
+        vel = cxv.Tangent.from_([4, 5, 6], "m/s", cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
         assert "velocity" in repr(pv)
 

--- a/tests/unit/vectors/test_coordinate.py
+++ b/tests/unit/vectors/test_coordinate.py
@@ -22,19 +22,12 @@ import coordinax.frames as cxf
 import coordinax.main as cx
 import coordinax.manifolds as cxm
 import coordinax.representations as cxr
-from coordinax.vectors import Coordinate, Point, Tangent
+import coordinax.vectors as cxv
+from coordinax.vectors import Coordinate, Tangent
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_point(
-    *xyz: float, unit: str = "m", frame: cxf.AbstractReferenceFrame = cxf.noframe
-) -> Point:
-    """Cartesian position point."""
-    p = cx.Point.from_(list(xyz), unit)
-    return replace(p, frame=frame)
 
 
 def _make_vel(
@@ -56,22 +49,22 @@ class TestConstruction:
 
     def test_base_only(self) -> None:
         """Coordinate with only a base point, no field vectors."""
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         pv = Coordinate(point=base)
         assert pv.point is base
         assert len(list(pv.keys())) == 0
 
     def test_base_with_one_field(self) -> None:
         """Coordinate with base point + one field vector."""
-        base = _make_point(1, 2, 3)
-        vel = _make_vel(10, 20, 30)
+        base = cxv.Point.from_([1, 2, 3], "m")
+        vel = cx.Tangent.from_([10, 20, 30], cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
         assert pv.point is base
         assert "velocity" in list(pv.keys())
 
     def test_base_with_multiple_fields(self) -> None:
         """Coordinate with base + two field vectors."""
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         vel = _make_vel(10, 20, 30)
         acc = cx.Tangent.from_(
             {"x": u.Q(0.1, "m/s^2"), "y": u.Q(0.2, "m/s^2"), "z": u.Q(0.3, "m/s^2")},
@@ -90,8 +83,8 @@ class TestConstruction:
 
     def test_field_must_not_be_Point(self) -> None:
         """Passing a Point as a field vector must raise TypeError."""
-        base = _make_point(1, 2, 3)
-        another_pos = _make_point(4, 5, 6)  # also a Point (PointGeometry)
+        base = cxv.Point.from_([1, 2, 3], "m")
+        another_pos = cxv.Point.from_([4, 5, 6], "m")
         with pytest.raises(TypeError, match="must be a Tangent"):
             Coordinate(point=base, second_pos=another_pos)
 
@@ -106,7 +99,7 @@ class TestFrameAlignment:
 
     def test_noframe_noframe_no_conversion(self) -> None:
         """Field with noframe when point has noframe: no conversion (identity)."""
-        base = _make_point(1, 0, 0)  # noframe
+        base = cxv.Point.from_([1, 0, 0], "m")  # noframe
         vel = _make_vel(1, 0, 0)  # noframe
         pv = Coordinate(point=base, velocity=vel)
         # Same frame — no conversion, same object returned
@@ -114,14 +107,14 @@ class TestFrameAlignment:
 
     def test_same_real_frame_no_conversion(self) -> None:
         """Field with same real frame as point: no conversion needed."""
-        base = _make_point(1, 0, 0, frame=cxf.alice)
+        base = cxv.Point.from_([1, 0, 0], "m", cxf.alice)
         vel = _make_vel(1, 0, 0, frame=cxf.alice)
         pv = Coordinate(point=base, velocity=vel)
         assert pv["velocity"].frame is cxf.alice
 
     def test_different_frame_converts(self) -> None:
         """Field in different frame is converted to point's frame."""
-        base = _make_point(1, 0, 0, frame=cxf.alice)
+        base = cxv.Point.from_([1, 0, 0], "m", cxf.alice)
         vel = _make_vel(1, 0, 0, frame=cxf.alex)  # alex != alice
         pv = Coordinate(point=base, velocity=vel)
         # After construction, velocity must be in alice's frame
@@ -129,13 +122,13 @@ class TestFrameAlignment:
 
     def test_frame_property_is_point_frame(self) -> None:
         """pv.frame is always equal to point.frame."""
-        base = _make_point(1, 0, 0, frame=cxf.alice)
+        base = cxv.Point.from_([1, 0, 0], "m", cxf.alice)
         pv = Coordinate(point=base)
         assert pv.frame is cxf.alice
 
     def test_multiple_fields_all_converted(self) -> None:
         """All field vectors are converted to point's frame."""
-        base = _make_point(1, 0, 0, frame=cxf.alice)
+        base = cxv.Point.from_([1, 0, 0], "m", cxf.alice)
         vel = _make_vel(1, 0, 0, frame=cxf.alex)
         acc_data = {
             "x": u.Q(0.1, "m/s^2"),
@@ -152,6 +145,99 @@ class TestFrameAlignment:
 
 
 # ---------------------------------------------------------------------------
+# TestChartAlignment
+# ---------------------------------------------------------------------------
+
+
+def _make_sph_vel(r: float, theta: float, phi: float) -> Tangent:
+    """Spherical tangent vector (coord_vel) in sph3d.
+
+    r component in m/s, theta and phi components in rad/s.
+    """
+    data = {
+        "r": u.Q(r, "m/s"),
+        "theta": u.Q(theta, "rad/s"),
+        "phi": u.Q(phi, "rad/s"),
+    }
+    return cx.Tangent.from_(data, cxc.sph3d, cxr.coord_vel)
+
+
+class TestChartAlignment:
+    """Test automatic chart-alignment of fibre vectors on construction.
+
+    On construction, each field must be converted to point.chart via a
+    Jacobian pushforward so that Coordinate.cconvert() can safely pass
+    at=self.point without a chart-mismatch error.
+    """
+
+    def test_mismatched_chart_field_is_converted(self) -> None:
+        """Field supplied in sph3d is converted to point's cart3d chart."""
+        base = cxv.Point.from_([1.0, 0.0, 0.0], "m")  # cart3d
+        # velocity given in spherical coords at (r=1, θ=π/2, φ=0) — same point
+        vel_sph = _make_sph_vel(1.0, 0.0, 0.0)
+        pv = Coordinate(point=base, velocity=vel_sph)
+        assert pv["velocity"].chart == cxc.cart3d
+
+    def test_same_chart_no_change(self) -> None:
+        """Field already in point's chart is left unchanged."""
+        base = cxv.Point.from_([1.0, 0.0, 0.0], "m")  # cart3d
+        vel = _make_vel(1.0, 0.0, 0.0)  # also cart3d
+        pv = Coordinate(point=base, velocity=vel)
+        # same chart — object is the same instance (no conversion occurred)
+        assert pv["velocity"] is vel
+
+    def test_mismatched_chart_numerically_correct(self) -> None:
+        """Value after chart-alignment equals value pre-converted manually."""
+        base = cxv.Point.from_([1.0, 0.0, 0.0], "m")  # cart3d, at (1,0,0)
+        vel_sph = _make_sph_vel(1.0, 0.0, 0.0)  # radial unit velocity in sph3d
+
+        # Pre-convert manually: get sph3d representation of the same base point,
+        # then push the tangent forward to cart3d.
+        base_sph = cx.cconvert(base, cxc.sph3d)
+        vel_cart_manual = cx.cconvert(vel_sph, cxc.cart3d, at=base_sph)
+
+        pv = Coordinate(point=base, velocity=vel_sph)
+        vel_cart_auto = pv["velocity"]
+
+        assert jnp.allclose(
+            vel_cart_auto["x"].value, vel_cart_manual["x"].value, atol=1e-6
+        )
+        assert jnp.allclose(
+            vel_cart_auto["y"].value, vel_cart_manual["y"].value, atol=1e-6
+        )
+        assert jnp.allclose(
+            vel_cart_auto["z"].value, vel_cart_manual["z"].value, atol=1e-6
+        )
+
+    def test_cconvert_after_mismatched_chart_init_succeeds(self) -> None:
+        """Cconvert must not raise after constructing with a mismatched-chart field."""
+        base = cxv.Point.from_([1.0, 0.0, 0.0], "m")  # cart3d
+        vel_sph = _make_sph_vel(1.0, 0.0, 0.0)
+        pv = Coordinate(point=base, velocity=vel_sph)
+        # This must not raise (original bug: would raise chart-mismatch ValueError)
+        pv_sph = pv.cconvert(cxc.sph3d)
+        assert pv_sph.point.chart == cxc.sph3d
+        assert pv_sph["velocity"].chart == cxc.sph3d
+
+    def test_multiple_fields_different_charts(self) -> None:
+        """Multiple fields with different charts are all converted to point.chart."""
+        base = cxv.Point.from_([1.0, 0.0, 0.0], "m")  # cart3d
+        vel_sph = _make_sph_vel(1.0, 0.0, 0.0)
+        acc_sph = cx.Tangent.from_(
+            {
+                "r": u.Q(0.1, "m/s^2"),
+                "theta": u.Q(0.0, "rad/s^2"),
+                "phi": u.Q(0.0, "rad/s^2"),
+            },
+            cxc.sph3d,
+            cxr.coord_acc,
+        )
+        pv = Coordinate(point=base, velocity=vel_sph, acceleration=acc_sph)
+        assert pv["velocity"].chart == cxc.cart3d
+        assert pv["acceleration"].chart == cxc.cart3d
+
+
+# ---------------------------------------------------------------------------
 # TestMappingAPI
 # ---------------------------------------------------------------------------
 
@@ -161,7 +247,7 @@ class TestMappingAPI:
 
     @pytest.fixture
     def pv(self) -> Coordinate:
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         vel = _make_vel(10, 20, 30)
         return Coordinate(point=base, velocity=vel)
 
@@ -206,39 +292,39 @@ class TestProperties:
     """Test properties that delegate to the base point."""
 
     def test_chart_delegates_to_point(self) -> None:
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         pv = Coordinate(point=base)
         assert pv.chart == cxc.cart3d
 
     def test_rep_delegates_to_point(self) -> None:
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         pv = Coordinate(point=base)
         assert pv.rep == cxr.point
 
     def test_manifold_delegates_to_point(self) -> None:
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         pv = Coordinate(point=base)
         assert isinstance(pv.manifold, cxm.AbstractManifold)
 
     def test_frame_delegates_to_point(self) -> None:
-        base = _make_point(1, 2, 3, frame=cxf.alice)
+        base = cxv.Point.from_([1, 2, 3], "m", cxf.alice)
         pv = Coordinate(point=base)
         assert pv.frame is cxf.alice
 
     def test_shape_scalar(self) -> None:
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         vel = _make_vel(10, 20, 30)
         pv = Coordinate(point=base, velocity=vel)
         assert pv.shape == ()
 
     def test_shape_batched_base(self) -> None:
-        base = cx.Point.from_(jnp.ones((2, 3)), "m")
+        base = cxv.Point.from_(jnp.ones((2, 3)), "m")
         pv = Coordinate(point=base)
         assert pv.shape == (2,)
 
     def test_shape_broadcast(self) -> None:
         """Batched base (2,) and scalar velocity () broadcast to (2,)."""
-        base = cx.Point.from_(jnp.ones((2, 3)), "m")
+        base = cxv.Point.from_(jnp.ones((2, 3)), "m")
         vel = _make_vel(10, 20, 30)  # scalar shape ()
         pv = Coordinate(point=base, velocity=vel)
         assert pv.shape == (2,)
@@ -254,14 +340,14 @@ class TestCconvert:
 
     def test_base_only_cart_to_sph(self) -> None:
         """Base-only bundle converts base as a point map."""
-        base = _make_point(1, 0, 0)
+        base = cxv.Point.from_([1, 0, 0], "m")  # cart3d
         pv = Coordinate(point=base)
         pv_sph = pv.cconvert(cxc.sph3d)
         assert pv_sph.point.chart == cxc.sph3d
 
     def test_base_cart_to_sph_values(self) -> None:
         """[1,0,0] in Cartesian → [r=1, theta=π/2, phi=0] in Spherical."""
-        base = _make_point(1.0, 0.0, 0.0)
+        base = cxv.Point.from_([1.0, 0.0, 0.0], "m")
         pv = Coordinate(point=base)
         pv_sph = pv.cconvert(cxc.sph3d)
         assert jnp.allclose(pv_sph.point["r"].value, jnp.array(1.0), atol=1e-6)
@@ -272,7 +358,7 @@ class TestCconvert:
 
     def test_velocity_uses_tangent_map(self) -> None:
         """Velocity at [1,0,0] in Cartesian converts via Jacobian to Spherical."""
-        base = _make_point(1.0, 0.0, 0.0)
+        base = cxv.Point.from_([1.0, 0.0, 0.0], "m")
         vel = _make_vel(1.0, 0.0, 0.0)  # radial velocity in Cartesian
         pv = Coordinate(point=base, velocity=vel)
         pv_sph = pv.cconvert(cxc.sph3d)
@@ -283,7 +369,7 @@ class TestCconvert:
 
     def test_round_trip(self) -> None:
         """Cart → sph → cart should recover original base values."""
-        base = _make_point(1.0, 2.0, 0.0)
+        base = cxv.Point.from_([1.0, 2.0, 0.0], "m")  # cart3d
         pv = Coordinate(point=base)
         pv_rt = pv.cconvert(cxc.sph3d).cconvert(cxc.cart3d)
         assert jnp.allclose(pv_rt.point["x"].value, base["x"].value, atol=1e-6)
@@ -291,7 +377,7 @@ class TestCconvert:
 
     def test_identity_same_chart(self) -> None:
         """Converting to the same chart returns equivalent values."""
-        base = _make_point(1.0, 2.0, 3.0)
+        base = cxv.Point.from_([1.0, 2.0, 3.0], "m")  # cart3d
         vel = _make_vel(4.0, 5.0, 6.0)
         pv = Coordinate(point=base, velocity=vel)
         pv_same = pv.cconvert(cxc.cart3d)
@@ -300,7 +386,7 @@ class TestCconvert:
 
     def test_pv_method_agrees_with_cx_function(self) -> None:
         """pv.cconvert(chart) and cx.cconvert(pv, chart) agree."""
-        base = _make_point(1.0, 0.0, 0.0)
+        base = cxv.Point.from_([1.0, 0.0, 0.0], "m")  # cart3d
         pv = Coordinate(point=base)
         via_method = pv.cconvert(cxc.sph3d)
         via_func = cx.cconvert(pv, cxc.sph3d)
@@ -317,14 +403,14 @@ class TestFromDispatches:
 
     def test_from_pointed_vector_is_identity(self) -> None:
         """Coordinate.from_(pv) returns the same object."""
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         pv = Coordinate(point=base)
         pv2 = Coordinate.from_(pv)
         assert pv2 is pv
 
     def test_from_point_wraps(self) -> None:
         """Coordinate.from_(Point) wraps it as a point-only bundle."""
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         pv = Coordinate.from_(base)
         assert isinstance(pv, Coordinate)
         assert pv.point is base
@@ -332,7 +418,7 @@ class TestFromDispatches:
 
     def test_from_mapping_with_point_key(self) -> None:
         """Coordinate.from_(mapping) detects 'point' key for base."""
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         vel = _make_vel(4, 5, 6)
         pv = Coordinate.from_({"point": base, "velocity": vel})
         assert isinstance(pv, Coordinate)
@@ -340,7 +426,7 @@ class TestFromDispatches:
 
     def test_from_mapping_explicit_point_kwarg(self) -> None:
         """Coordinate.from_(mapping, point=...) uses explicit base."""
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         vel = _make_vel(4, 5, 6)
         pv = Coordinate.from_({"velocity": vel}, point=base)
         assert pv.point is base
@@ -356,8 +442,8 @@ class TestJAXCompat:
 
     def test_pytree_flatten_unflatten(self) -> None:
         """Pytree round-trip preserves structure."""
-        base = _make_point(1.0, 2.0, 3.0)
-        vel = _make_vel(4.0, 5.0, 6.0)
+        base = cxv.Point.from_([1, 2, 3], "m")
+        vel = _make_vel(4, 5, 6)
         pv = Coordinate(point=base, velocity=vel)
         leaves, treedef = jax.tree.flatten(pv)
         pv2 = jax.tree.unflatten(treedef, leaves)
@@ -366,7 +452,7 @@ class TestJAXCompat:
 
     def test_jit_cconvert(self) -> None:
         """Cconvert works under jax.jit."""
-        base = _make_point(1.0, 0.0, 0.0)
+        base = cxv.Point.from_([1, 0, 0], "m")
         pv = Coordinate(point=base)
 
         @jax.jit
@@ -378,13 +464,13 @@ class TestJAXCompat:
 
     def test_batch_indexing(self) -> None:
         """pv[0] returns a Coordinate sliced along the batch axis."""
-        base = cx.Point.from_(jnp.ones((2, 3)), "m")
+        base = cxv.Point.from_(jnp.ones((2, 3)), "m")
         vel_data = {
             "x": u.Q(jnp.ones((2,)), "m/s"),
             "y": u.Q(jnp.ones((2,)), "m/s"),
             "z": u.Q(jnp.ones((2,)), "m/s"),
         }
-        vel = cx.Tangent.from_(vel_data, cxc.cart3d, cxr.coord_vel)
+        vel = cxv.Tangent.from_(vel_data, cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
         pv0 = pv[0]
         assert isinstance(pv0, Coordinate)
@@ -392,13 +478,13 @@ class TestJAXCompat:
 
     def test_vmap_cconvert(self) -> None:
         """Vmap over a Coordinate converts correctly."""
-        base = cx.Point.from_(jnp.ones((2, 3)), "m")
+        base = cxv.Point.from_(jnp.ones((2, 3)), "m")
         vel_data = {
             "x": u.Q(jnp.ones((2,)), "m/s"),
             "y": u.Q(jnp.zeros((2,)), "m/s"),
             "z": u.Q(jnp.zeros((2,)), "m/s"),
         }
-        vel = cx.Tangent.from_(vel_data, cxc.cart3d, cxr.coord_vel)
+        vel = cxv.Tangent.from_(vel_data, cxc.cart3d, cxr.coord_vel)
         pv = Coordinate(point=base, velocity=vel)
 
         def convert_one(p: Coordinate) -> Coordinate:
@@ -410,8 +496,8 @@ class TestJAXCompat:
 
     def test_jit_with_fields(self) -> None:
         """Jit with velocity field runs correctly."""
-        base = _make_point(1.0, 0.0, 0.0)
-        vel = _make_vel(1.0, 0.0, 0.0)
+        base = cxv.Point.from_([1, 0, 0], "m")
+        vel = _make_vel(1, 0, 0)
         pv = Coordinate(point=base, velocity=vel)
 
         @jax.jit
@@ -433,8 +519,8 @@ class TestFieldCharts:
 
     def test_field_charts_override(self) -> None:
         """field_charts allows velocity to convert to a different chart than base."""
-        base = _make_point(1.0, 0.0, 0.0)
-        vel = _make_vel(1.0, 0.0, 0.0)
+        base = cxv.Point.from_([1, 0, 0], "m")
+        vel = _make_vel(1, 0, 0)
         pv = Coordinate(point=base, velocity=vel)
         pv_mixed = pv.cconvert(cxc.sph3d, field_charts={"velocity": cxc.cart3d})
         assert pv_mixed.point.chart == cxc.sph3d
@@ -442,8 +528,8 @@ class TestFieldCharts:
 
     def test_field_charts_empty_uses_default(self) -> None:
         """Empty field_charts dict behaves as default (all fields use to_chart)."""
-        base = _make_point(1.0, 0.0, 0.0)
-        vel = _make_vel(1.0, 0.0, 0.0)
+        base = cxv.Point.from_([1, 0, 0], "m")
+        vel = _make_vel(1, 0, 0)
         pv = Coordinate(point=base, velocity=vel)
         pv_a = pv.cconvert(cxc.sph3d, field_charts={})
         pv_b = pv.cconvert(cxc.sph3d)
@@ -466,8 +552,8 @@ class TestFromErrors:
 
     def test_from_mapping_explicit_point_kwarg_takes_precedence(self) -> None:
         """Explicit point= kwarg wins over 'point' key in the mapping."""
-        base1 = _make_point(1, 2, 3)
-        base2 = _make_point(4, 5, 6)
+        base1 = cxv.Point.from_([1, 2, 3], "m")
+        base2 = cxv.Point.from_([4, 5, 6], "m")
         vel = _make_vel(1, 0, 0)
         pv = Coordinate.from_({"point": base1, "velocity": vel}, point=base2)
         assert pv.point is base2
@@ -482,23 +568,23 @@ class TestReprStr:
     """Test __repr__ and __str__ output."""
 
     def test_repr_contains_coordinate(self) -> None:
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         pv = Coordinate(point=base)
         assert "Coordinate" in repr(pv)
 
     def test_repr_contains_point(self) -> None:
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         pv = Coordinate(point=base)
         assert "Point" in repr(pv)
 
     def test_str_nonempty(self) -> None:
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         vel = _make_vel(4, 5, 6)
         pv = Coordinate(point=base, velocity=vel)
         assert str(pv)
 
     def test_repr_with_fields_contains_field_name(self) -> None:
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         vel = _make_vel(4, 5, 6)
         pv = Coordinate(point=base, velocity=vel)
         assert "velocity" in repr(pv)
@@ -513,11 +599,11 @@ class TestManifoldProperty:
     """Test Coordinate.manifold delegates to point.M."""
 
     def test_manifold_is_abstract_manifold(self) -> None:
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         pv = Coordinate(point=base)
         assert isinstance(pv.manifold, cxm.AbstractManifold)
 
     def test_manifold_matches_point_M(self) -> None:
-        base = _make_point(1, 2, 3)
+        base = cxv.Point.from_([1, 2, 3], "m")
         pv = Coordinate(point=base)
         assert pv.manifold == base.M

--- a/tests/unit/vectors/test_coordinate.py
+++ b/tests/unit/vectors/test_coordinate.py
@@ -141,20 +141,22 @@ def _make_sph_vel(r: float, theta: float, phi: float) -> Tangent:
 
 
 class TestChartAlignment:
-    """Test automatic chart-alignment of fibre vectors on construction.
+    """Test that fibre charts are preserved on construction.
 
-    On construction, each field must be converted to point.chart via a
-    Jacobian pushforward so that Coordinate.cconvert() can safely pass
-    at=self.point without a chart-mismatch error.
+    cconvert handles fibres in arbitrary charts correctly.
+
+    Fibres are NOT chart-aligned on construction; each fibre retains the
+    chart it was supplied with.  Chart conversion is handled lazily by
+    Coordinate.cconvert, which expresses self.point in the fibre's current
+    chart before passing it as 'at' to the Jacobian pushforward.
     """
 
-    def test_mismatched_chart_field_is_converted(self) -> None:
-        """Field supplied in sph3d is converted to point's cart3d chart."""
+    def test_mismatched_chart_field_preserved(self) -> None:
+        """Field supplied in sph3d retains its sph3d chart after construction."""
         base = cxv.Point.from_([1, 0, 0], "m")  # cart3d
-        # velocity given in spherical coords at (r=1, θ=π/2, φ=0) — same point
         vel_sph = _make_sph_vel(1.0, 0.0, 0.0)
         pv = Coordinate(point=base, velocity=vel_sph)
-        assert pv["velocity"].chart == cxc.cart3d
+        assert pv["velocity"].chart == cxc.sph3d
 
     def test_same_chart_no_change(self) -> None:
         """Field already in point's chart is left unchanged."""
@@ -164,41 +166,40 @@ class TestChartAlignment:
         # same chart — object is the same instance (no conversion occurred)
         assert pv["velocity"] is vel
 
-    def test_mismatched_chart_numerically_correct(self) -> None:
-        """Value after chart-alignment equals value pre-converted manually."""
+    def test_cconvert_mismatched_chart_numerically_correct(self) -> None:
+        """Cconvert on a bundle with a sph3d fibre gives correct cart3d values."""
         base = cxv.Point.from_([1, 0, 0], "m")  # cart3d, at (1,0,0)
         vel_sph = _make_sph_vel(1, 0, 0)  # radial unit velocity in sph3d
 
-        # Pre-convert manually: get sph3d representation of the same base point,
-        # then push the tangent forward to cart3d.
+        # Expected result: manually push sph3d fibre to cart3d.
         base_sph = cx.cconvert(base, cxc.sph3d)
-        vel_cart_manual = cx.cconvert(vel_sph, cxc.cart3d, at=base_sph)
+        vel_cart_expected = cx.cconvert(vel_sph, cxc.cart3d, at=base_sph)
 
         pv = Coordinate(point=base, velocity=vel_sph)
-        vel_cart_auto = pv["velocity"]
+        pv_cart = pv.cconvert(cxc.cart3d)
 
         assert jnp.allclose(
-            vel_cart_auto["x"].value, vel_cart_manual["x"].value, atol=1e-6
+            pv_cart["velocity"]["x"].value, vel_cart_expected["x"].value, atol=1e-6
         )
         assert jnp.allclose(
-            vel_cart_auto["y"].value, vel_cart_manual["y"].value, atol=1e-6
+            pv_cart["velocity"]["y"].value, vel_cart_expected["y"].value, atol=1e-6
         )
         assert jnp.allclose(
-            vel_cart_auto["z"].value, vel_cart_manual["z"].value, atol=1e-6
+            pv_cart["velocity"]["z"].value, vel_cart_expected["z"].value, atol=1e-6
         )
 
     def test_cconvert_after_mismatched_chart_init_succeeds(self) -> None:
-        """Cconvert must not raise after constructing with a mismatched-chart field."""
+        """Cconvert must succeed when a fibre was supplied in a different chart."""
         base = cxv.Point.from_([1, 0, 0], "m")  # cart3d
         vel_sph = _make_sph_vel(1, 0, 0)
         pv = Coordinate(point=base, velocity=vel_sph)
-        # This must not raise (original bug: would raise chart-mismatch ValueError)
+        # Fibre is in sph3d; cconvert to sph3d must not raise
         pv_sph = pv.cconvert(cxc.sph3d)
         assert pv_sph.point.chart == cxc.sph3d
         assert pv_sph["velocity"].chart == cxc.sph3d
 
-    def test_multiple_fields_different_charts(self) -> None:
-        """Multiple fields with different charts are all converted to point.chart."""
+    def test_multiple_fields_different_charts_preserved(self) -> None:
+        """Multiple fields with different charts each retain their original chart."""
         base = cxv.Point.from_([1, 0, 0], "m")  # cart3d
         vel_sph = _make_sph_vel(1, 0, 0)
         acc_sph = cx.Tangent.from_(
@@ -211,8 +212,8 @@ class TestChartAlignment:
             cxr.coord_acc,
         )
         pv = Coordinate(point=base, velocity=vel_sph, acceleration=acc_sph)
-        assert pv["velocity"].chart == cxc.cart3d
-        assert pv["acceleration"].chart == cxc.cart3d
+        assert pv["velocity"].chart == cxc.sph3d
+        assert pv["acceleration"].chart == cxc.sph3d
 
 
 # ---------------------------------------------------------------------------
@@ -512,6 +513,49 @@ class TestFieldCharts:
         pv_a = pv.cconvert(cxc.sph3d, field_charts={})
         pv_b = pv.cconvert(cxc.sph3d)
         assert pv_a["velocity"].chart == pv_b["velocity"].chart
+
+    def test_cconvert_on_field_charts_output(self) -> None:
+        """Cconvert on a mixed-chart Coordinate (from field_charts) must not raise.
+
+        After ``pv.cconvert(sph3d, field_charts={"velocity": cart3d})``, the
+        result has ``point.chart=sph3d`` and ``velocity.chart=cart3d``.  A
+        subsequent ``cconvert`` to a *different* target chart must resolve
+        ``at`` in the fibre's own chart (cart3d), not in ``point.chart``
+        (sph3d), to satisfy Tangent's at-chart requirement.
+        """
+        base = cxv.Point.from_([1, 0, 0], "m")
+        vel = cxv.Tangent.from_([1, 0, 0], "m/s", cxc.cart3d, cxr.coord_vel)
+        pv = Coordinate(point=base, velocity=vel)
+        # Build a mixed-chart bundle: point→sph3d, velocity stays in cart3d
+        pv_mixed = pv.cconvert(cxc.sph3d, field_charts={"velocity": cxc.cart3d})
+        assert pv_mixed.point.chart == cxc.sph3d
+        assert pv_mixed["velocity"].chart == cxc.cart3d
+
+        # Second cconvert to sph3d: velocity (cart3d→sph3d) needs a Jacobian,
+        # and at must be expressed in cart3d (velocity's source chart), not sph3d.
+        # Without per-fibre at computation this raises a chart-mismatch error.
+        pv_sph = pv_mixed.cconvert(cxc.sph3d)
+        assert pv_sph.point.chart == cxc.sph3d
+        assert pv_sph["velocity"].chart == cxc.sph3d
+
+    def test_cconvert_on_create_unchecked_output(self) -> None:
+        """Cconvert on a Coordinate built via _create_unchecked with mixed charts.
+
+        ``_create_unchecked`` is used by ``cconvert`` itself (for field_charts
+        results) and can produce bundles where ``velocity.chart != point.chart``.
+        A subsequent ``cconvert`` must compute ``at`` in each fibre's chart.
+        """
+        base_sph = cx.cconvert(cxv.Point.from_([1, 0, 0], "m"), cxc.sph3d)
+        vel_cart = cxv.Tangent.from_([1, 0, 0], "m/s", cxc.cart3d, cxr.coord_vel)
+        # Manually build a bundle with mismatched charts (as _create_unchecked allows)
+        pv = Coordinate._create_unchecked(base_sph, {"velocity": vel_cart})
+        assert pv.point.chart == cxc.sph3d
+        assert pv["velocity"].chart == cxc.cart3d
+
+        # cconvert must not raise even though velocity.chart != point.chart
+        pv_sph = pv.cconvert(cxc.sph3d)
+        assert pv_sph.point.chart == cxc.sph3d
+        assert pv_sph["velocity"].chart == cxc.sph3d
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/vectors/test_coordinate.py
+++ b/tests/unit/vectors/test_coordinate.py
@@ -169,7 +169,7 @@ class TestMappingAPI:
         assert isinstance(pv["velocity"], Tangent)
 
     def test_getitem_unknown_key_raises(self, pv: Coordinate) -> None:
-        with pytest.raises((KeyError, Exception)):
+        with pytest.raises(KeyError):
             _ = pv["nonexistent"]
 
     def test_keys_contains_fields(self, pv: Coordinate) -> None:

--- a/tests/unit/vectors/test_tangent.py
+++ b/tests/unit/vectors/test_tangent.py
@@ -136,7 +136,7 @@ class TestCheckInit:
 
     def test_raises_for_wrong_data_keys(self):
         """Construction raises when data keys don't match chart components."""
-        with pytest.raises(ValueError, match="data keys"):
+        with pytest.raises(ValueError, match="Data keys do not match"):
             cx.Tangent(
                 data={"wrong": u.Q(1.0, "m/s")},
                 chart=cxc.cart3d,

--- a/tests/unit/vectors/test_tangent.py
+++ b/tests/unit/vectors/test_tangent.py
@@ -128,6 +128,60 @@ class TestVectorConstruction:
 
 
 # ======================================================================
+# __check_init__
+
+
+class TestCheckInit:
+    """Tests for ``Tangent.__check_init__``."""
+
+    def test_raises_for_wrong_data_keys(self):
+        """Construction raises when data keys don't match chart components."""
+        with pytest.raises(ValueError, match="data keys"):
+            cx.Tangent(
+                data={"wrong": u.Q(1.0, "m/s")},
+                chart=cxc.cart3d,
+                basis=cxr.coord_basis,
+                semantic=cxr.vel,
+            )
+
+    def test_raises_for_missing_data_key(self):
+        """Construction raises when a chart component is absent from data."""
+        with pytest.raises(ValueError, match="data"):
+            cx.Tangent(
+                data={"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s")},  # z missing
+                chart=cxc.cart3d,
+                basis=cxr.coord_basis,
+                semantic=cxr.vel,
+            )
+
+    def test_valid_data_does_not_raise(self):
+        """Construction succeeds when data keys match chart components exactly."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        assert v is not None
+
+    def test_check_init_calls_manifold_check_chart(self):
+        """__check_init__ enforces that the chart belongs to the manifold atlas.
+
+        Tangent mirrors Point: both call M.check_chart(self.chart).
+        """
+        # Verify this is consistent with Point's behavior. For any valid chart,
+        # M == chart.M so the check is always True. The key property is that the
+        # call is made (not silently skipped).
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        assert v.M.has_chart(v.chart)
+
+
+# ======================================================================
 # M property
 
 

--- a/tests/unit/vectors/test_tangent.py
+++ b/tests/unit/vectors/test_tangent.py
@@ -1,0 +1,698 @@
+"""Tests for ``coordinax.vectors.Tangent``."""
+
+__all__: tuple[str, ...] = ()
+
+from dataclasses import replace
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.frames as cxf
+import coordinax.main as cx
+import coordinax.manifolds as cxm
+import coordinax.representations as cxr
+from coordinax.internal import CDict
+
+# ======================================================================
+# Helpers
+
+
+def _cart3d_vel_data() -> CDict:
+    return {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")}
+
+
+def _cart3d_dpl_data() -> CDict:
+    return {"x": u.Q(0.1, "m"), "y": u.Q(0.2, "m"), "z": u.Q(0.3, "m")}
+
+
+def _make_vel(
+    *xyz: float, unit: str = "m/s", frame: cxf.AbstractReferenceFrame = cxf.noframe
+) -> cx.Tangent:
+    """Cartesian velocity Tangent with optional frame."""
+    data = {"x": u.Q(xyz[0], unit), "y": u.Q(xyz[1], unit), "z": u.Q(xyz[2], unit)}
+    v = cx.Tangent.from_(data, cxc.cart3d, cxr.coord_vel)
+    return replace(v, frame=frame)
+
+
+# ======================================================================
+# Construction
+
+
+class TestVectorConstruction:
+    """Tests for ``Tangent(data, chart, basis, semantic)`` construction."""
+
+    def test_basic_construction_with_coord_vel(self):
+        """Construct a Tangent with coord_basis and vel semantic - smoke test."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        assert v is not None
+
+    def test_basic_construction_with_phys_dpl(self):
+        """Construct a Tangent with phys_basis and dpl semantic - smoke test."""
+        v = cx.Tangent(
+            data=_cart3d_dpl_data(),
+            chart=cxc.cart3d,
+            basis=cxr.phys_basis,
+            semantic=cxr.dpl,
+        )
+        assert v is not None
+
+    def test_data_accessible_by_component_name(self):
+        """Components accessible via string indexing."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        assert v["x"] == u.Q(1.0, "m/s")
+        assert v["y"] == u.Q(2.0, "m/s")
+        assert v["z"] == u.Q(3.0, "m/s")
+
+    def test_chart_stored(self):
+        """Chart field stores the given chart."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        assert v.chart == cxc.cart3d
+
+    def test_basis_stored(self):
+        """Basis field stores the given basis."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        assert v.basis == cxr.coord_basis
+
+    def test_semantic_stored(self):
+        """Semantic field stores the given semantic kind."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        assert v.semantic == cxr.vel
+
+    def test_different_semantics_all_constructable(self):
+        """vel, dpl, acc semantics all construct without error."""
+        for semantic, data in [
+            (cxr.vel, _cart3d_vel_data()),
+            (cxr.dpl, _cart3d_dpl_data()),
+            (
+                cxr.acc,
+                {
+                    "x": u.Q(0.1, "m/s^2"),
+                    "y": u.Q(0.2, "m/s^2"),
+                    "z": u.Q(0.0, "m/s^2"),
+                },
+            ),
+        ]:
+            v = cx.Tangent(
+                data=data, chart=cxc.cart3d, basis=cxr.coord_basis, semantic=semantic
+            )
+            assert v.semantic is semantic
+
+
+# ======================================================================
+# M property
+
+
+class TestVectorM:
+    """Tests for the ``M`` property (manifold from chart)."""
+
+    def test_M_is_abstract_manifold(self):
+        """M returns an AbstractManifold instance."""
+        v = cx.Tangent.from_(_cart3d_vel_data(), cxc.cart3d, cxr.coord_basis, cxr.vel)
+        assert isinstance(v.M, cxm.AbstractManifold)
+
+    def test_M_matches_chart_manifold(self):
+        """M is the same manifold as the chart's M."""
+        v = cx.Tangent.from_(_cart3d_vel_data(), cxc.cart3d, cxr.coord_basis, cxr.vel)
+        assert v.M == cxc.cart3d.M
+
+
+# ======================================================================
+# rep property
+
+
+class TestVectorRep:
+    """Tests for the computed ``rep`` property."""
+
+    def test_rep_is_representation_instance(self):
+        """Rep returns a Representation instance."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        assert isinstance(v.rep, cxr.Representation)
+
+    def test_rep_has_tangent_geometry(self):
+        """rep.geom_kind is TangentGeometry."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        assert isinstance(v.rep.geom_kind, cxr.TangentGeometry)
+
+    def test_rep_matches_coord_vel(self):
+        """Rep matches the cxr.coord_vel singleton for coord_basis + vel."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        assert v.rep == cxr.coord_vel
+
+    def test_rep_matches_phys_dpl(self):
+        """Rep matches cxr.phys_disp for phys_basis + dpl."""
+        v = cx.Tangent(
+            data=_cart3d_dpl_data(),
+            chart=cxc.cart3d,
+            basis=cxr.phys_basis,
+            semantic=cxr.dpl,
+        )
+        assert v.rep == cxr.phys_disp
+
+    def test_rep_basis_is_stored_basis(self):
+        """rep.basis is the same as the stored basis field."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.phys_basis,
+            semantic=cxr.vel,
+        )
+        assert v.rep.basis == cxr.phys_basis
+
+    def test_rep_semantic_is_stored_semantic(self):
+        """rep.semantic_kind is the same as the stored semantic field."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.acc,
+        )
+        assert v.rep.semantic_kind == cxr.acc
+
+    def test_rep_is_not_point_rep(self):
+        """Tangent.rep is never the point representation."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        assert v.rep != cxr.point
+
+    def test_rep_computed_not_stored(self):
+        """Changing basis produces a different rep (rep computed from fields)."""
+        v1 = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        v2 = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.phys_basis,
+            semantic=cxr.vel,
+        )
+        assert v1.rep != v2.rep
+
+
+# ======================================================================
+# frame field
+
+
+class TestVectorFrame:
+    """Tests for the ``frame`` field on ``Tangent``."""
+
+    def test_default_frame_is_noframe(self):
+        """Tangent constructed without frame defaults to noframe."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        assert v.frame == cxf.noframe
+
+    def test_explicit_frame_stored(self):
+        """Explicitly provided frame is stored."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+            frame=cxf.alice,
+        )
+        assert v.frame == cxf.alice
+
+    def test_none_frame_converts_to_noframe(self):
+        """frame=None converts to noframe via converter."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+            frame=None,
+        )
+        assert v.frame == cxf.noframe
+
+
+# ======================================================================
+# from_ constructors
+
+
+class TestVectorFromConstructors:
+    """Tests for ``Tangent.from_`` dispatches."""
+
+    def test_from_vector_identity(self):
+        """Tangent.from_(vector) returns the same object."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        v2 = cx.Tangent.from_(v)
+        assert v2 is v
+
+    def test_from_dict_chart_basis_semantic(self):
+        """Tangent.from_(dict, chart, basis, semantic) constructs correctly."""
+        data = _cart3d_vel_data()
+        v = cx.Tangent.from_(data, cxc.cart3d, cxr.coord_basis, cxr.vel)
+        assert isinstance(v, cx.Tangent)
+        assert v.chart == cxc.cart3d
+        assert v.basis == cxr.coord_basis
+        assert v.semantic == cxr.vel
+
+    def test_from_dict_chart_basis_semantic_frame(self):
+        """Tangent.from_(dict, chart, basis, semantic, frame) sets frame."""
+        data = _cart3d_vel_data()
+        v = cx.Tangent.from_(data, cxc.cart3d, cxr.coord_basis, cxr.vel, cxf.alice)
+        assert v.frame == cxf.alice
+
+    def test_from_array_unit_chart_basis_semantic(self):
+        """Tangent.from_(array, unit, chart, basis, semantic) constructs correctly."""
+        v = cx.Tangent.from_(
+            jnp.array([1.0, 2.0, 3.0]), "m/s", cxc.cart3d, cxr.coord_basis, cxr.vel
+        )
+        assert isinstance(v, cx.Tangent)
+        assert v.chart == cxc.cart3d
+        assert v.basis == cxr.coord_basis
+        assert v.semantic == cxr.vel
+
+    def test_from_rep_dispatch_with_tangent_rep(self):
+        """Tangent.from_(data, chart, rep) with tangent rep dispatches to Tangent."""
+        data = _cart3d_vel_data()
+        v = cx.Tangent.from_(data, cxc.cart3d, cxr.coord_vel)
+        assert isinstance(v, cx.Tangent)
+        assert v.basis == cxr.coord_basis
+        assert v.semantic == cxr.vel
+
+    def test_from_rep_with_point_rep_raises(self):
+        """Tangent.from_(data, chart, point_rep) raises TypeError."""
+        data = _cart3d_vel_data()
+        with pytest.raises(TypeError):
+            cx.Tangent.from_(data, cxc.cart3d, cxr.point)
+
+    def test_from_vector_frame_dispatch(self):
+        """Tangent.from_(vector, frame) sets frame on the vector."""
+        data = _cart3d_vel_data()
+        v = cx.Tangent.from_(data, cxc.cart3d, cxr.coord_basis, cxr.vel)
+        v2 = cx.Tangent.from_(v, cxf.alice)
+        assert v2.frame == cxf.alice
+        assert v2.basis == v.basis
+        assert v2.semantic == v.semantic
+
+    def test_from_any_frame_dispatch(self):
+        """Tangent.from_(dict, frame) infers chart/basis/semantic and sets frame."""
+        data = _cart3d_vel_data()
+        v = cx.Tangent.from_(data, cxf.alice)
+        assert isinstance(v, cx.Tangent)
+        assert v.frame == cxf.alice
+
+    def test_from_dict_chart_frame(self):
+        """Tangent.from_(dict, chart, frame) infers basis/semantic and sets frame."""
+        data = _cart3d_vel_data()
+        v = cx.Tangent.from_(data, cxc.cart3d, cxf.alice)
+        assert isinstance(v, cx.Tangent)
+        assert v.chart == cxc.cart3d
+        assert v.frame == cxf.alice
+
+
+# ======================================================================
+# cconvert
+
+
+class TestVectorCconvert:
+    """Tests for ``Tangent.cconvert`` chart conversion."""
+
+    def test_cconvert_cart_to_sph_preserves_rep(self):
+        """Cconvert changes chart but preserves basis and semantic."""
+        v = cx.Tangent.from_(_cart3d_vel_data(), cxc.cart3d, cxr.coord_basis, cxr.vel)
+        pt = cx.Point.from_([1.0, 0.0, 0.0], "m")  # base point for tangent map
+        v_sph = v.cconvert(cxc.sph3d, at=pt)
+        assert isinstance(v_sph, cx.Tangent)
+        assert v_sph.chart == cxc.sph3d
+        assert v_sph.basis == cxr.coord_basis
+        assert v_sph.semantic == cxr.vel
+
+    def test_cconvert_preserves_frame(self):
+        """Cconvert preserves the frame field."""
+        v = cx.Tangent.from_(
+            _cart3d_vel_data(), cxc.cart3d, cxr.coord_basis, cxr.vel, cxf.alice
+        )
+        pt = cx.Point.from_([1.0, 0.0, 0.0], "m")
+        v_sph = v.cconvert(cxc.sph3d, at=pt)
+        assert v_sph.frame == cxf.alice
+
+    def test_cconvert_identity_chart_returns_same_data(self):
+        """Cconvert to same chart returns same data."""
+        v = cx.Tangent.from_(_cart3d_vel_data(), cxc.cart3d, cxr.coord_basis, cxr.vel)
+        pt = cx.Point.from_([1.0, 0.0, 0.0], "m")
+        v2 = v.cconvert(cxc.cart3d, at=pt)
+        assert isinstance(v2, cx.Tangent)
+        assert v2.chart == cxc.cart3d
+
+    def test_cconvert_radial_velocity_at_x_axis(self):
+        """Radial velocity [1,0,0] at [1,0,0] maps to vr=1, vθ=0, vφ=0."""
+        v = cx.Tangent.from_(
+            {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+            cxc.cart3d,
+            cxr.coord_basis,
+            cxr.vel,
+        )
+        pt = cx.Point.from_([1.0, 0.0, 0.0], "m")
+        v_sph = v.cconvert(cxc.sph3d, at=pt)
+        assert jnp.allclose(v_sph["r"].value, jnp.array(1.0), atol=1e-6)
+        assert jnp.allclose(v_sph["theta"].value, jnp.array(0.0), atol=1e-6)
+        assert jnp.allclose(v_sph["phi"].value, jnp.array(0.0), atol=1e-6)
+
+    def test_cconvert_round_trip_cart_sph_cart(self):
+        """Cconvert cart→sph→cart recovers original component values."""
+        data = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(0.0, "m/s")}
+        v = cx.Tangent.from_(data, cxc.cart3d, cxr.coord_basis, cxr.vel)
+        pt = cx.Point.from_([1.0, 2.0, 0.0], "m")
+        v_rt = v.cconvert(cxc.sph3d, at=pt).cconvert(
+            cxc.cart3d, at=pt.cconvert(cxc.sph3d)
+        )
+        assert jnp.allclose(v_rt["x"].value, jnp.array(1.0), atol=1e-5)
+        assert jnp.allclose(v_rt["y"].value, jnp.array(2.0), atol=1e-5)
+
+
+# ======================================================================
+# shape / slicing
+
+
+class TestVectorShape:
+    """Tests for shape and indexing."""
+
+    def test_shape_scalar(self):
+        """Scalar components give empty shape."""
+        v = cx.Tangent(
+            data=_cart3d_vel_data(),
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        assert v.shape == ()
+
+    def test_shape_batch(self):
+        """Batched components give non-empty shape."""
+        data = {
+            "x": u.Q([1.0, 2.0], "m/s"),
+            "y": u.Q([3.0, 4.0], "m/s"),
+            "z": u.Q([5.0, 6.0], "m/s"),
+        }
+        v = cx.Tangent(
+            data=data,
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        assert v.shape == (2,)
+
+    def test_slice_indexing(self):
+        """Integer slice indexing returns a new Tangent."""
+        data = {
+            "x": u.Q([1.0, 2.0], "m/s"),
+            "y": u.Q([3.0, 4.0], "m/s"),
+            "z": u.Q([5.0, 6.0], "m/s"),
+        }
+        v = cx.Tangent(
+            data=data,
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        v0 = v[0]
+        assert isinstance(v0, cx.Tangent)
+        assert v0.shape == ()
+
+    def test_slice_preserves_chart_basis_semantic(self):
+        """Integer indexing preserves chart, basis, and semantic."""
+        data = {
+            "x": u.Q([1.0, 2.0], "m/s"),
+            "y": u.Q([3.0, 4.0], "m/s"),
+            "z": u.Q([5.0, 6.0], "m/s"),
+        }
+        v = cx.Tangent(
+            data=data,
+            chart=cxc.cart3d,
+            basis=cxr.coord_basis,
+            semantic=cxr.vel,
+        )
+        v0 = v[0]
+        assert v0.chart == cxc.cart3d
+        assert v0.basis == cxr.coord_basis
+        assert v0.semantic == cxr.vel
+
+    def test_slice_values_correct(self):
+        """Indexed values match the original batch element."""
+        data = {
+            "x": u.Q([1.0, 2.0], "m/s"),
+            "y": u.Q([3.0, 4.0], "m/s"),
+            "z": u.Q([5.0, 6.0], "m/s"),
+        }
+        v = cx.Tangent(
+            data=data, chart=cxc.cart3d, basis=cxr.coord_basis, semantic=cxr.vel
+        )
+        assert v[1]["x"].value == jnp.array(2.0)
+        assert v[1]["y"].value == jnp.array(4.0)
+
+
+# ======================================================================
+# JAX compatibility
+
+
+class TestVectorJAXCompat:
+    """Tests for JAX integration: pytree, jit, vmap."""
+
+    def test_pytree_flatten_unflatten_scalar(self):
+        """Pytree round-trip preserves structure for a scalar Tangent."""
+        v = cx.Tangent.from_(_cart3d_vel_data(), cxc.cart3d, cxr.coord_vel)
+        leaves, treedef = jax.tree.flatten(v)
+        v2 = jax.tree.unflatten(treedef, leaves)
+        assert v2.chart == v.chart
+        assert v2.basis == v.basis
+        assert v2.semantic == v.semantic
+        assert v2["x"] == v["x"]
+
+    def test_pytree_flatten_unflatten_batch(self):
+        """Pytree round-trip preserves batch Tangent."""
+        data = {
+            "x": u.Q([1.0, 2.0], "m/s"),
+            "y": u.Q([3.0, 4.0], "m/s"),
+            "z": u.Q([5.0, 6.0], "m/s"),
+        }
+        v = cx.Tangent(
+            data=data, chart=cxc.cart3d, basis=cxr.coord_basis, semantic=cxr.vel
+        )
+        leaves, treedef = jax.tree.flatten(v)
+        v2 = jax.tree.unflatten(treedef, leaves)
+        assert v2.shape == (2,)
+
+    def test_jit_identity(self):
+        """A JIT-compiled identity function returns an equivalent Tangent."""
+        v = cx.Tangent.from_(_cart3d_vel_data(), cxc.cart3d, cxr.coord_vel)
+
+        @jax.jit
+        def identity(x: cx.Tangent) -> cx.Tangent:
+            return x
+
+        v2 = identity(v)
+        assert v2.chart == v.chart
+        assert jnp.allclose(v2["x"].value, v["x"].value)
+
+    def test_jit_cconvert(self):
+        """Cconvert under jax.jit produces the correct chart."""
+        v = cx.Tangent.from_(_cart3d_vel_data(), cxc.cart3d, cxr.coord_vel)
+        pt = cx.Point.from_([1.0, 0.0, 0.0], "m")
+
+        @jax.jit
+        def convert(vec: cx.Tangent, base: cx.Point) -> cx.Tangent:
+            return vec.cconvert(cxc.sph3d, at=base)
+
+        v_sph = convert(v, pt)
+        assert v_sph.chart == cxc.sph3d
+
+    def test_vmap_cconvert(self):
+        """Vmap over a batch of base points applies Jacobian per-element."""
+        v = cx.Tangent.from_(
+            {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+            cxc.cart3d,
+            cxr.coord_vel,
+        )
+        pts_batch = cx.Point.from_(jnp.ones((2, 3)), "m")
+
+        def convert_one(pt: cx.Point) -> cx.Tangent:
+            return v.cconvert(cxc.sph3d, at=pt)
+
+        result = jax.vmap(convert_one)(pts_batch)
+        assert result.shape == (2,)
+        assert result.chart == cxc.sph3d
+
+
+# ======================================================================
+# repr / str
+
+
+class TestVectorRepr:
+    """Tests for __repr__ and __str__."""
+
+    def test_repr_contains_class_name(self):
+        """Repr includes 'Tangent'."""
+        v = cx.Tangent.from_(_cart3d_vel_data(), cxc.cart3d, cxr.coord_vel)
+        assert "Tangent" in repr(v)
+
+    def test_str_contains_chart_name(self):
+        """Str contains the chart class name."""
+        v = cx.Tangent.from_(_cart3d_vel_data(), cxc.cart3d, cxr.coord_vel)
+        assert "Cart3D" in str(v)
+
+    def test_repr_different_from_str(self):
+        """Repr and str produce distinct (but non-empty) strings."""
+        v = cx.Tangent.from_(_cart3d_vel_data(), cxc.cart3d, cxr.coord_vel)
+        assert repr(v)  # non-empty
+        assert str(v)  # non-empty
+
+
+# ======================================================================
+# change_basis(Point, AbstractLinearBasis) -> Tangent[Displacement]
+
+
+class TestChangeBasisPointToDisplacement:
+    """Tests for the Point -> Tangent[Displacement] promotion dispatch."""
+
+    def _make_point(self) -> cx.Point:
+        return cx.Point.from_([1.0, 2.0, 3.0], "m")
+
+    def test_returns_tangent(self):
+        """change_basis(Point, coord_basis) returns a Tangent."""
+        pt = self._make_point()
+        disp = cxr.change_basis(pt, cxr.coord_basis)
+        assert isinstance(disp, cx.Tangent)
+
+    def test_semantic_is_displacement(self):
+        """Resulting Tangent has Displacement semantic."""
+        pt = self._make_point()
+        disp = cxr.change_basis(pt, cxr.coord_basis)
+        assert isinstance(disp.semantic, cxr.Displacement)
+
+    def test_basis_is_preserved(self):
+        """Resulting Tangent carries the requested basis."""
+        pt = self._make_point()
+        disp = cxr.change_basis(pt, cxr.coord_basis)
+        assert disp.basis == cxr.coord_basis
+
+    def test_phys_basis_is_preserved(self):
+        """Works with PhysicalBasis as well."""
+        pt = self._make_point()
+        disp = cxr.change_basis(pt, cxr.phys_basis)
+        assert disp.basis == cxr.phys_basis
+
+    def test_chart_is_unchanged(self):
+        """Resulting Tangent has the same chart as the input Point."""
+        pt = self._make_point()
+        disp = cxr.change_basis(pt, cxr.coord_basis)
+        assert disp.chart == pt.chart
+
+    def test_data_is_unchanged(self):
+        """Component data is identical (not a copy or transformation)."""
+        pt = self._make_point()
+        disp = cxr.change_basis(pt, cxr.coord_basis)
+        assert disp.data is pt.data
+
+    def test_frame_is_preserved(self):
+        """Frame from the input Point is carried over."""
+        pt = self._make_point()
+        disp = cxr.change_basis(pt, cxr.coord_basis)
+        assert disp.frame == pt.frame
+
+    def test_rep_is_tangent_geometry(self):
+        """Resulting representation has TangentGeometry."""
+        pt = self._make_point()
+        disp = cxr.change_basis(pt, cxr.coord_basis)
+        assert isinstance(disp.rep.geom_kind, cxr.TangentGeometry)
+
+    def test_rep_matches_coord_disp(self):
+        """coord_basis promotion produces coord_disp representation."""
+        pt = self._make_point()
+        disp = cxr.change_basis(pt, cxr.coord_basis)
+        assert disp.rep == cxr.coord_disp
+
+    def test_rep_matches_phys_disp(self):
+        """phys_basis promotion produces phys_disp representation."""
+        pt = self._make_point()
+        disp = cxr.change_basis(pt, cxr.phys_basis)
+        assert disp.rep == cxr.phys_disp
+
+    def test_accessible_from_main(self):
+        """change_basis is accessible via coordinax.main."""
+        pt = self._make_point()
+        disp = cx.change_basis(pt, cxr.coord_basis)
+        assert isinstance(disp, cx.Tangent)
+
+    def test_spherical_chart(self):
+        """Works for a non-Cartesian (spherical) Point."""
+        pt = cx.Point.from_(
+            {"r": u.Q(1.0, "m"), "theta": u.Q(0.5, "rad"), "phi": u.Q(0.0, "rad")},
+            cxc.sph3d,
+        )
+        disp = cxr.change_basis(pt, cxr.coord_basis)
+        assert isinstance(disp, cx.Tangent)
+        assert disp.chart == cxc.sph3d
+        assert isinstance(disp.semantic, cxr.Displacement)
+
+    def test_jit_compatible(self):
+        """The promotion is JIT-compatible."""
+        pt = self._make_point()
+
+        @jax.jit
+        def promote(p):
+            return cxr.change_basis(p, cxr.coord_basis)
+
+        disp = promote(pt)
+        assert isinstance(disp, cx.Tangent)
+        assert isinstance(disp.semantic, cxr.Displacement)

--- a/tests/unit/vectors/test_tangent.py
+++ b/tests/unit/vectors/test_tangent.py
@@ -146,7 +146,7 @@ class TestCheckInit:
 
     def test_raises_for_missing_data_key(self):
         """Construction raises when a chart component is absent from data."""
-        with pytest.raises(ValueError, match="data"):
+        with pytest.raises(ValueError, match="Data keys do not match"):
             cx.Tangent(
                 data={"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s")},  # z missing
                 chart=cxc.cart3d,


### PR DESCRIPTION
Add Tangent vector type for tangent space elements with explicit basis and semantic information, and Coordinate type for vector bundles anchored at base points. Both types support chart conversion via Jacobian pushforward and frame transformations with automatic frame alignment.

- Implement Tangent class with computed representation from basis/semantic
- Implement Coordinate class as vector bundle with base point and fibre vectors
- Register JAX primitive operations for both types via quax dispatch
- Update spec with detailed Tangent and Coordinate specifications
- Add comprehensive unit and integration tests
- Support batch indexing, component access, and coordinate transformations