### PR TITLE
🔧 config: migrate from pre-commit to prek

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,14 +36,14 @@ py -m install -v -e .[dev]
 
 # Post setup
 
-You should prepare pre-commit, which will help you by checking that commits pass required checks:
+You should prepare prek, which will help you by checking that commits pass required checks:
 
 ```bash
-pip install pre-commit # or brew install pre-commit on macOS
-pre-commit install # Will install a pre-commit hook into the git repo
+pip install prek # or brew install prek on macOS
+prek install # Will install a prek hook into the git repo
 ```
 
-You can also/alternatively run `pre-commit run` (changes only) or `pre-commit run --all-files` to check even without installing the hook.
+You can also/alternatively run `prek run` (changes only) or `prek run --all-files` to check even without installing the hook.
 
 # Testing
 
@@ -77,10 +77,10 @@ nox -s docs -- --serve
 
 # Pre-commit
 
-This project uses pre-commit for all style checking. While you can run it with nox, this is such an important tool that it deserves to be installed on its own. Install pre-commit and run:
+This project uses prek for all style checking. While you can run it with nox, this is such an important tool that it deserves to be installed on its own. Install prek and run:
 
 ```bash
-pre-commit run -a
+prek run --all-files
 ```
 
 to check all files.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -526,7 +526,7 @@ result = jnp.sqrt(d)  # Uses registered sqrt_p rule
   uv run nox -s all
   ```
 - Common sessions:
-  - `nox -s lint`: pre-commit + pylint
+  - `nox -s lint`: prek + pylint
   - `nox -s test`: pytest suite
   - `nox -s docs`: build documentation (add `--serve` to preview)
   - `nox -s pytest_benchmark`: run CodSpeed benchmarks

--- a/.github/skills/gitmoji-commit/SKILL.md
+++ b/.github/skills/gitmoji-commit/SKILL.md
@@ -89,7 +89,7 @@ Use [the full type reference](./references/types.md) to pick the most specific t
 | ♻️ | `refactor` | Internal restructure, no behaviour change |
 | ✅ | `test` | Add or update tests |
 | 🧹 | `chore` | Miscellaneous maintenance |
-| 🔧 | `config` | pyproject.toml, noxfile, pre-commit, config files |
+| 🔧 | `config` | pyproject.toml, noxfile, prek, config files |
 | 💚 | `ci` | GitHub Actions, CI workflows |
 | 👷 | `build` | Build system changes |
 | ⬆️ | `dep-bump` | Upgrade dependencies |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,3 @@
-ci:
-  autoupdate_schedule: "monthly"
-  autoupdate_commit_msg: "chore: update pre-commit hooks"
-  autofix_commit_msg: "style: pre-commit fixes"
-
 default_stages: [pre-commit, pre-push]
 
 repos:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <a href="https://codecov.io/gh/GalacticDynamics/coordinax"> <img alt="codecov" src="https://codecov.io/gh/GalacticDynamics/coordinax/graph/badge.svg" /> </a>
     <a href="https://scientific-python.org/specs/spec-0000/"> <img alt="ruff" src="https://img.shields.io/badge/SPEC-0-green?labelColor=%23004811&color=%235CA038" /> </a>
     <a href="https://docs.astral.sh/ruff/"> <img alt="ruff" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json" /> </a>
-    <a href="https://pre-commit.com"> <img alt="pre-commit" src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit" /> </a>
+    <a href="https://github.com/j178/prek"> <img alt="prek" src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/j178/prek/master/docs/assets/badge-v0.json" /> </a>
 </p>
 
 ---
@@ -180,7 +180,7 @@ If you found this library to be useful in academic work, then please cite.
 
 ## Development
 
-[![Actions Status][actions-badge]][actions-link] [![Documentation Status][rtd-badge]][rtd-link] [![codecov][codecov-badge]][codecov-link] [![SPEC 0 — Minimum Supported Dependencies][spec0-badge]][spec0-link] [![pre-commit][pre-commit-badge]][pre-commit-link] [![ruff][ruff-badge]][ruff-link]
+[![Actions Status][actions-badge]][actions-link] [![Documentation Status][rtd-badge]][rtd-link] [![codecov][codecov-badge]][codecov-link] [![SPEC 0 — Minimum Supported Dependencies][spec0-badge]][spec0-link] [![prek][prek-badge]][prek-link] [![ruff][ruff-badge]][ruff-link]
 
 We welcome contributions!
 
@@ -191,8 +191,8 @@ For the local development workflow, see `docs/dev.md`. For pull request expectat
 [actions-link]:             https://github.com/GalacticDynamics/coordinax/actions
 [codecov-badge]:            https://codecov.io/gh/GalacticDynamics/unxt/graph/badge.svg
 [codecov-link]:             https://codecov.io/gh/GalacticDynamics/unxt
-[pre-commit-badge]:         https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit
-[pre-commit-link]:          https://pre-commit.com
+[prek-badge]:               https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/j178/prek/master/docs/assets/badge-v0.json
+[prek-link]:                https://github.com/j178/prek
 [pypi-link]:                https://pypi.org/project/coordinax/
 [pypi-platforms]:           https://img.shields.io/pypi/pyversions/coordinax
 [pypi-version]:             https://img.shields.io/pypi/v/coordinax

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -37,7 +37,7 @@ cd coordinax
 uv sync --group dev --extra workspace
 ```
 
