### PR TITLE
🏷️ types(charts): make AbstractChart generic over manifold type MT

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -202,7 +202,7 @@ def cartesian_chart(obj: AbstractChart, /) -> AbstractChart:  # type: ignore[typ
 
 ```
 @plum.dispatch
-def cartesian_chart(obj: AbstractChart[Any, Any], /) -> AbstractChart[Any, Any]:
+def cartesian_chart(obj: AbstractChart[Any, Any, Any], /) -> AbstractChart[Any, Any, Any]:
     """This breaks plum's type matching!"""
     ...
 ```
@@ -210,7 +210,7 @@ def cartesian_chart(obj: AbstractChart[Any, Any], /) -> AbstractChart[Any, Any]:
 **Why this matters:**
 
 - Plum uses runtime type introspection to match function signatures
-- Parameterized generics (e.g., `AbstractChart[Any, Any]`) confuse plum's type matcher
+- Parameterized generics (e.g., `AbstractChart[Any, Any, Any]`) confuse plum's type matcher
 - Type checkers will warn about missing type arguments; use `type: ignore[type-arg]`
 - This applies to ALL generic types: `AbstractChart`, etc.
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -206,7 +206,7 @@ from typing import Any
 
 
 @plum.dispatch
-def process(obj: cxc.AbstractChart[Any, Any], /):
+def process(obj: cxc.AbstractChart[Any, Any, Any], /):
     ...
 ```
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1075,7 +1075,7 @@ The `coordinax.charts` module provides the chart-facing API for representing poi
 
     ```python
     class ChartExample(
-        AbstractFixedComponentsChart[tuple[Literal["x"]], Literal["Length"]]
+        AbstractFixedComponentsChart[Any, tuple[Literal["x"]], Literal["Length"]]
     ):
         pass
     ```

--- a/packages/coordinax.hypothesis/src/coordinax/hypothesis/charts/_src/charts_product.py
+++ b/packages/coordinax.hypothesis/src/coordinax/hypothesis/charts/_src/charts_product.py
@@ -72,7 +72,7 @@ def cartesian_product_factors(
     ndim: int | None = None,
     min_factors: int = 1,
     max_factors: int = 4,
-) -> tuple[cxc.AbstractChart[Any, Any], ...]:
+) -> tuple[cxc.AbstractChart[Any, Any, Any], ...]:
     """Generate factors and names for a product chart with target dimensionality.
 
     Parameters

--- a/packages/coordinax.hypothesis/src/coordinax/hypothesis/charts/_src/classes.py
+++ b/packages/coordinax.hypothesis/src/coordinax/hypothesis/charts/_src/classes.py
@@ -21,7 +21,7 @@ def chart_classes(
     *,
     exclude_abstract: bool | st.SearchStrategy[bool] = True,
     exclude: tuple[type, ...] = (),
-) -> type[cxc.AbstractChart[Any, Any]]:
+) -> type[cxc.AbstractChart[Any, Any, Any]]:
     """Strategy to draw chart classes.
 
     Parameters

--- a/packages/coordinax.hypothesis/src/coordinax/hypothesis/charts/_src/extend.py
+++ b/packages/coordinax.hypothesis/src/coordinax/hypothesis/charts/_src/extend.py
@@ -19,8 +19,9 @@ from coordinax.hypothesis.utils import draw_if_strategy
 def charts_like(
     draw: st.DrawFn,
     /,
-    chart: cxc.AbstractChart[Any, Any] | st.SearchStrategy[cxc.AbstractChart[Any, Any]],
-) -> cxc.AbstractChart[Any, Any]:
+    chart: cxc.AbstractChart[Any, Any, Any]
+    | st.SearchStrategy[cxc.AbstractChart[Any, Any, Any]],
+) -> cxc.AbstractChart[Any, Any, Any]:
     """Generate charts similar to the provided one.
 
     This strategy inspects the provided chart to determine its flags
@@ -64,7 +65,9 @@ def charts_like(
     template = draw_if_strategy(draw, chart)
 
     # Extract flags by looking through the MRO for AbstractDimensionalFlag subclasses
-    flags: tuple[type[cxc.AbstractDimensionalFlag | cxc.AbstractChart[Any, Any]], ...]
+    flags: tuple[
+        type[cxc.AbstractDimensionalFlag | cxc.AbstractChart[Any, Any, Any]], ...
+    ]
     flags = tuple(
         base
         for base in type(template).mro()

--- a/packages/coordinax.hypothesis/src/coordinax/hypothesis/charts/_src/utils.py
+++ b/packages/coordinax.hypothesis/src/coordinax/hypothesis/charts/_src/utils.py
@@ -15,7 +15,9 @@ EMPTY: Final = inspect.Parameter.empty
 
 
 def can_pt_map(
-    from_chart: cxc.AbstractChart[Any, Any], to_chart: cxc.AbstractChart[Any, Any], /
+    from_chart: cxc.AbstractChart[Any, Any, Any],
+    to_chart: cxc.AbstractChart[Any, Any, Any],
+    /,
 ) -> bool:
     """Return ``pt_map`` can convert between the two charts."""
     if type(to_chart) is type(from_chart):

--- a/packages/coordinax.hypothesis/src/coordinax/hypothesis/manifolds/_src/atlas.py
+++ b/packages/coordinax.hypothesis/src/coordinax/hypothesis/manifolds/_src/atlas.py
@@ -585,9 +585,9 @@ def atlases(  # noqa: F811
                 f"expected ndim={custom_ndim}."
             )
 
-    filtered_classes: list[type[cxc.AbstractChart[Any, Any]]] = []
+    filtered_classes: list[type[cxc.AbstractChart[Any, Any, Any]]] = []
     for cls in get_all_subclasses(cxc.AbstractChart, exclude_abstract=True):
-        cls = cast(type[cxc.AbstractChart[Any, Any]], cls)
+        cls = cast(type[cxc.AbstractChart[Any, Any, Any]], cls)
         try:
             chart = cls()
         except TypeError:

--- a/packages/coordinax.hypothesis/src/coordinax/hypothesis/manifolds/_src/manifold.py
+++ b/packages/coordinax.hypothesis/src/coordinax/hypothesis/manifolds/_src/manifold.py
@@ -19,7 +19,9 @@ from coordinax.hypothesis.utils import (
 )
 
 
-def _is_zero_arg_constructible(chart_cls: type[cxc.AbstractChart[Any, Any]], /) -> bool:
+def _is_zero_arg_constructible(
+    chart_cls: type[cxc.AbstractChart[Any, Any, Any]], /
+) -> bool:
     """Return True if chart_cls can be instantiated with no arguments."""
     try:
         chart_cls()
@@ -30,11 +32,11 @@ def _is_zero_arg_constructible(chart_cls: type[cxc.AbstractChart[Any, Any]], /) 
 
 def _matching_chart_classes_for_ndim(
     ndim: int, /
-) -> tuple[type[cxc.AbstractChart[Any, Any]], ...]:
+) -> tuple[type[cxc.AbstractChart[Any, Any, Any]], ...]:
     """Return zero-arg chart classes with default instance ndim == target ndim."""
-    classes: list[type[cxc.AbstractChart[Any, Any]]] = []
+    classes: list[type[cxc.AbstractChart[Any, Any, Any]]] = []
     for cls in get_all_subclasses(cxc.AbstractChart, exclude_abstract=True):
-        cls = cast(type[cxc.AbstractChart[Any, Any]], cls)
+        cls = cast(type[cxc.AbstractChart[Any, Any, Any]], cls)
         if not _is_zero_arg_constructible(cls):
             continue
         if cls().ndim == ndim:

--- a/src/coordinax/_src/base/atlas.py
+++ b/src/coordinax/_src/base/atlas.py
@@ -105,7 +105,7 @@ class AbstractAtlas(metaclass=abc.ABCMeta):
     """Dimension of the manifold that this atlas covers."""
 
     @abc.abstractmethod
-    def default_chart(self) -> "coordinax.charts.AbstractChart[Any, Any]":
+    def default_chart(self) -> "coordinax.charts.AbstractChart[Any, Any, Any]":
         """Return a default chart from the atlas.
 
         >>> import coordinax.manifolds as cxm
@@ -118,7 +118,7 @@ class AbstractAtlas(metaclass=abc.ABCMeta):
 
     def default_chart_for(
         self, M: "coordinax.manifolds.AbstractManifold", /
-    ) -> "coordinax.charts.AbstractChart[Any, Any]":
+    ) -> "coordinax.charts.AbstractChart[Any, Any, Any]":
         """Return a default chart from the atlas for the given manifold.
 
         This is a thin convenience wrapper over ``self.default_chart()`` that
@@ -145,7 +145,9 @@ class AbstractAtlas(metaclass=abc.ABCMeta):
         return dataclasses.replace(chart, M=M)
 
     @abc.abstractmethod
-    def has_chart(self, chart: "coordinax.charts.AbstractChart[Any, Any]", /) -> bool:
+    def has_chart(
+        self, chart: "coordinax.charts.AbstractChart[Any, Any, Any]", /
+    ) -> bool:
         """Return whether the atlas supports the given chart.
 
         >>> import coordinax.manifolds as cxm
@@ -159,7 +161,9 @@ class AbstractAtlas(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError  # pragma: no cover
 
-    def __contains__(self, chart: "coordinax.charts.AbstractChart[Any, Any]") -> bool:
+    def __contains__(
+        self, chart: "coordinax.charts.AbstractChart[Any, Any, Any]"
+    ) -> bool:
         """Return whether the atlas supports the given chart.
 
         >>> import coordinax.manifolds as cxm

--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -11,6 +11,7 @@ __all__ = (
     "is_not_abstract_chart_subclass",
     "MISSING",
     "CDictT",
+    "MT",
 )
 
 import abc
@@ -41,6 +42,7 @@ from .manifold import AbstractManifold
 from coordinax._src.custom_types import CDictT, Ds, Ks
 
 GAT = TypeVar("GAT", bound=type(L[" ", "  "]))  # ty: ignore[invalid-type-form]
+MT = TypeVar("MT", bound=AbstractManifold)
 V = TypeVar("V")
 
 # Charts are registered in CHART_CLASSES when they are defined, via
@@ -48,11 +50,13 @@ V = TypeVar("V")
 # dispatch and other purposes. We use a weak set to avoid keeping classes alive
 # unnecessarily, and a mapping proxy to prevent modification of the set from
 # outside this module.
-CHART_CLASSES: weakref.WeakSet[type["AbstractChart[Any, Any]"]] = weakref.WeakSet()
-
-NON_ABC_CHART_CLASSES: weakref.WeakSet[type["AbstractChart[Any, Any]"]] = (
+CHART_CLASSES: weakref.WeakSet[type["AbstractChart[AbstractManifold, Any, Any]"]] = (
     weakref.WeakSet()
 )
+
+NON_ABC_CHART_CLASSES: weakref.WeakSet[
+    type["AbstractChart[AbstractManifold, Any, Any]"]
+] = weakref.WeakSet()
 
 chart_dataclass_decorator = dataclasses.dataclass(
     frozen=True, slots=False, repr=False, eq=False
@@ -77,10 +81,10 @@ MISSINGDEFAULT = MissingDefault()
 
 
 @jtu.register_static
-class AbstractChart(Generic[Ks, Ds], metaclass=abc.ABCMeta):
+class AbstractChart(Generic[MT, Ks, Ds], metaclass=abc.ABCMeta):
     """Abstract base class for charts (coordinate representations)."""
 
-    M: AbstractManifold
+    M: MT
     """The manifold that this chart belongs to.
 
     Default is `no_manifold` for charts that do not belong to any manifold.
@@ -128,7 +132,7 @@ class AbstractChart(Generic[Ks, Ds], metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def cartesian(self) -> "AbstractChart[Ks, Ds]":
+    def cartesian(self) -> "AbstractChart[MT, Ks, Ds]":
         """Return the corresponding Cartesian chart."""
         raise NotImplementedError  # pragma: no cover
 
@@ -339,7 +343,7 @@ def _get_tuple(tp: GAT, /) -> GAT:
     return tuple(arg.__args__[0] for arg in get_args(tp))
 
 
-class AbstractFixedComponentsChart(AbstractChart[Ks, Ds]):
+class AbstractFixedComponentsChart(AbstractChart[MT, Ks, Ds]):
     """Abstract base class for charts with fixed components and dimensions."""
 
     _components: Ks
@@ -354,10 +358,10 @@ class AbstractFixedComponentsChart(AbstractChart[Ks, Ds]):
                     origin, AbstractFixedComponentsChart
                 ):
                     args = get_args(base)
-                    if len(args) != 2:
+                    if len(args) != 3:
                         raise TypeError
-                    cls._components = _get_tuple(args[0])
-                    cls._coord_dimensions = _get_tuple(args[1])
+                    cls._components = _get_tuple(args[1])
+                    cls._coord_dimensions = _get_tuple(args[2])
                     break
 
         super().__init_subclass__(**kw)  # AbstractChart has.

--- a/src/coordinax/_src/base/manifold.py
+++ b/src/coordinax/_src/base/manifold.py
@@ -179,7 +179,7 @@ class AbstractManifold(metaclass=abc.ABCMeta):
         """
         return self.atlas.ndim
 
-    def default_chart(self) -> "coordinax.charts.AbstractChart[Any, Any]":
+    def default_chart(self) -> "coordinax.charts.AbstractChart[Any, Any, Any]":
         """Return a default chart from the atlas.
 
         This is a convenience property that proxies to the atlas default chart.
@@ -192,7 +192,9 @@ class AbstractManifold(metaclass=abc.ABCMeta):
         """
         return self.atlas.default_chart()
 
-    def has_chart(self, chart: "coordinax.charts.AbstractChart[Any, Any]", /) -> bool:
+    def has_chart(
+        self, chart: "coordinax.charts.AbstractChart[Any, Any, Any]", /
+    ) -> bool:
         """Return whether ``chart`` belongs to this manifold atlas.
 
         >>> import coordinax.manifolds as cxm
@@ -205,7 +207,9 @@ class AbstractManifold(metaclass=abc.ABCMeta):
         """
         return self.atlas.has_chart(chart)
 
-    def check_chart(self, chart: "coordinax.charts.AbstractChart[Any, Any]", /) -> None:
+    def check_chart(
+        self, chart: "coordinax.charts.AbstractChart[Any, Any, Any]", /
+    ) -> None:
         """Check that ``chart`` belongs to this manifold atlas.
 
         >>> import coordinax.manifolds as cxm
@@ -221,7 +225,7 @@ class AbstractManifold(metaclass=abc.ABCMeta):
 
     def angle_between(
         self,
-        chart: "coordinax.charts.AbstractChart[Any, Any]",
+        chart: "coordinax.charts.AbstractChart[Any, Any, Any]",
         uvec: CDict,
         vvec: CDict,
         /,

--- a/src/coordinax/_src/charts/d0.py
+++ b/src/coordinax/_src/charts/d0.py
@@ -4,8 +4,8 @@ __all__ = ("Abstract0D", "Cart0D", "cart0d")
 
 import dataclasses
 
-from typing import Any, Final, Literal as L, final  # noqa: N817
-from typing_extensions import override
+from typing import Any, Final, Literal as L, Self  # noqa: N817
+from typing_extensions import TypeVar, override
 
 import jax.tree_util as jtu
 
@@ -20,7 +20,9 @@ from coordinax._src.euclidean.atlas import (
     EUCLIDEAN_ATLAS_DEFAULT_CHARTS,
     EuclideanAtlas,
 )
-from coordinax._src.euclidean.manifold import R0
+from coordinax._src.euclidean.manifold import R0, Rn
+
+MT = TypeVar("MT", bound=AbstractManifold, default=Rn)
 
 
 class Abstract0D(AbstractDimensionalFlag, n=0):
@@ -52,9 +54,8 @@ ZeroDDims = tuple[()]
 
 @EuclideanAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
-class Cart0D(AbstractFixedComponentsChart[ZeroDKeys, ZeroDDims], Abstract0D):
+class Cart0D(AbstractFixedComponentsChart[MT, ZeroDKeys, ZeroDDims], Abstract0D):
     """Zero-dimensional Cartesian chart.
 
     This chart has no coordinate components and no coordinate dimensions.
@@ -71,11 +72,11 @@ class Cart0D(AbstractFixedComponentsChart[ZeroDKeys, ZeroDDims], Abstract0D):
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = R0
+    M: MT = R0  # ty: ignore[invalid-assignment]
 
     @override
     @property
-    def cartesian(self) -> "Cart0D":
+    def cartesian(self) -> Self:
         """Return the canonical Cartesian chart for a 0D chart.
 
         >>> import coordinax.charts as cxc
@@ -85,7 +86,7 @@ class Cart0D(AbstractFixedComponentsChart[ZeroDKeys, ZeroDDims], Abstract0D):
         return self
 
 
-cart0d: Final = Cart0D()
+cart0d: Final = Cart0D(M=R0)
 """The canonical 0D Cartesian chart.
 
 >>> import coordinax.charts as cxc

--- a/src/coordinax/_src/charts/d1.py
+++ b/src/coordinax/_src/charts/d1.py
@@ -18,8 +18,8 @@ __all__ = (
 
 import dataclasses
 
-from typing import Any, Final, Literal as L, TypeVar, final  # noqa: N817
-from typing_extensions import override
+from typing import Any, Final, Literal as L, Self  # noqa: N817
+from typing_extensions import TypeVar, override
 
 import jax.tree_util as jtu
 
@@ -35,9 +35,10 @@ from coordinax._src.euclidean.atlas import (
     EUCLIDEAN_ATLAS_DEFAULT_CHARTS,
     EuclideanAtlas,
 )
-from coordinax._src.euclidean.manifold import R1
+from coordinax._src.euclidean.manifold import R1, Rn
 
 GAT = TypeVar("GAT", bound=type(L[" ", "  "]))  # ty: ignore[invalid-type-form]
+MT = TypeVar("MT", bound=AbstractManifold, default=Rn)
 V = TypeVar("V")
 
 
@@ -71,9 +72,8 @@ Cart1DDims = tuple[Len]
 
 
 @jtu.register_static
-@final
 @chart_dataclass_decorator
-class Cart1D(AbstractFixedComponentsChart[Cart1DKeys, Cart1DDims], Abstract1D):
+class Cart1D(AbstractFixedComponentsChart[MT, Cart1DKeys, Cart1DDims], Abstract1D):
     r"""One-dimensional Cartesian chart $(x)$.
 
     Components are ordered as ``("x",)`` with dimension ``("length",)``.
@@ -96,11 +96,11 @@ class Cart1D(AbstractFixedComponentsChart[Cart1DKeys, Cart1DDims], Abstract1D):
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = R1
+    M: MT = R1  # ty: ignore[invalid-assignment]
 
     @override
     @property
-    def cartesian(self) -> "Cart1D":
+    def cartesian(self) -> Self:
         """Return the canonical Cartesian chart for a 1D chart.
 
         >>> import coordinax.charts as cxc
@@ -132,9 +132,8 @@ Radial1DDims = tuple[Len]
 
 @EuclideanAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
-class Radial1D(AbstractFixedComponentsChart[RadialKeys, Radial1DDims], Abstract1D):
+class Radial1D(AbstractFixedComponentsChart[MT, RadialKeys, Radial1DDims], Abstract1D):
     r"""One-dimensional radial chart $(r)$.
 
     Components are ordered as ``("r",)`` with dimension ``("length",)``.
@@ -158,11 +157,11 @@ class Radial1D(AbstractFixedComponentsChart[RadialKeys, Radial1DDims], Abstract1
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = R1
+    M: MT = R1  # ty: ignore[invalid-assignment]
 
     @override
     @property
-    def cartesian(self) -> "Cart1D":
+    def cartesian(self) -> "Cart1D[MT]":
         """Return the canonical Cartesian chart for a 1D radial chart.
 
         >>> import coordinax.charts as cxc
@@ -173,7 +172,7 @@ class Radial1D(AbstractFixedComponentsChart[RadialKeys, Radial1DDims], Abstract1
         return Cart1D(M=self.M)
 
 
-radial1d: Final = Radial1D()
+radial1d: Final = Radial1D(M=R1)
 """The canonical 1D radial chart.
 
 >>> import coordinax.charts as cxc
@@ -191,9 +190,8 @@ TimeDims = tuple[L["time"]]
 
 @EuclideanAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
-class Time1D(AbstractFixedComponentsChart[TimeKeys, TimeDims], Abstract1D):
+class Time1D(AbstractFixedComponentsChart[MT, TimeKeys, TimeDims], Abstract1D):
     """One-dimensional time chart ``(t)``.
 
     Components are ordered as ``("t",)`` with dimension ``("time",)``.
@@ -216,7 +214,7 @@ class Time1D(AbstractFixedComponentsChart[TimeKeys, TimeDims], Abstract1D):
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = R1
+    M: MT = R1  # ty: ignore[invalid-assignment]
 
     @override
     @property
@@ -231,7 +229,7 @@ class Time1D(AbstractFixedComponentsChart[TimeKeys, TimeDims], Abstract1D):
         return time1d
 
 
-time1d: Final = Time1D()
+time1d: Final = Time1D(M=R1)
 """The canonical 1D time chart.
 
 >>> import coordinax.charts as cxc

--- a/src/coordinax/_src/charts/d2.py
+++ b/src/coordinax/_src/charts/d2.py
@@ -5,8 +5,8 @@ __all__ = ("Abstract2D", "Cart2D", "cart2d", "Polar2D", "polar2d")
 
 import dataclasses
 
-from typing import Any, Final, Literal as L, final  # noqa: N817
-from typing_extensions import override
+from typing import Any, Final, Literal as L, Self  # noqa: N817
+from typing_extensions import TypeVar, override
 
 import jax.tree_util as jtu
 
@@ -22,7 +22,9 @@ from coordinax._src.euclidean.atlas import (
     EUCLIDEAN_ATLAS_DEFAULT_CHARTS,
     EuclideanAtlas,
 )
-from coordinax._src.euclidean.manifold import R2
+from coordinax._src.euclidean.manifold import R2, Rn
+
+MT = TypeVar("MT", bound=AbstractManifold, default=Rn)
 
 
 class Abstract2D(AbstractDimensionalFlag, n=2):
@@ -57,9 +59,8 @@ Cart2DDims = tuple[Len, Len]
 
 @EuclideanAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
-class Cart2D(AbstractFixedComponentsChart[Cart2DKeys, Cart2DDims], Abstract2D):
+class Cart2D(AbstractFixedComponentsChart[MT, Cart2DKeys, Cart2DDims], Abstract2D):
     r"""Two-dimensional Cartesian chart $(x, y)$.
 
     Components are ordered as ``("x", "y")`` with dimensions ``("length",
@@ -83,11 +84,11 @@ class Cart2D(AbstractFixedComponentsChart[Cart2DKeys, Cart2DDims], Abstract2D):
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = R2
+    M: MT = R2  # ty: ignore[invalid-assignment]
 
     @override
     @property
-    def cartesian(self) -> "Cart2D":
+    def cartesian(self) -> Self:
         """Return the canonical Cartesian chart for a 2D chart.
 
         >>> import coordinax.charts as cxc
@@ -98,7 +99,7 @@ class Cart2D(AbstractFixedComponentsChart[Cart2DKeys, Cart2DDims], Abstract2D):
         return self
 
 
-cart2d: Final = Cart2D()
+cart2d: Final = Cart2D(M=R2)
 """The canonical 2D Cartesian chart.
 
 >>> import coordinax.charts as cxc
@@ -119,9 +120,8 @@ Polar2DDims = tuple[Len, Ang]
 
 @EuclideanAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
-class Polar2D(AbstractFixedComponentsChart[PolarKeys, Polar2DDims], Abstract2D):
+class Polar2D(AbstractFixedComponentsChart[MT, PolarKeys, Polar2DDims], Abstract2D):
     r"""Two-dimensional polar chart $(r, \theta)$.
 
     Components are ordered as ``("r", "theta")`` with dimensions ``("length",
@@ -145,11 +145,11 @@ class Polar2D(AbstractFixedComponentsChart[PolarKeys, Polar2DDims], Abstract2D):
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = R2
+    M: MT = R2  # ty: ignore[invalid-assignment]
 
     @override
     @property
-    def cartesian(self) -> "Cart2D":
+    def cartesian(self) -> "Cart2D[MT]":
         """Return the canonical Cartesian chart for a 2D chart.
 
         >>> import coordinax.charts as cxc
@@ -160,7 +160,7 @@ class Polar2D(AbstractFixedComponentsChart[PolarKeys, Polar2DDims], Abstract2D):
         return Cart2D(M=self.M)
 
 
-polar2d: Final = Polar2D()
+polar2d: Final = Polar2D(M=R2)
 """The canonical 2D polar chart.
 
 >>> import coordinax.charts as cxc

--- a/src/coordinax/_src/charts/d3.py
+++ b/src/coordinax/_src/charts/d3.py
@@ -21,7 +21,7 @@ __all__ = (
 import dataclasses
 
 from jaxtyping import Real
-from typing import Annotated, Any, Final, Literal as L, final  # noqa: N817
+from typing import Annotated, Any, Final, Literal as L, Self  # noqa: N817
 from typing_extensions import override
 
 import jax.tree_util as jtu
@@ -31,9 +31,9 @@ import quaxed.numpy as jnp
 import unxt as u
 
 from coordinax._src.base import (
+    MT,
     AbstractDimensionalFlag,
     AbstractFixedComponentsChart,
-    AbstractManifold,
     chart_dataclass_decorator,
     is_not_abstract_chart_subclass,
 )
@@ -79,9 +79,8 @@ Cart3DDims = tuple[Len, Len, Len]
 
 @EuclideanAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
-class Cart3D(AbstractFixedComponentsChart[Cart3DKeys, Cart3DDims], Abstract3D):
+class Cart3D(AbstractFixedComponentsChart[MT, Cart3DKeys, Cart3DDims], Abstract3D):
     r"""Three-dimensional Cartesian chart $(x, y, z)$.
 
     Components are ordered as ``("x", "y", "z")`` with dimensions ``("length",
@@ -105,11 +104,11 @@ class Cart3D(AbstractFixedComponentsChart[Cart3DKeys, Cart3DDims], Abstract3D):
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = R3
+    M: MT = R3  # ty: ignore[invalid-assignment]
 
     @override
     @property
-    def cartesian(self) -> "Cart3D":
+    def cartesian(self) -> Self:
         """Return the canonical Cartesian chart for a 3D chart.
 
         >>> import coordinax.charts as cxc
@@ -120,7 +119,7 @@ class Cart3D(AbstractFixedComponentsChart[Cart3DKeys, Cart3DDims], Abstract3D):
         return self
 
 
-cart3d: Final = Cart3D()
+cart3d: Final = Cart3D(M=R3)
 """The canonical 3D Cartesian chart.
 
 >>> import coordinax.charts as cxc
@@ -141,10 +140,9 @@ Cylindrical3DDims = tuple[Len, Ang, Len]
 
 @EuclideanAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
 class Cylindrical3D(
-    AbstractFixedComponentsChart[CylindricalKeys, Cylindrical3DDims], Abstract3D
+    AbstractFixedComponentsChart[MT, CylindricalKeys, Cylindrical3DDims], Abstract3D
 ):
     r"""Three-dimensional cylindrical chart $(\rho, \phi, z)$.
 
@@ -169,11 +167,11 @@ class Cylindrical3D(
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = R3
+    M: MT = R3  # ty: ignore[invalid-assignment]
 
     @override
     @property
-    def cartesian(self) -> Cart3D:
+    def cartesian(self) -> Cart3D[MT]:
         """Return the canonical Cartesian chart for a 3D cylindrical chart.
 
         >>> import coordinax.charts as cxc
@@ -183,7 +181,7 @@ class Cylindrical3D(
         return Cart3D(M=self.M)
 
 
-cyl3d: Final = Cylindrical3D()
+cyl3d: Final = Cylindrical3D(M=R3)
 """The canonical 3D cylindrical chart.
 
 >>> import coordinax.charts as cxc
@@ -196,15 +194,15 @@ True
 # Spherical
 
 
-class AbstractSpherical3D(AbstractFixedComponentsChart[Ks, Ds], Abstract3D):
+class AbstractSpherical3D(AbstractFixedComponentsChart[MT, Ks, Ds], Abstract3D):
     """Abstract spherical vector representation."""
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = R3
+    M: MT = R3  # ty: ignore[invalid-assignment]
 
     @override
     @property
-    def cartesian(self) -> Cart3D:
+    def cartesian(self) -> Cart3D[MT]:
         """Return the canonical Cartesian chart for a 3D chart.
 
         >>> import coordinax.charts as cxc
@@ -227,9 +225,8 @@ Spherical3DDims = tuple[Len, Ang, Ang]
 
 @EuclideanAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
-class Spherical3D(AbstractSpherical3D[SphericalKeys, Spherical3DDims]):
+class Spherical3D(AbstractSpherical3D[MT, SphericalKeys, Spherical3DDims]):
     r"""Three-dimensional spherical coordinates $(r, \theta, \phi)$.
 
     The Cartesian embedding is
@@ -259,7 +256,7 @@ class Spherical3D(AbstractSpherical3D[SphericalKeys, Spherical3DDims]):
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = R3
+    M: MT = R3  # ty: ignore[invalid-assignment]
 
     def check_data(self, data: CDictT, /, *, values: bool = False, **kw: Any) -> CDictT:
         super().check_data(data, **kw)
@@ -269,7 +266,7 @@ class Spherical3D(AbstractSpherical3D[SphericalKeys, Spherical3DDims]):
         return data
 
 
-sph3d: Final = Spherical3D()
+sph3d: Final = Spherical3D(M=R3)
 """The canonical 3D spherical chart.
 
 >>> import coordinax.charts as cxc
@@ -287,10 +284,9 @@ LonLatSpherical3DDims = tuple[Ang, Ang, Len]
 
 @EuclideanAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
 class LonLatSpherical3D(
-    AbstractSpherical3D[LonLatSphericalKeys, LonLatSpherical3DDims],
+    AbstractSpherical3D[MT, LonLatSphericalKeys, LonLatSpherical3DDims],
 ):
     r"""Longitude-latitude spherical coordinates.
 
@@ -319,7 +315,7 @@ class LonLatSpherical3D(
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = R3
+    M: MT = R3  # ty: ignore[invalid-assignment]
 
     def check_data(self, data: CDictT, /, *, values: bool = False, **kw: Any) -> CDictT:
         super().check_data(data, **kw)  # call base check
@@ -329,7 +325,7 @@ class LonLatSpherical3D(
         return data
 
 
-lonlat_sph3d: Final = LonLatSpherical3D()
+lonlat_sph3d: Final = LonLatSpherical3D(M=R3)
 """The canonical longitude-latitude spherical chart.
 
 >>> import coordinax.charts as cxc
@@ -347,10 +343,9 @@ LonCosLatSpherical3DDims = tuple[Ang, Ang, Len]
 
 @EuclideanAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
 class LonCosLatSpherical3D(
-    AbstractSpherical3D[LonCosLatSphericalKeys, LonCosLatSpherical3DDims]
+    AbstractSpherical3D[MT, LonCosLatSphericalKeys, LonCosLatSpherical3DDims]
 ):
     r"""Longitude-cos(latitude) spherical coordinates.
 
@@ -373,7 +368,7 @@ class LonCosLatSpherical3D(
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = R3
+    M: MT = R3  # ty: ignore[invalid-assignment]
 
     def check_data(self, data: CDictT, /, *, values: bool = False, **kw: Any) -> CDictT:
         super().check_data(data, **kw)  # call base check
@@ -383,7 +378,7 @@ class LonCosLatSpherical3D(
         return data
 
 
-loncoslat_sph3d: Final = LonCosLatSpherical3D()
+loncoslat_sph3d: Final = LonCosLatSpherical3D(M=R3)
 """The canonical longitude-cos(latitude) spherical chart.
 
 >>> import coordinax.charts as cxc
@@ -400,9 +395,8 @@ MathSphericalKeys = tuple[L["r"], L["theta"], L["phi"]]
 
 @EuclideanAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
-class MathSpherical3D(AbstractSpherical3D[MathSphericalKeys, Spherical3DDims]):
+class MathSpherical3D(AbstractSpherical3D[MT, MathSphericalKeys, Spherical3DDims]):
     r"""Mathematical-convention spherical coordinates $(r, \theta, \phi)$.
 
     In this convention:
@@ -429,7 +423,7 @@ class MathSpherical3D(AbstractSpherical3D[MathSphericalKeys, Spherical3DDims]):
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = R3
+    M: MT = R3  # ty: ignore[invalid-assignment]
 
     def check_data(self, data: CDictT, /, *, values: bool = False, **kw: Any) -> CDictT:
         super().check_data(data, **kw)  # call base check
@@ -438,7 +432,7 @@ class MathSpherical3D(AbstractSpherical3D[MathSphericalKeys, Spherical3DDims]):
         return data
 
 
-math_sph3d: Final = MathSpherical3D()
+math_sph3d: Final = MathSpherical3D(M=R3)
 """The canonical mathematical-convention spherical chart.
 
 >>> import coordinax.charts as cxc
@@ -456,11 +450,10 @@ ProlateSpheroidal3DDims = tuple[L["area"], L["area"], Ang]
 
 @EuclideanAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
 class ProlateSpheroidal3D(
     Abstract3D,
-    AbstractFixedComponentsChart[ProlateSpheroidalKeys, ProlateSpheroidal3DDims],
+    AbstractFixedComponentsChart[MT, ProlateSpheroidalKeys, ProlateSpheroidal3DDims],
 ):
     r"""Prolate spheroidal coordinates $(\mu, \nu, \phi)$ with focal length $\Delta$.
 
@@ -502,7 +495,7 @@ class ProlateSpheroidal3D(
     ]
     """Focal length of the coordinate system."""
 
-    M: AbstractManifold = R3
+    M: MT = R3  # ty: ignore[invalid-assignment]
 
     def check_data(self, data: CDictT, /, *, values: bool = False, **kw: Any) -> CDictT:
         super().check_data(data, **kw)  # call base check
@@ -516,7 +509,7 @@ class ProlateSpheroidal3D(
 
     @override
     @property
-    def cartesian(self) -> Cart3D:
+    def cartesian(self) -> Cart3D[MT]:
         """Return the canonical Cartesian chart for a 3D chart.
 
         >>> import coordinax.charts as cxc

--- a/src/coordinax/_src/charts/d6.py
+++ b/src/coordinax/_src/charts/d6.py
@@ -5,7 +5,7 @@ __all__ = ("Abstract6D", "PoincarePolar6D", "poincarepolar6d")
 
 import dataclasses
 
-from typing import Any, Final, Literal as L, NoReturn, final  # noqa: N817
+from typing import Any, Final, Literal as L, NoReturn  # noqa: N817
 from typing_extensions import override
 
 import jax.tree_util as jtu
@@ -54,10 +54,9 @@ PoincarePolarDims = tuple[
 
 
 @jtu.register_static
-@final
 @chart_dataclass_decorator
 class PoincarePolar6D(
-    AbstractFixedComponentsChart[PoincarePolarKeys, PoincarePolarDims], Abstract6D
+    AbstractFixedComponentsChart[Any, PoincarePolarKeys, PoincarePolarDims], Abstract6D
 ):
     r"""Six-dimensional Poincare-polar chart.
 

--- a/src/coordinax/_src/charts/dn.py
+++ b/src/coordinax/_src/charts/dn.py
@@ -5,8 +5,8 @@ __all__ = ("AbstractND", "CartND", "cartnd")
 
 import dataclasses
 
-from typing import Any, Final, Literal as L, final  # noqa: N817
-from typing_extensions import override
+from typing import Any, Final, Literal as L, Self  # noqa: N817
+from typing_extensions import TypeVar, override
 
 import jax.tree_util as jtu
 
@@ -19,8 +19,10 @@ from coordinax._src.base import (
 )
 from coordinax._src.custom_types import Len
 from coordinax._src.euclidean.atlas import EuclideanAtlas
-from coordinax._src.euclidean.manifold import RN
+from coordinax._src.euclidean.manifold import RN, Rn
 from coordinax._src.null import no_manifold
+
+MT = TypeVar("MT", bound=AbstractManifold, default=Rn)
 
 
 class AbstractND(AbstractDimensionalFlag, n="N"):
@@ -54,9 +56,8 @@ CartNDDims = tuple[Len]
 
 @EuclideanAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
-class CartND(AbstractFixedComponentsChart[CartNDKeys, CartNDDims], AbstractND):
+class CartND(AbstractFixedComponentsChart[MT, CartNDKeys, CartNDDims], AbstractND):
     r"""N-dimensional Cartesian chart.
 
     Components are ordered as ``("q",)`` with dimension ``("length",)``,
@@ -80,11 +81,11 @@ class CartND(AbstractFixedComponentsChart[CartNDKeys, CartNDDims], AbstractND):
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = RN
+    M: MT = RN  # ty: ignore[invalid-assignment]
 
     @override
     @property
-    def cartesian(self) -> "CartND":
+    def cartesian(self) -> Self:
         """Return the canonical Cartesian chart for an N-D chart.
 
         >>> import coordinax.charts as cxc

--- a/src/coordinax/_src/charts/register_guess.py
+++ b/src/coordinax/_src/charts/register_guess.py
@@ -28,7 +28,7 @@ from coordinax._src.custom_types import CDict
 
 # TODO: speed this up. The problem is that caching the results breaks something,
 # causing functions in other modules to fail type(x) is type(y) checks.
-def guess_chart_cls(obj: frozenset[str]) -> type[AbstractChart[Any, Any]]:
+def guess_chart_cls(obj: frozenset[str]) -> type[AbstractChart[Any, Any, Any]]:
     """Infer a chart class from the keys of a component dictionary.
 
     This only works on charts with fixed components.
@@ -119,7 +119,7 @@ def guess_chart(
     Cart1D(M=Rn(1))
 
     """
-    return cart1d
+    return cart1d  # ty: ignore[invalid-return-type]
 
 
 @plum.dispatch
@@ -135,7 +135,7 @@ def guess_chart(
     Cart2D(M=Rn(2))
 
     """
-    return cart2d
+    return cart2d  # ty: ignore[invalid-return-type]
 
 
 @plum.dispatch
@@ -151,7 +151,7 @@ def guess_chart(
     Cart3D(M=Rn(3))
 
     """
-    return cart3d
+    return cart3d  # ty: ignore[invalid-return-type]
 
 
 @plum.dispatch(precedence=-1)  # ty: ignore[no-matching-overload]
@@ -167,4 +167,4 @@ def guess_chart(
     CartND(M=Rn(True))
 
     """
-    return cartnd
+    return cartnd  # ty: ignore[invalid-return-type]

--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -238,7 +238,7 @@ def pt_map(
 # ===================================================================
 # Self representation conversions
 
-IDENTITY_TRANSFORM_CHARTS: Final[tuple[type[AbstractChart[Any, Any]], ...]] = (
+IDENTITY_TRANSFORM_CHARTS: Final[tuple[type[AbstractChart[Any, Any, Any]], ...]] = (
     # 0D
     Cart0D,
     # 1D

--- a/src/coordinax/_src/custom/atlas.py
+++ b/src/coordinax/_src/custom/atlas.py
@@ -48,10 +48,10 @@ class CustomAtlas(AbstractAtlas):
 
     """
 
-    charts: tuple[type[AbstractChart[Any, Any]], ...]
+    charts: tuple[type[AbstractChart[Any, Any, Any]], ...]
     """Explicitly registered chart classes for this atlas."""
 
-    chart_default: AbstractChart[Any, Any]
+    chart_default: AbstractChart[Any, Any, Any]
     """Stored default chart instance provided at construction."""
 
     def __post_init__(self) -> None:
@@ -80,7 +80,7 @@ class CustomAtlas(AbstractAtlas):
                     f"but expected {self.ndim}."
                 )
 
-    def default_chart(self) -> AbstractChart[Any, Any]:
+    def default_chart(self) -> AbstractChart[Any, Any, Any]:
         """Return the default chart for this atlas."""
         return self.chart_default
 
@@ -89,6 +89,6 @@ class CustomAtlas(AbstractAtlas):
         """Intrinsic dimension of the manifold."""
         return self.chart_default.ndim
 
-    def has_chart(self, chart: AbstractChart[Any, Any]) -> bool:
+    def has_chart(self, chart: AbstractChart[Any, Any, Any]) -> bool:
         """Return whether the atlas supports the given chart."""
         return type(chart) in self.charts and chart.ndim == self.ndim

--- a/src/coordinax/_src/custom_types.py
+++ b/src/coordinax/_src/custom_types.py
@@ -12,7 +12,8 @@ __all__: tuple[str, ...] = (
     "Ds",
 )
 
-from typing import Any, Literal, TypeAlias, TypeVar
+from typing import Any, Literal, TypeAlias
+from typing_extensions import TypeVar
 
 import unxt as u
 
@@ -34,5 +35,5 @@ CKey: TypeAlias = str
 CDict: TypeAlias = dict[CKey, Any]
 CDictT = TypeVar("CDictT", bound=CDict)
 
-Ks = TypeVar("Ks", bound=tuple[CKey, ...])
-Ds = TypeVar("Ds", bound=tuple[str | None, ...])
+Ks = TypeVar("Ks", bound=tuple[CKey, ...], default=tuple[str, ...])
+Ds = TypeVar("Ds", bound=tuple[str | None, ...], default=tuple[str | None, ...])

--- a/src/coordinax/_src/embedded/chart.py
+++ b/src/coordinax/_src/embedded/chart.py
@@ -24,7 +24,9 @@ from coordinax._src.custom_types import CDict, Ds, Ks, OptUSys
 @jax.tree_util.register_static
 @final
 @chart_dataclass_decorator
-class EmbeddedChart(AbstractChart[Ks, Ds], Generic[IntrinsicT, AmbientT, Ks, Ds]):
+class EmbeddedChart(
+    AbstractChart[EmbeddedManifold, Ks, Ds], Generic[IntrinsicT, AmbientT, Ks, Ds]
+):
     r"""Chart for intrinsic coordinates on an embedding manifold.
 
     This is a convenience wrapper that combines an intrinsic chart with an

--- a/src/coordinax/_src/embedded/embedmap.py
+++ b/src/coordinax/_src/embedded/embedmap.py
@@ -12,8 +12,8 @@ import jax
 from coordinax._src.base import AbstractChart
 from coordinax._src.custom_types import CDict, OptUSys
 
-IntrinsicT = TypeVar("IntrinsicT", bound=AbstractChart[Any, Any])
-AmbientT = TypeVar("AmbientT", bound=AbstractChart[Any, Any])
+IntrinsicT = TypeVar("IntrinsicT", bound=AbstractChart[Any, Any, Any])
+AmbientT = TypeVar("AmbientT", bound=AbstractChart[Any, Any, Any])
 
 
 @jax.tree_util.register_static

--- a/src/coordinax/_src/embedded/manifold.py
+++ b/src/coordinax/_src/embedded/manifold.py
@@ -65,8 +65,8 @@ class EmbeddedManifold(AbstractManifold, Generic[IntrinsicT, AmbientT]):
     def embed(
         self,
         intrinsic_point: CDict,
-        from_intrinsic_chart: AbstractChart[Any, Any],
-        to_ambient_chart: AbstractChart[Any, Any],
+        from_intrinsic_chart: AbstractChart[Any, Any, Any],
+        to_ambient_chart: AbstractChart[Any, Any, Any],
         /,
         *,
         usys: OptUSys = None,
@@ -79,8 +79,8 @@ class EmbeddedManifold(AbstractManifold, Generic[IntrinsicT, AmbientT]):
     def project(
         self,
         ambient_point: CDict,
-        from_ambient_chart: AbstractChart[Any, Any],
-        to_intrinsic_chart: AbstractChart[Any, Any],
+        from_ambient_chart: AbstractChart[Any, Any, Any],
+        to_intrinsic_chart: AbstractChart[Any, Any, Any],
         /,
         *,
         usys: OptUSys = None,

--- a/src/coordinax/_src/euclidean/atlas.py
+++ b/src/coordinax/_src/euclidean/atlas.py
@@ -13,11 +13,11 @@ import coordinax.charts as cxc
 from coordinax._src.base import AbstractAtlas, AbstractChart
 from coordinax._src.exceptions import NoGlobalCartesianChartError
 
-CT = TypeVar("CT", bound=type[AbstractChart[Any, Any]])
+CT = TypeVar("CT", bound=type[AbstractChart[Any, Any, Any]])
 
-EUCLIDEAN_ATLAS_DEFAULT_CHARTS: Final[dict[int, AbstractChart[Any, Any]]] = {}
+EUCLIDEAN_ATLAS_DEFAULT_CHARTS: Final[dict[int, AbstractChart[Any, Any, Any]]] = {}
 
-EUCLIDEAN_ATLAS_ELIGIBLE_CHARTS: weakref.WeakSet[type[AbstractChart[Any, Any]]] = (
+EUCLIDEAN_ATLAS_ELIGIBLE_CHARTS: weakref.WeakSet[type[AbstractChart[Any, Any, Any]]] = (
     weakref.WeakSet()
 )
 
@@ -125,7 +125,7 @@ class EuclideanAtlas(AbstractAtlas):
     ndim: int
     """Dimension of the Euclidean manifold."""
 
-    def default_chart(self) -> AbstractChart[Any, Any]:
+    def default_chart(self) -> AbstractChart[Any, Any, Any]:
         """Return the default chart for this atlas.
 
         Examples
@@ -153,7 +153,7 @@ class EuclideanAtlas(AbstractAtlas):
         """
         return EUCLIDEAN_ATLAS_DEFAULT_CHARTS.get(self.ndim, cxc.cartnd)
 
-    def has_chart(self, chart: AbstractChart[Any, Any], /) -> bool:
+    def has_chart(self, chart: AbstractChart[Any, Any, Any], /) -> bool:
         """Return whether the atlas supports the given chart.
 
         This checks if the chart has the same dimension as the atlas and is

--- a/src/coordinax/_src/minkowski/atlas.py
+++ b/src/coordinax/_src/minkowski/atlas.py
@@ -11,7 +11,7 @@ import jax
 import coordinax.charts as cxc
 from coordinax._src.base import AbstractAtlas
 
-CT = TypeVar("CT", bound=type[cxc.AbstractChart[Any, Any]])
+CT = TypeVar("CT", bound=type[cxc.AbstractChart[Any, Any, Any]])
 
 
 @jax.tree_util.register_static
@@ -62,9 +62,9 @@ class MinkowskiAtlas(AbstractAtlas):
     ndim: int = 4
     """Dimension of Minkowski spacetime (always 4)."""
 
-    _ELIGIBLE_CHARTS: ClassVar[set[type[cxc.AbstractChart[Any, Any]]]] = set()
+    _ELIGIBLE_CHARTS: ClassVar[set[type[cxc.AbstractChart[Any, Any, Any]]]] = set()
 
-    def default_chart(self) -> cxc.AbstractChart[Any, Any]:
+    def default_chart(self) -> cxc.AbstractChart[Any, Any, Any]:
         """Return the default chart (canonical ``MinkowskiCT``).
 
         Examples
@@ -76,7 +76,7 @@ class MinkowskiAtlas(AbstractAtlas):
         """
         return cxc.minkowskict
 
-    def has_chart(self, chart: cxc.AbstractChart[Any, Any], /) -> bool:
+    def has_chart(self, chart: cxc.AbstractChart[Any, Any, Any], /) -> bool:
         """Return whether the chart belongs to this atlas.
 
         A chart belongs when its dimensionality is 4 and its class is

--- a/src/coordinax/_src/minkowski/charts.py
+++ b/src/coordinax/_src/minkowski/charts.py
@@ -14,7 +14,6 @@ from .atlas import MinkowskiAtlas
 from .manifold import MinkowskiManifold
 from coordinax._src.base import (
     AbstractFixedComponentsChart,
-    AbstractManifold,
     chart_dataclass_decorator,
 )
 from coordinax._src.charts.d4 import Abstract4D
@@ -31,7 +30,8 @@ _WRONG_M_MSG = "MinkowskiCT chart must belong to a MinkowskiManifold, got {typen
 @final
 @chart_dataclass_decorator
 class MinkowskiCT(
-    Abstract4D, AbstractFixedComponentsChart[MinkowskiCTKeys, MinkowskiCTDims]
+    Abstract4D,
+    AbstractFixedComponentsChart[MinkowskiManifold, MinkowskiCTKeys, MinkowskiCTDims],
 ):
     r"""4D Minkowski spacetime chart $(ct, x, y, z)$.
 
@@ -67,7 +67,7 @@ class MinkowskiCT(
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = dataclasses.field(default_factory=MinkowskiManifold)
+    M: MinkowskiManifold = MinkowskiManifold()
 
     def __post_init__(self) -> None:
         """Validate that M is compatible with this chart."""

--- a/src/coordinax/_src/product/chart.py
+++ b/src/coordinax/_src/product/chart.py
@@ -30,7 +30,7 @@ from coordinax._src.custom_types import CDict, Ds, Ks, OptUSys
 V = TypeVar("V")
 
 
-class AbstractCartesianProductChart(AbstractChart[Ks, Ds]):
+class AbstractCartesianProductChart(AbstractChart[CartesianProductManifold, Ks, Ds]):
     """Abstract base class for Cartesian product charts.
 
     A Cartesian product chart is defined by a finite ordered tuple of factor
@@ -56,7 +56,7 @@ class AbstractCartesianProductChart(AbstractChart[Ks, Ds]):
     - `components` must follow the key convention above
     """
 
-    factors: tuple["AbstractChart[Any, Any]", ...]
+    factors: tuple["AbstractChart[Any, Any, Any]", ...]
     """Ordered tuple of factor charts."""
 
     factor_names: tuple[str, ...]
@@ -316,7 +316,7 @@ class CartesianProductChart(AbstractCartesianProductChart[Ks, Ds]):
 
     """
 
-    factors: tuple[AbstractChart[Any, Any], ...]
+    factors: tuple[AbstractChart[Any, Any, Any], ...]
     """Ordered tuple of factor charts."""
 
     factor_names: tuple[str, ...]
@@ -360,11 +360,11 @@ class CartesianProductChart(AbstractCartesianProductChart[Ks, Ds]):
         cart_factors = tuple(cxcapi.cartesian_chart(f) for f in self.factors)
         # Check if already cartesian
         if cart_factors == self.factors:
-            return self
+            return self  # ty: ignore[invalid-return-type]
         cart_factors = cast("tuple[AbstractChart, ...]", cart_factors)
         return CartesianProductChart(cart_factors, self.factor_names)
 
-    def __getitem__(self, idx: str) -> AbstractChart[Any, Any]:
+    def __getitem__(self, idx: str) -> AbstractChart[Any, Any, Any]:
         """Allow indexing to access factor charts.
 
         Examples

--- a/src/coordinax/_src/product/galilean_ct.py
+++ b/src/coordinax/_src/product/galilean_ct.py
@@ -87,7 +87,7 @@ class GalileanCT(AbstractFlatCartesianProductChart[Ks, Ds]):
 
     """
 
-    spatial_chart: AbstractFixedComponentsChart[Any, Any] = field(default=cart3d)  # pylint: disable=invalid-field-call
+    spatial_chart: AbstractFixedComponentsChart[Any, Any, Any] = field(default=cart3d)  # pylint: disable=invalid-field-call
     """Spatial part of the representation. Defaults: `coordinax.charts.cart3d`."""
 
     _: KW_ONLY
@@ -105,13 +105,13 @@ class GalileanCT(AbstractFlatCartesianProductChart[Ks, Ds]):
     # Product Chart API
 
     @property
-    def time_chart(self) -> AbstractChart[Any, Any]:
+    def time_chart(self) -> AbstractChart[Any, Any, Any]:
         """Time factor chart (always `time1d`)."""
         return time1d
 
     @override
     @property
-    def factors(self) -> tuple[AbstractChart[Any, Any], ...]:
+    def factors(self) -> tuple[AbstractChart[Any, Any, Any], ...]:
         """Return (time1d, spatial_chart) as required by product chart spec."""
         return (self.time_chart, self.spatial_chart)
 
@@ -155,7 +155,7 @@ class GalileanCT(AbstractFlatCartesianProductChart[Ks, Ds]):
 
     @override
     @property
-    def cartesian(self) -> "GalileanCT":
+    def cartesian(self) -> "GalileanCT[Any, Any]":
         """Get a Cartesian-chart version of the given spacetime chart.
 
         Examples

--- a/src/coordinax/_src/spherical/atlas.py
+++ b/src/coordinax/_src/spherical/atlas.py
@@ -11,12 +11,12 @@ import jax
 
 from coordinax._src.base import AbstractAtlas, AbstractChart
 
-CT = TypeVar("CT", bound=type[AbstractChart[Any, Any]])
+CT = TypeVar("CT", bound=type[AbstractChart[Any, Any, Any]])
 
 
-SPHERICAL_ATLAS_DEFAULT_CHARTS: Final[dict[int, AbstractChart[Any, Any]]] = {}
+SPHERICAL_ATLAS_DEFAULT_CHARTS: Final[dict[int, AbstractChart[Any, Any, Any]]] = {}
 SPHERICAL_ATLAS_ELIGIBLE_CHARTS: Final[
-    weakref.WeakSet[type[AbstractChart[Any, Any]]]
+    weakref.WeakSet[type[AbstractChart[Any, Any, Any]]]
 ] = weakref.WeakSet()
 
 
@@ -59,11 +59,11 @@ class HyperSphericalAtlas(AbstractAtlas):
     ndim: int = 2
     """Dimension of the two-sphere."""
 
-    def default_chart(self) -> AbstractChart[Any, Any]:
+    def default_chart(self) -> AbstractChart[Any, Any, Any]:
         """Return the default chart (SphericalTwoSphere) for this atlas."""
         return SPHERICAL_ATLAS_DEFAULT_CHARTS[self.ndim]
 
-    def has_chart(self, chart: AbstractChart[Any, Any], /) -> bool:
+    def has_chart(self, chart: AbstractChart[Any, Any, Any], /) -> bool:
         """Return whether the atlas supports the given chart.
 
         Examples

--- a/src/coordinax/_src/spherical/chart.py
+++ b/src/coordinax/_src/spherical/chart.py
@@ -22,15 +22,15 @@ __all__ = (
 
 import dataclasses
 
-from typing import Any, Final, Literal as L, NoReturn, final  # noqa: N817
-from typing_extensions import override
+from typing import Any, Final, Literal as L, NoReturn  # noqa: N817
+from typing_extensions import TypeVar, override
 
 import jax.tree_util as jtu
 
 import unxt as u
 
 from .atlas import SPHERICAL_ATLAS_DEFAULT_CHARTS, HyperSphericalAtlas
-from .manifold import S1, S2
+from .manifold import S1, S2, Sn
 from coordinax._src.base import (
     AbstractFixedComponentsChart,
     AbstractManifold,
@@ -43,13 +43,15 @@ from coordinax._src.constants import Deg0, Deg90, Deg180
 from coordinax._src.custom_types import Ang, CDictT, Ds, Ks
 from coordinax._src.exceptions import NoGlobalCartesianChartError
 
+MT = TypeVar("MT", bound=AbstractManifold, default=Sn)
+
 _MSG_NO_CART: Final = (
     "{cls} has no global Cartesian representation. Use an embedding "
     "via EmbeddedChart or a specific local projection if/when provided."
 )
 
 
-class AbstractSphericalHyperSphere(AbstractFixedComponentsChart[Ks, Ds]):
+class AbstractSphericalHyperSphere(AbstractFixedComponentsChart[MT, Ks, Ds]):
     r"""Abstract base class for intrinsic charts on the unit hypersphere.
 
     All hypersphere charts represent coordinates on the surface of a unit
@@ -97,7 +99,7 @@ class AbstractSphericalHyperSphere(AbstractFixedComponentsChart[Ks, Ds]):
 # Base class for all circle charts
 
 
-class AbstractSphericalOneSphere(AbstractSphericalHyperSphere[Ks, Ds], Abstract1D):
+class AbstractSphericalOneSphere(AbstractSphericalHyperSphere[MT, Ks, Ds], Abstract1D):
     r"""Abstract base class for intrinsic charts on the unit circle.
 
     All circle charts represent coordinates on the surface of a unit circle.
@@ -120,10 +122,9 @@ CircularOneSphereDims = tuple[Ang]
 
 @HyperSphericalAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
 class CircularOneSphere(
-    AbstractSphericalOneSphere[CircularOneSphereKeys, CircularOneSphereDims]
+    AbstractSphericalOneSphere[MT, CircularOneSphereKeys, CircularOneSphereDims]
 ):
     """Standard circular coordinates on the unit circle.
 
@@ -149,7 +150,7 @@ class CircularOneSphere(
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = S1
+    M: MT = S1  # ty: ignore[invalid-assignment]
 
 
 sph1: Final = CircularOneSphere()
@@ -162,7 +163,7 @@ SPHERICAL_ATLAS_DEFAULT_CHARTS[1] = sph1
 
 
 @chart_dataclass_decorator
-class AbstractSphericalTwoSphere(AbstractSphericalHyperSphere[Ks, Ds], Abstract2D):
+class AbstractSphericalTwoSphere(AbstractSphericalHyperSphere[MT, Ks, Ds], Abstract2D):
     r"""Abstract base class for intrinsic charts on the unit two-sphere.
 
     All 2-sphere charts represent coordinates on the surface of a unit sphere.
@@ -185,7 +186,7 @@ class AbstractSphericalTwoSphere(AbstractSphericalHyperSphere[Ks, Ds], Abstract2
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = S2
+    M: MT = S2  # ty: ignore[invalid-assignment]
 
 
 # ===============================================================================
@@ -198,10 +199,9 @@ SphericalTwoSphereDims = tuple[Ang, Ang]
 
 @HyperSphericalAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
 class SphericalTwoSphere(
-    AbstractSphericalTwoSphere[SphericalTwoSphereKeys, SphericalTwoSphereDims],
+    AbstractSphericalTwoSphere[MT, SphericalTwoSphereKeys, SphericalTwoSphereDims],
 ):
     r"""Intrinsic chart on the unit two-sphere with components ``(theta, phi)``.
 
@@ -235,7 +235,7 @@ class SphericalTwoSphere(
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = S2
+    M: MT = S2  # ty: ignore[invalid-assignment]
 
     def check_data(self, data: CDictT, /, *, values: bool = False, **kw: Any) -> CDictT:
         # call base check
@@ -259,11 +259,10 @@ LonLatSphericalTwoSphereDims = tuple[Ang, Ang]
 
 @HyperSphericalAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
 class LonLatSphericalTwoSphere(
     AbstractSphericalTwoSphere[
-        LonLatSphericalTwoSphereKeys, LonLatSphericalTwoSphereDims
+        MT, LonLatSphericalTwoSphereKeys, LonLatSphericalTwoSphereDims
     ]
 ):
     r"""Longitude-latitude chart on the two-sphere.
@@ -289,7 +288,7 @@ class LonLatSphericalTwoSphere(
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = S2
+    M: MT = S2  # ty: ignore[invalid-assignment]
 
     def check_data(self, data: CDictT, /, *, values: bool = False, **kw: Any) -> CDictT:
         super().check_data(data, **kw)
@@ -311,11 +310,10 @@ LonCosLatSphericalTwoSphereDims = tuple[Ang, Ang]
 
 @HyperSphericalAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
 class LonCosLatSphericalTwoSphere(
     AbstractSphericalTwoSphere[
-        LonCosLatSphericalTwoSphereKeys, LonCosLatSphericalTwoSphereDims
+        MT, LonCosLatSphericalTwoSphereKeys, LonCosLatSphericalTwoSphereDims
     ]
 ):
     r"""Longitude-cos(latitude) chart on the two-sphere.
@@ -337,7 +335,7 @@ class LonCosLatSphericalTwoSphere(
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = S2
+    M: MT = S2  # ty: ignore[invalid-assignment]
 
     def check_data(self, data: CDictT, /, *, values: bool = False, **kw: Any) -> CDictT:
         super().check_data(data, **kw)
@@ -346,7 +344,7 @@ class LonCosLatSphericalTwoSphere(
         return data
 
 
-loncoslat_sph2: Final = LonCosLatSphericalTwoSphere()
+loncoslat_sph2: Final = LonCosLatSphericalTwoSphere(M=S2)
 """Longitude-cos(latitude) spherical coordinates on the two-sphere."""
 
 # ===============================================================================
@@ -357,10 +355,9 @@ MathSphericalTwoSphereKeys = tuple[L["theta"], L["phi"]]
 
 @HyperSphericalAtlas.register
 @jtu.register_static
-@final
 @chart_dataclass_decorator
 class MathSphericalTwoSphere(
-    AbstractSphericalTwoSphere[MathSphericalTwoSphereKeys, SphericalTwoSphereDims]
+    AbstractSphericalTwoSphere[MT, MathSphericalTwoSphereKeys, SphericalTwoSphereDims]
 ):
     r"""Math-convention chart on the two-sphere.
 
@@ -384,7 +381,7 @@ class MathSphericalTwoSphere(
     """
 
     _: dataclasses.KW_ONLY
-    M: AbstractManifold = S2
+    M: MT = S2  # ty: ignore[invalid-assignment]
 
     def check_data(self, data: CDictT, /, *, values: bool = False, **kw: Any) -> CDictT:
         super().check_data(data, **kw)
@@ -393,5 +390,5 @@ class MathSphericalTwoSphere(
         return data
 
 
-math_sph2: Final = MathSphericalTwoSphere()
+math_sph2: Final = MathSphericalTwoSphere(M=S2)
 """Standard spherical coordinates on the two-sphere with mathematics convention."""

--- a/src/coordinax/_src/spherical/embed.py
+++ b/src/coordinax/_src/spherical/embed.py
@@ -88,12 +88,12 @@ class TwoSphereIn3D(AbstractEmbeddingMap[IntrinsicT, AmbientT]):
     radius: u.AbstractQuantity | float | int = dataclasses.field()
 
     @property
-    def intrinsic(self) -> cxc.AbstractChart[Any, Any]:
+    def intrinsic(self) -> cxc.AbstractChart[Any, Any, Any]:
         """The intrinsic chart is always `coordinax.charts.SphericalTwoSphere`."""
         return cxc.sph2
 
     @property
-    def ambient(self) -> cxc.AbstractChart[Any, Any]:
+    def ambient(self) -> cxc.AbstractChart[Any, Any, Any]:
         """The ambient chart is always `coordinax.charts.Spherical3D`."""
         return cxc.sph3d
 
@@ -110,7 +110,7 @@ class TwoSphereIn3D(AbstractEmbeddingMap[IntrinsicT, AmbientT]):
 
 def embedded_twosphere(
     radius: float | u.AbstractQuantity,
-    ambient: cxc.AbstractChart[Any, Any] = cxc.sph3d,
+    ambient: cxc.AbstractChart[Any, Any, Any] = cxc.sph3d,
 ) -> EmbeddedManifold:
     """Create an `coordinax.manifolds.EmbeddedManifold` for the two-sphere.
 

--- a/src/coordinax/_src/spherical/register_ptmap.py
+++ b/src/coordinax/_src/spherical/register_ptmap.py
@@ -22,7 +22,7 @@ from coordinax._src.base import AbstractChart
 from coordinax._src.custom_types import CDict, OptUSys
 from coordinax._src.utils import uconvert_to_rad
 
-IDENTITY_TRANSFORM_CHARTS: Final[tuple[type[AbstractChart[Any, Any]], ...]] = (
+IDENTITY_TRANSFORM_CHARTS: Final[tuple[type[AbstractChart[Any, Any, Any]], ...]] = (
     SphericalTwoSphere,
     LonLatSphericalTwoSphere,
     LonCosLatSphericalTwoSphere,

--- a/src/coordinax/representations/_src/semantics.py
+++ b/src/coordinax/representations/_src/semantics.py
@@ -113,7 +113,7 @@ class AbstractSemanticKind(metaclass=abc.ABCMeta):
     @classmethod
     @abc.abstractmethod
     def coord_dimensions(
-        cls, chart: cxc.AbstractChart[Any, Any], /
+        cls, chart: cxc.AbstractChart[Any, Any, Any], /
     ) -> tuple[u.AbstractDimension | None, ...]:
         """Return the physical dimensions of the components for this semantic kind.
 
@@ -259,7 +259,7 @@ class Location(AbstractSemanticKind):
     @classmethod
     @ft.cache
     def coord_dimensions(
-        cls, chart: cxc.AbstractChart[Any, Any], /
+        cls, chart: cxc.AbstractChart[Any, Any, Any], /
     ) -> tuple[u.AbstractDimension | None, ...]:
         """Return the physical dimensions of each component for a location.
 
@@ -385,7 +385,7 @@ class AbstractTangentSemanticKind(AbstractSemanticKind):
     @classmethod
     @ft.cache
     def coord_dimensions(
-        cls, chart: cxc.AbstractChart[Any, Any], /
+        cls, chart: cxc.AbstractChart[Any, Any, Any], /
     ) -> tuple[u.AbstractDimension | None, ...]:
         """Return the physical dimensions of each component for this tangent kind.
 

--- a/src/coordinax/transforms/_src/actions/reflect.py
+++ b/src/coordinax/transforms/_src/actions/reflect.py
@@ -112,14 +112,14 @@ class Reflect(AbstractTransform):
 
     @staticmethod
     def _validate_shape_match(
-        H: HMatrix, cart: cxc.AbstractChart[Any, Any], /
+        H: HMatrix, cart: cxc.AbstractChart[Any, Any, Any], /
     ) -> HMatrix:
         n = H.shape[0]
         if cart.ndim != n or len(cart.components) != n:
             raise ValueError(_MSG_H_X_SHAPE_MISMATCH.format(H=H, cart=cart))
         return H
 
-    def _get_H(self, cart: cxc.AbstractChart[Any, Any], /) -> HMatrix:
+    def _get_H(self, cart: cxc.AbstractChart[Any, Any, Any], /) -> HMatrix:
         H = self._validate_square(self.H)
         return self._validate_shape_match(H, cart)
 
@@ -274,7 +274,10 @@ def act(
     }
 
     def _maybe(
-        factor_chart: cxc.AbstractChart[Any, Any], part: CDict, /, **ats: CDict | None
+        factor_chart: cxc.AbstractChart[Any, Any, Any],
+        part: CDict,
+        /,
+        **ats: CDict | None,
     ) -> CDict:
         cart = factor_chart.cartesian
         if cart.ndim != n or len(cart.components) != n:

--- a/src/coordinax/transforms/_src/actions/rotate.py
+++ b/src/coordinax/transforms/_src/actions/rotate.py
@@ -235,7 +235,7 @@ class Rotate(AbstractTransform):
 
     @staticmethod
     def _validate_shape_match(
-        R: HasShape, cart: cxc.AbstractChart[Any, Any], /
+        R: HasShape, cart: cxc.AbstractChart[Any, Any, Any], /
     ) -> RMatrix:
         n = R.shape[0]
         return eqx.error_if(
@@ -244,7 +244,7 @@ class Rotate(AbstractTransform):
             _MSG_R_X_SHAPE_MISMATCH.format(R=R, cart=cart),
         )
 
-    def _get_R(self, cart: cxc.AbstractChart[Any, Any], /) -> RMatrix:
+    def _get_R(self, cart: cxc.AbstractChart[Any, Any, Any], /) -> RMatrix:
         R = self.R
         R = eqx.error_if(R, callable(R), "need to call `materialize_transform`.")
         R = self._validate_square(R)
@@ -757,7 +757,10 @@ def act(
     }
 
     def _maybe(
-        factor_chart: cxc.AbstractChart[Any, Any], part: CDict, /, **ats: CDict | None
+        factor_chart: cxc.AbstractChart[Any, Any, Any],
+        part: CDict,
+        /,
+        **ats: CDict | None,
     ) -> CDict:
         # Determine if this factor's chart should be rotated.
         cart = factor_chart.cartesian

--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -88,14 +88,14 @@ class Scale(AbstractTransform):
 
     @staticmethod
     def _validate_shape_match(
-        S: SMatrix, cart: cxc.AbstractChart[Any, Any], /
+        S: SMatrix, cart: cxc.AbstractChart[Any, Any, Any], /
     ) -> SMatrix:
         n = S.shape[0]
         if cart.ndim != n or len(cart.components) != n:
             raise ValueError(_MSG_S_X_SHAPE_MISMATCH.format(S=S, cart=cart))
         return S
 
-    def _get_S(self, cart: cxc.AbstractChart[Any, Any], /) -> SMatrix:
+    def _get_S(self, cart: cxc.AbstractChart[Any, Any, Any], /) -> SMatrix:
         S = self._validate_square(self.S)
         return self._validate_shape_match(S, cart)
 
@@ -250,7 +250,10 @@ def act(
     }
 
     def _maybe(
-        factor_chart: cxc.AbstractChart[Any, Any], part: CDict, /, **ats: CDict | None
+        factor_chart: cxc.AbstractChart[Any, Any, Any],
+        part: CDict,
+        /,
+        **ats: CDict | None,
     ) -> CDict:
         cart = factor_chart.cartesian
         if cart.ndim != n or len(cart.components) != n:

--- a/src/coordinax/transforms/_src/actions/shear.py
+++ b/src/coordinax/transforms/_src/actions/shear.py
@@ -75,14 +75,14 @@ class Shear(AbstractTransform):
 
     @staticmethod
     def _validate_shape_match(
-        H: HMatrix, cart: cxc.AbstractChart[Any, Any], /
+        H: HMatrix, cart: cxc.AbstractChart[Any, Any, Any], /
     ) -> HMatrix:
         n = H.shape[0]
         if cart.ndim != n or len(cart.components) != n:
             raise ValueError(_MSG_H_X_SHAPE_MISMATCH.format(H=H, cart=cart))
         return H
 
-    def _get_H(self, cart: cxc.AbstractChart[Any, Any], /) -> HMatrix:
+    def _get_H(self, cart: cxc.AbstractChart[Any, Any, Any], /) -> HMatrix:
         H = self._validate_square(self.H)
         return self._validate_shape_match(H, cart)
 
@@ -237,7 +237,10 @@ def act(
     }
 
     def _maybe(
-        factor_chart: cxc.AbstractChart[Any, Any], part: CDict, /, **ats: CDict | None
+        factor_chart: cxc.AbstractChart[Any, Any, Any],
+        part: CDict,
+        /,
+        **ats: CDict | None,
     ) -> CDict:
         cart = factor_chart.cartesian
         if cart.ndim != n or len(cart.components) != n:

--- a/src/coordinax/vectors/_src/base.py
+++ b/src/coordinax/vectors/_src/base.py
@@ -34,7 +34,9 @@ if TYPE_CHECKING:
 Ks = TypeVar("Ks", bound=tuple[str, ...])
 Ds = TypeVar("Ds", bound=tuple[str | None, ...])
 ChartT = TypeVar(
-    "ChartT", bound=cxc.AbstractChart[Any, Any], default=cxc.AbstractChart[Any, Any]
+    "ChartT",
+    bound=cxc.AbstractChart[Any, Any, Any],
+    default=cxc.AbstractChart[Any, Any, Any],
 )
 GeomT = TypeVar("GeomT", bound=cxr.AbstractGeometry, default=cxr.AbstractGeometry)
 BasisT = TypeVar("BasisT", bound=cxr.AbstractBasis, default=cxr.AbstractBasis)

--- a/src/coordinax/vectors/_src/bundle.py
+++ b/src/coordinax/vectors/_src/bundle.py
@@ -31,7 +31,9 @@ from .tangent import Tangent, _vectorform_pdoc as _vec_vectorform_pdoc
 from coordinax.internal import OptUSys
 
 ChartT = TypeVar(
-    "ChartT", bound=cxc.AbstractChart[Any, Any], default=cxc.AbstractChart[Any, Any]
+    "ChartT",
+    bound=cxc.AbstractChart[Any, Any, Any],
+    default=cxc.AbstractChart[Any, Any, Any],
 )
 
 

--- a/src/coordinax/vectors/_src/point.py
+++ b/src/coordinax/vectors/_src/point.py
@@ -32,7 +32,9 @@ if TYPE_CHECKING:
     from .custom_types import CDict
 
 ChartT = TypeVar(
-    "ChartT", bound=cxc.AbstractChart[Any, Any], default=cxc.AbstractChart[Any, Any]
+    "ChartT",
+    bound=cxc.AbstractChart[Any, Any, Any],
+    default=cxc.AbstractChart[Any, Any, Any],
 )
 GeomT = TypeVar("GeomT", bound=cxr.AbstractGeometry, default=cxr.AbstractGeometry)
 BasisT = TypeVar("BasisT", bound=cxr.AbstractBasis, default=cxr.AbstractBasis)

--- a/src/coordinax/vectors/_src/tangent.py
+++ b/src/coordinax/vectors/_src/tangent.py
@@ -31,7 +31,9 @@ if TYPE_CHECKING:
     from coordinax.internal import CDict
 
 ChartT = TypeVar(
-    "ChartT", bound=cxc.AbstractChart[Any, Any], default=cxc.AbstractChart[Any, Any]
+    "ChartT",
+    bound=cxc.AbstractChart[Any, Any, Any],
+    default=cxc.AbstractChart[Any, Any, Any],
 )
 BasisT = TypeVar(
     "BasisT", bound=cxr.AbstractLinearBasis, default=cxr.AbstractLinearBasis


### PR DESCRIPTION
AbstractChart[MT, Ks, Ds] now carries its manifold type as the first generic parameter, enabling callers to express chart-manifold relationships in the type system.  AbstractFixedComponentsChart __init_subclass__ updated to expect 3 args (MT, Ks, Ds).  All concrete chart subclasses, atlases, vectors, transforms, and hypothesis helpers updated to the new three-parameter form.  TypeVar-bound defaults (M: MT = R3/S2) suppressed with type: ignore[assignment] where the type system cannot express the intent.