-This installs the local development toolchain, including `nox`, `pytest`, `pre-commit`, docs dependencies, and the workspace packages used by the full contributor workflow.
+This installs the local development toolchain, including `nox`, `pytest`, `prek`, docs dependencies, and the workspace packages used by the full contributor workflow.
 
 If you prefer to run tools without activating a shell environment, use `uv run ...` directly. For example:
 
@@ -78,13 +78,13 @@ The authoritative session definitions live in the repository root `noxfile.py`. 
 ### Main Sessions
 
 - `uv run nox -s all`: runs the default contributor gate: lint, test, and docs.
-- `uv run nox -s lint`: runs `precommit`, `pylint`, and `ty`.
+- `uv run nox -s lint`: runs `prek`, `pylint`, and `ty`.
 - `uv run nox -s test`: runs the default test session.
 - `uv run nox -s docs`: builds the documentation.
 
 ### Linting and Type Checks
 
-- `uv run nox -s precommit`: runs all pre-commit hooks.
+- `uv run nox -s precommit`: runs all prek/pre-commit hooks.
 - `uv run nox -s "pylint(package='coordinax')"`: run Pylint for the main package.
 - `uv run nox -s "pylint(package='api')"`: run Pylint for `coordinax.api`.
 - `uv run nox -s "pylint(package='astro')"`: run Pylint for `coordinax.astro`.

--- a/noxfile.py
+++ b/noxfile.py
@@ -87,7 +87,7 @@ def lint(s: nox.Session, /) -> None:
 @session(uv_groups=["lint"], reuse_venv=True)
 def precommit(s: nox.Session, /) -> None:
     """Run the linter."""
-    s.run("pre-commit", "run", "--all-files", *s.posargs)
+    s.run("prek", "run", "--all-files", *s.posargs)
 
 
 @session(uv_groups=["lint"], reuse_venv=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ docs = [
   "sphinxext-rediraffe>=0.2.7",
 ]
 ide = ["ipykernel>=7.1.0", "jaxmore>=0.2.0"]
-lint = ["pre-commit>=4.5.0", "pylint>=3.3.2", "ty>=0.0.19"]
+lint = ["prek>=0.4.0", "pylint>=3.3.2", "ty>=0.0.19"]
 nox = ["nox>=2024.10.9", "nox-uv>=0.6.3"]
 test = [
   "coordinax.curveframes",
@@ -156,7 +156,12 @@ skip = ["uv.lock"]
 
 
 [tool.repo-review]
-ignore = ["PC140"] # ty is run via nox, not pre-commit
+ignore = [
+  "PC140", # ty is run via prek, not pre-commit
+  "PC901", # custom autoupdate_commit_msg set in .pre-commit-config.yaml
+  "PC902", # custom autofix_commit_msg set in .pre-commit-config.yaml
+  "PC903", # autoupdate_schedule set in .pre-commit-config.yaml
+]
 
 
 [tool.commitizen]

--- a/uv.lock
+++ b/uv.lock
@@ -255,15 +255,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cfgv"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
-]
-
-[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -480,7 +471,7 @@ dev = [
     { name = "myst-parser" },
     { name = "nox" },
     { name = "nox-uv" },
-    { name = "pre-commit" },
+    { name = "prek" },
     { name = "pylint" },
     { name = "pytest" },
     { name = "pytest-arraydiff" },
@@ -530,7 +521,7 @@ ide = [
     { name = "jaxmore" },
 ]
 lint = [
-    { name = "pre-commit" },
+    { name = "prek" },
     { name = "pylint" },
     { name = "ty" },
 ]
@@ -613,7 +604,7 @@ dev = [
     { name = "myst-parser", specifier = ">=0.13" },
     { name = "nox", specifier = ">=2024.10.9" },
     { name = "nox-uv", specifier = ">=0.6.3" },
-    { name = "pre-commit", specifier = ">=4.5.0" },
+    { name = "prek", specifier = ">=0.4.0" },
     { name = "pylint", specifier = ">=3.3.2" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-arraydiff", specifier = ">=0.6.1" },
@@ -659,7 +650,7 @@ ide = [
     { name = "jaxmore", specifier = ">=0.2.0" },
 ]
 lint = [
-    { name = "pre-commit", specifier = ">=4.5.0" },
+    { name = "prek", specifier = ">=0.4.0" },
     { name = "pylint", specifier = ">=3.3.2" },
     { name = "ty", specifier = ">=0.0.19" },
 ]
@@ -1159,15 +1150,6 @@ wheels = [
 [package.optional-dependencies]
 numpy = [
     { name = "numpy" },
-]
-
-[[package]]
-name = "identify"
-version = "2.6.19"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -1728,15 +1710,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
-]
-
-[[package]]
 name = "nox"
 version = "2026.4.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1995,19 +1968,27 @@ wheels = [
 ]
 
 [[package]]
-name = "pre-commit"
-version = "4.6.0"
+name = "prek"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cfgv" },
-    { name = "identify" },
-    { name = "nodeenv" },
-    { name = "pyyaml" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/68/00050a4184f038a622855b1989b013d0ac5bfc0a29bf3cdbd1ed823595d8/prek-0.4.0.tar.gz", hash = "sha256:47f42477c8453c7440e4e656e5ab0c2a1e4c25daa5ed441a9ac1a2b7634abc12", size = 446399, upload-time = "2026-05-14T10:50:35.194Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/83/e4f5f574b8b3a80305a638e0cb2d46e3aa9596ac2b1e2dd6c910fedea376/prek-0.4.0-py3-none-linux_armv6l.whl", hash = "sha256:f4cba2132e038349b4b0a00a73b300e4192bae9f78fff8df0365c00bd19140e7", size = 5509604, upload-time = "2026-05-14T10:50:39.306Z" },
+    { url = "https://files.pythonhosted.org/packages/05/de/ee9b8648944d44a8403ca49172d60936f5476196a7baf38c86df4aec7243/prek-0.4.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:944670565dfb3800465355f299effa31572822566d10c6210e6f76bf399ddf53", size = 5877244, upload-time = "2026-05-14T10:50:54.213Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f8/2e6021993332a249667102de0960160aa942880b0634d3e8920d062ebdb4/prek-0.4.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a8272f32e698eae514556086ad73d02026ec00bbd4d26c420f761ea857cfd795", size = 5435063, upload-time = "2026-05-14T10:50:31.75Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/8b/98fef34684f52c7f5b7b56bce14aec2b24b7abbcd7b6523cc83a63f74c58/prek-0.4.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:a860fda0f27f872622689358a583e5f2a5771241331848233274f4cfeb8ae9bb", size = 5690323, upload-time = "2026-05-14T10:50:42.583Z" },
+    { url = "https://files.pythonhosted.org/packages/00/18/bf18cf0d3ab5b5eddadc6ade754ba6269ae857b32a4605036397ec56ccc1/prek-0.4.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:473ce0262e36b8e77b327941ad6d5747ac451b4c441cdc86dab95640b68fff72", size = 5423877, upload-time = "2026-05-14T10:50:36.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/1e/881f18b3cbf6fdca4ec8eb62d2c2e0cb9458fd4cebd136f5e0f76c7aa8d2/prek-0.4.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e46277b577991ccdc7b13e2cfa7d260ae13e77f5af543e50e188799f649f0ad8", size = 5830461, upload-time = "2026-05-14T10:50:45.885Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ea/1623391bdf1e103d7959cc7d41caedcd1ab982412c7db9f9f9ee5c0e09f4/prek-0.4.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b60bd4fdc323896a5bada2708734d16ff59ee5e32b8c390ae2ebe328426964a3", size = 6717949, upload-time = "2026-05-14T10:50:51.133Z" },
+    { url = "https://files.pythonhosted.org/packages/da/56/59d73f20d3bf5ec1d1e88f24473cf77fb485acefd285c1eb79d2f102e8dc/prek-0.4.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7203bff21e622a5482e956384c43990b0092faab02f72118275839a77a45e939", size = 6104294, upload-time = "2026-05-14T10:50:57.251Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/7f/c03e17c06069b96805c3579c00f830bad0e700f30aa3fed08c78958be77a/prek-0.4.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:44e3716a3e2983add2c094775d564536342011e84f770132389819c965513d6d", size = 5703788, upload-time = "2026-05-14T10:50:55.717Z" },
+    { url = "https://files.pythonhosted.org/packages/93/6f/f5664a1712ba214f67a0e93411dc62893a02165b5f04f3182e2c188d0623/prek-0.4.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6e3a0e43d7f345a5e32962736c335b5fc466d499f2556fb6f24028dd08108618", size = 5538311, upload-time = "2026-05-14T10:50:33.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/af/8a2aa0e02363e96d05a21ca73b4ea862459535bf6cf293710594396df450/prek-0.4.0-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:0d19efff4537e4a68b5bd61dcbf5ccb2dd8343df3ea9482aabe37d241ff18ddf", size = 5398617, upload-time = "2026-05-14T10:50:37.828Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/06/2b175e2ef812a3ab6ebab2dcd7aa0d03aea24852b73c6c4a30882800a01c/prek-0.4.0-py3-none-musllinux_1_1_i686.whl", hash = "sha256:0d9483404e5b8bf65111ee6b821e6cf7a5ba9c3a2065e7a0b7a39a17daaffcc9", size = 5685656, upload-time = "2026-05-14T10:50:40.781Z" },
+    { url = "https://files.pythonhosted.org/packages/39/00/aee25867a6e88bb5cadee41dd83745876a273d3c149612424cf068239a8e/prek-0.4.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:01d69684306c67917ed69497d0f523216f13f2306723b62e1ace454209477b45", size = 6217097, upload-time = "2026-05-14T10:50:52.903Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d2/e0cca68af94b7639badd3967fc37ae6159979baf6cc3c7f1d68f0a966bdf/prek-0.4.0-py3-none-win32.whl", hash = "sha256:ce2a8feb5dc1f1e748879d0e14c2145353059b830ac5e3f64d92127ab16efc78", size = 5204721, upload-time = "2026-05-14T10:50:49.269Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/462c907502e7b9f634c73de4e6d36fa44b5d652a52a9ddd51811b2030ca7/prek-0.4.0-py3-none-win_amd64.whl", hash = "sha256:b218d92ad5d2ff0b59240d7d837fa9edc61849894958acb3a225efff7a2faa65", size = 5595119, upload-time = "2026-05-14T10:50:47.482Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/a0/a0be2f73cbc8fd65a5e1de576aa5a5324339c7cc9f7dd328009a5e1a3ae1/prek-0.4.0-py3-none-win_arm64.whl", hash = "sha256:ff1f1fa311023418d40a443bca6928a9f5ce073d0b9130b641954183aa31736d", size = 5423774, upload-time = "2026-05-14T10:50:44.19Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace pre-commit references with prek in docs, CONTRIBUTING, copilot instructions, and the gitmoji skill. Remove the ci: block from .pre-commit-config.yaml and suppress the resulting PC901/902/903 repo-review warnings.