### PR TITLE
✨ feat: kinematic prolongation for act; Galactocentric velocities & Galactic frame

### DIFF
--- a/docs/api/transforms.md
+++ b/docs/api/transforms.md
@@ -26,10 +26,14 @@ out = cxfm.act(frame_op, None, v)
 
 ## Functional API
 
-- `act(transform, tau, x)`: apply a transform to data
+- `act(transform, tau, x)`: apply a transform to data (the kinematic prolongation for tangent data)
+- `pushforward(transform, tau, v, chart, rep, *, at)`: frozen-`tau` spatial differential (the law for `Displacement` data)
+- `prolong(transform, tau, jet, chart)`: joint kinematic prolongation of a jet `{0: q, 1: v, 2: a, ...}`
 - `simplify(transform)`: simplify transform structure
 - `compose(*transforms)`: compose transforms into `Composed`
 - `materialize_transform(transform, tau)`: materialize time-dependent transform parameters
+- `is_time_dependent(transform)`: whether any transform parameter is a callable of `tau`
+- `tau_derivative(f, tau, n=)`: unit-aware `n`-th derivative of a callable parameter
 
 ## Transform Types
 

--- a/docs/guides/transforms.md
+++ b/docs/guides/transforms.md
@@ -328,7 +328,33 @@ v_test = cxv.Point.from_([1, 0, 0], "km")
 v_combined = combined(tau_5s, v_test)
 ```
 
-When `act` encounters a `Composed` transform, it calls `materialize_transform` on each primitive with the same `tau` before applying it. Callable and static parts mix freely.
+When `act` encounters a `Composed` transform, each primitive is applied at the same `tau`; for tangent data the anchors (base point and velocity) are advanced between the steps so the chain rule is respected. Callable and static parts mix freely.
+
+## Time Dependence Couples the Ladder: Kinematic Prolongation
+
+Materialise-then-apply is the whole story only for **point** data. For tangent data (velocities, accelerations), `act` computes the **kinematic prolongation** of the transform's point action $\phi(\tau, x)$: if the transformed curve is $x'(\tau) = \phi(\tau, x(\tau))$, then
+
+$$
+v' = \partial_\tau \phi + \partial_x \phi \cdot v, \qquad
+a' = \partial_{\tau\tau} \phi + 2\,\partial_\tau \partial_x \phi \cdot v
+   + \partial_{xx}\phi(v, v) + \partial_x \phi \cdot a .
+$$
+
+Concretely:
+
+- a time-dependent `Translate` with offset $\delta(\tau)$ shifts velocities by $\dot\delta(\tau)$ and accelerations by $\ddot\delta(\tau)$;
+- a time-dependent `Rotate` $R(\tau)$ gives $v' = R v + \dot R\,x$ and the full Coriolis/centrifugal acceleration law;
+- `Boost` is the Galilean boost: points move by $\Delta v\,\tau$ (a time is **required** for point data), velocities shift by $\Delta v$. The fibre-only velocity kick that leaves points fixed is `Translate(..., semantic_kind=cxr.vel)`.
+
+Because the $\dot R\,x$-style terms depend on the base point, acting a time-dependent transform on a _lone_ velocity or acceleration requires the anchor keywords `at=` (and `at_vel=` for accelerations) — or act on a `Coordinate` bundle, which supplies the whole jet automatically.
+
+Three related verbs are exposed:
+
+- `act(op, tau, x, ...)` — order-$m$ tangent data transforms by the $m$-th prolongation above;
+- `pushforward(op, tau, v, chart, rep, at=...)` — the frozen-$\tau$ spatial differential $\partial_x\phi\cdot v$; this is the transformation law for `Displacement` data (a same-$\tau$ point difference never gains $\partial_\tau$ terms);
+- `prolong(op, tau, jet, chart)` — transform a whole jet `{0: q, 1: v, 2: a, ...}` jointly (what `Coordinate` bundles use).
+
+Helpers: `is_time_dependent(op)` tests for callable parameters, and `tau_derivative(f, tau, n=...)` takes unit-aware $\tau$-derivatives of a callable parameter.
 
 ## Quick Reference
 
@@ -343,5 +369,8 @@ When `act` encounters a `Composed` transform, it calls `materialize_transform` o
 | Invert | `op.inverse` |
 | Simplify | `op.simplify()` or `cxfm.simplify(op)` |
 | Time-dependent rotation | `cxfm.Rotate(callable_returning_matrix)` |
+| Act on a lone velocity (TD op) | `cxfm.act(op, tau, v, chart, rep, at=base_point)` |
+| Pushforward a displacement | `cxfm.pushforward(op, tau, d, chart, rep, at=...)` |
+| Prolong a jet | `cxfm.prolong(op, tau, {0: q, 1: v}, chart)` |
 | Time-dependent translation | `cxfm.Translate(callable_returning_dict, chart=...)` |
 | Materialise at time | `cxfm.materialize_transform(op, tau)` |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4569,16 +4569,33 @@ Each group corresponds to a set of transformations preserving a particular geome
 
     **Kinematic prolongation (ladder rule):** acting on tangent data of ladder
     order $m$, an order-$k$ Translate contributes $d^{m-k} a / d\tau^{m-k}$
-    for $m \ge k$ and is the identity for $m < k$. In particular:
+    for $m \ge k$ and is the identity for $m < k$.
+
+    For a $k=0$ offset the componentwise ladder rule holds when `delta` is
+    expressed in a **Cartesian-type (flat) chart**, where the point action is
+    a true translation of the ambient space (Jacobian = identity, no
+    base-point dependence). In that case:
 
     - a *static* $k=0$ Translate leaves displacements, velocities, and
       accelerations unchanged;
     - a *time-dependent* $k=0$ Translate additionally shifts velocities by
       $\dot a(\tau)$ and accelerations by $\ddot a(\tau)$ (the kinematic
       prolongation of the point action);
-    - `Displacement` data ($m=0$) is always unchanged — a displacement is a
-      same-$\tau$ point difference and the Jacobian of a translation is the
-      identity.
+    - `Displacement` data ($m=0$) is unchanged — a displacement is a
+      same-$\tau$ point difference and the Jacobian of a flat translation is
+      the identity.
+
+    A $k=0$ offset expressed in a **non-flat chart** is *not* a translation:
+    the point action pushes `delta` through the chart Jacobian at the point,
+    so it is base-point dependent. Tangent data (including displacements)
+    then transforms by the generic pushforward/prolongation of that point
+    action — which is generally not the identity, requires the base point
+    (``at=``, or a `~coordinax.Coordinate` bundle), and is computed by
+    autodiff rather than the componentwise rule.
+
+    Fibre-only offsets ($k \ge 1$) act componentwise in their own chart by
+    definition (their point action is the identity), independent of chart
+    flatness.
 
     **Fields:**
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2164,7 +2164,7 @@ Separating semantics from geometry provides two advantages:
     Abstract marker base class for semantic kinds of tangent vectors.
 
     - All tangent-vector semantic kinds (Displacement, Velocity, Acceleration) share the same Jacobian transformation law.
-    - Semantic kind is used for role-aware dispatch in frame transformations (e.g. `Boost` acts on `Velocity`, is identity on `Displacement`).
+    - Semantic kind is used for role-aware dispatch in frame transformations (e.g. a velocity kick `Translate(semantic_kind=vel)` acts on `Velocity` and is identity on `Displacement`).
 
     **`order` class variable** (`ClassVar[int]`):
 
@@ -4545,11 +4545,15 @@ Each group corresponds to a set of transformations preserving a particular geome
 
 !!! info `Translate`
 
-    A **Translate** is a transformation that adds a constant displacement to position components while leaving other representations unchanged.
+    A **Translate** is a transformation that adds an offset on the
+    time-derivative (semantic-kind) ladder. By default the offset is a
+    displacement (`semantic_kind=dpl`, ladder order $k=0$) that shifts
+    positions; with `semantic_kind=vel` ($k=1$) it is a fibre-only velocity
+    *kick*, and so on up the ladder.
 
     **Mathematical definition**:
 
-    The transform shifts all points by a constant displacement vector:
+    The default ($k=0$) transform shifts all points by a displacement vector:
 
     $$
     F(p) = p + a .
@@ -4557,16 +4561,30 @@ Each group corresponds to a set of transformations preserving a particular geome
 
     In Cartesian coordinates this is $ x’ = x + a .$
 
-    A time-dependent translation replaces the constant $a$ with a smooth curve $a(t)$:
+    A time-dependent translation replaces the constant $a$ with a smooth curve $a(\tau)$:
 
     $$
-    F_t(p) = p + a(t).
+    F_\tau(p) = p + a(\tau).
     $$
+
+    **Kinematic prolongation (ladder rule):** acting on tangent data of ladder
+    order $m$, an order-$k$ Translate contributes $d^{m-k} a / d\tau^{m-k}$
+    for $m \ge k$ and is the identity for $m < k$. In particular:
+
+    - a *static* $k=0$ Translate leaves displacements, velocities, and
+      accelerations unchanged;
+    - a *time-dependent* $k=0$ Translate additionally shifts velocities by
+      $\dot a(\tau)$ and accelerations by $\ddot a(\tau)$ (the kinematic
+      prolongation of the point action);
+    - `Displacement` data ($m=0$) is always unchanged — a displacement is a
+      same-$\tau$ point difference and the Jacobian of a translation is the
+      identity.
 
     **Fields:**
 
-    - `delta : CDict | Callable[[tau], CDict]` — the position offset $\Delta x$. If callable, evaluated at the time parameter `tau`.
+    - `delta : CDict | Callable[[tau], CDict]` — the offset. Its physical dimension follows `semantic_kind` (length for `dpl`, speed for `vel`, ...). If callable, evaluated at the time parameter `tau`.
     - `chart : AbstractChart` — the chart in which `delta` is expressed (static).
+    - `semantic_kind : AbstractTangentSemanticKind` (default `dpl`) — the ladder order $k$ of the offset.
     - `right_add : bool` (default `True`) — whether to compute $x + \Delta x$ (``True``) or $\Delta x + x$ (``False``).
 
     **Inverse:**
@@ -4737,25 +4755,28 @@ Each group corresponds to a set of transformations preserving a particular geome
 
 !!! info `Boost`
 
-    A **Boost** is a Galilean velocity-offset operator. It acts on phase-space data by adding a constant velocity $\Delta v$ to velocity components and leaving all other representations unchanged.
+    A **Boost** is the Galilean boost: the change to a frame moving at constant velocity $\Delta v$.
 
     **Mathematical definition** (in a Cartesian chart):
 
     $$
-    B_{\Delta v} : \dot{x} \mapsto \dot{x} + \Delta v.
+    B_{\Delta v} : (\tau, x) \mapsto (\tau,\, x + \Delta v\,\tau).
     $$
 
-    Positions, displacements, and accelerations are unchanged:
+    Its kinematic prolongation follows: points move by $\Delta v\,\tau$, velocities shift by $\Delta v$, and (for constant $\Delta v$) accelerations and displacements are unchanged:
 
     $$
-    B_{\Delta v}(x) = x, \quad
+    B_{\Delta v}(x) = x + \Delta v\,\tau, \quad
+    B_{\Delta v}(\dot{x}) = \dot{x} + \Delta v, \quad
     B_{\Delta v}(\Delta x) = \Delta x, \quad
     B_{\Delta v}(\ddot{x}) = \ddot{x}.
     $$
 
+    Equivalently, `Boost(dv)` is the time-dependent translation `Translate(delta=lambda tau: dv * tau)`. Contrast with `Translate(semantic_kind=vel)` — a fibre-only velocity *kick* that shifts velocities without moving points.
+
     **Fields:**
 
-    - `delta : CDict | Callable[[tau], CDict]` — the velocity offset $\Delta v$. If callable, evaluated at the time parameter `tau`.
+    - `delta : CDict | Callable[[tau], CDict]` — the boost velocity $\Delta v$. If callable, evaluated at the time parameter `tau` (and the prolongation gains the corresponding derivative terms).
     - `chart : AbstractChart` — the chart in which `delta` is expressed (static).
     - `right_add : bool` (default `True`) — whether to compute $\dot{x} + \Delta v$ (``True``) or $\Delta v + \dot{x}$ (``False``).
 
@@ -4763,10 +4784,10 @@ Each group corresponds to a set of transformations preserving a particular geome
 
     | Representation semantic kind | Effect of `act` |
     |------------------------------|-----------------|
-    | `Point` / `Location`         | identity        |
+    | `Point` / `Location`         | $x \mapsto x + \Delta v\,\tau$ (requires `tau`; `tau=None` raises `TypeError`) |
     | `Displacement`               | identity        |
     | `Velocity`                   | $\dot{x} \mapsto \dot{x} + \Delta v$ |
-    | `Acceleration`               | identity        |
+    | `Acceleration`               | identity (for constant $\Delta v$; gains $\dot{\Delta v}$ if time-dependent) |
 
     **`act` dispatch signature:**
 
@@ -4818,9 +4839,11 @@ Each group corresponds to a set of transformations preserving a particular geome
     >>> cxfm.act(boost, None, v, cxc.cart3d, cxr.coord_vel)
     {'x': Array(3., dtype=float64), 'y': Array(3., dtype=float64), 'z': Array(0., dtype=float64)}
 
+    Points move by ``delta * tau`` (a time parameter is required):
+
     >>> p = {"x": jnp.array(1.0), "y": jnp.array(2.0), "z": jnp.array(3.0)}
-    >>> cxfm.act(boost, None, p, cxc.cart3d, cxr.point)
-    {'x': Array(1., dtype=float64), 'y': Array(2., dtype=float64), 'z': Array(3., dtype=float64)}
+    >>> cxfm.act(boost, jnp.array(2.0), p, cxc.cart3d, cxr.point)
+    {'x': Array(3., dtype=float64), 'y': Array(2., dtype=float64), 'z': Array(3., dtype=float64)}
     ```
 
 </br>
@@ -4862,24 +4885,24 @@ A **reference frame** is an abstract label used to identify a coordinate descrip
     - **Spatial offset** from Alice's origin: $[\,100\,000\ \text{km},\; 10\,000\ \text{km},\; 0\,]$.
     - **Velocity** relative to Alice: $\approx 269\,813\ \text{km\,s}^{-1}$ ($\approx 0.9\,c$) along Alice's $x$-axis.
 
-    Because Bob is non-rotating, the Alice → Bob transformation requires only a spatial `Translate` followed by a Galilean `Boost`. No rotation is needed.
+    Because Bob is non-rotating, the Alice → Bob transformation requires only a spatial `Translate` followed by a velocity kick (`Translate(semantic_kind=vel)` — a fibre-only offset; contrast with `Boost`, the Galilean boost, whose point action moves positions by $\Delta v\,\tau$ and therefore requires a time). No rotation is needed.
 
     **Frame transition table:**
 
     | From → To     | Transform                          |
     |---------------|------------------------------------|
     | `Bob → Bob`   | `Identity()`                       |
-    | `Alice → Bob` | `Translate([100 000, 10 000, 0] km) \| Boost([269 813 212.2, 0, 0] m/s)` |
-    | `Bob → Alice` | inverse of Alice → Bob: `Boost([−269 813 212.2, 0, 0] m/s) \| Translate([−100 000, −10 000, 0] km)` |
+    | `Alice → Bob` | `Translate([100 000, 10 000, 0] km) \| Translate([269 813 212.2, 0, 0] m/s, semantic_kind=vel)` |
+    | `Bob → Alice` | inverse of Alice → Bob: `Translate([−269 813 212.2, 0, 0] m/s, semantic_kind=vel) \| Translate([−100 000, −10 000, 0] km)` |
 
     **Semantic behaviour** (per representation):
 
     | Representation semantic | Effect of Alice → Bob transform |
     |-------------------------|---------------------------------|
-    | `Point` / `Location`    | position shifted by `[100 000, 10 000, 0] km` |
-    | `Displacement`          | unchanged (both Translate and Boost are identity on displacements) |
+    | `Point` / `Location`    | position shifted by `[100 000, 10 000, 0] km` (the velocity kick is identity on points, so bare arrays/Quantities act as positions) |
+    | `Displacement`          | unchanged (both offsets are identity on displacements) |
     | `Velocity`              | velocity shifted by `[269 813 212.2, 0, 0] m/s` |
-    | `Acceleration`          | unchanged (`Boost` is identity on accelerations) |
+    | `Acceleration`          | unchanged (a constant velocity kick is identity on accelerations) |
 
     **Pre-defined instance:**
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -970,7 +970,7 @@ A non-exhaustive table of exported objects are:
 | `coordinax.representations` | `cconvert`, `change_basis`, `tangent_map`, </br> `Representation`, `point`, `coord_disp`, `coord_vel`, `coord_acc`, `phys_disp`, `phys_vel`, `phys_acc`, </br> `PointGeometry`, `point_geom`, `TangentGeometry`, `tangent_geom`, </br> `NoBasis`, `no_basis`, `CoordinateBasis`, `coord_basis`, `PhysicalBasis`, `phys_basis`, </br> `Location`, `loc`, `Displacement`, `dpl`, `Velocity`, `vel`, `Acceleration`, `acc`, </br> `guess_geometry_kind`, `guess_semantic_kind`, `guess_rep` |
 | `coordinax.vectors` | `Point`, `Tangent`, `Coordinate`, `ToUnitsOptions` |
 | `coordinax.manifolds` | `guess_manifold`, `scale_factors`, `angle_between`, </br> `EuclideanManifold`, `Rn`, `FlatMetric`, `R3`, </br> `EmbeddedManifold`, `EmbeddedChart` </br> `S2`, `embedded_twosphere`, </br> `CustomManifold`,`CustomAtlas`, </br> `CartesianProductManifold`, `galilean_spacetime` |
-| `coordinax.transforms` | `act`, `simplify`, `compose`, `materialize_transform`, </br> `AbstractTransform`, `Identity`, `Composed`, `Translate`, `Rotate`, `Reflect`, `Scale`, `Shear`, `Boost`, `identity`, </br> `AbstractTransformGroup`, `IdentityGroup`, `DiffeomorphismGroup`, `AffineGroup`, `EuclideanGroup`, `OrthogonalGroup`, `SpecialOrthogonalGroup`, `PoincareGroup`, `LorentzGroup`, `ProperOrthochronousLorentzGroup` |
+| `coordinax.transforms` | `act`, `pushforward`, `prolong`, `simplify`, `compose`, `materialize_transform`, `is_time_dependent`, `tau_derivative`, </br> `AbstractTransform`, `Identity`, `Composed`, `Translate`, `Rotate`, `Reflect`, `Scale`, `Shear`, `Boost`, `identity`, </br> `AbstractTransformGroup`, `IdentityGroup`, `DiffeomorphismGroup`, `AffineGroup`, `EuclideanGroup`, `OrthogonalGroup`, `SpecialOrthogonalGroup`, `PoincareGroup`, `LorentzGroup`, `ProperOrthochronousLorentzGroup` |
 | `coordinax.frames` | `frame_transition`, </br> `AbstractReferenceFrame`, `FrameTransformError`, </br> `NoFrame`, `Alice`, `Alex`, `Bob`, `bob`, `TransformedReferenceFrame` |
 
 </br>
@@ -4916,7 +4916,7 @@ A **reference frame** is an abstract label used to identify a coordinate descrip
 
     | Representation semantic | Effect of Alice → Bob transform |
     |-------------------------|---------------------------------|
-    | `Point` / `Location`    | position shifted by `[100 000, 10 000, 0] km` (the velocity kick is identity on points, so bare arrays/Quantities act as positions) |
+    | `Point` / `Location`    | position shifted by `[100 000, 10 000, 0] km` (unitful Quantities act as positions; bare unitless arrays are rejected — the velocity kick cannot tell a position array from a velocity array) |
     | `Displacement`          | unchanged (both offsets are identity on displacements) |
     | `Velocity`              | velocity shifted by `[269 813 212.2, 0, 0] m/s` |
     | `Acceleration`          | unchanged (a constant velocity kick is identity on accelerations) |

--- a/packages/coordinax.api/src/coordinax/api/transforms.py
+++ b/packages/coordinax.api/src/coordinax/api/transforms.py
@@ -1,6 +1,6 @@
 """Representations."""
 
-__all__: tuple[str, ...] = ("act", "compose")
+__all__: tuple[str, ...] = ("act", "compose", "prolong", "pushforward")
 
 from typing import Any
 
@@ -105,6 +105,89 @@ def act(*args: Any, **kwargs: Any) -> Any:
     >>> op = R | T  # rotate then translate
     >>> cxfm.act(op, None, q).round(3)
     Q([1., 1., 0.], 'km')
+
+    """
+    raise NotImplementedError  # pragma: no cover
+
+
+@plum.dispatch.abstract
+def pushforward(*args: Any, **kwargs: Any) -> Any:
+    r"""Apply the frozen-$\tau$ spatial differential of a transform.
+
+    For a transform with point action $\phi(\tau, x)$, this computes the
+    pushforward of a tangent vector $v$ anchored at the base point ``at``:
+
+    $$ v' = \partial_x \phi(\tau, \cdot)\big|_{\mathrm{at}} \cdot v $$
+
+    holding the time parameter fixed. This is the transformation law for
+    `Displacement` data (a same-$\tau$ point difference) and coincides with
+    `act` on all tangent kinds for time-independent transforms.
+
+    Contrast with `act` on kinematic tangent data (velocity, acceleration,
+    ...), which is the full *prolongation* and includes $\partial_\tau \phi$
+    terms for time-dependent transforms.
+
+    Canonical signature::
+
+        pushforward(op, tau, v, chart, rep, /, *, at=None, usys=None)
+
+    ``at`` is required whenever the transform's point action is nonlinear in
+    the chart coordinates (e.g. any transform in a non-Cartesian chart);
+    linear/affine fast paths may not need it.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import coordinax.transforms as cxfm
+
+    A displacement is invariant under any translation, even a time-dependent
+    one (the Jacobian of a translation is the identity):
+
+    >>> delta = lambda t: {"x": u.Q(3.0, "km/s") * t, "y": u.Q(0.0, "km"),
+    ...                    "z": u.Q(0.0, "km")}
+    >>> op = cxfm.Translate(delta, chart=cxc.cart3d)
+    >>> d = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(0.0, "km")}
+    >>> at = {"x": u.Q(0.0, "km"), "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")}
+    >>> cxfm.pushforward(op, u.Q(5.0, "s"), d, cxc.cart3d, cxr.coord_disp, at=at)
+    {'x': Q(1., 'km'), 'y': Q(2., 'km'), 'z': Q(0., 'km')}
+
+    """
+    raise NotImplementedError  # pragma: no cover
+
+
+@plum.dispatch.abstract
+def prolong(*args: Any, **kwargs: Any) -> Any:
+    r"""Apply the kinematic (jet) prolongation of a transform to a jet.
+
+    A *jet* is a dictionary of curve data keyed by time-derivative order:
+    ``{0: q, 1: v, 2: a, ...}`` — slot 0 is the base point (position), slot 1
+    the velocity, slot 2 the acceleration. All-integer keys keep the jet a
+    valid JAX pytree. Displacement data (a same-$\tau$ point difference, not
+    a curve derivative) is never a jet slot; it transforms by `pushforward`.
+
+    For a transform with point action $\phi(\tau, x)$ acting on a curve
+    $x(\tau)$ via $x'(\tau) = \phi(\tau, x(\tau))$, the transformed jet slots
+    are the total $\tau$-derivatives:
+
+    $$ v' = \partial_\tau \phi + \partial_x \phi \cdot v, \qquad
+       a' = \partial_{\tau\tau}\phi + 2\,\partial_\tau\partial_x\phi \cdot v
+            + \partial_{xx}\phi(v, v) + \partial_x \phi \cdot a, \ \ldots $$
+
+    This is the joint, order-consistent application of `act` to a full
+    phase-space state — the natural verb for `coordinax.Coordinate` bundles
+    and for time-dependent transforms, where higher slots depend on all
+    lower ones.
+
+    Canonical signature::
+
+        prolong(op, tau, jet, chart, /, *, usys=None) -> jet
+
+    See Also
+    --------
+    act : per-slot application (delegates here for time-dependent transforms)
+    pushforward : the frozen-tau spatial differential
 
     """
     raise NotImplementedError  # pragma: no cover

--- a/packages/coordinax.astro/docs/index.md
+++ b/packages/coordinax.astro/docs/index.md
@@ -59,6 +59,14 @@ The International Celestial Reference System (ICRS) is the standard celestial re
 frame = cxastro.ICRS()
 ```
 
+### Galactic
+
+The (heliocentric) IAU 1958 Galactic coordinate frame, related to ICRS by a fixed rotation (matching Astropy's Galactic frame, including the ICRS/FK5 frame bias). Parameter-free.
+
+```
+frame = cxastro.Galactic()
+```
+
 ### Galactocentric
 
 A reference frame centered on the Galactic center with configurable parameters.

--- a/packages/coordinax.astro/src/coordinax/astro/__init__.py
+++ b/packages/coordinax.astro/src/coordinax/astro/__init__.py
@@ -6,6 +6,8 @@ __all__ = (
     "AbstractSpaceFrame",
     "ICRS",
     "icrs",
+    "Galactic",
+    "galactic",
     "Galactocentric",
 )
 
@@ -16,8 +18,10 @@ with install_import_hook("coordinax.astro"):
         ICRS,
         AbstractSpaceFrame,
         DistanceModulus,
+        Galactic,
         Galactocentric,
         Parallax,
+        galactic,
         icrs,
     )
 

--- a/packages/coordinax.astro/src/coordinax/astro/_setup_package.py
+++ b/packages/coordinax.astro/src/coordinax/astro/_setup_package.py
@@ -65,6 +65,7 @@ def coordinax_frames_exports() -> dict[str, object]:
     """Return frame symbols exported to ``coordinax.frames`` via entry-point."""
     try:
         from ._src.base_frame import AbstractSpaceFrame  # noqa: PLC0415
+        from ._src.galactic import Galactic, galactic  # noqa: PLC0415
         from ._src.galactocentric import Galactocentric  # noqa: PLC0415
         from ._src.icrs import ICRS, icrs  # noqa: PLC0415
     except ImportError as exc:
@@ -80,5 +81,7 @@ def coordinax_frames_exports() -> dict[str, object]:
         "AbstractSpaceFrame": AbstractSpaceFrame,
         "ICRS": ICRS,
         "icrs": icrs,
+        "Galactic": Galactic,
+        "galactic": galactic,
         "Galactocentric": Galactocentric,
     }

--- a/packages/coordinax.astro/src/coordinax/astro/_src/__init__.py
+++ b/packages/coordinax.astro/src/coordinax/astro/_src/__init__.py
@@ -4,6 +4,7 @@ from .base_frame import *
 from .constants import *
 from .distance_modulus import *
 from .frame_transforms import *
+from .galactic import *
 from .galactocentric import *
 from .icrs import *
 from .parallax import *

--- a/packages/coordinax.astro/src/coordinax/astro/_src/frame_transforms.py
+++ b/packages/coordinax.astro/src/coordinax/astro/_src/frame_transforms.py
@@ -11,8 +11,10 @@ import quaxed.numpy as jnp
 import unxt as u
 
 import coordinax.frames as cxf
+import coordinax.representations as cxr
 import coordinax.transforms as cxfm
 from .base_frame import AbstractSpaceFrame
+from .galactic import ICRS_TO_GALACTIC_MATRIX, Galactic
 from .galactocentric import Galactocentric
 from .icrs import ICRS, icrs
 
@@ -50,7 +52,8 @@ def frame_transition(
       Rotate(f64[3,3](jax)),
       Rotate(f64[3,3](jax)),
       Translate( {...}, chart=Cart3D(M=Rn(3)) ),
-      Rotate(f64[3,3](jax))
+      Rotate(f64[3,3](jax)),
+      Translate( {...}, chart=Cart3D(M=Rn(3)), semantic_kind=vel )
     ))
 
     """  # noqa: E501
@@ -83,6 +86,88 @@ def frame_transition(from_frame: ICRS, to_frame: ICRS, /) -> cxfm.Identity:
 
 
 @plum.dispatch
+def frame_transition(from_frame: Galactic, to_frame: Galactic, /) -> cxfm.Identity:
+    """Return an identity operator for the Galactic->Galactic transformation.
+
+    >>> import coordinax.frames as cxf
+    >>> import coordinax.astro as cxastro
+
+    >>> cxf.frame_transition(cxastro.galactic, cxastro.galactic)
+    Identity()
+
+    """
+    return cxfm.identity
+
+
+@plum.dispatch
+def frame_transition(from_frame: ICRS, to_frame: Galactic, /) -> cxfm.Rotate:
+    r"""Return an ICRS to Galactic frame transformation operator.
+
+    The Galactic frame is related to ICRS by a fixed rotation (the IAU 1958
+    definition, via Astropy's FK4-B1950-derived matrix including the ICRS/FK5
+    frame bias). Being a pure static rotation, it acts on positions,
+    displacements, velocities, and accelerations alike by the rotation
+    matrix.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.astro as cxastro
+
+    >>> frame_op = cx.frame_transition(cxastro.icrs, cxastro.galactic)
+    >>> frame_op
+    Rotate(f64[3,3](jax))
+
+    The North Galactic Pole (in ICRS) maps to the +z axis:
+
+    >>> ngp = cx.Point.from_(
+    ...     {"lon": u.Q(192.8594812065348, "deg"), "lat": u.Q(27.12825118085622, "deg"),
+    ...      "distance": u.Q(1, "kpc")}, cx.lonlat_sph3d)
+    >>> print(frame_op(ngp).cconvert(cx.cart3d).round(6))
+    <Point: chart=Cart3D (x, y, z) [kpc]
+        [0. 0. 1.]>
+
+    Velocities rotate too:
+
+    >>> v = cx.Tangent.from_([100.0, 0.0, 0.0], "km/s")
+    >>> print(frame_op(None, v).round(3))
+    <Tangent: chart=Cart3D (x, y, z) [km / s]
+        [ -5.488  49.411 -86.767]>
+
+    """
+    del from_frame, to_frame
+    return cxfm.Rotate(ICRS_TO_GALACTIC_MATRIX)
+
+
+@plum.dispatch
+def frame_transition(from_frame: Galactic, to_frame: ICRS, /) -> cxfm.Rotate:
+    r"""Return a Galactic to ICRS frame transformation operator.
+
+    The inverse of the ICRS -> Galactic rotation (the matrix transpose).
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.astro as cxastro
+
+    >>> fwd = cx.frame_transition(cxastro.icrs, cxastro.galactic)
+    >>> bwd = cx.frame_transition(cxastro.galactic, cxastro.icrs)
+
+    >>> q = u.Q([1.0, 2.0, 3.0], "kpc")
+    >>> bwd(fwd(q)).round(6)
+    Q([1., 2., 3.], 'kpc')
+
+    """
+    del from_frame, to_frame
+    return cxfm.Rotate(ICRS_TO_GALACTIC_MATRIX).inverse
+
+
+# ---------------------------------------------------------------
+
+
+@plum.dispatch
 def frame_transition(
     from_frame: Galactocentric, to_frame: Galactocentric, /
 ) -> cxfm.Composed:
@@ -101,12 +186,14 @@ def frame_transition(
     >>> frame_op2 = cxf.frame_transition(gcf_frame, gcf_frame2)
     >>> frame_op2
     Composed((
+      Translate( {...}, chart=Cart3D(M=Rn(3)), semantic_kind=vel ),
       Rotate(f64[3,3](jax)),
       Translate( {...}, chart=Cart3D(M=Rn(3)) ),
       Rotate(f64[3,3](jax)),
       Rotate(f64[3,3](jax)),
       Translate( {...}, chart=Cart3D(M=Rn(3)) ),
-      Rotate(f64[3,3](jax))
+      Rotate(f64[3,3](jax)),
+      Translate( {...}, chart=Cart3D(M=Rn(3)), semantic_kind=vel )
     ))
 
     """
@@ -154,7 +241,8 @@ def frame_transition(from_frame: ICRS, to_frame: Galactocentric, /) -> cxfm.Comp
     Composed((
       Rotate(f64[3,3](jax)),
       Translate( {...}, chart=Cart3D(M=Rn(3)) ),
-      Rotate(f64[3,3](jax))
+      Rotate(f64[3,3](jax)),
+      Translate( {...}, chart=Cart3D(M=Rn(3)), semantic_kind=vel )
     ))
 
     Transform a position at the origin of ICRS to Galactocentric:
@@ -167,6 +255,19 @@ def frame_transition(from_frame: ICRS, to_frame: Galactocentric, /) -> cxfm.Comp
     The result shows the Sun's position in Galactocentric coordinates: the Sun
     is about 8.1 kpc from the Galactic center along the x-axis and about 21 pc
     above the Galactic plane.
+
+    Velocities are transformed too: a star at rest in ICRS moves with the
+    solar velocity in the Galactocentric frame:
+
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> point = cx.Point.from_([0, 0, 0], "pc")
+    >>> vel = cx.Tangent.from_([0.0, 0.0, 0.0], "km/s")
+    >>> pv = cx.Coordinate(point=point, velocity=vel)
+    >>> out = frame_op(None, pv)
+    >>> print(out["velocity"])
+    <Tangent: chart=Cart3D (x, y, z) [km / s]
+        [ 12.9  245.6    7.78]>
 
     Works with unxt Quantities too:
 
@@ -192,7 +293,8 @@ def frame_transition(from_frame: ICRS, to_frame: Galactocentric, /) -> cxfm.Comp
     - R: Combined rotation matrix (longitude x latitude x roll)
     - offset_q: Translation by the Galactic center distance
     - H: Rotation to account for Sun's height above plane
-    - offset_v: Velocity boost to Galactocentric rest frame
+    - offset_v: Solar-velocity kick to the Galactocentric rest frame
+      (a fibre-only ``Translate(semantic_kind=vel)``)
 
     The default Galactocentric frame uses parameters from the Astropy default
     values (as of v4.0), which are based on various literature sources.
@@ -215,15 +317,16 @@ def frame_transition(from_frame: ICRS, to_frame: Galactocentric, /) -> cxfm.Comp
     # Post-rotation spatial offset to Galactic center.
     offset_q = cxfm.Translate.from_(-galcen["distance"] * jnp.asarray([1, 0, 0]))
 
-    # TODO: re-add when Boost is a class
-    # # Post-rotation velocity offset
-    # galcen_v_sun = to_frame.galcen_v_sun
-    # offset_v = cxf.Boost(galcen_v_sun.data, chart=galcen_v_sun.chart)
+    # Post-rotation velocity offset: the solar-velocity kick. This is a
+    # fibre-only velocity translation (`Translate(semantic_kind=vel)`): the
+    # frame transform is a fixed-epoch snapshot, so positions are not advected
+    # in time. (Contrast with `coordinax.transforms.Boost`, the Galilean
+    # boost, whose point action moves positions by v*tau.)
+    v_sun = to_frame.galcen_v_sun
+    offset_v = cxfm.Translate(v_sun.data, chart=v_sun.chart, semantic_kind=cxr.vel)
 
-    # # Total Operator
-    # return R | offset_q | H | offset_v
     # Total Operator
-    return R | offset_q | H
+    return R | offset_q | H | offset_v
 
 
 # ---------------------------------------------------------------

--- a/packages/coordinax.astro/src/coordinax/astro/_src/frame_transforms.py
+++ b/packages/coordinax.astro/src/coordinax/astro/_src/frame_transforms.py
@@ -14,7 +14,7 @@ import coordinax.frames as cxf
 import coordinax.representations as cxr
 import coordinax.transforms as cxfm
 from .base_frame import AbstractSpaceFrame
-from .galactic import ICRS_TO_GALACTIC_MATRIX, Galactic
+from .galactic import GALACTIC_TO_ICRS_MATRIX, ICRS_TO_GALACTIC_MATRIX, Galactic
 from .galactocentric import Galactocentric
 from .icrs import ICRS, icrs
 
@@ -161,7 +161,7 @@ def frame_transition(from_frame: Galactic, to_frame: ICRS, /) -> cxfm.Rotate:
 
     """
     del from_frame, to_frame
-    return cxfm.Rotate(ICRS_TO_GALACTIC_MATRIX).inverse
+    return cxfm.Rotate(GALACTIC_TO_ICRS_MATRIX)
 
 
 # ---------------------------------------------------------------
@@ -259,8 +259,6 @@ def frame_transition(from_frame: ICRS, to_frame: Galactocentric, /) -> cxfm.Comp
     Velocities are transformed too: a star at rest in ICRS moves with the
     solar velocity in the Galactocentric frame:
 
-    >>> import coordinax.charts as cxc
-    >>> import coordinax.representations as cxr
     >>> point = cx.Point.from_([0, 0, 0], "pc")
     >>> vel = cx.Tangent.from_([0.0, 0.0, 0.0], "km/s")
     >>> pv = cx.Coordinate(point=point, velocity=vel)

--- a/packages/coordinax.astro/src/coordinax/astro/_src/galactic.py
+++ b/packages/coordinax.astro/src/coordinax/astro/_src/galactic.py
@@ -1,0 +1,64 @@
+"""Astronomy reference frames."""
+
+__all__ = ("Galactic", "galactic")
+
+
+from typing import final
+
+import jax.numpy as jnp
+
+from .base_frame import AbstractSpaceFrame
+
+#: Rotation matrix taking ICRS Cartesian components to Galactic Cartesian
+#: components. This is the effective ICRS -> Galactic rotation used by
+#: Astropy, which defines the Galactic frame from the FK4 B1950 values of
+#: Blaauw et al. (1960) and routes ICRS -> FK5(J2000) -> Galactic, so the
+#: matrix includes the ~25 mas ICRS/FK5 frame bias. It therefore differs at
+#: the sub-arcsecond level from matrices built directly from the J2000 NGP
+#: Euler angles (e.g. Liu, Zhu, & Zhang 2011, A&A 526, A16).
+ICRS_TO_GALACTIC_MATRIX = jnp.asarray(
+    [
+        [-0.054875657712591654, -0.8734370519556157, -0.48383507361671546],
+        [0.49410943719272676, -0.44482972122329517, 0.7469821839866674],
+        [-0.8676661375596576, -0.19807633727300053, 0.4559838136873017],
+    ]
+)
+
+
+@final
+class Galactic(AbstractSpaceFrame):
+    """The (heliocentric) Galactic coordinate frame.
+
+    The IAU 1958 Galactic coordinate system: centered on the solar system
+    barycenter with the x-axis toward the Galactic center, the z-axis toward
+    the North Galactic Pole, and longitude/latitude ``(l, b)`` as the angular
+    coordinates. It is related to `~coordinax.astro.ICRS` by a fixed rotation
+    (no translation and no velocity offset — contrast with
+    `~coordinax.astro.Galactocentric`, which is centered on the Galactic
+    center and moves with it).
+
+    The rotation matches Astropy's Galactic frame, which is defined from the
+    FK4 B1950 values of Blaauw et al. (1960) precessed to J2000, including
+    the ICRS/FK5 frame bias.
+
+    Examples
+    --------
+    >>> import coordinax.astro as cxastro
+    >>> frame = cxastro.Galactic()
+    >>> frame
+    Galactic()
+
+    Transform a position from ICRS to Galactic:
+
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> op = cx.frame_transition(cxastro.icrs, cxastro.galactic)
+    >>> q = cx.Point.from_([1.0, 0.0, 0.0], "kpc")
+    >>> print(op(q).round(3))
+    <Point: chart=Cart3D (x, y, z) [kpc]
+        [-0.055  0.494 -0.868]>
+
+    """
+
+
+galactic = Galactic()  # canonical instance for convenience

--- a/packages/coordinax.astro/src/coordinax/astro/_src/galactic.py
+++ b/packages/coordinax.astro/src/coordinax/astro/_src/galactic.py
@@ -5,7 +5,7 @@ __all__ = ("Galactic", "galactic")
 
 from typing import final
 
-import jax.numpy as jnp
+import numpy as np
 
 from .base_frame import AbstractSpaceFrame
 
@@ -16,12 +16,18 @@ from .base_frame import AbstractSpaceFrame
 #: matrix includes the ~25 mas ICRS/FK5 frame bias. It therefore differs at
 #: the sub-arcsecond level from matrices built directly from the J2000 NGP
 #: Euler angles (e.g. Liu, Zhu, & Zhang 2011, A&A 526, A16).
-ICRS_TO_GALACTIC_MATRIX = jnp.asarray(
+# NOTE: a NumPy float64 array, not a JAX array: JAX would silently truncate
+# these constants to float32 at import time when jax_enable_x64 is off,
+# discarding precision before any computation. As a NumPy array the constant
+# keeps full precision; conversion (and any x32 truncation) happens only at
+# use, under the runtime's own dtype policy.
+ICRS_TO_GALACTIC_MATRIX = np.asarray(
     [
         [-0.054875657712591654, -0.8734370519556157, -0.48383507361671546],
         [0.49410943719272676, -0.44482972122329517, 0.7469821839866674],
         [-0.8676661375596576, -0.19807633727300053, 0.4559838136873017],
-    ]
+    ],
+    dtype=np.float64,
 )
 
 #: The inverse (transpose) rotation, taking Galactic Cartesian components to

--- a/packages/coordinax.astro/src/coordinax/astro/_src/galactic.py
+++ b/packages/coordinax.astro/src/coordinax/astro/_src/galactic.py
@@ -24,6 +24,11 @@ ICRS_TO_GALACTIC_MATRIX = jnp.asarray(
     ]
 )
 
+#: The inverse (transpose) rotation, taking Galactic Cartesian components to
+#: ICRS Cartesian components. Precomputed so the reverse frame transition does
+#: not construct-and-invert an operator at call time.
+GALACTIC_TO_ICRS_MATRIX = ICRS_TO_GALACTIC_MATRIX.T
+
 
 @final
 class Galactic(AbstractSpaceFrame):

--- a/packages/coordinax.astro/src/coordinax/astro/_src/galactocentric.py
+++ b/packages/coordinax.astro/src/coordinax/astro/_src/galactocentric.py
@@ -67,14 +67,14 @@ class Galactocentric(AbstractSpaceFrame):
         default=u.Q(jnp.array(20.8), "pc"),
     )
 
-    # #: Velocity of the Sun in the Galactic center frame.
-    # #: https://ui.adsabs.harvard.edu/abs/2018RNAAS...2..210D
-    # #: https://ui.adsabs.harvard.edu/abs/2018A%26A...615L..15G
-    # #: https://ui.adsabs.harvard.edu/abs/2004ApJ...616..872R
-    # galcen_v_sun: cxv.Vector[cxc.Cart3D, cxr.TangentGeometry] = eqx.field(
-    #     converter=cxv.Vector[cxc.Cart3D, cxr.TangentGeometry].from_,
-    #     default=galcen_v_sun_default,
-    # )
+    #: Velocity of the Sun in the Galactic center frame.
+    #: https://ui.adsabs.harvard.edu/abs/2018RNAAS...2..210D
+    #: https://ui.adsabs.harvard.edu/abs/2018A%26A...615L..15G
+    #: https://ui.adsabs.harvard.edu/abs/2004ApJ...616..872R
+    galcen_v_sun: cxv.Tangent = eqx.field(  # ty: ignore[invalid-assignment]
+        converter=Unless(cxv.Tangent, cxv.Tangent.from_),
+        default=GALCEN_V_SUN_DEFAULT,
+    )
 
     # --------
 

--- a/packages/coordinax.astro/tests/unit/test_astro_module.py
+++ b/packages/coordinax.astro/tests/unit/test_astro_module.py
@@ -11,6 +11,8 @@ def test_module_exports() -> None:
         "AbstractSpaceFrame",
         "ICRS",
         "icrs",
+        "Galactic",
+        "galactic",
         "Galactocentric",
     }
 

--- a/packages/coordinax.astro/tests/unit/test_frame_transforms.py
+++ b/packages/coordinax.astro/tests/unit/test_frame_transforms.py
@@ -15,6 +15,7 @@ import unxt_hypothesis as ust
 import coordinax.astro as cxastro
 import coordinax.frames as cxf
 import coordinax.main as cx
+import coordinax.representations as cxr
 import coordinax.transforms as cxfm
 import coordinax.vectors as cxv
 from coordinax.astro._src.galactic import ICRS_TO_GALACTIC_MATRIX
@@ -485,3 +486,48 @@ def test_galactic_matrix_is_float64():
     """
     assert isinstance(ICRS_TO_GALACTIC_MATRIX, np.ndarray)
     assert ICRS_TO_GALACTIC_MATRIX.dtype == np.float64
+
+
+def test_galactocentric_spherical_velocity_fibre():
+    """The velocity kick handles non-Cartesian velocity fibres.
+
+    Proper-motion-style (spherical) velocity data must traverse the
+    ICRS->Galactocentric chain and agree with the same physics computed
+    from a Cartesian velocity fibre.
+    """
+    usys = u.unitsystems.galactic
+    op = cxf.frame_transition(cxastro.ICRS(), cxastro.Galactocentric())
+    pt = cxv.Point.from_(
+        {"lon": u.Q(30.0, "deg"), "lat": u.Q(10.0, "deg"), "distance": u.Q(1.0, "kpc")},
+        cx.lonlat_sph3d,
+    )
+    vel_sph = cxv.Tangent(
+        {
+            "lon": u.Q(1e-12, "rad/s"),
+            "lat": u.Q(0.0, "rad/s"),
+            "distance": u.Q(10.0, "km/s"),
+        },
+        cx.lonlat_sph3d,
+        cxr.coord_basis,
+        cxr.vel,
+    )
+    out = cx.act(op, None, cxv.Coordinate(pt, vel=vel_sph), usys=usys)
+
+    # reference: same input with a Cartesian velocity fibre
+    vel_cart = cx.cconvert(vel_sph, cx.cart3d, at=pt.data, usys=usys)
+    out_ref = cx.act(
+        op,
+        None,
+        cxv.Coordinate(cx.cconvert(pt, cx.cart3d), vel=vel_cart),
+        usys=usys,
+    )
+    out_v = cx.cconvert(
+        out._data["vel"],
+        cx.cart3d,
+        at=cx.cconvert(out.point, out._data["vel"].chart).data,
+        usys=usys,
+    )
+    for k in "xyz":
+        a = u.ustrip("km/s", out_v.data[k])
+        b = u.ustrip("km/s", out_ref._data["vel"].data[k])
+        assert jnp.allclose(a, b, rtol=1e-5)

--- a/packages/coordinax.astro/tests/unit/test_frame_transforms.py
+++ b/packages/coordinax.astro/tests/unit/test_frame_transforms.py
@@ -14,7 +14,10 @@ import unxt_hypothesis as ust
 
 import coordinax.astro as cxastro
 import coordinax.frames as cxf
+import coordinax.main as cx
 import coordinax.transforms as cxfm
+import coordinax.vectors as cxv
+from coordinax.astro._src.galactic import ICRS_TO_GALACTIC_MATRIX
 
 
 def _to_np(x: object, unit: str) -> np.ndarray:
@@ -33,11 +36,18 @@ def _as_astropy_galactocentric(frame: cxastro.Galactocentric):
         distance=u.ustrip("kpc", galcen["distance"]) * apyu.kpc,
         frame="icrs",
     )
+    v_sun = frame.galcen_v_sun.data
+    kms = apyu.km / apyu.s
     return apyc.Galactocentric(
         galcen_coord=galcen_coord,
         galcen_distance=u.ustrip("kpc", galcen["distance"]) * apyu.kpc,
         z_sun=u.ustrip("pc", frame.z_sun) * apyu.pc,
         roll=u.ustrip("deg", frame.roll) * apyu.deg,
+        galcen_v_sun=apyc.CartesianDifferential(
+            d_x=u.ustrip("km/s", v_sun["x"]) * kms,
+            d_y=u.ustrip("km/s", v_sun["y"]) * kms,
+            d_z=u.ustrip("km/s", v_sun["z"]) * kms,
+        ),
     )
 
 
@@ -208,3 +218,260 @@ class TestFrameTransformProperties:
         got = cxfm.act(op, None, q).ustrip("pc")
         expected = _astropy_icrs_to_gcf_xyz_pc((xyz[0], xyz[1], xyz[2]), gcf)
         np.testing.assert_allclose(got, expected, rtol=0, atol=1e-6)
+
+
+# ===================================================================
+# Velocity (phase-space) transforms
+
+
+def _astropy_icrs_to_gcf_phase_space(
+    xyz_pc: Iterable[float],
+    vxyz_kms: Iterable[float],
+    frame: cxastro.Galactocentric,
+):
+    apyc = pytest.importorskip("astropy.coordinates")
+    apyu = pytest.importorskip("astropy.units")
+
+    x, y, z = xyz_pc
+    vx, vy, vz = vxyz_kms
+    sc = apyc.SkyCoord(
+        x=x * apyu.pc,
+        y=y * apyu.pc,
+        z=z * apyu.pc,
+        v_x=vx * apyu.km / apyu.s,
+        v_y=vy * apyu.km / apyu.s,
+        v_z=vz * apyu.km / apyu.s,
+        representation_type="cartesian",
+        differential_type="cartesian",
+        frame=apyc.ICRS(),
+    )
+    out = sc.transform_to(_as_astropy_galactocentric(frame))
+    q = out.cartesian
+    v = q.differentials["s"]
+    kms = apyu.km / apyu.s
+    return (
+        np.array([q.x.to_value(apyu.pc), q.y.to_value(apyu.pc), q.z.to_value(apyu.pc)]),
+        np.array([v.d_x.to_value(kms), v.d_y.to_value(kms), v.d_z.to_value(kms)]),
+    )
+
+
+def _coordinate(xyz_pc, vxyz_kms):
+    return cx.Coordinate(
+        point=cx.Point.from_(list(xyz_pc), "pc"),
+        velocity=cx.Tangent.from_(list(vxyz_kms), "km/s"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("xyz_pc", "vxyz_kms"),
+    [
+        ((0, 0, 0), (0, 0, 0)),  # Sun at rest -> galcen_v_sun
+        ((150, -220, 310), (30, -15, 22)),
+        ((-5000, 3200, 1200), (-120, 80, 40)),
+    ],
+)
+def test_icrs_to_galactocentric_matches_astropy_velocities(xyz_pc, vxyz_kms) -> None:
+    """ICRS->Galactocentric phase-space transforms match Astropy."""
+    gcf = cxastro.Galactocentric()
+    op = cxf.frame_transition(cxastro.ICRS(), gcf)
+
+    out = cxfm.act(op, None, _coordinate(xyz_pc, vxyz_kms))
+    got_q = np.array([_to_np(v, "pc") for v in out.point.data.values()])
+    got_v = np.array([_to_np(v, "km/s") for v in out["velocity"].data.values()])
+
+    exp_q, exp_v = _astropy_icrs_to_gcf_phase_space(xyz_pc, vxyz_kms, gcf)
+    np.testing.assert_allclose(got_q, exp_q, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(got_v, exp_v, rtol=0, atol=1e-6)
+
+
+def test_star_at_rest_in_icrs_moves_with_solar_velocity() -> None:
+    """A star at rest in ICRS has velocity galcen_v_sun in the GCF."""
+    gcf = cxastro.Galactocentric()
+    op = cxf.frame_transition(cxastro.ICRS(), gcf)
+
+    out = cxfm.act(op, None, _coordinate((0, 0, 0), (0, 0, 0)))
+    got_v = np.array([_to_np(v, "km/s") for v in out["velocity"].data.values()])
+    exp_v = np.array([_to_np(v, "km/s") for v in gcf.galcen_v_sun.data.values()])
+    np.testing.assert_allclose(got_v, exp_v, rtol=0, atol=1e-10)
+
+
+def test_icrs_galactocentric_phase_space_roundtrip() -> None:
+    """ICRS -> GCF -> ICRS is the identity on positions and velocities."""
+    icrs = cxastro.ICRS()
+    gcf = cxastro.Galactocentric()
+
+    fwd = cxf.frame_transition(icrs, gcf)
+    bwd = cxf.frame_transition(gcf, icrs)
+
+    pv = _coordinate((450, -100, 220), (12.0, -34.0, 5.0))
+    back = cxfm.act(bwd, None, cxfm.act(fwd, None, pv))
+
+    np.testing.assert_allclose(
+        np.array([_to_np(v, "pc") for v in back.point.data.values()]),
+        np.array([_to_np(v, "pc") for v in pv.point.data.values()]),
+        rtol=0,
+        atol=1e-6,
+    )
+    np.testing.assert_allclose(
+        np.array([_to_np(v, "km/s") for v in back["velocity"].data.values()]),
+        np.array([_to_np(v, "km/s") for v in pv["velocity"].data.values()]),
+        rtol=0,
+        atol=1e-9,
+    )
+
+
+def test_custom_galcen_v_sun_velocities_match_astropy() -> None:
+    """A non-default galcen_v_sun is honored and matches Astropy."""
+    apyc = pytest.importorskip("astropy.coordinates")
+    apyu = pytest.importorskip("astropy.units")
+
+    v_sun = cxv.Tangent.from_([11.1, 232.24, 7.25], "km/s")
+    gcf = cxastro.Galactocentric(galcen_v_sun=v_sun)
+
+    # coordinax side
+    op = cxf.frame_transition(cxastro.ICRS(), gcf)
+    out = cxfm.act(op, None, _coordinate((100, 200, -50), (5.0, -3.0, 8.0)))
+    got_v = np.array([_to_np(v, "km/s") for v in out["velocity"].data.values()])
+
+    # astropy side (rebuild the frame with the custom v_sun)
+    apy_frame = _as_astropy_galactocentric(gcf)
+    kms = apyu.km / apyu.s
+    apy_frame = apyc.Galactocentric(
+        galcen_coord=apy_frame.galcen_coord,
+        galcen_distance=apy_frame.galcen_distance,
+        z_sun=apy_frame.z_sun,
+        roll=apy_frame.roll,
+        galcen_v_sun=apyc.CartesianDifferential(
+            d_x=11.1 * kms, d_y=232.24 * kms, d_z=7.25 * kms
+        ),
+    )
+    sc = apyc.SkyCoord(
+        x=100 * apyu.pc,
+        y=200 * apyu.pc,
+        z=-50 * apyu.pc,
+        v_x=5.0 * kms,
+        v_y=-3.0 * kms,
+        v_z=8.0 * kms,
+        representation_type="cartesian",
+        differential_type="cartesian",
+        frame=apyc.ICRS(),
+    )
+    v = sc.transform_to(apy_frame).cartesian.differentials["s"]
+    exp_v = np.array([v.d_x.to_value(kms), v.d_y.to_value(kms), v.d_z.to_value(kms)])
+    np.testing.assert_allclose(got_v, exp_v, rtol=0, atol=1e-6)
+
+
+# ===================================================================
+# Galactic frame
+
+
+def _astropy_galactic_phase_space(xyz_pc, vxyz_kms, from_frame, to_frame):
+    """Transform cartesian phase-space data between astropy frames."""
+    apyc = pytest.importorskip("astropy.coordinates")
+    apyu = pytest.importorskip("astropy.units")
+
+    kms = apyu.km / apyu.s
+    rep = apyc.CartesianRepresentation(
+        x=xyz_pc[0] * apyu.pc,
+        y=xyz_pc[1] * apyu.pc,
+        z=xyz_pc[2] * apyu.pc,
+        differentials=apyc.CartesianDifferential(
+            d_x=vxyz_kms[0] * kms, d_y=vxyz_kms[1] * kms, d_z=vxyz_kms[2] * kms
+        ),
+    )
+    out = from_frame.realize_frame(rep).transform_to(to_frame).cartesian
+    v = out.differentials["s"]
+    return (
+        np.array(
+            [out.x.to_value(apyu.pc), out.y.to_value(apyu.pc), out.z.to_value(apyu.pc)]
+        ),
+        np.array([v.d_x.to_value(kms), v.d_y.to_value(kms), v.d_z.to_value(kms)]),
+    )
+
+
+@pytest.mark.parametrize(
+    ("xyz_pc", "vxyz_kms"),
+    [
+        ((100, 0, 0), (0, 0, 0)),
+        ((150, -220, 310), (30, -15, 22)),
+        ((-5000, 3200, 1200), (-120, 80, 40)),
+    ],
+)
+def test_icrs_to_galactic_matches_astropy(xyz_pc, vxyz_kms) -> None:
+    """ICRS->Galactic phase-space transforms match Astropy."""
+    apyc = pytest.importorskip("astropy.coordinates")
+
+    op = cxf.frame_transition(cxastro.icrs, cxastro.galactic)
+    out = cxfm.act(op, None, _coordinate(xyz_pc, vxyz_kms))
+    got_q = np.array([_to_np(v, "pc") for v in out.point.data.values()])
+    got_v = np.array([_to_np(v, "km/s") for v in out["velocity"].data.values()])
+
+    exp_q, exp_v = _astropy_galactic_phase_space(
+        xyz_pc, vxyz_kms, apyc.ICRS(), apyc.Galactic()
+    )
+    np.testing.assert_allclose(got_q, exp_q, rtol=0, atol=1e-8)
+    np.testing.assert_allclose(got_v, exp_v, rtol=0, atol=1e-8)
+
+
+def test_galactic_icrs_roundtrip() -> None:
+    """ICRS -> Galactic -> ICRS is the identity on positions and velocities."""
+    fwd = cxf.frame_transition(cxastro.icrs, cxastro.galactic)
+    bwd = cxf.frame_transition(cxastro.galactic, cxastro.icrs)
+
+    pv = _coordinate((450, -100, 220), (12.0, -34.0, 5.0))
+    back = cxfm.act(bwd, None, cxfm.act(fwd, None, pv))
+
+    np.testing.assert_allclose(
+        np.array([_to_np(v, "pc") for v in back.point.data.values()]),
+        np.array([_to_np(v, "pc") for v in pv.point.data.values()]),
+        rtol=0,
+        atol=1e-9,
+    )
+    np.testing.assert_allclose(
+        np.array([_to_np(v, "km/s") for v in back["velocity"].data.values()]),
+        np.array([_to_np(v, "km/s") for v in pv["velocity"].data.values()]),
+        rtol=0,
+        atol=1e-12,
+    )
+
+
+def test_galactic_rotation_is_orthogonal() -> None:
+    """The ICRS->Galactic rotation matrix is a proper rotation."""
+    R = np.asarray(ICRS_TO_GALACTIC_MATRIX)
+    np.testing.assert_allclose(R @ R.T, np.eye(3), rtol=0, atol=1e-14)
+    np.testing.assert_allclose(np.linalg.det(R), 1.0, rtol=0, atol=1e-13)
+
+
+def test_ngp_maps_to_z_axis() -> None:
+    """The North Galactic Pole (ICRS) maps to +z in Galactic coordinates."""
+    op = cxf.frame_transition(cxastro.icrs, cxastro.galactic)
+    ngp = cx.Point.from_(
+        {
+            "lon": u.Q(192.8594812065348, "deg"),
+            "lat": u.Q(27.12825118085622, "deg"),
+            "distance": u.Q(1.0, "kpc"),
+        },
+        cx.lonlat_sph3d,
+    )
+    out = cxfm.act(op, None, ngp).cconvert(cx.cart3d)
+    got = np.array([_to_np(v, "kpc") for v in out.data.values()])
+    np.testing.assert_allclose(got, [0.0, 0.0, 1.0], rtol=0, atol=1e-7)
+
+
+def test_galactic_to_galactocentric_via_fallback_matches_astropy() -> None:
+    """Galactic->Galactocentric (generic route through ICRS) matches Astropy."""
+    apyc = pytest.importorskip("astropy.coordinates")
+
+    gcf = cxastro.Galactocentric()
+    op = cxf.frame_transition(cxastro.galactic, gcf)
+
+    xyz, vxyz = (150, -220, 310), (30.0, -15.0, 22.0)
+    out = cxfm.act(op, None, _coordinate(xyz, vxyz))
+    got_q = np.array([_to_np(v, "pc") for v in out.point.data.values()])
+    got_v = np.array([_to_np(v, "km/s") for v in out["velocity"].data.values()])
+
+    exp_q, exp_v = _astropy_galactic_phase_space(
+        xyz, vxyz, apyc.Galactic(), _as_astropy_galactocentric(gcf)
+    )
+    np.testing.assert_allclose(got_q, exp_q, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(got_v, exp_v, rtol=0, atol=1e-6)

--- a/packages/coordinax.astro/tests/unit/test_frame_transforms.py
+++ b/packages/coordinax.astro/tests/unit/test_frame_transforms.py
@@ -475,3 +475,13 @@ def test_galactic_to_galactocentric_via_fallback_matches_astropy() -> None:
     )
     np.testing.assert_allclose(got_q, exp_q, rtol=0, atol=1e-6)
     np.testing.assert_allclose(got_v, exp_v, rtol=0, atol=1e-6)
+
+
+def test_galactic_matrix_is_float64():
+    """The Galactic rotation constant keeps float64 regardless of the x64 flag.
+
+    A JAX-array constant would be silently truncated to float32 at import
+    time under jax_enable_x64=False, discarding precision before use.
+    """
+    assert isinstance(ICRS_TO_GALACTIC_MATRIX, np.ndarray)
+    assert ICRS_TO_GALACTIC_MATRIX.dtype == np.float64

--- a/packages/coordinax.curveframes/src/coordinax/curveframes/_src/register_act.py
+++ b/packages/coordinax.curveframes/src/coordinax/curveframes/_src/register_act.py
@@ -104,12 +104,11 @@ def act(
     Array(True, dtype=bool)
 
     """
-    # Iterate the (Translate, Rotate) pipeline, threading the
-    # intermediate result through each sub-transform's act dispatch.
-    result: Any = x
-    for sub_op in op.transforms:
-        result = cxfm.act(sub_op, tau, result, chart, rep, **kw)
-    return result  # ty: ignore[invalid-return-type]
+    # Delegate to Composed, which threads the pipeline AND advances the
+    # tangent anchors (at/at_vel) between the time-dependent sub-transforms —
+    # a hand-rolled loop that forwards `at` unchanged would evaluate the
+    # Rotate's dR/dtau term at the un-translated base point.
+    return cxfm.act(cxfm.Composed(op.transforms), tau, x, chart, rep, **kw)  # ty: ignore[invalid-return-type]
 
 
 @plum.dispatch
@@ -172,9 +171,40 @@ def act(  # noqa: F811
     True
 
     """
-    # Same pipeline iteration, but the CDict flows through each
-    # sub-transform's CDict-aware act dispatch.
-    result: Any = x
-    for sub_op in op.transforms:
-        result = cxfm.act(sub_op, tau, result, chart, rep, **kw)
-    return result  # ty: ignore[invalid-return-type]
+    # Delegate to Composed (see the Quantity overload for why: anchor
+    # threading between the time-dependent sub-transforms).
+    return cxfm.act(cxfm.Composed(op.transforms), tau, x, chart, rep, **kw)  # ty: ignore[invalid-return-type]
+
+
+@plum.dispatch
+def pushforward(
+    op: AbstractParallelTransportTransform,
+    tau: Any,
+    v: CDict,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+    *,
+    at: CDict | None = None,
+    usys: Any = None,
+) -> CDict:
+    """Frozen-tau pushforward: delegate to the Composed pipeline."""
+    return cxfm.pushforward(  # ty: ignore[invalid-return-type]
+        cxfm.Composed(op.transforms), tau, v, chart, rep, at=at, usys=usys
+    )
+
+
+@plum.dispatch
+def prolong(
+    op: AbstractParallelTransportTransform,
+    tau: Any,
+    jet: dict,
+    chart: cxc.AbstractChart,
+    /,
+    *,
+    usys: Any = None,
+) -> dict:
+    """Kinematic prolongation of a jet: delegate to the Composed pipeline."""
+    return cxfm.prolong(  # ty: ignore[invalid-return-type]
+        cxfm.Composed(op.transforms), tau, jet, chart, usys=usys
+    )

--- a/packages/coordinax.curveframes/tests/test_act.py
+++ b/packages/coordinax.curveframes/tests/test_act.py
@@ -1,0 +1,47 @@
+"""Tests for parallel-transport transform act dispatches."""
+
+import pytest
+
+import quaxed.numpy as jnp
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.curveframes as cxfc
+import coordinax.representations as cxr
+import coordinax.transforms as cxfm
+
+
+class TestTangentAnchorThreading:
+    """The pipeline must advance anchors between its TD sub-transforms.
+
+    Regression for the final-audit finding: forwarding `at` unchanged into
+    the Rotate step evaluated dR/dtau at the un-translated base point.
+    """
+
+    @staticmethod
+    def _fs():
+        def circle(tau):
+            t = tau.ustrip("s")
+            return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), 0.0 * t]), "km")
+
+        return cxfc.FrenetSerretTransform.from_curve(circle, tau_unit=u.unit("s"))
+
+    def test_velocity_matches_generic_prolongation(self):
+        from coordinax.transforms._src.actions.prolong import prolong_jet
+
+        fs = self._fs()
+        tau = u.Q(0.3, "s")
+        at = {"x": u.Q(2.0, "km"), "y": u.Q(1.0, "km"), "z": u.Q(0.5, "km")}
+        v = {"x": u.Q(0.1, "km/s"), "y": u.Q(-0.2, "km/s"), "z": u.Q(0.05, "km/s")}
+        fast = cxfm.act(fs, tau, v, cxc.cart3d, cxr.coord_vel, at=at)
+        gen = prolong_jet(fs, tau, {0: at, 1: v}, cxc.cart3d)
+        for k in "xyz":
+            assert jnp.allclose(
+                u.ustrip("km/s", fast[k]), u.ustrip("km/s", gen[1][k]), atol=1e-6
+            )
+
+    def test_velocity_without_at_raises(self):
+        fs = self._fs()
+        v = {"x": u.Q(0.1, "km/s"), "y": u.Q(-0.2, "km/s"), "z": u.Q(0.05, "km/s")}
+        with pytest.raises(TypeError, match="requires the base point"):
+            cxfm.act(fs, u.Q(0.3, "s"), v, cxc.cart3d, cxr.coord_vel)

--- a/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/frames.py
+++ b/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/frames.py
@@ -7,6 +7,7 @@ parameters and enable seamless integration between the two libraries.
 Supported Frames:
 
 - ICRS: International Celestial Reference System
+- Galactic: heliocentric Galactic (l, b) coordinate system
 - Galactocentric: Galactic center-based coordinate system
 
 All conversions are implemented using plum's `@plum.conversion_method` decorator,
@@ -146,6 +147,71 @@ def astropy_icrs_to_coordinax_icrs(frame: apyc.ICRS, /) -> cxastro.ICRS:
 
 
 # =============================================================================
+# Galactic
+
+
+@plum.conversion_method(cxastro.Galactic, apyc.BaseCoordinateFrame)
+@plum.conversion_method(cxastro.Galactic, apyc.Galactic)
+def coordinax_galactic_to_astropy_galactic(frame: cxastro.Galactic, /) -> apyc.Galactic:
+    """Convert coordinax Galactic frame to Astropy Galactic frame.
+
+    The (heliocentric) Galactic frame has no frame-specific parameters in
+    either library, so the conversion is straightforward.
+
+    >>> import coordinax.astro as cxa
+    >>> import astropy.coordinates as apyc
+    >>> import plum
+
+    >>> cx_frame = cxastro.Galactic()
+    >>> plum.convert(cx_frame, apyc.Galactic)
+    <Galactic Frame>
+
+    >>> plum.convert(cx_frame, apyc.BaseCoordinateFrame)
+    <Galactic Frame>
+
+    """
+    return apyc.Galactic()
+
+
+@cxf.AbstractReferenceFrame.from_.dispatch  # ty: ignore[unresolved-attribute]
+def from_(cls: type[cxastro.Galactic], obj: apyc.Galactic, /) -> cxastro.Galactic:
+    """Construct from a `astropy.coordinates.Galactic`.
+
+    >>> import coordinax.astro as cxastro
+    >>> from plum import convert
+    >>> import astropy.coordinates as apyc
+
+    >>> apy_frame = apyc.Galactic()
+    >>> cxastro.Galactic.from_(apy_frame)
+    Galactic()
+
+    """
+    if obj.has_data:
+        raise ValueError("Astropy frame must not have data.")
+    return cls()
+
+
+@plum.conversion_method(apyc.Galactic, cxastro.AbstractSpaceFrame)
+@plum.conversion_method(apyc.Galactic, cxastro.Galactic)
+def astropy_galactic_to_coordinax_galactic(frame: apyc.Galactic, /) -> cxastro.Galactic:
+    """Convert Astropy Galactic frame to coordinax Galactic frame.
+
+    >>> import astropy.coordinates as apyc
+    >>> import coordinax.astro as cxastro
+    >>> import plum
+
+    >>> apy_frame = apyc.Galactic()
+    >>> plum.convert(apy_frame, cxastro.Galactic)
+    Galactic()
+
+    >>> plum.convert(apy_frame, cxastro.AbstractSpaceFrame)
+    Galactic()
+
+    """
+    return cxastro.galactic
+
+
+# =============================================================================
 # Galactocentric
 
 
@@ -208,15 +274,15 @@ def coordinax_galactocentric_to_astropy_galactocentric(
     # Convert the galcen position
     galcen_coord = apyc.ICRS(plum.convert(frame.galcen, apyc.SphericalRepresentation))
 
-    # # Convert the galcen velocity
-    # galcen_v_sun: apyc.CartesianDifferential = plum.convert(
-    #     frame.galcen_v_sun, apyc.CartesianDifferential
-    # )
+    # Convert the galcen velocity
+    galcen_v_sun: apyc.CartesianDifferential = plum.convert(
+        frame.galcen_v_sun, apyc.CartesianDifferential
+    )
 
     return apyc.Galactocentric(
         galcen_coord=galcen_coord,
         galcen_distance=plum.convert(frame.galcen["distance"], apyu.Quantity),
-        # galcen_v_sun=galcen_v_sun,
+        galcen_v_sun=galcen_v_sun,
         z_sun=plum.convert(frame.z_sun, apyu.Quantity),
         roll=plum.convert(frame.roll, apyu.Quantity),
     )
@@ -240,11 +306,22 @@ def from_(
     >>> gcf
     Galactocentric(
       galcen=Point(
-        { 'lon': Q(f64[], 'deg'), 'lat': Q(f64[], 'deg'), 'distance': Q(f64[], 'kpc') },
-        chart=LonLatSpherical3D(M=Rn(3)), frame=ICRS()
+        {
+          'lon': Q(f64[], 'deg'),
+          'lat': Q(f64[], 'deg'),
+          'distance': Q(f64[], 'kpc')
+        },
+        chart=LonLatSpherical3D(M=Rn(3)),
+        frame=ICRS()
       ),
       roll=Angle(f64[], 'deg'),
-      z_sun=Quantity(f64[], 'pc')
+      z_sun=Quantity(f64[], 'pc'),
+      galcen_v_sun=Tangent(
+        {'x': Q(f64[], 'km / s'), 'y': Q(f64[], 'km / s'), 'z': Q(f64[], 'km / s')},
+        chart=Cart3D(M=Rn(3)),
+        basis=coord_basis,
+        semantic=vel
+      )
     )
 
     Checking equality
@@ -268,16 +345,15 @@ def from_(
         galcen_data, chart=cxc.lonlat_sph3d, frame=cxastro.icrs
     )
 
-    # # Convert galcen_v_sun to CartesianVel3D
-    # galcen_v_sun: cx.Tangent[cxc.Cart3D, cxr.PhysVel] = plum.convert(
-    #     frame.galcen_v_sun, cx.Tangent
-    # )
+    # Convert galcen_v_sun to a Cartesian velocity Tangent
+    # (astropy stores galcen_v_sun as a CartesianDifferential)
+    galcen_v_sun: cxv.Tangent = plum.convert(frame.galcen_v_sun, cxv.Tangent)
 
     return cxastro.Galactocentric(
         galcen=galcen,
         roll=plum.convert(frame.roll, u.Q),
         z_sun=plum.convert(frame.z_sun, u.Q),
-        # galcen_v_sun=galcen_v_sun,
+        galcen_v_sun=galcen_v_sun,
     )
 
 
@@ -314,11 +390,22 @@ def astropy_galactocentric_to_coordinax_galactocentric(
     >>> convert(apy_frame, cxastro.Galactocentric)
     Galactocentric(
       galcen=Point(
-        { 'lon': Q(f64[], 'deg'), 'lat': Q(f64[], 'deg'), 'distance': Q(f64[], 'kpc') },
-        chart=LonLatSpherical3D(M=Rn(3)), frame=ICRS()
+        {
+          'lon': Q(f64[], 'deg'),
+          'lat': Q(f64[], 'deg'),
+          'distance': Q(f64[], 'kpc')
+        },
+        chart=LonLatSpherical3D(M=Rn(3)),
+        frame=ICRS()
       ),
       roll=Angle(f64[], 'deg'),
-      z_sun=Quantity(f64[], 'pc')
+      z_sun=Quantity(f64[], 'pc'),
+      galcen_v_sun=Tangent(
+        {'x': Q(f64[], 'km / s'), 'y': Q(f64[], 'km / s'), 'z': Q(f64[], 'km / s')},
+        chart=Cart3D(M=Rn(3)),
+        basis=coord_basis,
+        semantic=vel
+      )
     )
 
     Convert with custom parameters:

--- a/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/frames.py
+++ b/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/frames.py
@@ -158,7 +158,7 @@ def coordinax_galactic_to_astropy_galactic(frame: cxastro.Galactic, /) -> apyc.G
     The (heliocentric) Galactic frame has no frame-specific parameters in
     either library, so the conversion is straightforward.
 
-    >>> import coordinax.astro as cxa
+    >>> import coordinax.astro as cxastro
     >>> import astropy.coordinates as apyc
     >>> import plum
 

--- a/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/vec_constructors.py
+++ b/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/vec_constructors.py
@@ -230,13 +230,22 @@ def from_astropy_skycoord(cls: type[cxv.Point], obj: apyc.SkyCoord, /) -> cxv.Po
       chart=Cart3D(M=Rn(3)),
       frame=Galactocentric(
         galcen=Point(
-          { 'lon': Q(266.4051, 'deg'), 'lat': Q(-28.936175, 'deg'),
+          {
+            'lon': Q(266.4051, 'deg'),
+            'lat': Q(-28.936175, 'deg'),
             'distance': Q(8.122, 'kpc')
           },
-          chart=LonLatSpherical3D(M=Rn(3)), frame=ICRS()
+          chart=LonLatSpherical3D(M=Rn(3)),
+          frame=ICRS()
         ),
         roll=Angle(0., 'deg'),
-        z_sun=Q(20.8, 'pc')
+        z_sun=Q(20.8, 'pc'),
+        galcen_v_sun=Tangent(
+          {'x': Q(12.9, 'km / s'), 'y': Q(245.6, 'km / s'), 'z': Q(7.78, 'km / s')},
+          chart=Cart3D(M=Rn(3)),
+          basis=coord_basis,
+          semantic=vel
+        )
       )
     )
 

--- a/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/vec_converters.py
+++ b/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/vec_converters.py
@@ -326,3 +326,63 @@ def apysph_to_lonlatsph(obj: apyc.SphericalRepresentation, /) -> cxv.Point:
 
     """
     return cxv.Point.from_(obj)  # ty: ignore[invalid-return-type]
+
+
+# =====================================
+# Cartesian velocity (Tangent <-> CartesianDifferential)
+
+
+@plum.conversion_method(cxv.Tangent, apyc.CartesianDifferential)
+def tangent_to_apycartdiff(obj: cxv.Tangent, /) -> apyc.CartesianDifferential:
+    """`coordinax.Tangent` (Cartesian velocity) -> `astropy.CartesianDifferential`.
+
+    >>> import unxt as u
+    >>> import coordinax.vectors as cxv
+
+    >>> vel = cxv.Tangent.from_([12.9, 245.6, 7.78], "km/s")
+    >>> convert(vel, apyc.CartesianDifferential)
+    <CartesianDifferential (d_x, d_y, d_z) in km / s
+        (12.9, 245.6, 7.78)>
+
+    """
+    # Check that the tangent has velocity semantics.
+    obj = check_semantics(obj, need=cxr.Velocity)
+    if obj.chart != cxc.cart3d:
+        msg = (
+            "Tangent -> CartesianDifferential conversion requires a "
+            f"Cartesian chart; got {obj.chart!r}. Convert with `cconvert` "
+            "(supplying `at=`) first."
+        )
+        raise ValueError(msg)
+
+    return apyc.CartesianDifferential(
+        d_x=plum.convert(obj["x"], apyu.Quantity),
+        d_y=plum.convert(obj["y"], apyu.Quantity),
+        d_z=plum.convert(obj["z"], apyu.Quantity),
+    )
+
+
+@plum.conversion_method(apyc.CartesianDifferential, cxv.Tangent)
+def apycartdiff_to_tangent(obj: apyc.CartesianDifferential, /) -> cxv.Tangent:
+    """`astropy.CartesianDifferential` -> `coordinax.Tangent` (Cartesian velocity).
+
+    >>> import astropy.units as apyu
+    >>> import astropy.coordinates as apyc
+    >>> import coordinax.vectors as cxv
+
+    >>> dif = apyc.CartesianDifferential(
+    ...     d_x=12.9 * apyu.km / apyu.s,
+    ...     d_y=245.6 * apyu.km / apyu.s,
+    ...     d_z=7.78 * apyu.km / apyu.s,
+    ... )
+    >>> print(convert(dif, cxv.Tangent))
+    <Tangent: chart=Cart3D (x, y, z) [km / s]
+        [ 12.9  245.6    7.78]>
+
+    """
+    data = {
+        "x": plum.convert(obj.d_x, u.Q),  # ty: ignore[unresolved-attribute]
+        "y": plum.convert(obj.d_y, u.Q),  # ty: ignore[unresolved-attribute]
+        "z": plum.convert(obj.d_z, u.Q),  # ty: ignore[unresolved-attribute]
+    }
+    return cxv.Tangent(data, cxc.cart3d, cxr.coord_basis, cxr.vel)  # ty: ignore[missing-argument]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,8 @@ describe_command = [
 
 
 [tool.codespell]
-skip = ["uv.lock"]
+ignore-words-list = "precessed,precessing"
+skip              = ["uv.lock"]
 
 
 [tool.repo-review]

--- a/src/coordinax/frames/_src/example.py
+++ b/src/coordinax/frames/_src/example.py
@@ -8,9 +8,9 @@ from typing import cast, final
 import plum
 
 import unxt as u
-from dataclassish import replace
 
 import coordinax.api.frames as cxfapi
+import coordinax.charts as cxc
 import coordinax.representations as cxr
 import coordinax.transforms as cxfm
 from .base import AbstractReferenceFrame
@@ -242,8 +242,11 @@ def frame_transition(from_frame: Alice, to_frame: Bob, /) -> cxfm.Composed:
 
     """
     shift = cxfm.Translate.from_([100_000, 10_000, 0], "km")
-    kick_delta = cxfm.Translate.from_(u.Q([269_813_212.2, 0, 0], "m/s"))
-    kick = replace(kick_delta, semantic_kind=cxr.vel)
+    kick = cxfm.Translate(
+        cxc.cdict(u.Q([269_813_212.2, 0, 0], "m/s"), cxc.cart3d),
+        chart=cxc.cart3d,
+        semantic_kind=cxr.vel,
+    )
     return shift | kick  # ty: ignore[unsupported-operator]
 
 

--- a/src/coordinax/frames/_src/example.py
+++ b/src/coordinax/frames/_src/example.py
@@ -135,15 +135,20 @@ class Bob(AbstractReferenceFrame):
       )
     ))
 
-    Applying the Alice -> Bob transform to a bare array treats the array as a
-    position; the velocity kick leaves positions unchanged:
+    A bare, unitless array is rejected: the velocity kick cannot tell a
+    position array (kick is identity) from a velocity array (kick applies),
+    so silently guessing would risk wrong physics. Use a Quantity, cdict, or
+    typed vector instead:
 
     >>> import jax.numpy as jnp
     >>> import unxt as u
     >>> import coordinax.transforms as cxfm
     >>> x = jnp.asarray([0.0, 0.0, 0.0])
-    >>> cxfm.act(op, None, x, usys=u.unitsystems.si)
-    Array([1.e+08, 1.e+07, 0.e+00], dtype=float64)
+    >>> try:
+    ...     cxfm.act(op, None, x, usys=u.unitsystems.si)
+    ... except TypeError as e:
+    ...     print(str(e)[:30])
+    A fibre offset (Translate with
 
     Applying the Alice -> Bob transform to a ``Quantity`` works:
 

--- a/src/coordinax/frames/_src/example.py
+++ b/src/coordinax/frames/_src/example.py
@@ -8,8 +8,10 @@ from typing import cast, final
 import plum
 
 import unxt as u
+from dataclassish import replace
 
 import coordinax.api.frames as cxfapi
+import coordinax.representations as cxr
 import coordinax.transforms as cxfm
 from .base import AbstractReferenceFrame
 
@@ -104,7 +106,8 @@ class Bob(AbstractReferenceFrame):
       ≈ 269 813 km s⁻¹ (≈ 0.9 c) along Alice's x-axis.
 
     Because Bob is non-rotating, no rotation operator is required; the
-    transformation only needs a spatial translation and a Galilean boost.
+    transformation only needs a spatial translation and a velocity kick
+    (a ``Translate`` with ``semantic_kind=vel``).
 
     Examples
     --------
@@ -115,28 +118,32 @@ class Bob(AbstractReferenceFrame):
     >>> cxf.frame_transition(cxf.bob, cxf.bob)
     Identity()
 
-    Transition from Alice's frame to Bob's frame (translate then boost):
+    Transition from Alice's frame to Bob's frame (translate then velocity
+    kick):
 
     >>> op = cxf.frame_transition(cxf.alice, cxf.bob)
     >>> print(op)
     Composed((
-      Translate( {...}, chart=Cart3D(M=Rn(3)) ),
-      Boost( {...}, chart=Cart3D(M=Rn(3)) )
+      Translate(
+          {'x': Q(100000, 'km'), 'y': Q(10000, 'km'), 'z': Q(0, 'km')},
+          chart=Cart3D(M=Rn(3))
+      ),
+      Translate(
+          {'x': Q(2.69813212e+08, 'm / s'), 'y': Q(0., 'm / s'), 'z': Q(0., 'm / s')},
+          chart=Cart3D(M=Rn(3)),
+          semantic_kind=vel
+      )
     ))
 
-    Applying the Alice -> Bob transform to a bare array is not supported,
-    because the boost cannot infer whether the array represents a position or a
-    velocity:
+    Applying the Alice -> Bob transform to a bare array treats the array as a
+    position; the velocity kick leaves positions unchanged:
 
     >>> import jax.numpy as jnp
     >>> import unxt as u
     >>> import coordinax.transforms as cxfm
     >>> x = jnp.asarray([0.0, 0.0, 0.0])
-    >>> cxfm.act(
-    ...     op, None, x, usys=u.unitsystems.si
-    ... )
-    Traceback (most recent call last):
-    plum._resolver.NotFoundLookupError: ...
+    >>> cxfm.act(op, None, x, usys=u.unitsystems.si)
+    Array([1.e+08, 1.e+07, 0.e+00], dtype=float64)
 
     Applying the Alice -> Bob transform to a ``Quantity`` works:
 
@@ -203,14 +210,17 @@ def frame_transition(from_frame: Alice, to_frame: Bob, /) -> cxfm.Composed:
     r"""Transform from Alice's frame to Bob's frame.
 
     This is an example of a reference frame transformation that includes
-    both a spatial translation (Translate) and a velocity boost (Boost).
+    both a spatial translation and a velocity kick (a ``Translate`` with
+    ``semantic_kind=vel`` — the fibre-only offset; contrast with
+    `coordinax.transforms.Boost`, the true Galilean boost, whose point action
+    moves positions by $\Delta v \, \tau$ and therefore requires a time).
 
-    The Boost has well-defined actions on kinematic roles:
+    The velocity kick has well-defined actions on kinematic roles:
 
-    - **Point**: identity (points are unchanged by a Galilean boost)
-    - **Pos**: identity (displacements are Galilean invariant)
-    - **Vel**: adds $v_0$
-    - **PhysAcc**: identity (for constant boost)
+    - **Point**: identity (points are unchanged by a velocity kick)
+    - **Displacement**: identity (Galilean invariant)
+    - **Velocity**: adds $v_0$
+    - **Acceleration**: identity (for a constant kick)
 
     Examples
     --------
@@ -223,12 +233,13 @@ def frame_transition(from_frame: Alice, to_frame: Bob, /) -> cxfm.Composed:
 
     >>> op = cxf.frame_transition(alice, bob)
     >>> print(op)
-    Composed(( Translate(...), Boost(...) ))
+    Composed(( Translate(...), Translate(...) ))
 
     """
     shift = cxfm.Translate.from_([100_000, 10_000, 0], "km")
-    boost = cxfm.Boost.from_([269_813_212.2, 0, 0], "m/s")
-    return shift | boost  # ty: ignore[unsupported-operator]
+    kick_delta = cxfm.Translate.from_(u.Q([269_813_212.2, 0, 0], "m/s"))
+    kick = replace(kick_delta, semantic_kind=cxr.vel)
+    return shift | kick  # ty: ignore[unsupported-operator]
 
 
 @plum.dispatch.multi((Alex, Alice), (Bob, Alice))
@@ -243,10 +254,17 @@ def frame_transition(
     >>> cxf.frame_transition(cxf.alex, cxf.alice)
     Composed(( Rotate(...), Translate(...) ))
 
-    >>> cxf.frame_transition(cxf.bob, cxf.alice)
+    >>> print(cxf.frame_transition(cxf.bob, cxf.alice))
     Composed((
-      Boost( {...}, chart=Cart3D(M=Rn(3)) ),
-      Translate( {...}, chart=Cart3D(M=Rn(3)) )
+      Translate(
+          {'x': Q(-2.69813212e+08, 'm / s'), ...},
+          chart=Cart3D(M=Rn(3)),
+          semantic_kind=vel
+      ),
+      Translate(
+          {'x': Q(-100000, 'km'), 'y': Q(-10000, 'km'), 'z': Q(0, 'km')},
+          chart=Cart3D(M=Rn(3))
+      )
     ))
 
     """

--- a/src/coordinax/representations/_src/semantics.py
+++ b/src/coordinax/representations/_src/semantics.py
@@ -457,7 +457,10 @@ class AbstractTangentSemanticKind(AbstractSemanticKind):
         if hasattr(super(), "__init_subclass__"):
             super().__init_subclass__(**kwargs)
 
-        if not hasattr(cls, "order"):
+        # NOTE: AbstractSemanticKind declares `order: ClassVar[int | None] = None`
+        # (None for non-ladder kinds), so a tangent subclass that fails to set
+        # `order` inherits None rather than missing the attribute.
+        if getattr(cls, "order", None) is None:
             raise TypeError(
                 f"{cls.__name__!r} must define class variable 'order' as an int "
                 "before registration in the tangent time-order ladder."

--- a/src/coordinax/representations/_src/semantics.py
+++ b/src/coordinax/representations/_src/semantics.py
@@ -107,6 +107,14 @@ class AbstractSemanticKind(metaclass=abc.ABCMeta):
     canonical_name: ClassVar[str | None] = None
     """Canonical name for the geometric kind."""
 
+    order: ClassVar[int | None] = None
+    """Time-derivative ladder order, or ``None`` if not on the ladder.
+
+    Tangent semantic kinds (`AbstractTangentSemanticKind`) override this with
+    an ``int`` (0=displacement, 1=velocity, 2=acceleration, ...); non-ladder
+    kinds such as `Location` leave it as ``None``.
+    """
+
     # ===============================================================
     # Dimension API
 

--- a/src/coordinax/transforms/__init__.py
+++ b/src/coordinax/transforms/__init__.py
@@ -21,9 +21,13 @@ from ._setup_package import install_import_hook
 __all__: tuple[str, ...] = (
     # API
     "act",
+    "pushforward",
+    "prolong",
     "simplify",
     "compose",
     "materialize_transform",
+    "is_time_dependent",
+    "tau_derivative",
     # Groups
     "AbstractTransformGroup",
     "IdentityGroup",
@@ -62,7 +66,9 @@ with install_import_hook("coordinax.transforms"):
         Shear,
         Translate,
         identity,
+        is_time_dependent,
         materialize_transform,
+        tau_derivative,
     )
     from ._src.groups import (
         AbstractTransformGroup,
@@ -76,7 +82,7 @@ with install_import_hook("coordinax.transforms"):
         ProperOrthochronousLorentzGroup,
         SpecialOrthogonalGroup,
     )
-    from coordinax.api.transforms import act, compose, simplify
+    from coordinax.api.transforms import act, compose, prolong, pushforward, simplify
 
 
 _TRANSFORM_EXPORTS_ENTRYPOINT_GROUP: Final = "coordinax.transforms"

--- a/src/coordinax/transforms/_src/actions/__init__.py
+++ b/src/coordinax/transforms/_src/actions/__init__.py
@@ -8,6 +8,7 @@ from .composite import *
 from .constants import *
 from .custom_types import *
 from .identity import *
+from .prolong import *
 from .reflect import *
 from .register_apply import *
 from .rotate import *

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -229,8 +229,10 @@ def prolong(
 ) -> dict:
     r"""Prolong an additive operator slot-wise.
 
-    An additive operator's point Jacobian is the identity, so its
-    prolongation has no cross-slot coupling: each jet slot transforms
+    When the offset and the jet live in the same Cartesian-type (flat) chart
+    (or the operator is a fibre-only offset, whose point action is the
+    identity), the point Jacobian is the identity and the prolongation has
+    no cross-slot coupling: each jet slot transforms
     independently by the operator's ladder rule (slot $m$ gains
     $d^{m-k}\delta/d\tau^{m-k}$ for the operator's ladder order $k$). This
     also makes fibre-only offsets (e.g. ``Translate(semantic_kind=vel)``) —

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -259,26 +259,21 @@ def prolong(
     from .prolong import prolong_jet  # noqa: PLC0415 - avoid cycle
 
     k = getattr(op, "semantic_kind", cxr.dpl).order
-    if chart == op.chart and (k != 0 or is_flat_chart(op.chart)):
+    if k != 0 or (chart == op.chart and is_flat_chart(chart)):
+        # The jet always supplies the base point, so fibre kicks (k >= 1)
+        # work even cross-chart: `act` pushes the offset through the chart
+        # Jacobian at jet[0] when the charts differ.
         return {
-            m: cxfmapi.act(op, tau, slot, chart, _slot_rep(m), usys=usys)
+            m: cxfmapi.act(op, tau, slot, chart, _slot_rep(m), at=jet[0], usys=usys)
             for m, slot in jet.items()
         }
 
-    # Otherwise: a point-active offset (ladder order 0) is fully captured by
-    # the point action — whether the jet is in a different chart or the
-    # offset lives in a non-Cartesian chart (where the point action is
-    # base-point dependent and the slot-wise ladder rule does not apply) —
-    # so use the generic prolongation. A fibre-only offset has no
-    # well-defined cross-chart rule (same as `act`).
-    if k == 0:
-        return prolong_jet(op, tau, jet, chart, usys=usys)
-    msg = (
-        f"{type(op).__name__}.delta is defined in chart {op.chart!r}, "
-        f"but the jet is in chart {chart!r}. "
-        "Convert delta to the target chart before constructing the operator."
-    )
-    raise ValueError(msg)
+    # A point-active offset (ladder order 0) outside the flat matching case
+    # is fully captured by the point action — whether the jet is in a
+    # different chart or the offset lives in a non-Cartesian chart (where the
+    # point action is base-point dependent and the slot-wise ladder rule does
+    # not apply) — so use the generic prolongation.
+    return prolong_jet(op, tau, jet, chart, usys=usys)
 
 
 # ============================================================================

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -19,6 +19,7 @@ from dataclassish import field_items
 from unxt.quantity import AllowValue, is_any_quantity
 
 import coordinax.charts as cxc
+import coordinax.representations as cxr
 from .base import AbstractTransform
 from .composed import Composed
 from .custom_types import CDict
@@ -200,6 +201,80 @@ def from_(cls: type[AbstractAdd], x: ArrayLike, unit: str) -> AbstractAdd:
 
     """
     return cls.from_(u.Q(x, unit))  # ty: ignore[invalid-return-type]
+
+
+# ============================================================================
+# prolong
+
+
+def _slot_rep(m: int, /) -> Any:
+    """Return the coordinate-basis representation for jet slot ``m``."""
+    if m == 0:
+        return cxr.point
+    kind: cxr.AbstractTangentSemanticKind = cxr.vel
+    while kind.order < m:
+        kind = kind.derivative()
+    return cxr.Representation(cxr.tangent_geom, cxr.coord_basis, kind)
+
+
+@plum.dispatch
+def prolong(
+    op: AbstractAdd,
+    tau: Any,
+    jet: dict,
+    chart: cxc.AbstractChart,
+    /,
+    *,
+    usys: Any = None,
+) -> dict:
+    r"""Prolong an additive operator slot-wise.
+
+    An additive operator's point Jacobian is the identity, so its
+    prolongation has no cross-slot coupling: each jet slot transforms
+    independently by the operator's ladder rule (slot $m$ gains
+    $d^{m-k}\delta/d\tau^{m-k}$ for the operator's ladder order $k$). This
+    also makes fibre-only offsets (e.g. ``Translate(semantic_kind=vel)``) —
+    which are invisible to the generic point-action prolongation — correct
+    under ``prolong``.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import coordinax.transforms as cxfm
+
+    >>> kick = cxfm.Translate(
+    ...     {"x": u.Q(100.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+    ...     chart=cxc.cart3d, semantic_kind=cxr.vel,
+    ... )
+    >>> jet = {0: {"x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")},
+    ...        1: {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")}}
+    >>> out = cxfm.prolong(kick, None, jet, cxc.cart3d)
+    >>> out[0]["x"], out[1]["x"]
+    (Q(1., 'm'), Q(101., 'm / s'))
+
+    """
+    import coordinax.api.transforms as cxfmapi  # noqa: PLC0415 - avoid cycle
+    from .prolong import prolong_jet  # noqa: PLC0415 - avoid cycle
+
+    if chart == op.chart:
+        return {
+            m: cxfmapi.act(op, tau, slot, chart, _slot_rep(m), usys=usys)
+            for m, slot in jet.items()
+        }
+
+    # Jet in a different chart: a point-active offset (ladder order 0) is
+    # fully captured by the point action, which handles the chart mapping —
+    # use the generic prolongation. A fibre-only offset has no well-defined
+    # cross-chart rule (same as `act`).
+    k = getattr(op, "semantic_kind", cxr.dpl).order
+    if k == 0:
+        return prolong_jet(op, tau, jet, chart, usys=usys)
+    msg = (
+        f"{type(op).__name__}.delta is defined in chart {op.chart!r}, "
+        f"but the jet is in chart {chart!r}. "
+        "Convert delta to the target chart before constructing the operator."
+    )
+    raise ValueError(msg)
 
 
 # ============================================================================

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -203,6 +203,43 @@ def from_(cls: type[AbstractAdd], x: ArrayLike, unit: str) -> AbstractAdd:
 
 
 # ============================================================================
+# pushforward
+
+
+@plum.dispatch
+def pushforward(
+    op: AbstractAdd,
+    tau: Any,
+    v: CDict,
+    chart: cxc.AbstractChart,
+    rep: Any,
+    /,
+    *,
+    at: CDict | None = None,
+    usys: Any = None,
+) -> CDict:
+    r"""Pushforward under an additive operator: identity.
+
+    The point action of an additive operator is a translation of the ambient
+    (flat) space, whose differential is the identity, so tangent components
+    are unchanged. No base point is required.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import coordinax.transforms as cxfm
+
+    >>> op = cxfm.Translate.from_([1, 2, 3], "km")
+    >>> d = {"x": u.Q(1.0, "km"), "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")}
+    >>> cxfm.pushforward(op, None, d, cxc.cart3d, cxr.coord_disp)
+    {'x': Q(1., 'km'), 'y': Q(0., 'km'), 'z': Q(0., 'km')}
+
+    """
+    del op, tau, chart, rep, at, usys
+    return v
+
+
+# ============================================================================
 # Simplification
 
 

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -295,11 +295,17 @@ def pushforward(
     at: CDict | None = None,
     usys: Any = None,
 ) -> CDict:
-    r"""Pushforward under an additive operator: identity.
+    r"""Pushforward under an additive operator.
 
-    The point action of an additive operator is a translation of the ambient
-    (flat) space, whose differential is the identity, so tangent components
-    are unchanged. No base point is required.
+    When the offset and the data live in the same Cartesian-type (flat)
+    chart — or the operator is a fibre-only offset (ladder order $k \geq 1$,
+    identity point action) — the point action's differential is the identity,
+    tangent components are unchanged, and no base point is required.
+
+    A $k=0$ offset in a non-flat chart, or acting on data in a different or
+    non-flat chart, is not a flat translation: the differential is base-point
+    dependent, so this defers to the generic engine, which **requires** the
+    base point ``at``.
 
     >>> import unxt as u
     >>> import coordinax.charts as cxc
@@ -312,11 +318,11 @@ def pushforward(
     {'x': Q(1., 'km'), 'y': Q(0., 'km'), 'z': Q(0., 'km')}
 
     """
-    # A k=0 offset in a non-Cartesian chart is NOT a flat translation: its
-    # point action pushes delta through the chart Jacobian at the point, so
-    # the differential is base-point dependent. Defer to the generic engine.
+    # A k=0 offset is a flat translation only when delta and the data live
+    # in the same Cartesian-type chart; otherwise the differential is
+    # base-point dependent. Defer to the generic engine.
     k = getattr(op, "semantic_kind", cxr.dpl).order
-    if k == 0 and not is_flat_chart(op.chart):
+    if k == 0 and not (chart == op.chart and is_flat_chart(chart)):
         from .prolong import pushforward_generic  # noqa: PLC0415 - avoid cycle
 
         return pushforward_generic(op, tau, v, chart, rep, at=at, usys=usys)

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -263,8 +263,18 @@ def prolong(
         # The jet always supplies the base point, so fibre kicks (k >= 1)
         # work even cross-chart: `act` pushes the offset through the chart
         # Jacobian at jet[0] when the charts differ.
+        # The base point anchors the tangent slots only: slot 0 IS the point,
+        # so it gets no 'at' (a strict point dispatch need not accept one).
         return {
-            m: cxfmapi.act(op, tau, slot, chart, _slot_rep(m), at=jet[0], usys=usys)
+            m: cxfmapi.act(
+                op,
+                tau,
+                slot,
+                chart,
+                _slot_rep(m),
+                usys=usys,
+                **({"at": jet[0]} if m else {}),
+            )
             for m, slot in jet.items()
         }
 

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -24,7 +24,7 @@ from .base import AbstractTransform
 from .composed import Composed
 from .custom_types import CDict
 from .identity import Identity, identity
-from .utils import Neg
+from .utils import Neg, is_flat_chart
 from coordinax.internal import jax_scalar_handler, pos_named_objs
 
 
@@ -256,17 +256,19 @@ def prolong(
     import coordinax.api.transforms as cxfmapi  # noqa: PLC0415 - avoid cycle
     from .prolong import prolong_jet  # noqa: PLC0415 - avoid cycle
 
-    if chart == op.chart:
+    k = getattr(op, "semantic_kind", cxr.dpl).order
+    if chart == op.chart and (k != 0 or is_flat_chart(op.chart)):
         return {
             m: cxfmapi.act(op, tau, slot, chart, _slot_rep(m), usys=usys)
             for m, slot in jet.items()
         }
 
-    # Jet in a different chart: a point-active offset (ladder order 0) is
-    # fully captured by the point action, which handles the chart mapping —
-    # use the generic prolongation. A fibre-only offset has no well-defined
-    # cross-chart rule (same as `act`).
-    k = getattr(op, "semantic_kind", cxr.dpl).order
+    # Otherwise: a point-active offset (ladder order 0) is fully captured by
+    # the point action — whether the jet is in a different chart or the
+    # offset lives in a non-Cartesian chart (where the point action is
+    # base-point dependent and the slot-wise ladder rule does not apply) —
+    # so use the generic prolongation. A fibre-only offset has no
+    # well-defined cross-chart rule (same as `act`).
     if k == 0:
         return prolong_jet(op, tau, jet, chart, usys=usys)
     msg = (
@@ -310,6 +312,15 @@ def pushforward(
     {'x': Q(1., 'km'), 'y': Q(0., 'km'), 'z': Q(0., 'km')}
 
     """
+    # A k=0 offset in a non-Cartesian chart is NOT a flat translation: its
+    # point action pushes delta through the chart Jacobian at the point, so
+    # the differential is base-point dependent. Defer to the generic engine.
+    k = getattr(op, "semantic_kind", cxr.dpl).order
+    if k == 0 and not is_flat_chart(op.chart):
+        from .prolong import pushforward_generic  # noqa: PLC0415 - avoid cycle
+
+        return pushforward_generic(op, tau, v, chart, rep, at=at, usys=usys)
+
     del op, tau, chart, rep, at, usys
     return v
 

--- a/src/coordinax/transforms/_src/actions/base.py
+++ b/src/coordinax/transforms/_src/actions/base.py
@@ -469,6 +469,13 @@ def is_time_dependent(op: Any, /) -> bool:
     False
 
     """
+    if not dataclasses.is_dataclass(op):
+        msg = (
+            "is_time_dependent expects a transform (a dataclass instance); "
+            f"got {type(op).__name__!r}."
+        )
+        raise TypeError(msg)
+
     # NOTE: no `is_leaf=callable` — operators themselves define __call__, and
     # descending into composite operators as pytrees is exactly what makes
     # this rule match `materialize_transform`'s eqx.partition(callable).

--- a/src/coordinax/transforms/_src/actions/base.py
+++ b/src/coordinax/transforms/_src/actions/base.py
@@ -1,6 +1,6 @@
 """Base classes for operators on coordinates."""
 
-__all__ = ("AbstractTransform", "materialize_transform")
+__all__ = ("AbstractTransform", "is_time_dependent", "materialize_transform")
 
 import abc
 import dataclasses
@@ -423,3 +423,54 @@ def materialize_transform(op: OpT, tau: Any, /) -> OpT:
 
     # Create a new operator of the same type with the evaluated parameters
     return type(op)(**evaluated_params)
+
+
+def is_time_dependent(op: Any, /) -> bool:
+    r"""Whether any parameter of the operator is a callable of ``tau``.
+
+    This is a static (trace-time) check mirroring the partition rule of
+    `materialize_transform`: an operator is time-dependent iff any leaf of its
+    dataclass-field values is callable. Composite operators (e.g. ``Composed``)
+    are time-dependent iff any of their component operators is, which follows
+    from the same rule since the components are pytree children.
+
+    Parameters
+    ----------
+    op
+        The operator to inspect.
+
+    Returns
+    -------
+    bool
+        A plain Python bool, safe to branch on during JAX tracing.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.transforms as cxfm
+
+    >>> static = cxfm.Translate.from_([1, 2, 3], "km")
+    >>> cxfm.is_time_dependent(static)
+    False
+
+    >>> moving = cxfm.Translate(
+    ...     lambda t: cx.cdict(u.Q([t.ustrip("s"), 0, 0], "km")), chart=cxc.cart3d
+    ... )
+    >>> cxfm.is_time_dependent(moving)
+    True
+
+    A composition is time-dependent iff any component is:
+
+    >>> cxfm.is_time_dependent(static | moving)
+    True
+    >>> cxfm.is_time_dependent(static | cxfm.Identity())
+    False
+
+    """
+    # NOTE: no `is_leaf=callable` — operators themselves define __call__, and
+    # descending into composite operators as pytrees is exactly what makes
+    # this rule match `materialize_transform`'s eqx.partition(callable).
+    params = [getattr(op, field.name) for field in dataclasses.fields(op)]
+    return any(callable(leaf) for leaf in jtu.leaves(params))

--- a/src/coordinax/transforms/_src/actions/boost.py
+++ b/src/coordinax/transforms/_src/actions/boost.py
@@ -2,7 +2,7 @@
 
 __all__ = ("Boost",)
 
-from typing import Any, cast, final
+from typing import TYPE_CHECKING, Any, cast, final
 
 import jax.tree as jtu
 import plum
@@ -16,8 +16,10 @@ import coordinax.charts as cxc
 import coordinax.representations as cxr
 from .add import AbstractAdd
 from .custom_types import CDict, OptUSys
-from .prolong import tau_derivative
 from coordinax.transforms._src.groups import AffineGroup, DiffeomorphismGroup
+
+if TYPE_CHECKING:
+    from .translate import Translate
 
 _MSG_TAU_REQUIRED_POINT = (
     "act(Boost, ...) on point data requires a time parameter: the Galilean "
@@ -112,6 +114,13 @@ def _boost_displacement(op: Boost, /) -> Any:
     return g
 
 
+def _as_translate(op: Boost, /) -> "Translate":
+    """Return the equivalent displacement Translate: delta = dv(tau) * tau."""
+    from .translate import Translate  # noqa: PLC0415 - avoid module cycle
+
+    return Translate(_boost_displacement(op), chart=op.chart, right_add=op.right_add)
+
+
 # ============================================================================
 # act
 
@@ -159,42 +168,39 @@ def act(
     """
     del kw
 
-    # --- Point input: x + dv * tau, via the Translate point machinery.
+    # --- Point input: x + dv * tau, via the Translate ladder machinery.
     if rep == cxr.point:
         if tau is None:
             raise TypeError(_MSG_TAU_REQUIRED_POINT)
-        from .translate import Translate  # noqa: PLC0415 - avoid module cycle
-
-        eff = Translate(_boost_displacement(op), chart=op.chart, right_add=op.right_add)
-        return cast("CDict", cxfmapi.act(eff, tau, x, chart, rep, usys=usys))
+        return cast(
+            "CDict", cxfmapi.act(_as_translate(op), tau, x, chart, rep, usys=usys)
+        )
 
     # --- Tangent input of ladder order m.
-    m = rep.semantic_kind.order  # ty: ignore[unresolved-attribute]
+    m = rep.semantic_kind.order
     # Displacements are invariant (the Jacobian of a translation is I).
     if m == 0:
         return x
 
-    # Contribution: d^m (dv(tau) * tau) / dtau^m.
+    # Static dv: closed forms that need no time parameter.
     if not callable(op.delta):
-        if m == 1:
-            contribution = op.delta
-        else:
+        if m != 1:
             # Constant dv: higher derivatives of dv*tau vanish.
             return x
-    else:
-        if tau is None:
-            raise TypeError(_MSG_TAU_REQUIRED_TANGENT.format(m=m))
-        contribution = tau_derivative(_boost_displacement(op), tau, n=m)
+        if op.chart != chart:
+            msg = _MSG_CHART_MISMATCH.format(chart=chart, op_chart=op.chart)
+            raise ValueError(msg)
+        return cast(
+            "CDict",
+            jtu.map(
+                jnp.add,
+                *((x, op.delta) if op.right_add else (op.delta, x)),
+                is_leaf=u.quantity.is_any_quantity,
+            ),
+        )
 
-    if op.chart != chart:
-        msg = _MSG_CHART_MISMATCH.format(chart=chart, op_chart=op.chart)
-        raise ValueError(msg)
-
-    return cast(
-        "CDict",
-        jtu.map(
-            jnp.add,
-            *((x, contribution) if op.right_add else (contribution, x)),
-            is_leaf=u.quantity.is_any_quantity,
-        ),
-    )
+    # Time-dependent dv: delegate to the equivalent displacement Translate,
+    # whose ladder rule computes d^m (dv(tau) * tau) / dtau^m.
+    if tau is None:
+        raise TypeError(_MSG_TAU_REQUIRED_TANGENT.format(m=m))
+    return cast("CDict", cxfmapi.act(_as_translate(op), tau, x, chart, rep, usys=usys))

--- a/src/coordinax/transforms/_src/actions/boost.py
+++ b/src/coordinax/transforms/_src/actions/boost.py
@@ -1,4 +1,4 @@
-"""Boost (velocity-offset) operator."""
+"""Boost (Galilean boost) operator."""
 
 __all__ = ("Boost",)
 
@@ -9,50 +9,87 @@ import plum
 
 import quaxed.numpy as jnp
 import unxt as u
+from unxt.quantity import is_any_quantity
 
+import coordinax.api.transforms as cxfmapi
 import coordinax.charts as cxc
 import coordinax.representations as cxr
 from .add import AbstractAdd
-from .base import materialize_transform
 from .custom_types import CDict, OptUSys
-from coordinax.transforms._src.groups import DiffeomorphismGroup
+from .prolong import tau_derivative
+from coordinax.transforms._src.groups import AffineGroup, DiffeomorphismGroup
+
+_MSG_TAU_REQUIRED_POINT = (
+    "act(Boost, ...) on point data requires a time parameter: the Galilean "
+    "boost moves points by delta_v * tau. Got tau=None."
+)
+_MSG_TAU_REQUIRED_TANGENT = (
+    "act(Boost, ...) with a time-dependent delta on order-{m} tangent data "
+    "requires a time parameter; got tau=None."
+)
+_MSG_CHART_MISMATCH = (
+    "Boost requires the input chart to match the boost chart. "
+    "Got input chart={chart!r} and boost chart={op_chart!r}."
+)
 
 
 @final
 class Boost(AbstractAdd):
-    r"""Operator for boosting velocities (Galilean velocity offset).
+    r"""Operator for Galilean boosts.
 
-    A Boost operator adds a constant velocity offset :math:`\Delta v` to the
-    velocity components of a phase-space point.  It acts trivially on position
-    (point) data, displacement data, and acceleration data.
+    A Galilean boost is the change to a frame moving at constant velocity
+    $\Delta v$ (see the inhomogeneous Galilean group):
 
-    Formally, in a Cartesian chart:
-    :math:`B_{\Delta v}:\; \dot{x} \mapsto \dot{x} + \Delta v`.
+    $$ B_{\Delta v}:\; (\tau, x) \mapsto (\tau,\, x + \Delta v\, \tau). $$
+
+    Its kinematic prolongation follows: points move by $\Delta v\,\tau$,
+    velocities shift by $\Delta v$, and accelerations are unchanged (for a
+    constant $\Delta v$). Displacements (same-$\tau$ point differences) are
+    invariant.
+
+    Equivalently, ``Boost(dv)`` is the time-dependent translation
+    ``Translate(delta=lambda tau: dv * tau)`` — the closed forms here are the
+    prolongation of exactly that point action.
+
+    Contrast with ``Translate(semantic_kind=vel)``: that operator is a pure
+    velocity *kick* (an impulse) that shifts only the velocity fibre and does
+    not move points.
 
     Parameters
     ----------
     delta : CDict | Callable[[tau], CDict]
-        The velocity offset to apply.
-        If callable, will be evaluated at the time parameter ``tau``.
+        The boost velocity. If callable, it is evaluated at the time
+        parameter ``tau`` and the prolongation gains the corresponding
+        derivative terms.
 
     Examples
     --------
-    >>> import jax.numpy as jnp
+    >>> import unxt as u
     >>> import coordinax.charts as cxc
     >>> import coordinax.representations as cxr
     >>> import coordinax.transforms as cxfm
 
     Create a boost operator:
 
-    >>> delta_v = {"x": jnp.array(1.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
-    >>> boost = cxfm.Boost(delta_v, chart=cxc.cart3d)
-    >>> boost
-    Boost({'x': 1.0, 'y': 0.0, 'z': 0.0}, chart=Cart3D(M=Rn(3)))
+    >>> dv = {"x": u.Q(1.0, "km/s"), "y": u.Q(0.0, "km/s"), "z": u.Q(0.0, "km/s")}
+    >>> boost = cxfm.Boost(dv, chart=cxc.cart3d)
 
-    The inverse negates the velocity offset:
+    The boost moves points by ``dv * tau``:
 
-    >>> boost.inverse
-    Boost({'x': -1.0, 'y': -0.0, 'z': -0.0}, chart=Cart3D(M=Rn(3)))
+    >>> p = {"x": u.Q(0.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(0.0, "km")}
+    >>> cxfm.act(boost, u.Q(3.0, "s"), p, cxc.cart3d, cxr.point)
+    {'x': Q(3., 'km'), 'y': Q(2., 'km'), 'z': Q(0., 'km')}
+
+    and shifts velocities by ``dv``:
+
+    >>> v = {"x": u.Q(2.0, "km/s"), "y": u.Q(0.0, "km/s"), "z": u.Q(0.0, "km/s")}
+    >>> cxfm.act(boost, u.Q(3.0, "s"), v, cxc.cart3d, cxr.coord_vel)
+    {'x': Q(3., 'km / s'), 'y': Q(0., 'km / s'), 'z': Q(0., 'km / s')}
+
+    The inverse negates the boost velocity:
+
+    >>> boost.inverse.delta["x"]
+    Q(-1., 'km / s')
 
     """
 
@@ -61,7 +98,18 @@ class Boost(AbstractAdd):
     def groups(cls) -> frozenset[type]:
         """Return the groups to which this map belongs."""
         del cls
-        return frozenset((DiffeomorphismGroup,))
+        return frozenset((AffineGroup, DiffeomorphismGroup))
+
+
+def _boost_displacement(op: Boost, /) -> Any:
+    r"""Return the boost's displacement function $g(\tau) = \Delta v(\tau)\tau$."""
+    delta = op.delta
+
+    def g(tau: Any, /) -> CDict:
+        dv = delta(tau) if callable(delta) else delta  # ty: ignore[call-top-callable]
+        return jtu.map(lambda c: c * tau, dv, is_leaf=is_any_quantity)
+
+    return g
 
 
 # ============================================================================
@@ -79,56 +127,74 @@ def act(
     usys: OptUSys = None,
     **kw: Any,
 ) -> CDict:
-    """Apply Boost to a component dictionary.
+    r"""Apply a Galilean boost to a component dictionary.
 
-    A Boost only affects velocity vectors; it is the identity for points,
-    displacements, and accelerations.
+    The point action is $x \mapsto x + \Delta v\,\tau$; tangent data of
+    ladder order $m$ gains $d^m(\Delta v\,\tau)/d\tau^m$ (so $\Delta v$ for
+    velocities and, for constant $\Delta v$, nothing for accelerations).
+    Displacements are invariant.
 
     Examples
     --------
-    >>> import jax.numpy as jnp
+    >>> import unxt as u
     >>> import coordinax.charts as cxc
     >>> import coordinax.representations as cxr
     >>> import coordinax.transforms as cxfm
 
-    Boost acts on velocity (shifts components):
+    >>> dv = {"x": u.Q(1.0, "km/s"), "y": u.Q(0.0, "km/s"), "z": u.Q(0.0, "km/s")}
+    >>> boost = cxfm.Boost(dv, chart=cxc.cart3d)
 
-    >>> boost = cxfm.Boost(
-    ...     {"x": jnp.array(1.0), "y": jnp.array(0.0), "z": jnp.array(0.0)},
-    ...     chart=cxc.cart3d,
-    ... )
-    >>> v = {"x": jnp.array(2.0), "y": jnp.array(3.0), "z": jnp.array(0.0)}
-    >>> cxfm.act(boost, None, v, cxc.cart3d, cxr.coord_vel)
-    {'x': Array(3., dtype=float64, ...), 'y': Array(3., dtype=float64, ...),
-     'z': Array(0., dtype=float64, ...)}
+    Boost shifts velocity components:
 
-    Boost is identity for positions:
+    >>> v = {"x": u.Q(2.0, "km/s"), "y": u.Q(3.0, "km/s"), "z": u.Q(0.0, "km/s")}
+    >>> cxfm.act(boost, u.Q(0.0, "s"), v, cxc.cart3d, cxr.coord_vel)
+    {'x': Q(3., 'km / s'), 'y': Q(3., 'km / s'), 'z': Q(0., 'km / s')}
 
-    >>> p = {"x": jnp.array(1.0), "y": jnp.array(2.0), "z": jnp.array(3.0)}
-    >>> cxfm.act(boost, None, p, cxc.cart3d, cxr.point)
-    {'x': Array(1., dtype=float64, ...), 'y': Array(2., dtype=float64, ...),
-     'z': Array(3., dtype=float64, ...)}
+    A static boost leaves accelerations unchanged:
+
+    >>> a = {"x": u.Q(1.0, "km/s2"), "y": u.Q(0.0, "km/s2"), "z": u.Q(0.0, "km/s2")}
+    >>> cxfm.act(boost, u.Q(0.0, "s"), a, cxc.cart3d, cxr.coord_acc)
+    {'x': Q(1., 'km / s2'), 'y': Q(0., 'km / s2'), 'z': Q(0., 'km / s2')}
 
     """
-    del kw, usys
+    del kw
 
-    op_eval = materialize_transform(op, tau)
+    # --- Point input: x + dv * tau, via the Translate point machinery.
+    if rep == cxr.point:
+        if tau is None:
+            raise TypeError(_MSG_TAU_REQUIRED_POINT)
+        from .translate import Translate  # noqa: PLC0415 - avoid module cycle
 
-    if isinstance(rep.semantic_kind, cxr.Velocity):
-        if chart != op_eval.chart:
-            msg = (
-                "Boost requires the input chart to match the boost chart. "
-                f"Got input chart={chart!r} and boost chart={op_eval.chart!r}."
-            )
-            raise ValueError(msg)
-        return cast(
-            "CDict",
-            jtu.map(
-                jnp.add,
-                *((x, op_eval.delta) if op_eval.right_add else (op_eval.delta, x)),
-                is_leaf=u.quantity.is_any_quantity,
-            ),
-        )
+        eff = Translate(_boost_displacement(op), chart=op.chart, right_add=op.right_add)
+        return cast("CDict", cxfmapi.act(eff, tau, x, chart, rep, usys=usys))
 
-    # Identity for points, displacements, and accelerations.
-    return x
+    # --- Tangent input of ladder order m.
+    m = rep.semantic_kind.order  # ty: ignore[unresolved-attribute]
+    # Displacements are invariant (the Jacobian of a translation is I).
+    if m == 0:
+        return x
+
+    # Contribution: d^m (dv(tau) * tau) / dtau^m.
+    if not callable(op.delta):
+        if m == 1:
+            contribution = op.delta
+        else:
+            # Constant dv: higher derivatives of dv*tau vanish.
+            return x
+    else:
+        if tau is None:
+            raise TypeError(_MSG_TAU_REQUIRED_TANGENT.format(m=m))
+        contribution = tau_derivative(_boost_displacement(op), tau, n=m)
+
+    if op.chart != chart:
+        msg = _MSG_CHART_MISMATCH.format(chart=chart, op_chart=op.chart)
+        raise ValueError(msg)
+
+    return cast(
+        "CDict",
+        jtu.map(
+            jnp.add,
+            *((x, contribution) if op.right_add else (contribution, x)),
+            is_leaf=u.quantity.is_any_quantity,
+        ),
+    )

--- a/src/coordinax/transforms/_src/actions/boost.py
+++ b/src/coordinax/transforms/_src/actions/boost.py
@@ -16,6 +16,7 @@ import coordinax.charts as cxc
 import coordinax.representations as cxr
 from .add import AbstractAdd
 from .custom_types import CDict, OptUSys
+from .utils import is_flat_chart
 from coordinax.transforms._src.groups import AffineGroup, DiffeomorphismGroup
 
 if TYPE_CHECKING:
@@ -28,10 +29,6 @@ _MSG_TAU_REQUIRED_POINT = (
 _MSG_TAU_REQUIRED_TANGENT = (
     "act(Boost, ...) with a time-dependent delta on order-{m} tangent data "
     "requires a time parameter; got tau=None."
-)
-_MSG_CHART_MISMATCH = (
-    "Boost requires the input chart to match the boost chart. "
-    "Got input chart={chart!r} and boost chart={op_chart!r}."
 )
 
 
@@ -166,19 +163,31 @@ def act(
     {'x': Q(1., 'km / s2'), 'y': Q(0., 'km / s2'), 'z': Q(0., 'km / s2')}
 
     """
-    del kw
-
     # --- Point input: x + dv * tau, via the Translate ladder machinery.
     if rep == cxr.point:
         if tau is None:
             raise TypeError(_MSG_TAU_REQUIRED_POINT)
         return cast(
-            "CDict", cxfmapi.act(_as_translate(op), tau, x, chart, rep, usys=usys)
+            "CDict",
+            cxfmapi.act(_as_translate(op), tau, x, chart, rep, usys=usys, **kw),
         )
 
-    # --- Tangent input of ladder order m.
+    # The closed forms below hold only when dv and the data live in the same
+    # Cartesian-type (flat) chart, where the boost's point action is a flat
+    # translation at each tau. Otherwise the action is base-point dependent
+    # in the data's coordinates — delegate everything (including
+    # displacements) to the equivalent displacement Translate, whose generic
+    # fallback handles the anchors (at=, at_vel=) and raises informative
+    # errors when they are missing.
+    if not (chart == op.chart and is_flat_chart(chart)):
+        return cast(
+            "CDict",
+            cxfmapi.act(_as_translate(op), tau, x, chart, rep, usys=usys, **kw),
+        )
+
+    # --- Tangent input of ladder order m, flat matching chart.
     m = rep.semantic_kind.order
-    # Displacements are invariant (the Jacobian of a translation is I).
+    # Displacements are invariant (the Jacobian of a flat translation is I).
     if m == 0:
         return x
 
@@ -187,9 +196,6 @@ def act(
         if m != 1:
             # Constant dv: higher derivatives of dv*tau vanish.
             return x
-        if op.chart != chart:
-            msg = _MSG_CHART_MISMATCH.format(chart=chart, op_chart=op.chart)
-            raise ValueError(msg)
         return cast(
             "CDict",
             jtu.map(
@@ -203,4 +209,6 @@ def act(
     # whose ladder rule computes d^m (dv(tau) * tau) / dtau^m.
     if tau is None:
         raise TypeError(_MSG_TAU_REQUIRED_TANGENT.format(m=m))
-    return cast("CDict", cxfmapi.act(_as_translate(op), tau, x, chart, rep, usys=usys))
+    return cast(
+        "CDict", cxfmapi.act(_as_translate(op), tau, x, chart, rep, usys=usys, **kw)
+    )

--- a/src/coordinax/transforms/_src/actions/composed.py
+++ b/src/coordinax/transforms/_src/actions/composed.py
@@ -280,23 +280,29 @@ def act(
     {'x': Q(1, 'km'), 'y': Q(2, 'km'), 'z': Q(3, 'km')}
 
     """
-    # 'at' tracks the evolving base point for tangent Jacobians: advance it
-    # after each sub-op so the next step evaluates at the correct anchor.
+    # 'at' / 'at_vel' track the evolving jet slots (base point and velocity)
+    # for tangent transformations: advance them after each sub-op so the next
+    # step evaluates at the correct anchor.
     current_at = kw.get("at")
-    kw_no_at = {k: v for k, v in kw.items() if k != "at"}
+    current_at_vel = kw.get("at_vel")
+    kw_rest = {k: v for k, v in kw.items() if k not in ("at", "at_vel")}
     result = x
     for sub_op in op.transforms:
-        result = cxfmapi.act(
-            sub_op,
-            tau,
-            result,
-            chart,
-            rep,
-            **({**kw, "at": current_at} if current_at is not None else kw),
-        )
+        step_kw = dict(kw_rest)
+        if current_at is not None:
+            step_kw["at"] = current_at
+        if current_at_vel is not None:
+            step_kw["at_vel"] = current_at_vel
+        result = cxfmapi.act(sub_op, tau, result, chart, rep, **step_kw)
+        # Advance the anchor jet (velocity first: it needs the old base point).
+        if current_at_vel is not None:
+            at_kw = {"at": current_at} if current_at is not None else {}
+            current_at_vel = cxfmapi.act(
+                sub_op, tau, current_at_vel, chart, cxr.coord_vel, **kw_rest, **at_kw
+            )
         if current_at is not None:
             current_at = cxfmapi.act(
-                sub_op, tau, current_at, chart, cxr.point, **kw_no_at
+                sub_op, tau, current_at, chart, cxr.point, **kw_rest
             )
     return cast("CDict", result)
 
@@ -351,6 +357,69 @@ def act(
     for xfm in op.transforms:
         result = cxfmapi.act(xfm, tau, result, **kw)
     return result  # ty: ignore[invalid-return-type]
+
+
+# ===================================================================
+# `prolong` / `pushforward` for Composed
+
+
+@plum.dispatch
+def prolong(
+    op: Composed,
+    tau: Any,
+    jet: dict,
+    chart: cxc.AbstractChart,
+    /,
+    **kw: object,
+) -> dict:
+    """Prolong a Composed transform: fold the prolongations left-to-right.
+
+    Jets compose by the chain rule, so the prolongation of a composition is
+    the composition of the prolongations. Each sub-transform materializes its
+    time-dependent parameters exactly once per step.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.transforms as cxfm
+
+    >>> dv = {"x": u.Q(1.0, "km/s"), "y": u.Q(0.0, "km/s"), "z": u.Q(0.0, "km/s")}
+    >>> pipe = cxfm.Composed((cxfm.Boost(dv, chart=cxc.cart3d), cxfm.Identity()))
+    >>> jet = {0: {"x": u.Q(0.0, "km"), "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")},
+    ...        1: {"x": u.Q(0.0, "km/s"), "y": u.Q(0.0, "km/s"),
+    ...            "z": u.Q(0.0, "km/s")}}
+    >>> out = cxfm.prolong(pipe, u.Q(2.0, "s"), jet, cxc.cart3d)
+    >>> out[0]["x"], out[1]["x"]
+    (Q(2., 'km'), Q(1., 'km / s'))
+
+    """
+    result = jet
+    for sub_op in op.transforms:
+        result = cast("dict", cxfmapi.prolong(sub_op, tau, result, chart, **kw))
+    return result
+
+
+@plum.dispatch
+def pushforward(
+    op: Composed,
+    tau: Any,
+    v: CDict,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+    *,
+    at: CDict | None = None,
+    **kw: object,
+) -> CDict:
+    """Pushforward under a Composed transform: fold, advancing the base point."""
+    result = v
+    current_at = at
+    for sub_op in op.transforms:
+        result = cxfmapi.pushforward(
+            sub_op, tau, result, chart, rep, at=current_at, **kw
+        )
+        if current_at is not None:
+            current_at = cxfmapi.act(sub_op, tau, current_at, chart, cxr.point, **kw)
+    return cast("CDict", result)
 
 
 # ===================================================================

--- a/src/coordinax/transforms/_src/actions/composed.py
+++ b/src/coordinax/transforms/_src/actions/composed.py
@@ -282,21 +282,23 @@ def act(
     """
     # 'at' / 'at_vel' track the evolving jet slots (base point and velocity)
     # for tangent transformations: advance them after each sub-op so the next
-    # step evaluates at the correct anchor.
+    # step evaluates at the correct anchor. Whether each anchor is provided is
+    # loop-invariant, so the step kwargs dict is built once and updated.
     current_at = kw.get("at")
     current_at_vel = kw.get("at_vel")
     kw_rest = {k: v for k, v in kw.items() if k not in ("at", "at_vel")}
+    step_kw = dict(kw_rest)
+    at_kw = {"at": current_at} if current_at is not None else {}
     result = x
     for sub_op in op.transforms:
-        step_kw = dict(kw_rest)
         if current_at is not None:
             step_kw["at"] = current_at
+            at_kw["at"] = current_at
         if current_at_vel is not None:
             step_kw["at_vel"] = current_at_vel
         result = cxfmapi.act(sub_op, tau, result, chart, rep, **step_kw)
         # Advance the anchor jet (velocity first: it needs the old base point).
         if current_at_vel is not None:
-            at_kw = {"at": current_at} if current_at is not None else {}
             current_at_vel = cxfmapi.act(
                 sub_op, tau, current_at_vel, chart, cxr.coord_vel, **kw_rest, **at_kw
             )

--- a/src/coordinax/transforms/_src/actions/identity.py
+++ b/src/coordinax/transforms/_src/actions/identity.py
@@ -155,3 +155,22 @@ def act(op: Identity, tau: Any, x: Any, /, *args: Any, **kw: Any) -> Any:
     """
     del args, tau, kw  # unused
     return x
+
+
+# Precedence=1 to catch all input types, mirroring `act`.
+@plum.dispatch(precedence=1)  # ty: ignore[no-matching-overload]
+def pushforward(op: Identity, tau: Any, v: Any, /, *args: Any, **kw: Any) -> Any:
+    """Identity pushforward - returns the tangent data unchanged.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import coordinax.transforms as cxfm
+
+    >>> d = {"x": u.Q(1, "km"), "y": u.Q(2, "km"), "z": u.Q(3, "km")}
+    >>> cxfm.pushforward(cxfm.identity, None, d, cxc.cart3d, cxr.coord_disp) is d
+    True
+
+    """
+    del op, tau, args, kw
+    return v

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -35,6 +35,7 @@ Two related verbs are distinguished:
 __all__ = (
     "JetDict",
     "prolong_jet",
+    "prolong_slot",
     "pushforward_generic",
     "tau_derivative",
 )
@@ -236,18 +237,13 @@ def pushforward_generic(
     data and, for time-independent transforms, for all tangent kinds.
 
     """
+    order = rep.semantic_kind.order
     if at is None:
-        msg = _MSG_AT_REQUIRED.format(
-            verb="pushforward",
-            op=type(op).__name__,
-            m=rep.semantic_kind.order,  # ty: ignore[unresolved-attribute]
-        )
+        msg = _MSG_AT_REQUIRED.format(verb="pushforward", op=type(op).__name__, m=order)
         raise TypeError(msg)
 
     in_units = _cdict_units(at)
-    # Primal act (used only for output units; dead-code-eliminated under jit).
-    y0 = cxfmapi.act(op, tau, at, chart, cxr.point, usys=usys)
-    out_units = _cdict_units(y0)
+    out_units = _point_act_units(op, tau, at, chart, usys=usys)
 
     def f(xv: dict[str, Any], /) -> dict[str, Any]:
         x = _attach_cdict(xv, in_units)
@@ -257,7 +253,6 @@ def pushforward_generic(
     # Strip v consistently with the base point: v_k is expressed in
     # in_unit_k / T for a common time unit T, so the stripped values form a
     # valid coordinate tangent. Any common T works; prefer tau's unit.
-    order = rep.semantic_kind.order  # ty: ignore[unresolved-attribute]
     time_unit = _pushforward_time_unit(tau, in_units, _cdict_units(v), order)
     v_vals = {k: _strip_leaf(_per_time(in_units[k], time_unit, order), v[k]) for k in v}
     at_vals = _strip_cdict(at, in_units)
@@ -266,6 +261,30 @@ def pushforward_generic(
     return _attach_cdict(
         dy, {k: _per_time(un, time_unit, order) for k, un in out_units.items()}
     )
+
+
+def _point_act_units(
+    op: AbstractTransform,
+    tau: Any,
+    q0: CDict,
+    chart: cxc.AbstractChart,
+    /,
+    *,
+    usys: OptUSys,
+) -> dict[str, Any]:
+    """Per-component output units of the point action, without computing values.
+
+    Units are static metadata on Quantities, so `jax.eval_shape` discovers
+    them without evaluating the action; a real evaluation is the fallback for
+    non-traceable actions.
+    """
+    try:
+        y0 = jax.eval_shape(
+            lambda q: cxfmapi.act(op, tau, q, chart, cxr.point, usys=usys), q0
+        )
+    except Exception:  # noqa: BLE001 - non-jax actions fall back to a real call
+        y0 = cxfmapi.act(op, tau, q0, chart, cxr.point, usys=usys)
+    return _cdict_units(cast("CDict", y0))
 
 
 def _pushforward_time_unit(
@@ -338,20 +357,16 @@ def prolong_jet(
             msg = _MSG_JET_SLOT_MISSING.format(op=type(op).__name__, m=max_order, k=m)
             raise TypeError(msg)
 
-    time_dep = is_time_dependent(op)
-    if time_dep and tau is None and max_order >= 1:
+    if is_time_dependent(op) and tau is None and max_order >= 1:
         msg = _MSG_TAU_REQUIRED.format(op=type(op).__name__)
         raise TypeError(msg)
 
-    # Slot 0: the plain point action (this is also the primal for units).
-    y0 = cast("CDict", cxfmapi.act(op, tau, q0, chart, cxr.point, usys=usys))
-    out: JetDict = {0: y0}
-
     if max_order == 0:
-        return out
+        y0 = cast("CDict", cxfmapi.act(op, tau, q0, chart, cxr.point, usys=usys))
+        return {0: y0}
 
     in_units = _cdict_units(q0)
-    out_units = _cdict_units(y0)
+    out_units = _point_act_units(op, tau, q0, chart, usys=usys)
     tau_val, tau_unit = _tau_value_unit(tau) if tau is not None else (None, None)
     if tau_val is None:
         # Time-independent op with no tau: differentiate at a dummy time.
@@ -375,12 +390,12 @@ def prolong_jet(
     ]
 
     slot_outs = _total_derivative_chain(f, tau_val, q0_vals, slot_vals)
-    for m, ym in enumerate(slot_outs, start=1):
-        out[m] = _attach_cdict(
+    return {
+        m: _attach_cdict(
             ym, {k: _per_time(un, tau_unit, m) for k, un in out_units.items()}
         )
-
-    return out
+        for m, ym in enumerate(slot_outs)
+    }
 
 
 def _total_derivative_chain(
@@ -389,27 +404,31 @@ def _total_derivative_chain(
     q0_vals: dict[str, Any],
     slot_vals: list[dict[str, Any]],
     /,
-) -> list[dict[str, Any]]:
+) -> tuple[dict[str, Any], ...]:
     r"""Evaluate the chain of total-derivative laws of ``f`` along a jet.
 
-    Builds $f_m(t, x, d_1, \ldots, d_m) = \mathrm{jvp}(f_{m-1}, (t, x, d_1,
-    \ldots, d_{m-1}), (1, d_1, d_2, \ldots, d_m))$ and returns
-    $[f_1(\ldots), f_2(\ldots), \ldots]$ — the transformed jet slot values.
+    Nests $F_m(t, x, d_1, \ldots, d_m) = \mathrm{jvp}(F_{m-1}, (t, x, d_1,
+    \ldots, d_{m-1}), (1, d_1, d_2, \ldots, d_m))$, threading the primals
+    through each level so that one evaluation of the outermost $F_M$ yields
+    every jet slot $(y_0, y_1, \ldots, y_M)$ — lower orders are not
+    recomputed per slot.
     """
-    outs: list[dict[str, Any]] = []
-    prev = f
-    args: list[Any] = [tau_val, q0_vals]
-    for dm in slot_vals:
 
-        def curr(
-            *a: Any, _prev: Callable[..., dict[str, Any]] = prev
-        ) -> dict[str, Any]:
-            return jax.jvp(_prev, a[:-1], (jax_np.ones_like(a[0]), *a[2:]))[1]
+    def chain0(t: Any, x: dict[str, Any], /) -> tuple[dict[str, Any], ...]:
+        return (f(t, x),)
 
-        args.append(dm)
-        outs.append(curr(*args))
-        prev = curr
-    return outs
+    chain = chain0
+    for _ in slot_vals:
+
+        def chain(
+            *a: Any, _prev: Callable[..., tuple[dict[str, Any], ...]] = chain
+        ) -> tuple[dict[str, Any], ...]:
+            primals, tangents = a[:-1], (jax_np.ones_like(a[0]), *a[2:])
+            p, t = jax.jvp(_prev, primals, tangents)
+            # p holds (y0..y_{m-1}); the last tangent is d/dtau y_{m-1} = y_m.
+            return (*p, t[-1])
+
+    return chain(tau_val, q0_vals, *slot_vals)
 
 
 # =============================================================================
@@ -479,13 +498,35 @@ def act(
 
     """
     del kw
-    m = rep.semantic_kind.order  # ty: ignore[unresolved-attribute]
+    m = rep.semantic_kind.order
 
     if m == 0 or not is_time_dependent(op):
         return cast(
             "CDict", cxfmapi.pushforward(op, tau, x, chart, rep, at=at, usys=usys)
         )
 
+    return prolong_slot(op, tau, x, chart, m, at=at, at_vel=at_vel, usys=usys)
+
+
+def prolong_slot(
+    op: AbstractTransform,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractChart,
+    m: int,
+    /,
+    *,
+    at: CDict | None,
+    at_vel: CDict | None,
+    usys: OptUSys,
+) -> CDict:
+    """Apply the m-th prolongation to a single order-``m`` slot.
+
+    Validates that the lower jet slots are available (the base point ``at``
+    and, for ``m == 2``, the velocity ``at_vel``), assembles the jet, and
+    returns the transformed slot. Shared by the generic tangent rule and by
+    operator fast paths that fall back to the generic prolongation.
+    """
     if tau is None:
         raise TypeError(_MSG_TAU_REQUIRED.format(op=type(op).__name__))
     if at is None:

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -252,8 +252,8 @@ def pushforward_generic(
 
     # Strip v consistently with the base point: v_k is expressed in
     # in_unit_k / T for a common time unit T, so the stripped values form a
-    # valid coordinate tangent. Any common T works; prefer tau's unit.
-    time_unit = _pushforward_time_unit(tau, in_units, _cdict_units(v), order)
+    # valid coordinate tangent.
+    time_unit = _common_time_unit(tau, in_units, _cdict_units(v), order)
     v_vals = {k: _strip_leaf(_per_time(in_units[k], time_unit, order), v[k]) for k in v}
     at_vals = _strip_cdict(at, in_units)
 
@@ -287,16 +287,28 @@ def _point_act_units(
     return _cdict_units(cast("CDict", y0))
 
 
-def _pushforward_time_unit(
+def _common_time_unit(
     tau: Any, in_units: dict[str, Any], v_units: dict[str, Any], order: int, /
 ) -> Any:
-    """Choose a common time unit for stripping order-``order`` tangent data."""
+    """Choose a common time unit T for stripping order-``order`` tangent data.
+
+    Any dimensionally-consistent T is mathematically valid, but the choice
+    fixes the *units* of the output (``out_unit / T**order``). Prefer deriving
+    T from the data itself (``T**order = in_unit / v_unit``) so that outputs
+    preserve the data's own units — e.g. a ``kpc/Myr`` velocity pushes forward
+    to ``kpc/Myr``, not ``kpc/s``. Fall back to ``tau``'s unit, then to
+    seconds for a unitful/raw mix.
+    """
     if order == 0:
         return None
+    for k, vu in v_units.items():
+        iu = in_units.get(k)
+        if vu is not None and iu is not None:
+            ratio = iu / vu
+            return ratio if order == 1 else ratio ** (1.0 / order)
     tau_unit = u.unit_of(tau) if tau is not None else None
     if tau_unit is not None:
         return tau_unit
-    # No unitful tau: derive from the data if it carries units, else raw.
     if any(un is not None for un in v_units.values()):
         return u.unit("s")
     return None
@@ -367,32 +379,42 @@ def prolong_jet(
 
     in_units = _cdict_units(q0)
     out_units = _point_act_units(op, tau, q0, chart, usys=usys)
-    tau_val, tau_unit = _tau_value_unit(tau) if tau is not None else (None, None)
-    if tau_val is None:
-        # Time-independent op with no tau: differentiate at a dummy time.
-        tau_val = jnp.zeros(())
-        if any(un is not None for un in in_units.values()):
-            tau_unit = u.unit("s")
+    # The common time unit T fixes the units of the output slots
+    # (out_unit / T**m); derive it from the data so units are preserved.
+    # Everything in the chain — the jet slots AND tau itself — is expressed
+    # per T so the chain rule's dtau- and dx-contributions add consistently.
+    time_unit = _common_time_unit(tau, in_units, _cdict_units(jet[1]), 1)
+    if tau is None:
+        tau_val = jnp.zeros(())  # unused: f below ignores tv when tau is None
+    elif time_unit is not None:
+        tau_val = u.ustrip(time_unit, tau)
+    else:
+        tau_val = jnp.asarray(tau)
 
     comps = tuple(q0.keys())
 
     def f(tv: Any, xv: dict[str, Any], /) -> dict[str, Any]:
-        t = _attach_leaf(tau_unit, tv)
+        # With tau=None the point action is applied AT tau=None — no dummy
+        # time is fabricated. The (unused) tv slot then contributes exactly
+        # zero to the derivatives, and a point action that genuinely requires
+        # a time raises its own informative error instead of being silently
+        # evaluated at a made-up instant.
+        t = _attach_leaf(time_unit, tv) if tau is not None else None
         x = _attach_cdict(xv, in_units)
         y = cxfmapi.act(op, t, x, chart, cxr.point, usys=usys)
         return _strip_cdict(y, out_units)
 
-    # Stripped jet slots: slot m in units in_unit_k / tau_unit**m.
+    # Stripped jet slots: slot m in units in_unit_k / T**m.
     q0_vals = _strip_cdict(q0, in_units)
     slot_vals = [
-        {k: _strip_leaf(_per_time(in_units[k], tau_unit, m), jet[m][k]) for k in comps}
+        {k: _strip_leaf(_per_time(in_units[k], time_unit, m), jet[m][k]) for k in comps}
         for m in range(1, max_order + 1)
     ]
 
     slot_outs = _total_derivative_chain(f, tau_val, q0_vals, slot_vals)
     return {
         m: _attach_cdict(
-            ym, {k: _per_time(un, tau_unit, m) for k, un in out_units.items()}
+            ym, {k: _per_time(un, time_unit, m) for k, un in out_units.items()}
         )
         for m, ym in enumerate(slot_outs)
     }

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -332,6 +332,39 @@ def _common_time_unit(
     return None
 
 
+def _chain_time(tau: Any, time_unit: Any, /) -> tuple[Any, Callable[[Any], Any]]:
+    """Prepare tau for the derivative chain.
+
+    Returns the raw chain value of tau (expressed per the common time unit T)
+    and a converter mapping chain values back to what the point action
+    expects:
+
+    - ``tau=None``: the point action is applied AT tau=None — no dummy time
+      is fabricated; the (unused) chain slot contributes exactly zero, and a
+      point action that genuinely requires a time raises its own informative
+      error instead of being silently evaluated at a made-up instant.
+    - unitful tau: expressed in T so the chain rule's dtau- and
+      dx-contributions add consistently.
+    - raw (unitless) tau: passed through raw — the user's callables expect a
+      number — with the derivative direction interpreted as per T (the
+      documented raw-tau convention; cf. `tau_derivative`).
+    """
+    tau_is_unitful = tau is not None and u.unit_of(tau) is not None
+    if tau is None:
+        tau_val: Any = jnp.zeros(())  # unused: to_time ignores its argument
+    elif tau_is_unitful and time_unit is not None:
+        tau_val = u.ustrip(time_unit, tau)
+    else:
+        tau_val = jnp.asarray(tau)
+
+    def to_time(tv: Any, /) -> Any:
+        if tau is None:
+            return None
+        return _attach_leaf(time_unit, tv) if tau_is_unitful else tv
+
+    return tau_val, to_time
+
+
 # =============================================================================
 # prolong_jet: joint kinematic prolongation of a jet of coordinate data
 
@@ -413,24 +446,13 @@ def prolong_jet(
     # Everything in the chain — the jet slots AND tau itself — is expressed
     # per T so the chain rule's dtau- and dx-contributions add consistently.
     time_unit = _common_time_unit(tau, in_units, _cdict_units(jet[1]), 1)
-    if tau is None:
-        tau_val = jnp.zeros(())  # unused: f below ignores tv when tau is None
-    elif time_unit is not None:
-        tau_val = u.ustrip(time_unit, tau)
-    else:
-        tau_val = jnp.asarray(tau)
+    tau_val, to_time = _chain_time(tau, time_unit)
 
     comps = tuple(q0.keys())
 
     def f(tv: Any, xv: dict[str, Any], /) -> dict[str, Any]:
-        # With tau=None the point action is applied AT tau=None — no dummy
-        # time is fabricated. The (unused) tv slot then contributes exactly
-        # zero to the derivatives, and a point action that genuinely requires
-        # a time raises its own informative error instead of being silently
-        # evaluated at a made-up instant.
-        t = _attach_leaf(time_unit, tv) if tau is not None else None
         x = _attach_cdict(xv, in_units)
-        y = cxfmapi.act(op, t, x, chart, cxr.point, usys=usys)
+        y = cxfmapi.act(op, to_time(tv), x, chart, cxr.point, usys=usys)
         return _strip_cdict(y, out_units)
 
     # Stripped jet slots: slot m in units in_unit_k / T**m.

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -190,7 +190,9 @@ def tau_derivative(f: Callable[[Any], Any], tau: Any, /, *, n: int = 1) -> Any:
     # evaluation where possible (eval_shape preserves static unit metadata).
     try:
         y0 = jax.eval_shape(f, tau)
-    except Exception:  # noqa: BLE001 - non-jax callables fall back to a real call
+    except TypeError:
+        # Not abstractly traceable (e.g. concretization inside f): fall back
+        # to a real call. Other errors (units, shapes) propagate.
         y0 = f(tau)
     leaves0, treedef = jtu.flatten(y0, is_leaf=is_any_quantity)
     units = [u.unit_of(leaf) for leaf in leaves0]
@@ -284,7 +286,10 @@ def _point_act_units(
         y0 = jax.eval_shape(
             lambda q: cxfmapi.act(op, tau, q, chart, cxr.point, usys=usys), q0
         )
-    except Exception:  # noqa: BLE001 - non-jax actions fall back to a real call
+    except TypeError:
+        # Not abstractly traceable (e.g. concretization inside the point
+        # action): fall back to a real call. Other errors (units, shapes)
+        # propagate.
         y0 = cxfmapi.act(op, tau, q0, chart, cxr.point, usys=usys)
     return _cdict_units(cast("CDict", y0))
 

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -40,6 +40,8 @@ __all__ = (
     "tau_derivative",
 )
 
+from fractions import Fraction
+
 from collections.abc import Callable
 from typing import Any, TypeAlias, cast
 
@@ -305,7 +307,7 @@ def _common_time_unit(
         iu = in_units.get(k)
         if vu is not None and iu is not None:
             ratio = iu / vu
-            return ratio if order == 1 else ratio ** (1.0 / order)
+            return ratio if order == 1 else ratio ** Fraction(1, order)
     tau_unit = u.unit_of(tau) if tau is not None else None
     if tau_unit is not None:
         return tau_unit

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -370,6 +370,17 @@ def prolong_jet(
         if m not in jet:
             msg = _MSG_JET_SLOT_MISSING.format(op=type(op).__name__, m=max_order, k=m)
             raise TypeError(msg)
+        if set(jet[m]) != set(q0):
+            missing = sorted(set(q0) - set(jet[m]))
+            extra = sorted(set(jet[m]) - set(q0))
+            msg = (
+                f"prolong({type(op).__name__}, ...): jet slot {m} components "
+                f"do not match slot 0's {sorted(q0)}"
+                + (f"; missing {missing}" if missing else "")
+                + (f"; unexpected {extra}" if extra else "")
+                + "."
+            )
+            raise TypeError(msg)
 
     if is_time_dependent(op) and tau is None and max_order >= 1:
         msg = _MSG_TAU_REQUIRED.format(op=type(op).__name__)

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -1,0 +1,545 @@
+r"""Generic jet-prolongation engine for transform actions.
+
+This module implements the *kinematic prolongation* of a transform's point
+action to tangent data of any time-derivative order, via forward-mode
+automatic differentiation.
+
+Mathematical background:
+
+Let $\phi(\tau, x)$ be the point action of a transform (possibly with
+time-dependent parameters). If a curve satisfies $x'(\tau) = \phi(\tau,
+x(\tau))$ then the transformed velocity and acceleration are the total
+$\tau$-derivatives
+
+$$
+v' = \partial_\tau \phi + \partial_x \phi \cdot v, \qquad
+a' = \partial_{\tau\tau} \phi + 2 \partial_\tau \partial_x \phi \cdot v
+     + \partial_{xx} \phi(v, v) + \partial_x \phi \cdot a,
+$$
+
+and so on for higher orders. These are computed here with nested `jax.jvp`
+in the joint $(\tau, x)$ argument, so arbitrary time dependence and
+compositions are handled correctly by the chain rule.
+
+Two related verbs are distinguished:
+
+- ``act`` on order-$m$ tangent data ($m \geq 1$: velocity, acceleration, ...)
+  is the $m$-th prolongation above.
+- ``pushforward`` is the frozen-$\tau$ spatial differential $\partial_x
+  \phi(\tau, \cdot) \cdot v$. This is the transformation law for
+  `Displacement` data (order 0), which is a same-$\tau$ point difference and
+  never gains $\partial_\tau$ terms. For time-independent transforms the two
+  verbs coincide.
+"""
+
+__all__ = (
+    "JetDict",
+    "prolong_jet",
+    "pushforward_generic",
+    "tau_derivative",
+)
+
+from collections.abc import Callable
+from typing import Any, TypeAlias, cast
+
+import jax
+import jax.numpy as jax_np
+import jax.tree as jtu
+import plum
+
+import quaxed.numpy as jnp
+import unxt as u
+from unxt.quantity import is_any_quantity
+
+import coordinax.api.transforms as cxfmapi
+import coordinax.charts as cxc
+import coordinax.representations as cxr
+from .base import AbstractTransform, is_time_dependent
+from .custom_types import CDict, OptUSys
+
+JetDict: TypeAlias = dict[int, CDict]
+"""A jet of curve data: ``{0: q, 1: v, 2: a, ...}``.
+
+Keys are time-derivative orders of the curve $x(\tau)$: slot 0 is the base
+point (position), slot 1 the velocity, slot 2 the acceleration, and so on.
+All-integer keys keep the jet a valid JAX pytree (jit/vmap-safe).
+
+Note the distinction from the tangent semantic-kind ladder: `Displacement`
+(ladder order 0) is a same-$\tau$ point difference, *not* a curve derivative,
+so it is never a jet slot — displacement fibres transform by ``pushforward``.
+"""
+
+_MSG_TAU_REQUIRED = (
+    "act/prolong for the time-dependent transform {op} on tangent data "
+    "requires a time parameter; got tau=None."
+)
+_MSG_AT_REQUIRED = (
+    "{verb}({op}, ...) on order-{m} tangent data requires the base point "
+    "via the keyword argument 'at' (a CDict in the same chart), or use a "
+    "coordinax.Coordinate bundle which supplies it automatically."
+)
+_MSG_AT_VEL_REQUIRED = (
+    "act({op}, ...) on order-{m} tangent data with a time-dependent "
+    "transform requires the lower-order jet slots; pass 'at_vel' (the "
+    "velocity at the base point) or use a coordinax.Coordinate bundle."
+)
+_MSG_JET_SLOT_MISSING = (
+    "prolong({op}, ...) requires all jet slots 1..{m}; slot {k} is missing."
+)
+
+
+# =============================================================================
+# Unit-handling helpers
+
+
+def _strip_leaf(unit: Any, leaf: Any, /) -> Any:
+    """Strip a leaf to a raw array in the given unit (no-op if unit is None)."""
+    return u.ustrip(unit, leaf) if unit is not None else jnp.asarray(leaf)
+
+
+def _attach_leaf(unit: Any, val: Any, /) -> Any:
+    """Attach a unit to a raw value (no-op if unit is None)."""
+    return u.Q(val, unit) if unit is not None else val
+
+
+def _cdict_units(x: CDict, /) -> dict[str, Any]:
+    """Per-component units of a CDict (None for raw-array components)."""
+    return {k: u.unit_of(v) for k, v in x.items()}
+
+
+def _strip_cdict(x: CDict, units: dict[str, Any], /) -> dict[str, Any]:
+    return {k: _strip_leaf(units[k], v) for k, v in x.items()}
+
+
+def _attach_cdict(vals: dict[str, Any], units: dict[str, Any], /) -> CDict:
+    return {k: _attach_leaf(units[k], v) for k, v in vals.items()}
+
+
+def _per_time(unit: Any, tau_unit: Any, order: int, /) -> Any:
+    """Return the unit ``unit / tau_unit**order`` (None-propagating)."""
+    if unit is None:
+        return None
+    if order == 0 or tau_unit is None:
+        return unit
+    return unit / tau_unit**order
+
+
+def _tau_value_unit(tau: Any, /) -> tuple[Any, Any]:
+    """Split tau into (raw value, unit-or-None)."""
+    tau_unit = u.unit_of(tau)
+    tau_val = u.ustrip(tau_unit, tau) if tau_unit is not None else jnp.asarray(tau)
+    return tau_val, tau_unit
+
+
+# =============================================================================
+# tau_derivative: unit-aware d^n/dtau^n of a callable parameter
+
+
+def tau_derivative(f: Callable[[Any], Any], tau: Any, /, *, n: int = 1) -> Any:
+    r"""Compute the ``n``-th derivative of ``f`` with respect to ``tau``.
+
+    ``f`` is a callable of a single (possibly unitful) time parameter,
+    returning a pytree whose leaves are `unxt.Quantity` or raw arrays (e.g. a
+    ``CDict`` transform parameter, or a rotation-matrix array). The result has
+    the same tree structure with each leaf's unit divided by
+    ``unit(tau)**n``.
+
+    This is the pytree, multi-unit analog of `unxt.experimental.jacfwd`: the
+    output units are recorded from one structural evaluation, the computation
+    runs on stripped raw values through nested `jax.jvp`, and the units are
+    re-attached afterwards.
+
+    Notes
+    -----
+    - ``f`` must be JAX-traceable.
+    - Raw-array leaves stay raw: their derivative values are per
+      ``unit(tau)``; callers using unitless parameters are responsible for
+      consistent time units (e.g. via a unit system).
+    - Batched ``tau`` is supported elementwise (the derivative is taken along
+      the all-ones tangent, which is the elementwise derivative for
+      broadcasting parameter functions).
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> from coordinax.transforms import tau_derivative
+
+    >>> delta = lambda t: {"x": u.Q(3.0, "km/s") * t, "y": u.Q(0.0, "km")}
+    >>> tau_derivative(delta, u.Q(5.0, "s"))
+    {'x': Q(3., 'km / s'), 'y': Q(0., 'km / s')}
+
+    Second derivative of a quadratic:
+
+    >>> delta = lambda t: {"x": u.Q(0.5, "m/s2") * t**2}
+    >>> tau_derivative(delta, u.Q(4.0, "s"), n=2)
+    {'x': Q(1., 'm / s2')}
+
+    """
+    if n < 0:
+        msg = f"tau_derivative requires n >= 0, got {n}."
+        raise ValueError(msg)
+    if n == 0:
+        return f(tau)
+
+    tau_val, tau_unit = _tau_value_unit(tau)
+
+    # Discover the output structure and per-leaf units without a full
+    # evaluation where possible (eval_shape preserves static unit metadata).
+    try:
+        y0 = jax.eval_shape(f, tau)
+    except Exception:  # noqa: BLE001 - non-jax callables fall back to a real call
+        y0 = f(tau)
+    leaves0, treedef = jtu.flatten(y0, is_leaf=is_any_quantity)
+    units = [u.unit_of(leaf) for leaf in leaves0]
+
+    def g(tv: Any, /) -> list[Any]:
+        t = _attach_leaf(tau_unit, tv)
+        leaves, _ = jtu.flatten(f(t), is_leaf=is_any_quantity)
+        return [_strip_leaf(un, leaf) for un, leaf in zip(units, leaves, strict=True)]
+
+    gn = g
+    for _ in range(n):
+
+        def gnext(tv: Any, /, *, _prev: Callable[[Any], list[Any]] = gn) -> list[Any]:
+            return jax.jvp(_prev, (tv,), (jax_np.ones_like(tv),))[1]
+
+        gn = gnext
+
+    out_vals = gn(tau_val)
+    out_leaves = [
+        _attach_leaf(_per_time(un, tau_unit, n), v)
+        for un, v in zip(units, out_vals, strict=True)
+    ]
+    return jtu.unflatten(treedef, out_leaves)
+
+
+# =============================================================================
+# Generic pushforward: frozen-tau spatial differential
+
+
+def pushforward_generic(
+    op: AbstractTransform,
+    tau: Any,
+    v: CDict,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+    *,
+    at: CDict | None = None,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Frozen-$\tau$ differential $\partial_x \phi(\tau, \cdot) \cdot v$.
+
+    Computes the spatial pushforward of the tangent vector ``v`` (anchored at
+    the base point ``at``) under the transform's point action, holding the
+    time parameter fixed. This is the transformation law for `Displacement`
+    data and, for time-independent transforms, for all tangent kinds.
+
+    """
+    if at is None:
+        msg = _MSG_AT_REQUIRED.format(
+            verb="pushforward",
+            op=type(op).__name__,
+            m=rep.semantic_kind.order,  # ty: ignore[unresolved-attribute]
+        )
+        raise TypeError(msg)
+
+    in_units = _cdict_units(at)
+    # Primal act (used only for output units; dead-code-eliminated under jit).
+    y0 = cxfmapi.act(op, tau, at, chart, cxr.point, usys=usys)
+    out_units = _cdict_units(y0)
+
+    def f(xv: dict[str, Any], /) -> dict[str, Any]:
+        x = _attach_cdict(xv, in_units)
+        y = cast("CDict", cxfmapi.act(op, tau, x, chart, cxr.point, usys=usys))
+        return _strip_cdict(y, out_units)
+
+    # Strip v consistently with the base point: v_k is expressed in
+    # in_unit_k / T for a common time unit T, so the stripped values form a
+    # valid coordinate tangent. Any common T works; prefer tau's unit.
+    order = rep.semantic_kind.order  # ty: ignore[unresolved-attribute]
+    time_unit = _pushforward_time_unit(tau, in_units, _cdict_units(v), order)
+    v_vals = {k: _strip_leaf(_per_time(in_units[k], time_unit, order), v[k]) for k in v}
+    at_vals = _strip_cdict(at, in_units)
+
+    _, dy = jax.jvp(f, (at_vals,), (v_vals,))
+    return _attach_cdict(
+        dy, {k: _per_time(un, time_unit, order) for k, un in out_units.items()}
+    )
+
+
+def _pushforward_time_unit(
+    tau: Any, in_units: dict[str, Any], v_units: dict[str, Any], order: int, /
+) -> Any:
+    """Choose a common time unit for stripping order-``order`` tangent data."""
+    if order == 0:
+        return None
+    tau_unit = u.unit_of(tau) if tau is not None else None
+    if tau_unit is not None:
+        return tau_unit
+    # No unitful tau: derive from the data if it carries units, else raw.
+    if any(un is not None for un in v_units.values()):
+        return u.unit("s")
+    return None
+
+
+# =============================================================================
+# prolong_jet: joint kinematic prolongation of a jet of coordinate data
+
+
+def prolong_jet(
+    op: AbstractTransform,
+    tau: Any,
+    jet: JetDict,
+    chart: cxc.AbstractChart,
+    /,
+    *,
+    usys: OptUSys = None,
+) -> JetDict:
+    r"""Apply the kinematic prolongation of ``op`` to a jet of curve data.
+
+    ``jet`` maps time-derivative orders of the curve to component
+    dictionaries: ``{0: q, 1: v, 2: a, ...}``. Slot 0 (the base point) is
+    transformed by the point action; each slot $m \geq 1$ by the $m$-th total
+    $\tau$-derivative of the point action along the curve the jet represents
+    (nested `jax.jvp`).
+
+    All slots ``0..max(jet)`` must be present: the $m$-th prolongation
+    depends on every lower-order slot.
+
+    Examples
+    --------
+    A uniformly moving translation acting on a phase-space jet — the velocity
+    gains the translation's rate:
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.transforms as cxfm
+
+    >>> delta = lambda t: {"x": u.Q(3.0, "km/s") * t, "y": u.Q(0.0, "km"),
+    ...                    "z": u.Q(0.0, "km")}
+    >>> op = cxfm.Translate(delta, chart=cxc.cart3d)
+    >>> jet = {
+    ...     0: {"x": u.Q(1.0, "km"), "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")},
+    ...     1: {"x": u.Q(0.0, "km/s"), "y": u.Q(1.0, "km/s"), "z": u.Q(0.0, "km/s")},
+    ... }
+    >>> out = cxfm.prolong(op, u.Q(2.0, "s"), jet, cxc.cart3d)
+    >>> out[0]["x"], out[1]["x"]
+    (Q(7., 'km'), Q(3., 'km / s'))
+
+    """
+    if 0 not in jet:
+        msg = "prolong requires the base point at jet slot 0."
+        raise TypeError(msg)
+    q0 = jet[0]
+    max_order = max(jet)
+    for m in range(1, max_order + 1):
+        if m not in jet:
+            msg = _MSG_JET_SLOT_MISSING.format(op=type(op).__name__, m=max_order, k=m)
+            raise TypeError(msg)
+
+    time_dep = is_time_dependent(op)
+    if time_dep and tau is None and max_order >= 1:
+        msg = _MSG_TAU_REQUIRED.format(op=type(op).__name__)
+        raise TypeError(msg)
+
+    # Slot 0: the plain point action (this is also the primal for units).
+    y0 = cast("CDict", cxfmapi.act(op, tau, q0, chart, cxr.point, usys=usys))
+    out: JetDict = {0: y0}
+
+    if max_order == 0:
+        return out
+
+    in_units = _cdict_units(q0)
+    out_units = _cdict_units(y0)
+    tau_val, tau_unit = _tau_value_unit(tau) if tau is not None else (None, None)
+    if tau_val is None:
+        # Time-independent op with no tau: differentiate at a dummy time.
+        tau_val = jnp.zeros(())
+        if any(un is not None for un in in_units.values()):
+            tau_unit = u.unit("s")
+
+    comps = tuple(q0.keys())
+
+    def f(tv: Any, xv: dict[str, Any], /) -> dict[str, Any]:
+        t = _attach_leaf(tau_unit, tv)
+        x = _attach_cdict(xv, in_units)
+        y = cxfmapi.act(op, t, x, chart, cxr.point, usys=usys)
+        return _strip_cdict(y, out_units)
+
+    # Stripped jet slots: slot m in units in_unit_k / tau_unit**m.
+    q0_vals = _strip_cdict(q0, in_units)
+    slot_vals = [
+        {k: _strip_leaf(_per_time(in_units[k], tau_unit, m), jet[m][k]) for k in comps}
+        for m in range(1, max_order + 1)
+    ]
+
+    slot_outs = _total_derivative_chain(f, tau_val, q0_vals, slot_vals)
+    for m, ym in enumerate(slot_outs, start=1):
+        out[m] = _attach_cdict(
+            ym, {k: _per_time(un, tau_unit, m) for k, un in out_units.items()}
+        )
+
+    return out
+
+
+def _total_derivative_chain(
+    f: Callable[..., dict[str, Any]],
+    tau_val: Any,
+    q0_vals: dict[str, Any],
+    slot_vals: list[dict[str, Any]],
+    /,
+) -> list[dict[str, Any]]:
+    r"""Evaluate the chain of total-derivative laws of ``f`` along a jet.
+
+    Builds $f_m(t, x, d_1, \ldots, d_m) = \mathrm{jvp}(f_{m-1}, (t, x, d_1,
+    \ldots, d_{m-1}), (1, d_1, d_2, \ldots, d_m))$ and returns
+    $[f_1(\ldots), f_2(\ldots), \ldots]$ — the transformed jet slot values.
+    """
+    outs: list[dict[str, Any]] = []
+    prev = f
+    args: list[Any] = [tau_val, q0_vals]
+    for dm in slot_vals:
+
+        def curr(
+            *a: Any, _prev: Callable[..., dict[str, Any]] = prev
+        ) -> dict[str, Any]:
+            return jax.jvp(_prev, a[:-1], (jax_np.ones_like(a[0]), *a[2:]))[1]
+
+        args.append(dm)
+        outs.append(curr(*args))
+        prev = curr
+    return outs
+
+
+# =============================================================================
+# Generic plum registrations
+#
+# All generic (AbstractTransform) rules register at precedence=-1 so that any
+# concrete per-operator registration (default precedence 0) wins, as do the
+# Identity catch-all (precedence 1) and QMatrix funnels (precedence 2).
+
+
+@plum.dispatch(precedence=-1)  # ty: ignore[no-matching-overload]
+def act(
+    op: AbstractTransform,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+    **kw: Any,
+) -> CDict:
+    """Redispatch on the representation's geometry kind (generic funnel)."""
+    return cast("CDict", cxfmapi.act(op, tau, x, chart, rep.geom_kind, rep, **kw))
+
+
+@plum.dispatch(precedence=-1)  # ty: ignore[no-matching-overload]
+def act(
+    op: AbstractTransform,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractChart,
+    geom: cxr.PointGeometry,
+    rep: cxr.Representation,
+    /,
+    **kw: Any,
+) -> CDict:
+    """Raise: a transform must register its own point action (the primitive)."""
+    msg = (
+        f"{type(op).__name__} does not register a point action "
+        "act(op, tau, x: CDict, chart, rep) — the point action is the "
+        "primitive every transform must implement."
+    )
+    raise NotImplementedError(msg)
+
+
+@plum.dispatch(precedence=-1)  # ty: ignore[no-matching-overload]
+def act(
+    op: AbstractTransform,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractChart,
+    geom: cxr.TangentGeometry,
+    rep: cxr.Representation,
+    /,
+    *,
+    at: CDict | None = None,
+    at_vel: CDict | None = None,
+    usys: OptUSys = None,
+    **kw: Any,
+) -> CDict:
+    r"""Transform tangent data: pushforward or kinematic prolongation.
+
+    - Order-0 (displacement) data and all data under time-independent
+      transforms transform by the frozen-$\tau$ ``pushforward``.
+    - Under a time-dependent transform, order-$m$ data ($m \geq 1$) transforms
+      by the $m$-th prolongation, which requires the lower jet slots: the base
+      point ``at`` and, for $m = 2$, the velocity ``at_vel``.
+
+    """
+    del kw
+    m = rep.semantic_kind.order  # ty: ignore[unresolved-attribute]
+
+    if m == 0 or not is_time_dependent(op):
+        return cast(
+            "CDict", cxfmapi.pushforward(op, tau, x, chart, rep, at=at, usys=usys)
+        )
+
+    if tau is None:
+        raise TypeError(_MSG_TAU_REQUIRED.format(op=type(op).__name__))
+    if at is None:
+        raise TypeError(_MSG_AT_REQUIRED.format(verb="act", op=type(op).__name__, m=m))
+
+    jet: JetDict = {0: at, m: x}
+    if m >= 2:
+        if at_vel is None:
+            raise TypeError(_MSG_AT_VEL_REQUIRED.format(op=type(op).__name__, m=m))
+        jet[1] = at_vel
+    if m > 2:
+        msg = (
+            f"act on order-{m} tangent data requires jet slots 1..{m - 1}; "
+            "use coordinax.transforms.prolong with a full jet instead."
+        )
+        raise TypeError(msg)
+
+    out = cast("JetDict", cxfmapi.prolong(op, tau, jet, chart, usys=usys))
+    return out[m]
+
+
+# -----------------------------------------------------------------------------
+# pushforward
+
+
+@plum.dispatch(precedence=-1)  # ty: ignore[no-matching-overload]
+def pushforward(
+    op: AbstractTransform,
+    tau: Any,
+    v: CDict,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+    *,
+    at: CDict | None = None,
+    usys: OptUSys = None,
+) -> CDict:
+    """Push tangent data forward via forward-mode AD of the point action."""
+    return pushforward_generic(op, tau, v, chart, rep, at=at, usys=usys)
+
+
+# -----------------------------------------------------------------------------
+# prolong
+
+
+@plum.dispatch(precedence=-1)  # ty: ignore[no-matching-overload]
+def prolong(
+    op: AbstractTransform,
+    tau: Any,
+    jet: dict,
+    chart: cxc.AbstractChart,
+    /,
+    *,
+    usys: OptUSys = None,
+) -> dict:
+    """Prolong a jet via nested forward-mode AD (generic rule)."""
+    return prolong_jet(op, tau, jet, chart, usys=usys)

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -245,6 +245,17 @@ def pushforward_generic(
     if at is None:
         msg = _MSG_AT_REQUIRED.format(verb="pushforward", op=type(op).__name__, m=order)
         raise TypeError(msg)
+    if set(v) != set(at):
+        missing = sorted(set(at) - set(v))
+        extra = sorted(set(v) - set(at))
+        msg = (
+            f"pushforward({type(op).__name__}, ...): the tangent components "
+            f"do not match the base point's {sorted(at)}"
+            + (f"; missing {missing}" if missing else "")
+            + (f"; unexpected {extra}" if extra else "")
+            + "."
+        )
+        raise TypeError(msg)
 
     in_units = _cdict_units(at)
     out_units = _point_act_units(op, tau, at, chart, usys=usys)

--- a/src/coordinax/transforms/_src/actions/rotate.py
+++ b/src/coordinax/transforms/_src/actions/rotate.py
@@ -431,6 +431,18 @@ def from_(cls: type[Rotate], obj: jtransform.Rotation, /) -> Rotate:
     return cls(obj.as_matrix())
 
 
+_MSG_TAU_REQUIRED_R = (
+    "act/pushforward(Rotate, ...) with a time-dependent (callable) rotation "
+    "matrix requires a time parameter; got tau=None."
+)
+
+
+def _check_tau(op: "Rotate", tau: Any, /) -> None:
+    """Raise an informative TypeError before materializing a callable R."""
+    if tau is None and callable(op.R):
+        raise TypeError(_MSG_TAU_REQUIRED_R)
+
+
 # ============================================================================
 # Simplification
 
@@ -501,6 +513,7 @@ def act(
         raise TypeError(msg)
 
     # Process rotation
+    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
     R = op_eval._get_R(chart)
 
@@ -538,6 +551,7 @@ def act(
         raise ValueError(msg)
 
     # Rotation matrix
+    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
     R = op_eval._get_R(chart)
     return jnp.einsum("ij,...j->...i", R, x)  # ty: ignore[invalid-return-type]
@@ -598,6 +612,7 @@ def act(
     # print("CART", cart.__class__, chart.__class__)
     comps_cart = cart.components
 
+    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
     R = op_eval._get_R(cart)
 
@@ -671,6 +686,7 @@ def _rotate_pushforward_cdict(
 
     """
     cart = chart.cartesian
+    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
     R = op_eval._get_R(cart)
 
@@ -857,6 +873,7 @@ def act(
       base-point.
 
     """
+    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
     n = op_eval._validate_square(op_eval.R).shape[-1]
 

--- a/src/coordinax/transforms/_src/actions/rotate.py
+++ b/src/coordinax/transforms/_src/actions/rotate.py
@@ -28,7 +28,7 @@ import coordinax.representations as cxr
 from .base import AbstractTransform, materialize_transform
 from .custom_types import CDict, HasShape, OptUSys
 from .identity import identity
-from .prolong import tau_derivative
+from .prolong import prolong_slot
 from .utils import Neg
 from coordinax.internal import pack_uniform_unit
 from coordinax.transforms._src import groups
@@ -790,36 +790,27 @@ def act(
     """
     del geom, kw
 
-    m = rep.semantic_kind.order  # ty: ignore[unresolved-attribute]
+    m = rep.semantic_kind.order
     # Displacements and time-independent rotations: pure pushforward.
     if m == 0 or not callable(op.R):
         return _rotate_pushforward_cdict(op, tau, x, chart, rep, at=at, usys=usys)
 
-    # Time-dependent rotation: the prolongation needs the lower jet slots.
-    if tau is None:
-        msg = (
-            "act(Rotate, ...) with a time-dependent rotation on tangent data "
-            "requires a time parameter; got tau=None."
-        )
-        raise TypeError(msg)
-    if at is None:
-        msg = (
-            f"act(Rotate, ...) with a time-dependent rotation on order-{m} "
-            "tangent data requires the base point via 'at' (the dR/dtau term "
-            "acts on the position), or use a coordinax.Coordinate bundle."
-        )
-        raise TypeError(msg)
-
     cart = chart.cartesian
-    if m == 1 and chart is cart:
+    if m == 1 and chart is cart and tau is not None and at is not None:
         # Closed form in Cartesian components: v' = R v + dR/dtau x.
-        op_eval = materialize_transform(op, tau)
-        R = op_eval._get_R(cart)
+        # One jvp evaluates R(tau) and dR/dtau together.
+        tau_unit = u.unit_of(tau)
+        tau_val = u.ustrip(tau_unit, tau) if tau_unit is not None else jnp.asarray(tau)
+        R_fn = op.R
+        R, Rdot = jax.jvp(
+            lambda tv: R_fn(u.Q(tv, tau_unit) if tau_unit is not None else tv),  # ty: ignore[call-top-callable]
+            (tau_val,),
+            (jax.numpy.ones_like(tau_val),),
+        )
+        R = op._validate_shape_match(op._validate_square(R), cart)
         comps = cart.components
         v_arr, v_unit = pack_uniform_unit(x, keys=comps)
         at_arr, at_unit = pack_uniform_unit(at, keys=comps)
-        tau_unit = u.unit_of(tau)
-        Rdot = tau_derivative(op.R, tau, n=1)  # raw array, per unit(tau)
         Rv = u.Q(jnp.einsum("ij,...j->...i", R, v_arr), v_unit)
         Rdot_at = u.Q(
             jnp.einsum("ij,...j->...i", Rdot, at_arr),
@@ -828,19 +819,9 @@ def act(
         out_arr = u.ustrip(v_unit, Rv + Rdot_at)
         return cast("CDict", cxc.cdict(out_arr, v_unit, comps))
 
-    # General case (acceleration, or non-Cartesian chart): generic prolongation.
-    jet: dict[int, CDict] = {0: at, m: x}
-    if m >= 2:
-        if at_vel is None:
-            msg = (
-                f"act(Rotate, ...) with a time-dependent rotation on order-{m} "
-                "tangent data requires 'at_vel' (the velocity at the base "
-                "point), or use a coordinax.Coordinate bundle."
-            )
-            raise TypeError(msg)
-        jet[1] = at_vel
-    out = cast("dict[int, CDict]", cxfmapi.prolong(op, tau, jet, chart, usys=usys))
-    return out[m]
+    # General case (acceleration, or non-Cartesian chart): generic prolongation
+    # (which also owns the missing-tau / missing-anchor errors).
+    return prolong_slot(op, tau, x, chart, m, at=at, at_vel=at_vel, usys=usys)
 
 
 # -----------------------------------------------

--- a/src/coordinax/transforms/_src/actions/rotate.py
+++ b/src/coordinax/transforms/_src/actions/rotate.py
@@ -812,7 +812,7 @@ def act(
         return _rotate_pushforward_cdict(op, tau, x, chart, rep, at=at, usys=usys)
 
     cart = chart.cartesian
-    if m == 1 and chart is cart and tau is not None and at is not None:
+    if m == 1 and chart == cart and tau is not None and at is not None:
         # Closed form in Cartesian components: v' = R v + dR/dtau x.
         # One jvp evaluates R(tau) and dR/dtau together.
         tau_unit = u.unit_of(tau)

--- a/src/coordinax/transforms/_src/actions/rotate.py
+++ b/src/coordinax/transforms/_src/actions/rotate.py
@@ -28,7 +28,7 @@ import coordinax.representations as cxr
 from .base import AbstractTransform, materialize_transform
 from .custom_types import CDict, HasShape, OptUSys
 from .identity import identity
-from .prolong import prolong_slot
+from .prolong import _attach_leaf, _strip_leaf, prolong_slot
 from .utils import Neg
 from coordinax.internal import pack_uniform_unit
 from coordinax.transforms._src import groups
@@ -827,7 +827,9 @@ def act(
         comps = cart.components
         v_arr, v_unit = pack_uniform_unit(x, keys=comps)
         at_arr, at_unit = pack_uniform_unit(at, keys=comps)
-        Rv = u.Q(jnp.einsum("ij,...j->...i", R, v_arr), v_unit)
+        # None units mean "stay raw" throughout, mirroring the generic
+        # engine's _attach_leaf/_strip_leaf policy for unitless data.
+        Rv = _attach_leaf(v_unit, jnp.einsum("ij,...j->...i", R, v_arr))
         # dR/dtau is per tau's unit; for a raw (unitless) tau with unitful
         # data, interpret it in the data's own time base T = at_unit/v_unit
         # (the same policy as the generic engine's _common_time_unit), so
@@ -838,8 +840,10 @@ def act(
             rdot_unit = v_unit
         else:
             rdot_unit = at_unit
-        Rdot_at = u.Q(jnp.einsum("ij,...j->...i", Rdot, at_arr), rdot_unit)
-        out_arr = u.ustrip(v_unit, Rv + Rdot_at)
+        Rdot_at = _attach_leaf(rdot_unit, jnp.einsum("ij,...j->...i", Rdot, at_arr))
+        out_arr = _strip_leaf(v_unit, Rv + Rdot_at)
+        if v_unit is None:
+            return {k: out_arr[..., i] for i, k in enumerate(comps)}
         return cast("CDict", cxc.cdict(out_arr, v_unit, comps))
 
     # General case (acceleration, or non-Cartesian chart): generic prolongation

--- a/src/coordinax/transforms/_src/actions/rotate.py
+++ b/src/coordinax/transforms/_src/actions/rotate.py
@@ -828,10 +828,17 @@ def act(
         v_arr, v_unit = pack_uniform_unit(x, keys=comps)
         at_arr, at_unit = pack_uniform_unit(at, keys=comps)
         Rv = u.Q(jnp.einsum("ij,...j->...i", R, v_arr), v_unit)
-        Rdot_at = u.Q(
-            jnp.einsum("ij,...j->...i", Rdot, at_arr),
-            at_unit / tau_unit if tau_unit is not None else at_unit,
-        )
+        # dR/dtau is per tau's unit; for a raw (unitless) tau with unitful
+        # data, interpret it in the data's own time base T = at_unit/v_unit
+        # (the same policy as the generic engine's _common_time_unit), so
+        # Rdot@at carries at_unit/T = v_unit and the sum is consistent.
+        if tau_unit is not None:
+            rdot_unit = at_unit / tau_unit if at_unit is not None else None
+        elif at_unit is not None and v_unit is not None:
+            rdot_unit = v_unit
+        else:
+            rdot_unit = at_unit
+        Rdot_at = u.Q(jnp.einsum("ij,...j->...i", Rdot, at_arr), rdot_unit)
         out_arr = u.ustrip(v_unit, Rv + Rdot_at)
         return cast("CDict", cxc.cdict(out_arr, v_unit, comps))
 

--- a/src/coordinax/transforms/_src/actions/rotate.py
+++ b/src/coordinax/transforms/_src/actions/rotate.py
@@ -28,6 +28,7 @@ import coordinax.representations as cxr
 from .base import AbstractTransform, materialize_transform
 from .custom_types import CDict, HasShape, OptUSys
 from .identity import identity
+from .prolong import tau_derivative
 from .utils import Neg
 from coordinax.internal import pack_uniform_unit
 from coordinax.transforms._src import groups
@@ -615,21 +616,18 @@ def act(
     return cast("CDict", out)
 
 
-@plum.dispatch
-def act(
-    op: Rotate,
+def _rotate_pushforward_cdict(
+    op: "Rotate",
     tau: Any,
     x: CDict,
     chart: cxc.AbstractChart,
-    geom: cxr.TangentGeometry,
     rep: cxr.Representation,
     /,
     *,
     at: CDict | None = None,
     usys: OptUSys = None,
-    **kw: Any,
 ) -> CDict:
-    """Apply a spatial rotation to a TangentGeometry coordinate dictionary.
+    """Frozen-tau Jacobian pushforward of tangent data under a rotation.
 
     Rotation acts on tangent vectors via the Jacobian pushforward, not as a
     direct coordinate substitution.  The algorithm is:
@@ -672,8 +670,6 @@ def act(
     1.0
 
     """
-    del geom, kw
-
     cart = chart.cartesian
     op_eval = materialize_transform(op, tau)
     R = op_eval._get_R(cart)
@@ -709,6 +705,142 @@ def act(
 
     # Pull rotated tangent back to original chart via inverse Jacobian.
     return cxr.tangent_map(p_cart_rot, cart, rep, chart, at=at_cart_rot, usys=usys)  # ty: ignore[missing-argument]
+
+
+@plum.dispatch
+def pushforward(
+    op: Rotate,
+    tau: Any,
+    v: CDict,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+    *,
+    at: CDict | None = None,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Frozen-$\tau$ pushforward of tangent data under a rotation: $R(\tau) v$.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import coordinax.transforms as cxfm
+
+    >>> op = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+    >>> v = {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")}
+    >>> out = cxfm.pushforward(op, None, v, cxc.cart3d, cxr.coord_vel)
+    >>> out["y"].round(3)
+    Q(1., 'm / s')
+
+    """
+    return _rotate_pushforward_cdict(op, tau, v, chart, rep, at=at, usys=usys)
+
+
+@plum.dispatch
+def act(
+    op: Rotate,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractChart,
+    geom: cxr.TangentGeometry,
+    rep: cxr.Representation,
+    /,
+    *,
+    at: CDict | None = None,
+    at_vel: CDict | None = None,
+    usys: OptUSys = None,
+    **kw: Any,
+) -> CDict:
+    r"""Apply a rotation to tangent data (kinematic prolongation).
+
+    - Displacement data and any data under a time-independent rotation
+      transform by the frozen-$\tau$ pushforward $v \mapsto R(\tau) v$.
+    - Under a time-dependent rotation $R(\tau)$, velocities gain the
+      $\dot R$ term of the prolongation, $v' = R v + \dot R x$, which
+      requires the base point ``at``; accelerations gain
+      $a' = R a + 2 \dot R v + \ddot R x$, requiring ``at`` and ``at_vel``.
+
+    Examples
+    --------
+    >>> import quaxed.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import coordinax.transforms as cxfm
+    >>> from jaxtyping import Array, Real
+
+    A uniformly rotating frame (angular speed 1 rad/s about z):
+
+    >>> def R_func(t) -> Real[Array, "3 3"]:
+    ...     th = t.ustrip("s")
+    ...     st, ct = jnp.sin(th), jnp.cos(th)
+    ...     return jnp.array([[ct, -st, 0.0], [st, ct, 0.0], [0.0, 0.0, 1.0]])
+    >>> op = cxfm.Rotate.from_(R_func)
+
+    At tau=0 the rotation is the identity but the velocity still gains the
+    $\dot R x$ (angular) term:
+
+    >>> at = {"x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> v = {"x": u.Q(0.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")}
+    >>> out = cxfm.act(op, u.Q(0.0, "s"), v, cxc.cart3d, cxr.tangent_geom,
+    ...                cxr.coord_vel, at=at)
+    >>> out["y"].round(3)
+    Q(1., 'm / s')
+
+    """
+    del geom, kw
+
+    m = rep.semantic_kind.order  # ty: ignore[unresolved-attribute]
+    # Displacements and time-independent rotations: pure pushforward.
+    if m == 0 or not callable(op.R):
+        return _rotate_pushforward_cdict(op, tau, x, chart, rep, at=at, usys=usys)
+
+    # Time-dependent rotation: the prolongation needs the lower jet slots.
+    if tau is None:
+        msg = (
+            "act(Rotate, ...) with a time-dependent rotation on tangent data "
+            "requires a time parameter; got tau=None."
+        )
+        raise TypeError(msg)
+    if at is None:
+        msg = (
+            f"act(Rotate, ...) with a time-dependent rotation on order-{m} "
+            "tangent data requires the base point via 'at' (the dR/dtau term "
+            "acts on the position), or use a coordinax.Coordinate bundle."
+        )
+        raise TypeError(msg)
+
+    cart = chart.cartesian
+    if m == 1 and chart is cart:
+        # Closed form in Cartesian components: v' = R v + dR/dtau x.
+        op_eval = materialize_transform(op, tau)
+        R = op_eval._get_R(cart)
+        comps = cart.components
+        v_arr, v_unit = pack_uniform_unit(x, keys=comps)
+        at_arr, at_unit = pack_uniform_unit(at, keys=comps)
+        tau_unit = u.unit_of(tau)
+        Rdot = tau_derivative(op.R, tau, n=1)  # raw array, per unit(tau)
+        Rv = u.Q(jnp.einsum("ij,...j->...i", R, v_arr), v_unit)
+        Rdot_at = u.Q(
+            jnp.einsum("ij,...j->...i", Rdot, at_arr),
+            at_unit / tau_unit if tau_unit is not None else at_unit,
+        )
+        out_arr = u.ustrip(v_unit, Rv + Rdot_at)
+        return cast("CDict", cxc.cdict(out_arr, v_unit, comps))
+
+    # General case (acceleration, or non-Cartesian chart): generic prolongation.
+    jet: dict[int, CDict] = {0: at, m: x}
+    if m >= 2:
+        if at_vel is None:
+            msg = (
+                f"act(Rotate, ...) with a time-dependent rotation on order-{m} "
+                "tangent data requires 'at_vel' (the velocity at the base "
+                "point), or use a coordinax.Coordinate bundle."
+            )
+            raise TypeError(msg)
+        jet[1] = at_vel
+    out = cast("dict[int, CDict]", cxfmapi.prolong(op, tau, jet, chart, usys=usys))
+    return out[m]
 
 
 # -----------------------------------------------

--- a/src/coordinax/transforms/_src/actions/translate.py
+++ b/src/coordinax/transforms/_src/actions/translate.py
@@ -43,8 +43,10 @@ class Translate(AbstractAdd):
     Parameters
     ----------
     delta : CDict | Callable[[tau], CDict]
-        The displacement to apply. Must have length dimension.  If callable,
-        will be evaluated at the time parameter ``tau``.
+        The offset to apply. Its physical dimension follows ``semantic_kind``:
+        length for the default displacement kind (``dpl``), speed for a
+        velocity kick (``vel``), and so on up the time-derivative ladder. If
+        callable, it is evaluated at the time parameter ``tau``.
 
     Notes
     -----
@@ -129,6 +131,18 @@ class Translate(AbstractAdd):
     # inverse and __neg__ inherited from AbstractAdd
 
 
+_MSG_TAU_REQUIRED = (
+    "act(Translate, ...) with a time-dependent (callable) delta requires a "
+    "time parameter; got tau=None."
+)
+
+
+def _check_tau(op: "Translate", tau: Any, /) -> None:
+    """Raise an informative TypeError before materializing a callable delta."""
+    if tau is None and callable(op.delta):
+        raise TypeError(_MSG_TAU_REQUIRED)
+
+
 # ============================================================================
 # act
 
@@ -184,6 +198,7 @@ def act(
     )
 
     # Process Translation
+    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
 
     # Convert delta to array using chart components and usys
@@ -244,6 +259,7 @@ def act(
         return x
 
     # Process Translation
+    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
 
     # Convert delta to array using chart components and usys
@@ -321,14 +337,11 @@ def act(
     # Contribution: d^(m-k) delta / dtau^(m-k).
     n = m - k
     if n == 0:
+        _check_tau(op, tau)
         delta = materialize_transform(op, tau).delta
     elif callable(op.delta):
         if tau is None:
-            msg = (
-                "act(Translate, ...) with a time-dependent delta on "
-                f"order-{m} tangent data requires a time parameter; got tau=None."
-            )
-            raise TypeError(msg)
+            raise TypeError(_MSG_TAU_REQUIRED)
         delta = tau_derivative(op.delta, tau, n=n)
     else:
         # Static delta: all tau-derivatives vanish.
@@ -362,6 +375,7 @@ def _translate_point_cdict(
     usys: OptUSys = None,
 ) -> CDict:
     """Shift a point by the (materialized) delta, via the Cartesian chart."""
+    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
 
     # Translate in Cartesian space, then map back.

--- a/src/coordinax/transforms/_src/actions/translate.py
+++ b/src/coordinax/transforms/_src/actions/translate.py
@@ -56,15 +56,23 @@ class Translate(AbstractAdd):
     (``dpl``: $k=0$, ``vel``: $k=1$, ...). Acting on data of ladder order $m$
     (points behave as the curve position for $k=0$):
 
-    - $k = 0$: shifts points by $\delta(\tau)$; velocities gain
-      $\dot\delta(\tau)$ and accelerations $\ddot\delta(\tau)$ when
-      ``delta`` is time-dependent (the kinematic prolongation).
+    - $k = 0$ with ``delta`` in a Cartesian-type (flat) chart: shifts points
+      by $\delta(\tau)$; velocities gain $\dot\delta(\tau)$ and
+      accelerations $\ddot\delta(\tau)$ when ``delta`` is time-dependent
+      (the kinematic prolongation); ``Displacement`` data ($m = 0$) is
+      unaffected (a displacement is a same-$\tau$ point difference and the
+      Jacobian of a flat translation is the identity).
+    - $k = 0$ with ``delta`` in a non-flat chart: the point action pushes
+      ``delta`` through the chart Jacobian at the point, so it is base-point
+      dependent. All tangent data — including displacements — transforms by
+      the generic pushforward/prolongation of the point action, which is
+      generally not the identity and requires the base point (``at=``, or a
+      `~coordinax.Coordinate` bundle).
     - $k \geq 1$: identity on points and on all orders $m < k$; order $m = k$
       gains $\delta(\tau)$; orders $m > k$ gain
-      $d^{m-k}\delta/d\tau^{m-k}$ when ``delta`` is time-dependent.
-    - ``Displacement`` data ($m = 0$) is always unaffected: a displacement is
-      a same-$\tau$ point difference and the Jacobian of a translation is the
-      identity.
+      $d^{m-k}\delta/d\tau^{m-k}$ when ``delta`` is time-dependent. The
+      componentwise rule is definitional (the point action is the identity),
+      independent of chart flatness.
 
     Examples
     --------

--- a/src/coordinax/transforms/_src/actions/translate.py
+++ b/src/coordinax/transforms/_src/actions/translate.py
@@ -341,13 +341,15 @@ def act(
     if m < k:
         return x
 
-    # The flat ladder rule below is the prolongation of the point action only
-    # when a k=0 delta lives in a Cartesian chart, where the point action is
-    # a true translation. In a non-Cartesian chart the point action pushes
-    # delta through the chart Jacobian AT the point, so it is base-point
-    # dependent and its prolongation/pushforward gains coupling terms — defer
-    # to the generic autodiff engine (which requires the base point 'at').
-    if k == 0 and not is_flat_chart(op.chart):
+    # The componentwise ladder rule below is the prolongation of the point
+    # action only when the k=0 delta and the data live in the SAME
+    # Cartesian-type chart, where the point action is a true translation. If
+    # delta lives in a non-flat chart (pushed through the chart Jacobian AT
+    # the point) or the data's chart is non-flat / different (the translation
+    # is nonlinear in the data's coordinates), the pushforward/prolongation
+    # gains base-point-dependent coupling terms — defer to the generic
+    # autodiff engine (which requires the base point 'at').
+    if k == 0 and not (chart == op.chart and is_flat_chart(chart)):
         return _act_translate_nonflat(op, tau, x, chart, rep, m, kw, usys)
 
     # Displacements are same-tau point differences (never gain dtau terms and
@@ -368,6 +370,8 @@ def act(
         # Static delta: all tau-derivatives vanish.
         return x
 
+    # Only k >= 1 fibre kicks reach here cross-chart (k=0 routed to the
+    # generic engine above); they have no well-defined cross-chart rule.
     if op.chart != chart:
         msg = (
             f"Translate.delta is defined in chart {op.chart!r}, "
@@ -397,7 +401,7 @@ def _act_translate_nonflat(
     usys: OptUSys,
     /,
 ) -> CDict:
-    """Generic-engine fallback for a k=0 delta in a non-Cartesian chart."""
+    """Generic-engine fallback for a k=0 offset that is not a flat translation."""
     if m == 0 or not is_time_dependent(op):
         return cast(
             "CDict",

--- a/src/coordinax/transforms/_src/actions/translate.py
+++ b/src/coordinax/transforms/_src/actions/translate.py
@@ -310,8 +310,8 @@ def act(
             return x
         return _translate_point_cdict(op, tau, x, chart, usys=usys)
 
-    # --- Tangent input of ladder order m.
-    m = rep.semantic_kind.order  # ty: ignore[unresolved-attribute]
+    # --- Tangent input of ladder order m (int for all tangent kinds).
+    m = cast("int", rep.semantic_kind.order)
     # Displacements are same-tau point differences (never gain dtau terms and
     # the Jacobian of a translation is the identity); lower-order fibres are
     # untouched by a higher-order offset.

--- a/src/coordinax/transforms/_src/actions/translate.py
+++ b/src/coordinax/transforms/_src/actions/translate.py
@@ -19,6 +19,7 @@ from .add import AbstractAdd
 from .base import materialize_transform
 from .composed import Composed
 from .custom_types import CDict, OptUSys
+from .prolong import tau_derivative
 from coordinax.internal import pack_uniform_unit
 from coordinax.transforms._src import groups
 
@@ -47,10 +48,19 @@ class Translate(AbstractAdd):
 
     Notes
     -----
-    - Only applicable to ``Point`` role vectors
-    - Raises ``TypeError`` when applied to other roles (e.g., ``PhysVel``)
-    - The ``delta`` is interpreted as a ``PhysDisp``-role displacement
-      internally
+    The ``semantic_kind`` field sets the ladder order $k$ of the offset
+    (``dpl``: $k=0$, ``vel``: $k=1$, ...). Acting on data of ladder order $m$
+    (points behave as the curve position for $k=0$):
+
+    - $k = 0$: shifts points by $\delta(\tau)$; velocities gain
+      $\dot\delta(\tau)$ and accelerations $\ddot\delta(\tau)$ when
+      ``delta`` is time-dependent (the kinematic prolongation).
+    - $k \geq 1$: identity on points and on all orders $m < k$; order $m = k$
+      gains $\delta(\tau)$; orders $m > k$ gain
+      $d^{m-k}\delta/d\tau^{m-k}$ when ``delta`` is time-dependent.
+    - ``Displacement`` data ($m = 0$) is always unaffected: a displacement is
+      a same-$\tau$ point difference and the Jacobian of a translation is the
+      identity.
 
     Examples
     --------
@@ -257,10 +267,13 @@ def act(
     usys: OptUSys = None,
     **kw: Any,
 ) -> CDict:
-    """Apply Translate to a Point-valued component dictionary.
+    r"""Apply Translate to a component dictionary (ladder rule).
 
-    Dispatches on ``op.semantic_kind`` to determine which representations
-    are shifted.
+    The behavior follows the time-derivative ladder: with $k$ the operator's
+    ``semantic_kind`` order and $m$ the input's ladder order, the input gains
+    $d^{m-k}\delta/d\tau^{m-k}$ for $m \geq k$ (points act as the curve
+    position for $k = 0$), and is unaffected for $m < k$ or for
+    ``Displacement`` data ($m = 0$).
 
     >>> import coordinax.transforms as cxfm
     >>> import unxt as u
@@ -272,94 +285,106 @@ def act(
     >>> cxfm.act(shift, None, x, cxc.cart3d, cxr.point)
     {'x': Q(1, 'km'), 'y': Q(2, 'km'), 'z': Q(3, 'km')}
 
+    A static translate does not affect velocities:
+
+    >>> v = {"x": u.Q(1.0, "km/s"), "y": u.Q(0.0, "km/s"), "z": u.Q(0.0, "km/s")}
+    >>> cxfm.act(shift, None, v, cxc.cart3d, cxr.coord_vel)
+    {'x': Q(1., 'km / s'), 'y': Q(0., 'km / s'), 'z': Q(0., 'km / s')}
+
+    But a time-dependent translate boosts velocities by its rate
+    (the kinematic prolongation):
+
+    >>> delta = lambda t: {"x": u.Q(3.0, "km/s") * t, "y": u.Q(0.0, "km"),
+    ...                    "z": u.Q(0.0, "km")}
+    >>> moving = cxfm.Translate(delta, chart=cxc.cart3d)
+    >>> cxfm.act(moving, u.Q(2.0, "s"), v, cxc.cart3d, cxr.coord_vel)
+    {'x': Q(4., 'km / s'), 'y': Q(0., 'km / s'), 'z': Q(0., 'km / s')}
+
     """
     del kw
-    return _act_translate_cdict(op.semantic_kind, op, tau, x, chart, rep, usys=usys)
+    k = op.semantic_kind.order
 
-
-@plum.dispatch
-def _act_translate_cdict(
-    sk: cxr.Displacement,
-    op: Translate,
-    tau: Any,
-    x: CDict,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    usys: OptUSys = None,
-) -> CDict:
-    """Displacement-semantic translate: shifts points only.
-
-    Per the spec, a spatial ``Translate`` is identity for all tangent
-    representations (displacements, velocities, accelerations).
-    """
-    op_eval = materialize_transform(op, tau)
-
+    # --- Point input: the curve position, shifted only by a k=0 translate.
     if rep == cxr.point:
-        # Translate in Cartesian space, then map back.
-        cart = chart.cartesian
-        x_cart = cxc.pt_map(x, chart, cart, usys=usys)
+        if k != 0:
+            return x
+        return _translate_point_cdict(op, tau, x, chart, usys=usys)
 
-        if op_eval.chart == cart:
-            delta_cart = op_eval.delta
-        else:
-            # Push delta through the Jacobian into Cartesian.
-            at_in_op_chart = cxc.pt_map(x_cart, cart, op_eval.chart, usys=usys)
-            delta_cart = cxr.tangent_map(  # ty: ignore[missing-argument]
-                op_eval.delta,
-                op_eval.chart,
-                cxr.coord_disp,
-                cart,
-                at=at_in_op_chart,
-                usys=usys,
-            )
-
-        x_cart2 = jtu.map(
-            jnp.add,
-            *((x_cart, delta_cart) if op_eval.right_add else (delta_cart, x_cart)),
-            is_leaf=u.quantity.is_any_quantity,
-        )
-        return cast("CDict", cxc.pt_map(x_cart2, cart, chart, usys=usys))
-
-    # Identity for displacements, velocities, accelerations, and all other
-    # tangent representations.
-    return x
-
-
-@plum.dispatch
-def _act_translate_cdict(
-    sk: cxr.AbstractTangentSemanticKind,
-    op: Translate,
-    tau: Any,
-    x: CDict,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    usys: OptUSys = None,
-) -> CDict:
-    """Velocity/acceleration-semantic translate: shifts matching tangent vectors."""
-    op_eval = materialize_transform(op, tau)
-
-    # A vel/acc-semantic translate does not move position points.
-    if rep == cxr.point:
+    # --- Tangent input of ladder order m.
+    m = rep.semantic_kind.order  # ty: ignore[unresolved-attribute]
+    # Displacements are same-tau point differences (never gain dtau terms and
+    # the Jacobian of a translation is the identity); lower-order fibres are
+    # untouched by a higher-order offset.
+    if m == 0 or m < k:
         return x
 
-    if rep.semantic_kind == sk:
-        if op_eval.chart != chart:
+    # Contribution: d^(m-k) delta / dtau^(m-k).
+    n = m - k
+    if n == 0:
+        delta = materialize_transform(op, tau).delta
+    elif callable(op.delta):
+        if tau is None:
             msg = (
-                f"Translate.delta is defined in chart {op_eval.chart!r}, "
-                f"but the representation is in chart {chart!r}. "
-                "Convert delta to the target chart before constructing Translate."
+                "act(Translate, ...) with a time-dependent delta on "
+                f"order-{m} tangent data requires a time parameter; got tau=None."
             )
-            raise ValueError(msg)
-        return cast(
-            "CDict",
-            jtu.map(
-                jnp.add,
-                *((x, op_eval.delta) if op_eval.right_add else (op_eval.delta, x)),
-                is_leaf=u.quantity.is_any_quantity,
-            ),
+            raise TypeError(msg)
+        delta = tau_derivative(op.delta, tau, n=n)
+    else:
+        # Static delta: all tau-derivatives vanish.
+        return x
+
+    if op.chart != chart:
+        msg = (
+            f"Translate.delta is defined in chart {op.chart!r}, "
+            f"but the representation is in chart {chart!r}. "
+            "Convert delta to the target chart before constructing Translate."
+        )
+        raise ValueError(msg)
+
+    return cast(
+        "CDict",
+        jtu.map(
+            jnp.add,
+            *((x, delta) if op.right_add else (delta, x)),
+            is_leaf=u.quantity.is_any_quantity,
+        ),
+    )
+
+
+def _translate_point_cdict(
+    op: Translate,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractChart,
+    /,
+    *,
+    usys: OptUSys = None,
+) -> CDict:
+    """Shift a point by the (materialized) delta, via the Cartesian chart."""
+    op_eval = materialize_transform(op, tau)
+
+    # Translate in Cartesian space, then map back.
+    cart = chart.cartesian
+    x_cart = cxc.pt_map(x, chart, cart, usys=usys)
+
+    if op_eval.chart == cart:
+        delta_cart = op_eval.delta
+    else:
+        # Push delta through the Jacobian into Cartesian.
+        at_in_op_chart = cxc.pt_map(x_cart, cart, op_eval.chart, usys=usys)
+        delta_cart = cxr.tangent_map(  # ty: ignore[missing-argument]
+            op_eval.delta,
+            op_eval.chart,
+            cxr.coord_disp,
+            cart,
+            at=at_in_op_chart,
+            usys=usys,
         )
 
-    # Identity for non-matching representations.
-    return x
+    x_cart2 = jtu.map(
+        jnp.add,
+        *((x_cart, delta_cart) if op_eval.right_add else (delta_cart, x_cart)),
+        is_leaf=u.quantity.is_any_quantity,
+    )
+    return cast("CDict", cxc.pt_map(x_cart2, cart, chart, usys=usys))

--- a/src/coordinax/transforms/_src/actions/translate.py
+++ b/src/coordinax/transforms/_src/actions/translate.py
@@ -13,13 +13,15 @@ import plum
 import quaxed.numpy as jnp
 import unxt as u
 
+import coordinax.api.transforms as cxfmapi
 import coordinax.charts as cxc
 import coordinax.representations as cxr
 from .add import AbstractAdd
-from .base import materialize_transform
+from .base import is_time_dependent, materialize_transform
 from .composed import Composed
 from .custom_types import CDict, OptUSys
-from .prolong import tau_derivative
+from .prolong import prolong_slot, tau_derivative
+from .utils import is_flat_chart
 from coordinax.internal import pack_uniform_unit
 from coordinax.transforms._src import groups
 
@@ -317,7 +319,6 @@ def act(
     {'x': Q(4., 'km / s'), 'y': Q(0., 'km / s'), 'z': Q(0., 'km / s')}
 
     """
-    del kw
     k = op.semantic_kind.order
 
     # --- Point input: the curve position, shifted only by a k=0 translate.
@@ -328,10 +329,22 @@ def act(
 
     # --- Tangent input of ladder order m (int for all tangent kinds).
     m = cast("int", rep.semantic_kind.order)
+    # Lower-order fibres are untouched by a higher-order offset.
+    if m < k:
+        return x
+
+    # The flat ladder rule below is the prolongation of the point action only
+    # when a k=0 delta lives in a Cartesian chart, where the point action is
+    # a true translation. In a non-Cartesian chart the point action pushes
+    # delta through the chart Jacobian AT the point, so it is base-point
+    # dependent and its prolongation/pushforward gains coupling terms — defer
+    # to the generic autodiff engine (which requires the base point 'at').
+    if k == 0 and not is_flat_chart(op.chart):
+        return _act_translate_nonflat(op, tau, x, chart, rep, m, kw, usys)
+
     # Displacements are same-tau point differences (never gain dtau terms and
-    # the Jacobian of a translation is the identity); lower-order fibres are
-    # untouched by a higher-order offset.
-    if m == 0 or m < k:
+    # the Jacobian of a flat translation is the identity).
+    if m == 0:
         return x
 
     # Contribution: d^(m-k) delta / dtau^(m-k).
@@ -362,6 +375,28 @@ def act(
             *((x, delta) if op.right_add else (delta, x)),
             is_leaf=u.quantity.is_any_quantity,
         ),
+    )
+
+
+def _act_translate_nonflat(
+    op: Translate,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    m: int,
+    kw: dict[str, Any],
+    usys: OptUSys,
+    /,
+) -> CDict:
+    """Generic-engine fallback for a k=0 delta in a non-Cartesian chart."""
+    if m == 0 or not is_time_dependent(op):
+        return cast(
+            "CDict",
+            cxfmapi.pushforward(op, tau, x, chart, rep, at=kw.get("at"), usys=usys),
+        )
+    return prolong_slot(
+        op, tau, x, chart, m, at=kw.get("at"), at_vel=kw.get("at_vel"), usys=usys
     )
 
 

--- a/src/coordinax/transforms/_src/actions/translate.py
+++ b/src/coordinax/transforms/_src/actions/translate.py
@@ -40,7 +40,10 @@ class Translate(AbstractAdd):
     Formally, in a Cartesian chart on $\mathbb{R}^n$: $T_\Delta:\; x \mapsto
     x+\Delta$.
 
-    Its differential (pushforward) is the identity: $(dT_\Delta)_x = I$.
+    In that flat setting its differential (pushforward) is the identity,
+    $(dT_\Delta)_x = I$. When ``delta`` lives in a non-flat chart, or acts on
+    data in a different or non-flat chart, the point action is base-point
+    dependent and the differential is NOT the identity — see the Notes.
 
     Parameters
     ----------
@@ -182,13 +185,18 @@ def act(
     >>> cxfm.act(shift, None, x,  cxc.cart3d, cxr.point, usys=usys)
     Array([1000., 2000., 3000.], dtype=float64)
 
-    Velocity-semantic translate is identity on point arrays:
+    A fibre kick (e.g. ``semantic_kind=vel``) cannot infer whether a bare,
+    unitless array is a position (kick is identity) or the matching tangent
+    data (kick applies) — that ambiguity is rejected loudly:
 
     >>> import coordinax.representations as cxr
     >>> from dataclassish import replace
     >>> vel_shift = replace(shift, semantic_kind=cxr.vel)
-    >>> cxfm.act(vel_shift, None, x, cxc.cart3d, cxr.point, usys=usys)
-    Array([0., 0., 0.], dtype=float64)
+    >>> try:
+    ...     cxfm.act(vel_shift, None, x, cxc.cart3d, cxr.point, usys=usys)
+    ... except TypeError as e:
+    ...     print(str(e)[:44])
+    A fibre offset (Translate with semantic_kind
 
     """
     del kw
@@ -196,9 +204,20 @@ def act(
     if rep != cxr.point:
         raise TypeError("Translate can only be applied to point representations")
 
-    # A vel/acc-semantic translate does not move position points.
+    # A bare, unitless array is ambiguous under a fibre kick: it could be a
+    # position (kick is identity) or the kick's own tangent data (kick
+    # applies). Silently choosing 'position' would drop the kick for velocity
+    # arrays — reject instead. (Quantities are unambiguous: units select the
+    # representation.)
     if not isinstance(op.semantic_kind, cxr.Displacement):
-        return jnp.asarray(x)
+        msg = (
+            f"A fibre offset (Translate with semantic_kind="
+            f"{op.semantic_kind!r}) cannot act on a bare array: it is "
+            "ambiguous whether the array is a position (offset is identity) "
+            "or tangent data (offset applies). Use a Quantity with units, a "
+            "component dict, or a typed vector."
+        )
+        raise TypeError(msg)
 
     if usys is None:
         raise TypeError("Translate requires usys to convert delta to x's units")
@@ -371,14 +390,11 @@ def act(
         return x
 
     # Only k >= 1 fibre kicks reach here cross-chart (k=0 routed to the
-    # generic engine above); they have no well-defined cross-chart rule.
+    # generic engine above). A kick is a tangent vector at the point, so it
+    # has a well-defined cross-chart rule: push its components through the
+    # chart Jacobian AT the base point (requires the anchor `at`).
     if op.chart != chart:
-        msg = (
-            f"Translate.delta is defined in chart {op.chart!r}, "
-            f"but the representation is in chart {chart!r}. "
-            "Convert delta to the target chart before constructing Translate."
-        )
-        raise ValueError(msg)
+        delta = _kick_delta_in_chart(op, delta, chart, kw.get("at"), usys)
 
     return cast(
         "CDict",
@@ -386,6 +402,34 @@ def act(
             jnp.add,
             *((x, delta) if op.right_add else (delta, x)),
             is_leaf=u.quantity.is_any_quantity,
+        ),
+    )
+
+
+def _kick_delta_in_chart(
+    op: Translate,
+    delta: CDict,
+    chart: cxc.AbstractChart,
+    at: CDict | None,
+    usys: OptUSys,
+    /,
+) -> CDict:
+    """Push a fibre-kick offset through the chart Jacobian at the base point."""
+    if at is None:
+        msg = (
+            f"Translate.delta (a fibre offset) is defined in chart "
+            f"{op.chart!r}, but the data is in chart {chart!r}. "
+            "Converting the offset requires the base point: pass 'at' (a "
+            "CDict in the data's chart) or use a coordinax.Coordinate "
+            "bundle, which supplies it automatically."
+        )
+        raise TypeError(msg)
+    at_in_op_chart = cxc.pt_map(at, chart, op.chart, usys=usys)
+    kick_rep = cxr.Representation(cxr.tangent_geom, cxr.coord_basis, op.semantic_kind)
+    return cast(
+        "CDict",
+        cxr.tangent_map(  # ty: ignore[missing-argument]
+            delta, op.chart, kick_rep, chart, at=at_in_op_chart, usys=usys
         ),
     )
 

--- a/src/coordinax/transforms/_src/actions/utils.py
+++ b/src/coordinax/transforms/_src/actions/utils.py
@@ -20,8 +20,20 @@ def is_flat_chart(chart: Any, /) -> bool:
     ambient space (Jacobian = identity, no base-point dependence). In any
     other chart an offset must be pushed through the chart Jacobian at the
     point, so additive fast paths do not apply.
+
+    A chart with no global Cartesian chart (e.g. ``PoincarePolar6D``) is not
+    flat: this predicate returns `False` rather than propagating
+    `~coordinax.charts.NoGlobalCartesianChartError`.
     """
-    return isinstance(chart, type(chart.cartesian))
+    from coordinax._src.exceptions import (  # noqa: PLC0415 - avoid cycle
+        NoGlobalCartesianChartError,
+    )
+
+    try:
+        cart = chart.cartesian
+    except NoGlobalCartesianChartError:
+        return False
+    return isinstance(chart, type(cart))
 
 
 @final

--- a/src/coordinax/transforms/_src/actions/utils.py
+++ b/src/coordinax/transforms/_src/actions/utils.py
@@ -3,7 +3,7 @@
 This module defines helpers for operator implementations.
 """
 
-__all__: tuple[str, ...] = ("Neg",)
+__all__: tuple[str, ...] = ("Neg", "is_flat_chart")
 
 import dataclasses
 
@@ -11,6 +11,17 @@ from typing import Any, final
 
 import jax.numpy as jnp
 import jax.tree as jtu
+
+
+def is_flat_chart(chart: Any, /) -> bool:
+    """Whether ``chart`` is a Cartesian-type chart (its own canonical Cartesian).
+
+    In such charts a componentwise offset IS a translation of the flat
+    ambient space (Jacobian = identity, no base-point dependence). In any
+    other chart an offset must be pushed through the chart Jacobian at the
+    point, so additive fast paths do not apply.
+    """
+    return isinstance(chart, type(chart.cartesian))
 
 
 @final

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -517,8 +517,23 @@ def subtract(lhs: Tangent, rhs: Tangent, /) -> Tangent:
 
 
 @plum.dispatch
-def act(op: cxfm.AbstractTransform, tau: Any, x: Tangent, /, **kw: Any) -> Tangent:
+def act(
+    op: cxfm.AbstractTransform,
+    tau: Any,
+    x: Tangent,
+    /,
+    *,
+    at: Any = None,
+    at_vel: Any = None,
+    **kw: Any,
+) -> Tangent:
     """Act a frame transform on a tangent Tangent.
+
+    ``at`` (the base point) and ``at_vel`` (the velocity at the base point)
+    anchor the transformation when it is needed — for Jacobian pushforwards in
+    non-Cartesian charts and for the kinematic prolongation under
+    time-dependent transforms. They may be `Point`/`Tangent` instances (whose
+    ``.data`` is used, after a chart check) or raw ``CDict`` data.
 
     >>> import jax.numpy as jnp
     >>> import unxt as u
@@ -537,8 +552,29 @@ def act(op: cxfm.AbstractTransform, tau: Any, x: Tangent, /, **kw: Any) -> Tange
         [0. 1. 0.]>
 
     """
+    at_data = _unwrap_anchor(at, x.chart, "at")
+    at_vel_data = _unwrap_anchor(at_vel, x.chart, "at_vel")
+    if at_data is not None:
+        kw["at"] = at_data
+    if at_vel_data is not None:
+        kw["at_vel"] = at_vel_data
     data = cxfmapi.act(op, tau, x.data, x.chart, x.rep, **kw)
     return replace(x, data=data)
+
+
+def _unwrap_anchor(anchor: Any, chart: Any, name: str, /) -> CDict | None:
+    """Unwrap a Point/Tangent anchor to its data, checking the chart."""
+    if anchor is None:
+        return None
+    if isinstance(anchor, (Point, Tangent)):
+        if anchor.chart != chart:
+            msg = (
+                f"{name!r} chart {anchor.chart!r} does not match "
+                f"the tangent's chart {chart!r}."
+            )
+            raise ValueError(msg)
+        return cast("CDict", anchor.data)
+    return cast("CDict", anchor)
 
 
 @plum.dispatch
@@ -591,7 +627,20 @@ def act(
     >>> pv_alex["velocity"].frame
     Alex()
 
+    A time-dependent transform prolongs the whole bundle jointly: a uniformly
+    moving translation boosts the velocity fibre by its rate:
+
+    >>> delta = lambda t: {"x": u.Q(3.0, "m/s") * t, "y": u.Q(0.0, "m"),
+    ...                    "z": u.Q(0.0, "m")}
+    >>> op = cx.Translate(delta, chart=cxc.cart3d)
+    >>> out = cx.act(op, u.Q(2.0, "s"), pv)
+    >>> out.point.data["x"], out["velocity"].data["x"]
+    (Q(7., 'm'), Q(4., 'm / s'))
+
     """
+    if cxfm.is_time_dependent(op):
+        return _act_coordinate_jet(op, tau, x, **kw)
+
     new_point = cxfm.act(op, tau, x.point, **kw)
     # Inject the base-point data as 'at' so non-Cartesian tangent dispatches
     # can evaluate the Jacobian at the correct location.  Callers may
@@ -612,6 +661,74 @@ def act(
         else:
             fibre_kw = kw_base
         new_fields[name] = cxfm.act(op, tau, fibre, **fibre_kw)
+    return Coordinate(point=new_point, **new_fields)
+
+
+def _act_coordinate_jet(
+    op: cxfm.AbstractTransform, tau: Any, x: Coordinate, /, **kw: Any
+) -> Coordinate:
+    """Act a time-dependent transform on a Coordinate via joint prolongation.
+
+    The point and all ladder fibres (velocity, acceleration, ...) form a jet
+    of the underlying curve; the transform's kinematic prolongation is applied
+    to the whole jet at once, so each fibre correctly gains the transform's
+    time-derivative terms. Displacement fibres (same-tau point differences)
+    transform by the frozen-tau pushforward at the base point.
+    """
+    usys = kw.get("usys")
+    point_chart = x.point.chart
+
+    # Assemble the jet in the point's chart. Fibres in other charts are
+    # converted in (and back out) via the Jacobian pushforward.
+    jet: dict[int, CDict] = {0: x.point.data}
+    ladder: dict[str, tuple[int, Any, Any]] = {}  # name -> (order, fibre, orig_chart)
+    push_fibres: dict[str, Any] = {}
+    for name, fibre in x._data.items():
+        order = getattr(fibre.rep.semantic_kind, "order", None)
+        if order is None or order == 0:
+            push_fibres[name] = fibre
+            continue
+        orig_chart = fibre.chart
+        f = fibre
+        if orig_chart != point_chart:
+            at_f = cast("Point", cxr.cconvert(x.point, orig_chart)).data
+            f = cast("Tangent", cxrapi.cconvert(f, point_chart, at=at_f, usys=usys))
+        if order in jet:
+            msg = (
+                f"Coordinate has multiple fibres at ladder order {order}; "
+                "the joint prolongation under a time-dependent transform is "
+                "ambiguous."
+            )
+            raise ValueError(msg)
+        jet[order] = cast("CDict", f.data)
+        ladder[name] = (order, f, orig_chart)
+
+    out_jet = cast(
+        "dict[int, CDict]", cxfmapi.prolong(op, tau, jet, point_chart, usys=usys)
+    )
+    new_point = replace(x.point, data=out_jet[0])
+
+    new_fields: dict[str, Any] = {}
+    for name, (order, f, orig_chart) in ladder.items():
+        nf = replace(f, data=out_jet[order])
+        if orig_chart != point_chart:
+            nf = cast(
+                "Tangent", cxrapi.cconvert(nf, orig_chart, at=out_jet[0], usys=usys)
+            )
+        new_fields[name] = nf
+
+    # Displacement (and other non-ladder) fibres: frozen-tau pushforward
+    # anchored at the pre-transform base point.
+    for name, fibre in push_fibres.items():
+        if fibre.chart == point_chart:
+            at_data = x.point.data
+        else:
+            at_data = cast("Point", cxr.cconvert(x.point, fibre.chart)).data
+        data = cxfmapi.pushforward(
+            op, tau, fibre.data, fibre.chart, fibre.rep, at=at_data, usys=usys
+        )
+        new_fields[name] = replace(fibre, data=data)
+
     return Coordinate(point=new_point, **new_fields)
 
 

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -639,7 +639,7 @@ def act(
 
     """
     if cxfm.is_time_dependent(op):
-        return _act_coordinate_jet(op, tau, x, **kw)
+        return _act_coordinate_jet(op, tau, x, usys=kw.get("usys"))
 
     new_point = cxfm.act(op, tau, x.point, **kw)
     # Inject the base-point data as 'at' so non-Cartesian tangent dispatches
@@ -653,19 +653,27 @@ def act(
     new_fields: dict[str, Any] = {}
     for name, fibre in x._data.items():
         if "at" not in kw_base:
-            if fibre.chart == x.point.chart:
-                at_data = x.point.data
-            else:
-                at_data = cast("Point", cxr.cconvert(x.point, fibre.chart)).data
-            fibre_kw = {**kw_base, "at": at_data}
+            fibre_kw = {**kw_base, "at": _point_data_in(x.point, fibre.chart)}
         else:
             fibre_kw = kw_base
         new_fields[name] = cxfm.act(op, tau, fibre, **fibre_kw)
     return Coordinate(point=new_point, **new_fields)
 
 
+def _point_data_in(point: Point, chart: Any, /) -> CDict:
+    """Return the point's data expressed in ``chart`` (no-op if it matches)."""
+    if point.chart == chart:
+        return point.data
+    return cast("Point", cxr.cconvert(point, chart)).data
+
+
 def _act_coordinate_jet(
-    op: cxfm.AbstractTransform, tau: Any, x: Coordinate, /, **kw: Any
+    op: cxfm.AbstractTransform,
+    tau: Any,
+    x: Coordinate,
+    /,
+    *,
+    usys: OptUSys = None,
 ) -> Coordinate:
     """Act a time-dependent transform on a Coordinate via joint prolongation.
 
@@ -675,7 +683,6 @@ def _act_coordinate_jet(
     time-derivative terms. Displacement fibres (same-tau point differences)
     transform by the frozen-tau pushforward at the base point.
     """
-    usys = kw.get("usys")
     point_chart = x.point.chart
 
     # Assemble the jet in the point's chart. Fibres in other charts are
@@ -684,14 +691,14 @@ def _act_coordinate_jet(
     ladder: dict[str, tuple[int, Any, Any]] = {}  # name -> (order, fibre, orig_chart)
     push_fibres: dict[str, Any] = {}
     for name, fibre in x._data.items():
-        order = getattr(fibre.rep.semantic_kind, "order", None)
+        order = fibre.rep.semantic_kind.order
         if order is None or order == 0:
             push_fibres[name] = fibre
             continue
         orig_chart = fibre.chart
         f = fibre
         if orig_chart != point_chart:
-            at_f = cast("Point", cxr.cconvert(x.point, orig_chart)).data
+            at_f = _point_data_in(x.point, orig_chart)
             f = cast("Tangent", cxrapi.cconvert(f, point_chart, at=at_f, usys=usys))
         if order in jet:
             msg = (
@@ -720,12 +727,14 @@ def _act_coordinate_jet(
     # Displacement (and other non-ladder) fibres: frozen-tau pushforward
     # anchored at the pre-transform base point.
     for name, fibre in push_fibres.items():
-        if fibre.chart == point_chart:
-            at_data = x.point.data
-        else:
-            at_data = cast("Point", cxr.cconvert(x.point, fibre.chart)).data
         data = cxfmapi.pushforward(
-            op, tau, fibre.data, fibre.chart, fibre.rep, at=at_data, usys=usys
+            op,
+            tau,
+            fibre.data,
+            fibre.chart,
+            fibre.rep,
+            at=_point_data_in(x.point, fibre.chart),
+            usys=usys,
         )
         new_fields[name] = replace(fibre, data=data)
 

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -638,7 +638,19 @@ def act(
     (Q(7., 'm'), Q(4., 'm / s'))
 
     """
-    if cxfm.is_time_dependent(op):
+    if _needs_joint_jet(op):
+        # The jet anchors are structurally the bundle's own point and fibres;
+        # caller-supplied anchor overrides are meaningless here — reject them
+        # loudly rather than silently ignoring them (the static path below
+        # honors an 'at' override, so silence would diverge invisibly).
+        unsupported = set(kw) - {"usys"}
+        if unsupported:
+            msg = (
+                "act on a Coordinate under a time-dependent transform "
+                f"does not accept keyword overrides {sorted(unsupported)}: "
+                "the bundle itself supplies the jet anchors."
+            )
+            raise TypeError(msg)
         return _act_coordinate_jet(op, tau, x, usys=kw.get("usys"))
 
     new_point = cxfm.act(op, tau, x.point, **kw)
@@ -658,6 +670,24 @@ def act(
             fibre_kw = kw_base
         new_fields[name] = cxfm.act(op, tau, fibre, **fibre_kw)
     return Coordinate(point=new_point, **new_fields)
+
+
+def _needs_joint_jet(op: cxfm.AbstractTransform, /) -> bool:
+    """Whether a Coordinate bundle must be transformed as a joint jet.
+
+    True when the op has time-dependent (callable) parameters, and also for
+    `Boost`, whose *point action* is intrinsically tau-dependent (x + dv*tau)
+    even when dv is a constant — its per-fibre closed forms then need the
+    lower jet slots that only the joint path supplies.
+
+    TODO: replace the isinstance test with a declared property on the
+    transform (tracked with the TimeDep parameter refactor, issue #537).
+    """
+    if isinstance(op, cxfm.Boost):
+        return True
+    if isinstance(op, cxfm.Composed):
+        return any(_needs_joint_jet(sub) for sub in op.transforms)
+    return cxfm.is_time_dependent(op)
 
 
 def _point_data_in(point: Point, chart: Any, /) -> CDict:

--- a/tests/benchmark/test_act_prolong.py
+++ b/tests/benchmark/test_act_prolong.py
@@ -94,14 +94,13 @@ def test_td_translate_jet_generic(benchmark, jet):
     )
 
 
-def test_td_rotate_jet_generic(benchmark, jet):
+def test_td_rotate_jet_generic(benchmark):
     def rot_z(t) -> Real[Array, "3 3"]:
         th = t.ustrip("s")
         st, ct = jnp.sin(th), jnp.cos(th)
         return jnp.array([[ct, -st, 0.0], [st, ct, 0.0], [0.0, 0.0, 1.0]])
 
     op = cxfm.Rotate.from_(rot_z)
-    jet2 = {k: v for k, v in jet.items() if k <= 1}
     jet2 = {
         0: q3(1.0, 2.0, 3.0, "m"),
         1: q3(0.5, -0.5, 0.0, "m/s"),

--- a/tests/benchmark/test_act_prolong.py
+++ b/tests/benchmark/test_act_prolong.py
@@ -1,0 +1,127 @@
+"""Benchmarks for `act`/`prolong` steady-state (jit-compiled) performance.
+
+Run with: uv run --no-project pytest tests/benchmark --benchmark-only
+(requires the ``benchmark`` extra: pytest-benchmark).
+"""
+
+from jaxtyping import Array, Real
+
+import jax
+import pytest
+
+import quaxed.numpy as jnp
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.representations as cxr
+import coordinax.transforms as cxfm
+
+pytest.importorskip("pytest_benchmark")
+
+
+def q3(x, y, z, unit):
+    return {"x": u.Q(x, unit), "y": u.Q(y, unit), "z": u.Q(z, unit)}
+
+
+@pytest.fixture
+def jet():
+    return {
+        0: q3(1.0, 2.0, 3.0, "km"),
+        1: q3(0.5, -0.5, 0.0, "km/s"),
+        2: q3(0.1, 0.0, -0.1, "km/s2"),
+    }
+
+
+def _bench_jitted(benchmark, fn, *args):
+    jitted = jax.jit(fn)
+    out = jitted(*args)  # compile
+    jax.block_until_ready(out)
+    benchmark(lambda: jax.block_until_ready(jitted(*args)))
+
+
+# ---------------------------------------------------------------------------
+# Regression guards: static ops must not slow down.
+
+
+def test_static_translate_point(benchmark, jet):
+    op = cxfm.Translate.from_([1, 2, 3], "km")
+    _bench_jitted(
+        benchmark, lambda x: cxfm.act(op, None, x, cxc.cart3d, cxr.point), jet[0]
+    )
+
+
+def test_static_rotate_vel(benchmark, jet):
+    op = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+    _bench_jitted(
+        benchmark,
+        lambda v: cxfm.act(op, None, v, cxc.cart3d, cxr.tangent_geom, cxr.coord_vel),
+        jet[1],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Time-dependent paths.
+
+
+def _moving_translate():
+    return cxfm.Translate(
+        lambda t: {
+            "x": u.Q(3.0, "km/s") * t,
+            "y": u.Q(0.0, "km"),
+            "z": u.Q(0.0, "km"),
+        },
+        chart=cxc.cart3d,
+    )
+
+
+def test_td_translate_vel_fast_path(benchmark, jet):
+    op = _moving_translate()
+    _bench_jitted(
+        benchmark,
+        lambda tau, v: cxfm.act(op, tau, v, cxc.cart3d, cxr.coord_vel),
+        u.Q(2.0, "s"),
+        jet[1],
+    )
+
+
+def test_td_translate_jet_generic(benchmark, jet):
+    op = _moving_translate()
+    _bench_jitted(
+        benchmark,
+        lambda tau, jet_: cxfm.prolong(op, tau, jet_, cxc.cart3d),
+        u.Q(2.0, "s"),
+        jet,
+    )
+
+
+def test_td_rotate_jet_generic(benchmark, jet):
+    def rot_z(t) -> Real[Array, "3 3"]:
+        th = t.ustrip("s")
+        st, ct = jnp.sin(th), jnp.cos(th)
+        return jnp.array([[ct, -st, 0.0], [st, ct, 0.0], [0.0, 0.0, 1.0]])
+
+    op = cxfm.Rotate.from_(rot_z)
+    jet2 = {k: v for k, v in jet.items() if k <= 1}
+    jet2 = {
+        0: q3(1.0, 2.0, 3.0, "m"),
+        1: q3(0.5, -0.5, 0.0, "m/s"),
+    }
+    _bench_jitted(
+        benchmark,
+        lambda tau, jet_: cxfm.prolong(op, tau, jet_, cxc.cart3d),
+        u.Q(2.0, "s"),
+        jet2,
+    )
+
+
+def test_composed_five_ops_point(benchmark, jet):
+    op = (
+        cxfm.Translate.from_([1, 0, 0], "km")
+        | cxfm.Rotate.from_euler("z", u.Q(45, "deg"))
+        | cxfm.Translate.from_([0, 1, 0], "km")
+        | cxfm.Rotate.from_euler("z", u.Q(-45, "deg"))
+        | cxfm.Translate.from_([0, 0, 1], "km")
+    )
+    _bench_jitted(
+        benchmark, lambda x: cxfm.act(op, None, x, cxc.cart3d, cxr.point), jet[0]
+    )

--- a/tests/unit/frames/test_bob_frame.py
+++ b/tests/unit/frames/test_bob_frame.py
@@ -41,7 +41,9 @@ class TestBobFrameTransitions:
         assert isinstance(op, cxfm.Composed)
         assert len(op.transforms) == 2
         assert isinstance(op.transforms[0], cxfm.Translate)
-        assert isinstance(op.transforms[1], cxfm.Boost)
+        # The velocity offset is a fibre-only kick: Translate(semantic_kind=vel).
+        assert isinstance(op.transforms[1], cxfm.Translate)
+        assert op.transforms[1].semantic_kind == cxr.vel
 
     def test_alice_to_bob_has_correct_chart(self):
         op = cxf.frame_transition(cxf.alice, cxf.bob)
@@ -53,7 +55,8 @@ class TestBobFrameTransitions:
         op = cxf.frame_transition(cxf.bob, cxf.alice)
         assert isinstance(op, cxfm.Composed)
         assert len(op.transforms) == 2
-        assert isinstance(op.transforms[0], cxfm.Boost)
+        assert isinstance(op.transforms[0], cxfm.Translate)
+        assert op.transforms[0].semantic_kind == cxr.vel
         assert isinstance(op.transforms[1], cxfm.Translate)
 
     def test_bob_to_alice_is_inverse_of_alice_to_bob(self):

--- a/tests/unit/transforms/test_active_semantics.py
+++ b/tests/unit/transforms/test_active_semantics.py
@@ -133,9 +133,12 @@ class TestActiveSemanticsProperty:
         back = cxfm.act(cxf.frame_transition(transformed, cxf.alice), None, fwd)
 
         assert isinstance(back, cxv.Point)
+        # Roundoff of a rotation roundtrip scales with the vector magnitude
+        # (~|q| * eps), so the tolerance must too; atol=1e-6 m matches the
+        # |q| <= 1e6 m strategy bound (same as test_alice_alex_roundtrip).
         for key in ("x", "y", "z"):
             np.testing.assert_allclose(
                 float(u.ustrip("m", q.data[key])),
                 float(u.ustrip("m", back.data[key])),
-                atol=1e-10,
+                atol=1e-6,
             )

--- a/tests/unit/transforms/test_boost.py
+++ b/tests/unit/transforms/test_boost.py
@@ -129,9 +129,14 @@ class TestBoostOnVelocity:
             # right_add=False: delta + x
             assert jnp.allclose(result[k], delta_v[k] + vel_cdict[k])
 
-    def test_raises_on_chart_mismatch(self, boost):
+    def test_chart_mismatch_defers_to_generic(self, boost):
+        """A mismatched data chart is well-defined via the generic engine.
+
+        It requires the base point (and a time, since the boost's point
+        action is time-dependent) rather than raising a chart error.
+        """
         v = {"rho": jnp.array(2.0), "phi": jnp.array(3.0), "z": jnp.array(4.0)}
-        with pytest.raises(ValueError, match="input chart to match the boost chart"):
+        with pytest.raises(TypeError, match=r"requires the base point|time parameter"):
             cxfm.act(boost, None, v, cxc.cyl3d, cxr.coord_vel)
 
 

--- a/tests/unit/transforms/test_boost.py
+++ b/tests/unit/transforms/test_boost.py
@@ -57,26 +57,34 @@ class TestBoostConstruction:
         for k in boost.delta:
             assert jnp.allclose(combined.delta[k], 2 * boost.delta[k])
 
-    def test_groups_is_diffeomorphism_only(self, boost):
-        assert boost.groups() == frozenset((cxfm.DiffeomorphismGroup,))
+    def test_groups_is_affine(self, boost):
+        # A Galilean boost is an affine (time-parameterized translation) map.
+        assert boost.groups() == frozenset((cxfm.AffineGroup, cxfm.DiffeomorphismGroup))
 
     def test_composed_groups_with_translate(self, boost):
         shift = cxfm.Translate.from_([1, 2, 3], "m")
         op = cxfm.Composed((shift, boost))
-        assert op.groups() == frozenset((cxfm.DiffeomorphismGroup,))
+        # Least common supergroup of Euclidean (Translate) and Affine (Boost).
+        assert op.groups() == frozenset((cxfm.AffineGroup, cxfm.DiffeomorphismGroup))
 
 
 # ============================================================================
 
 
 class TestBoostOnPoint:
-    """Boost should not affect points."""
+    """A Galilean boost moves points by delta_v * tau."""
 
-    def test_identity(self, boost):
+    def test_moves_point_by_dv_tau(self, boost, delta_v):
         p = {"x": jnp.array(1.0), "y": jnp.array(2.0), "z": jnp.array(3.0)}
-        result = cxfm.act(boost, None, p, cxc.cart3d, cxr.point)
+        tau = jnp.array(2.0)
+        result = cxfm.act(boost, tau, p, cxc.cart3d, cxr.point)
         for k, v in p.items():
-            assert jnp.allclose(result[k], v)
+            assert jnp.allclose(result[k], v + delta_v[k] * tau)
+
+    def test_raises_without_tau(self, boost):
+        p = {"x": jnp.array(1.0), "y": jnp.array(2.0), "z": jnp.array(3.0)}
+        with pytest.raises(TypeError, match="requires a time parameter"):
+            cxfm.act(boost, None, p, cxc.cart3d, cxr.point)
 
 
 class TestBoostOnDisplacement:

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -18,6 +18,7 @@ import coordinax.charts as cxc
 import coordinax.main as cx
 import coordinax.representations as cxr
 import coordinax.transforms as cxfm
+import coordinax.vectors as cxv
 from coordinax.transforms._src.actions.prolong import prolong_jet
 from coordinax.transforms._src.actions.utils import is_flat_chart
 
@@ -851,3 +852,206 @@ class TestNonCartesianOpChart:
             )
         # the true result is nonzero: it was previously silently identity
         assert not jnp.allclose(u.ustrip("km/s2", fast["r"]), 0.0)
+
+
+# ============================================================================
+# Final-audit regressions: fibre kicks, bundles, linear ops under new verbs
+
+
+class TestFibreKickCrossChart:
+    """A fibre kick is a tangent vector: cross-chart action via the Jacobian."""
+
+    kick = None  # built in tests to avoid import-time work
+
+    def test_kick_on_spherical_velocity_matches_tangent_map(self):
+        """Cartesian vel-kick on spherical velocity == Jacobian-mapped add."""
+        usys = u.unitsystems.si
+        dv = {k: u.Q(x, "km/s") for k, x in zip("xyz", (1.0, 0.0, 0.0), strict=False)}
+        kick = cxfm.Translate(dv, chart=cxc.cart3d, semantic_kind=cxr.vel)
+        at = {"r": u.Q(5.0, "km"), "theta": u.Q(1.0, "rad"), "phi": u.Q(0.5, "rad")}
+        v = {
+            "r": u.Q(0.3, "km/s"),
+            "theta": u.Q(0.01, "rad/s"),
+            "phi": u.Q(0.02, "rad/s"),
+        }
+        out = cxfm.act(kick, None, v, cxc.sph3d, cxr.coord_vel, at=at, usys=usys)
+        # reference: map delta into the spherical chart at the point, add
+        at_cart = cxc.pt_map(at, cxc.sph3d, cxc.cart3d, usys=usys)
+        vel_rep = cxr.Representation(cxr.tangent_geom, cxr.coord_basis, cxr.vel)
+        dv_sph = cxr.tangent_map(
+            dv, cxc.cart3d, vel_rep, cxc.sph3d, at=at_cart, usys=usys
+        )
+        for k, vk in v.items():
+            unit = u.unit_of(dv_sph[k])
+            expect = u.ustrip(unit, vk) + dv_sph[k].value
+            assert jnp.allclose(u.ustrip(unit, out[k]), expect, rtol=1e-6)
+
+    def test_kick_cross_chart_requires_at(self):
+        """Without the base point the cross-chart kick raises informatively."""
+        dv = {k: u.Q(x, "km/s") for k, x in zip("xyz", (1.0, 0.0, 0.0), strict=False)}
+        kick = cxfm.Translate(dv, chart=cxc.cart3d, semantic_kind=cxr.vel)
+        v = {
+            "r": u.Q(0.3, "km/s"),
+            "theta": u.Q(0.01, "rad/s"),
+            "phi": u.Q(0.02, "rad/s"),
+        }
+        with pytest.raises(TypeError, match="requires the base point"):
+            cxfm.act(kick, None, v, cxc.sph3d, cxr.coord_vel, usys=u.unitsystems.si)
+
+    def test_kick_rejects_bare_arrays(self):
+        """Unitless arrays are ambiguous under a kick: rejected, not no-op'd."""
+        dv = {k: u.Q(x, "km/s") for k, x in zip("xyz", (1.0, 0.0, 0.0), strict=False)}
+        kick = cxfm.Translate(dv, chart=cxc.cart3d, semantic_kind=cxr.vel)
+        arr = jnp.asarray([1.0, 0.0, 0.0])
+        with pytest.raises(TypeError, match="ambiguous"):
+            cxfm.act(kick, None, arr, cxc.cart3d, cxr.point, usys=u.unitsystems.si)
+
+
+class TestCoordinateBundleEdges:
+    """Bundle-layer seams from the final audit."""
+
+    @staticmethod
+    def _bundle(**fields):
+        pt = cxv.Point.from_([1.0, 2.0, 3.0], "km")
+        return cxv.Coordinate(pt, **fields)
+
+    def test_td_bundle_rejects_anchor_overrides(self):
+        """TD Coordinate act raises on at= instead of silently ignoring it."""
+        moving = cxfm.Translate(
+            lambda t: q3(3.0 * t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
+        )
+        vel = cxv.Tangent(
+            q3(0.1, 0.0, 0.0, "km/s"), cxc.cart3d, cxr.coord_basis, cxr.vel
+        )
+        coord = self._bundle(vel=vel)
+        with pytest.raises(TypeError, match="does not accept keyword overrides"):
+            cx.act(moving, u.Q(1.0, "s"), coord, at=q3(9.0, 0.0, 0.0, "km"))
+
+    def test_static_boost_bundle_with_nonflat_fibre(self):
+        """Static Boost on a bundle with a cylindrical fibre works.
+
+        Boost's point action is intrinsically tau-dependent, so the bundle
+        takes the joint-jet path even with a constant delta-v.
+        """
+        boost = cxfm.Boost(q3(1.0, 0.0, 0.0, "km/s"), chart=cxc.cart3d)
+        vel = cxv.Tangent(
+            q3(0.1, 0.0, 0.0, "km/s"), cxc.cart3d, cxr.coord_basis, cxr.vel
+        )
+        acc = cxv.Tangent(
+            {
+                "rho": u.Q(0.1, "km/s2"),
+                "phi": u.Q(0.0, "rad/s2"),
+                "z": u.Q(0.0, "km/s2"),
+            },
+            cxc.cyl3d,
+            cxr.coord_basis,
+            cxr.acc,
+        )
+        coord = self._bundle(vel=vel, acc=acc)
+        out = cx.act(boost, u.Q(1.0, "s"), coord, usys=u.unitsystems.si)
+        assert jnp.allclose(u.ustrip("km", out.point.data["x"]), 2.0)  # x + dv*tau
+        assert jnp.allclose(u.ustrip("km/s", out._data["vel"].data["x"]), 1.1)
+
+    def test_td_bundle_duplicate_ladder_order_raises(self):
+        """Two fibres at the same ladder order are ambiguous for the jet."""
+        moving = cxfm.Translate(
+            lambda t: q3(3.0 * t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
+        )
+        v1 = cxv.Tangent(
+            q3(0.1, 0.0, 0.0, "km/s"), cxc.cart3d, cxr.coord_basis, cxr.vel
+        )
+        v2 = cxv.Tangent(
+            q3(0.2, 0.0, 0.0, "km/s"), cxc.cart3d, cxr.coord_basis, cxr.vel
+        )
+        coord = self._bundle(vel=v1, vel2=v2)
+        with pytest.raises(ValueError, match="multiple fibres at ladder order"):
+            cx.act(moving, u.Q(1.0, "s"), coord)
+
+    def test_td_bundle_cross_chart_fibre_matches_cartesian(self):
+        """Cross-chart fibre round trip matches the Cartesian-fibre result.
+
+        A cylindrical velocity fibre under a TD op equals the same physics
+        computed with a Cartesian fibre.
+        """
+        moving = cxfm.Translate(
+            lambda t: q3(3.0 * t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
+        )
+        tau = u.Q(2.0, "s")
+        usys = u.unitsystems.si
+        vel_cart = cxv.Tangent(
+            q3(0.1, 0.2, 0.0, "km/s"), cxc.cart3d, cxr.coord_basis, cxr.vel
+        )
+        coord_cart = self._bundle(vel=vel_cart)
+        out_cart = cx.act(moving, tau, coord_cart, usys=usys)
+
+        vel_cyl = cxr.cconvert(vel_cart, cxc.cyl3d, at=coord_cart.point.data, usys=usys)
+        coord_cyl = self._bundle(vel=vel_cyl)
+        out_cyl = cx.act(moving, tau, coord_cyl, usys=usys)
+        # convert the cylindrical output fibre back to cartesian at the new point
+        back = cxr.cconvert(
+            out_cyl._data["vel"],
+            cxc.cart3d,
+            at=cxr.cconvert(out_cyl.point, cxc.cyl3d).data,
+            usys=usys,
+        )
+        for k in "xyz":
+            assert jnp.allclose(
+                u.ustrip("km/s", back.data[k]),
+                u.ustrip("km/s", out_cart._data["vel"].data[k]),
+                atol=1e-6,
+            )
+
+    def test_td_bundle_displacement_fibre_pushforward(self):
+        """Displacement fibres in a TD bundle take the frozen-tau pushforward.
+
+        They are invariant under a flat translation.
+        """
+        moving = cxfm.Translate(
+            lambda t: q3(3.0 * t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
+        )
+        d = cxv.Tangent(q3(0.5, 0.0, 0.0, "km"), cxc.cart3d, cxr.coord_basis, cxr.dpl)
+        coord = self._bundle(disp=d)
+        out = cx.act(moving, u.Q(2.0, "s"), coord)
+        assert jnp.allclose(u.ustrip("km", out._data["disp"].data["x"]), 0.5)
+
+
+class TestLinearOpsUnderNewVerbs:
+    """Shear/Reflect coverage via the generic engine (previously untested)."""
+
+    @pytest.mark.parametrize(
+        "op",
+        [
+            cxfm.Shear(
+                jnp.asarray([[1.0, 0.3, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+            ),
+            cxfm.Reflect.from_normal([1.0, 0.0, 0.0]),
+        ],
+        ids=["shear", "reflect"],
+    )
+    def test_pushforward_matches_act_on_velocity(self, op):
+        """Static linear ops: act on velocity == frozen-tau pushforward."""
+        at = q3(1.0, -2.0, 0.5, "m")
+        v = q3(0.3, 0.1, -0.2, "m/s")
+        a1 = cxfm.act(op, None, v, cxc.cart3d, cxr.coord_vel, at=at)
+        a2 = cxfm.pushforward(op, None, v, cxc.cart3d, cxr.coord_vel, at=at)
+        assert allclose_cdict(a1, a2, "m/s", atol=1e-8)
+
+    @pytest.mark.parametrize(
+        "op",
+        [
+            cxfm.Shear(
+                jnp.asarray([[1.0, 0.3, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+            ),
+            cxfm.Reflect.from_normal([1.0, 0.0, 0.0]),
+        ],
+        ids=["shear", "reflect"],
+    )
+    def test_prolong_jet_matches_per_slot(self, op):
+        """Prolong on a 1-jet gives the same slots as point-act + vel-act."""
+        at = q3(1.0, -2.0, 0.5, "m")
+        v = q3(0.3, 0.1, -0.2, "m/s")
+        jet = cxfm.prolong(op, None, {0: at, 1: v}, cxc.cart3d)
+        p_ref = cxfm.act(op, None, at, cxc.cart3d, cxr.point)
+        v_ref = cxfm.act(op, None, v, cxc.cart3d, cxr.coord_vel, at=at)
+        assert allclose_cdict(jet[0], p_ref, "m", atol=1e-8)
+        assert allclose_cdict(jet[1], v_ref, "m/s", atol=1e-8)

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -425,12 +425,25 @@ class TestErrors:
             cxfm.act(moving, None, v, cxc.cart3d, cxr.coord_vel)
 
     def test_prolong_missing_slot(self):
+        # A non-additive op: the generic chain needs every lower slot.
+        op = cxfm.Rotate.from_(rot_z)
+        jet = {0: q3(0.0, 0.0, 0.0, "m"), 2: q3(0.0, 0.0, 0.0, "m/s2")}
+        with pytest.raises(TypeError, match="slot 1 is missing"):
+            cxfm.prolong(op, u.Q(1.0, "s"), jet, cxc.cart3d)
+
+    def test_prolong_additive_skips_intermediate_slots(self):
+        # Additive ops prolong slot-wise: no intermediate slots required.
         moving = cxfm.Translate(
-            lambda t: q3(t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
+            lambda t: {
+                "x": 0.5 * u.Q(2.0, "km/s2") * t**2,
+                "y": u.Q(0.0, "km"),
+                "z": u.Q(0.0, "km"),
+            },
+            chart=cxc.cart3d,
         )
         jet = {0: q3(0.0, 0.0, 0.0, "km"), 2: q3(0.0, 0.0, 0.0, "km/s2")}
-        with pytest.raises(TypeError, match="slot 1 is missing"):
-            cxfm.prolong(moving, u.Q(1.0, "s"), jet, cxc.cart3d)
+        out = cxfm.prolong(moving, u.Q(1.0, "s"), jet, cxc.cart3d)
+        assert jnp.allclose(u.ustrip("km/s2", out[2]["x"]), 2.0)
 
     def test_static_scale_vel_requires_at(self):
         op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
@@ -474,3 +487,71 @@ class TestCoordinateBundle:
         out = cx.act(op, None, pv)
         assert jnp.allclose(u.ustrip("m", out.point.data["x"]), 2.0)
         assert jnp.allclose(u.ustrip("m/s", out["velocity"].data["x"]), 1.0)
+
+
+# ============================================================================
+# Fibre-only offsets through the jet path
+
+
+class TestFibreKickProlong:
+    """Fibre-only offsets must survive the joint (jet) prolongation path.
+
+    A `Translate(semantic_kind=vel)` has identity point action, so a
+    point-action-only prolongation would drop it; the slot-wise `prolong`
+    registered for additive operators keeps it.
+    """
+
+    def test_vel_kick_prolong_slotwise(self):
+        kick = cxfm.Translate(
+            q3(100.0, 0.0, 0.0, "m/s"), chart=cxc.cart3d, semantic_kind=cxr.vel
+        )
+        jet = {0: q3(1.0, 0.0, 0.0, "m"), 1: q3(1.0, 0.0, 0.0, "m/s")}
+        out = cxfm.prolong(kick, None, jet, cxc.cart3d)
+        assert jnp.allclose(u.ustrip("m", out[0]["x"]), 1.0)
+        assert jnp.allclose(u.ustrip("m/s", out[1]["x"]), 101.0)
+
+    def test_td_translate_composed_with_vel_kick_on_coordinate(self):
+        """Coordinate jet path == bare-tangent path for TD op | vel-kick."""
+        moving = cxfm.Translate(
+            lambda t: {
+                "x": u.Q(3.0, "m/s") * t,
+                "y": u.Q(0.0, "m"),
+                "z": u.Q(0.0, "m"),
+            },
+            chart=cxc.cart3d,
+        )
+        kick = cxfm.Translate(
+            q3(100.0, 0.0, 0.0, "m/s"), chart=cxc.cart3d, semantic_kind=cxr.vel
+        )
+        op = moving | kick
+        tau = u.Q(2.0, "s")
+
+        pv = cx.Coordinate(
+            point=cx.Point.from_([1.0, 0.0, 0.0], "m"),
+            velocity=cx.Tangent.from_([1.0, 0.0, 0.0], "m/s"),
+        )
+        out = cx.act(op, tau, pv)
+        # v' = v + delta-dot + kick = 1 + 3 + 100
+        assert jnp.allclose(u.ustrip("m/s", out["velocity"].data["x"]), 104.0)
+
+        # and it matches the bare-tangent path
+        v = q3(1.0, 0.0, 0.0, "m/s")
+        at = q3(1.0, 0.0, 0.0, "m")
+        bare = cxfm.act(op, tau, v, cxc.cart3d, cxr.coord_vel, at=at)
+        assert jnp.allclose(
+            u.ustrip("m/s", out["velocity"].data["x"]), u.ustrip("m/s", bare["x"])
+        )
+
+    def test_galilean_boost_prolong_slotwise(self):
+        """Boost's prolong (via AbstractAdd) matches its act closed forms."""
+        boost = cxfm.Boost(q3(1.0, 0.0, 0.0, "km/s"), chart=cxc.cart3d)
+        tau = u.Q(3.0, "s")
+        jet = {
+            0: q3(1.0, 2.0, 3.0, "km"),
+            1: q3(0.5, 0.0, 0.0, "km/s"),
+            2: q3(0.1, 0.0, 0.0, "km/s2"),
+        }
+        out = cxfm.prolong(boost, tau, jet, cxc.cart3d)
+        assert jnp.allclose(u.ustrip("km", out[0]["x"]), 4.0)  # x + dv*tau
+        assert jnp.allclose(u.ustrip("km/s", out[1]["x"]), 1.5)  # v + dv
+        assert jnp.allclose(u.ustrip("km/s2", out[2]["x"]), 0.1)  # a unchanged

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -416,6 +416,26 @@ class TestErrors:
                 op, u.Q(1.0, "s"), a, cxc.cart3d, cxr.tangent_geom, cxr.coord_acc, at=at
             )
 
+    def test_td_translate_point_requires_tau(self):
+        """Materializing a callable delta without tau raises informatively."""
+        moving = cxfm.Translate(
+            lambda t: q3(t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
+        )
+        p = q3(0.0, 0.0, 0.0, "km")
+        with pytest.raises(TypeError, match=r"time-dependent \(callable\) delta"):
+            cxfm.act(moving, None, p, cxc.cart3d, cxr.point)
+
+    def test_td_vel_kick_matching_order_requires_tau(self):
+        """A callable vel-kick on velocity data (n==0) also needs tau."""
+        kick = cxfm.Translate(
+            lambda t: q3(t.ustrip("s"), 0.0, 0.0, "km/s"),
+            chart=cxc.cart3d,
+            semantic_kind=cxr.vel,
+        )
+        v = q3(0.0, 0.0, 0.0, "km/s")
+        with pytest.raises(TypeError, match=r"time-dependent \(callable\) delta"):
+            cxfm.act(kick, None, v, cxc.cart3d, cxr.coord_vel)
+
     def test_td_translate_tangent_requires_tau(self):
         moving = cxfm.Translate(
             lambda t: q3(t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -1111,3 +1111,24 @@ class TestLinearOpsUnderNewVerbs:
             assert jnp.allclose(u.ustrip(unit, out[k]), gen[1][k].value, atol=1e-7)
         # omega = 1 per data-time-base; z-hat x x-hat = y-hat
         assert jnp.allclose(u.ustrip("m/s", out["y"]), 1.0, atol=1e-7)
+
+    def test_rotate_closed_form_fully_raw_data(self):
+        """Fully unitless data stays raw through the m=1 closed form.
+
+        Mirrors the generic engine's None-unit "stay raw" policy.
+        """
+
+        def rot_z_raw(t) -> Real[Array, "3 3"]:
+            st_, ct = jnp.sin(t), jnp.cos(t)
+            return jnp.array([[ct, -st_, 0.0], [st_, ct, 0.0], [0.0, 0.0, 1.0]])
+
+        op = cxfm.Rotate.from_(rot_z_raw)
+        at = {"x": jnp.asarray(1.0), "y": jnp.asarray(0.0), "z": jnp.asarray(0.0)}
+        v = {"x": jnp.asarray(0.0), "y": jnp.asarray(0.0), "z": jnp.asarray(0.0)}
+        tau = jnp.asarray(0.0)
+        out = cxfm.act(op, tau, v, cxc.cart3d, cxr.tangent_geom, cxr.coord_vel, at=at)
+        gen = prolong_jet(op, tau, {0: at, 1: v}, cxc.cart3d)
+        for k in out:
+            assert not u.quantity.is_any_quantity(out[k])  # stays raw
+            assert jnp.allclose(out[k], gen[1][k], atol=1e-7)
+        assert jnp.allclose(out["y"], 1.0, atol=1e-7)

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -19,6 +19,7 @@ import coordinax.main as cx
 import coordinax.representations as cxr
 import coordinax.transforms as cxfm
 from coordinax.transforms._src.actions.prolong import prolong_jet
+from coordinax.transforms._src.actions.utils import is_flat_chart
 
 # ============================================================================
 # Helpers
@@ -747,3 +748,9 @@ class TestNonCartesianOpChart:
         v = {"x": u.Q(1.0, "km/s"), "y": u.Q(0.0, "km/s"), "z": u.Q(0.0, "km/s")}
         out = cxfm.act(op, u.Q(2.0, "s"), v, cxc.cart3d, cxr.coord_vel)
         assert jnp.allclose(u.ustrip("km/s", out["x"]), 4.0)
+
+    def test_is_flat_chart_no_global_cartesian(self):
+        """Charts with no global Cartesian chart are non-flat, not an error."""
+        assert is_flat_chart(cxc.cart3d)
+        assert not is_flat_chart(cxc.sph3d)
+        assert not is_flat_chart(cxc.PoincarePolar6D())

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -416,6 +416,15 @@ class TestErrors:
                 op, u.Q(1.0, "s"), a, cxc.cart3d, cxr.tangent_geom, cxr.coord_acc, at=at
             )
 
+    def test_td_rotate_pushforward_requires_tau(self):
+        """Materializing a callable R without tau raises informatively."""
+        op = cxfm.Rotate.from_(rot_z)
+        d = q3(1.0, 0.0, 0.0, "m")
+        with pytest.raises(TypeError, match=r"time-dependent \(callable\) rotation"):
+            cxfm.pushforward(op, None, d, cxc.cart3d, cxr.coord_disp)
+        with pytest.raises(TypeError, match=r"time-dependent \(callable\) rotation"):
+            cxfm.act(op, None, d, cxc.cart3d, cxr.point)
+
     def test_td_translate_point_requires_tau(self):
         """Materializing a callable delta without tau raises informatively."""
         moving = cxfm.Translate(

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -799,3 +799,18 @@ class TestNonCartesianOpChart:
         out = cxfm.pushforward(op, None, a, cxc.cart3d, cxr.coord_acc, at=at)
         assert out["x"].unit == u.unit("kpc/Myr2")
         assert jnp.allclose(out["x"].value, 2.0)
+
+    def test_is_time_dependent_non_transform_raises(self):
+        """Non-dataclass inputs get a clear TypeError, not a dataclasses one."""
+        with pytest.raises(TypeError, match="expects a transform"):
+            cxfm.is_time_dependent(lambda t: t)
+
+    def test_prolong_jet_mismatched_slot_keys_raises(self):
+        """Jet slots with different components than slot 0 raise informatively."""
+        op = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+        jet = {
+            0: q3(1.0, 0.0, 0.0, "km"),
+            1: {"x": u.Q(0.0, "km/s"), "y": u.Q(0.0, "km/s")},  # missing z
+        }
+        with pytest.raises(TypeError, match=r"slot 1 .*missing \['z'\]"):
+            cxfm.prolong(op, None, jet, cxc.cart3d)

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -1077,3 +1077,14 @@ class TestLinearOpsUnderNewVerbs:
             unit = u.unit_of(refk)
             assert jnp.allclose(u.ustrip(unit, out[1][k]), refk.value, rtol=1e-6)
         assert jnp.allclose(u.ustrip("km", out[0]["r"]), 5.0)  # point untouched
+
+    def test_pushforward_mismatched_components_raises(self):
+        """Tangent components must match the base point's components."""
+        op = cxfm.Scale.from_factors([2.0, 2.0, 2.0])
+        at = q3(1.0, 0.0, 0.0, "m")
+        v_missing = {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s")}  # no z
+        with pytest.raises(TypeError, match=r"missing \['z'\]"):
+            cxfm.pushforward(op, None, v_missing, cxc.cart3d, cxr.coord_vel, at=at)
+        v_extra = q3(1.0, 0.0, 0.0, "m/s") | {"w": u.Q(0.0, "m/s")}
+        with pytest.raises(TypeError, match=r"unexpected \['w'\]"):
+            cxfm.pushforward(op, None, v_extra, cxc.cart3d, cxr.coord_vel, at=at)

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -5,6 +5,7 @@ equal the generic autodiff prolongation of the operator's point action.
 """
 
 from jaxtyping import Array, Real
+from typing import ClassVar
 
 import jax
 import pytest
@@ -17,6 +18,7 @@ import coordinax.charts as cxc
 import coordinax.main as cx
 import coordinax.representations as cxr
 import coordinax.transforms as cxfm
+from coordinax.transforms._src.actions.prolong import prolong_jet
 
 # ============================================================================
 # Helpers
@@ -653,3 +655,95 @@ class TestUnitPreservation:
         )
         with pytest.raises(TypeError, match="requires a time parameter"):
             generic(boost, None, jet, cxc.cart3d)
+
+
+# ============================================================================
+# Non-Cartesian operator charts (PR review): fast paths must defer to the
+# generic engine when delta lives in a chart where the point action is
+# base-point dependent.
+
+
+class TestNonCartesianOpChart:
+    """k=0 Translate with delta in a non-Cartesian chart."""
+
+    sph_at: ClassVar = {
+        "r": u.Q(5.0, "km"),
+        "theta": u.Q(1.0, "rad"),
+        "phi": u.Q(0.5, "rad"),
+    }
+    sph_v: ClassVar = {
+        "r": u.Q(0.3, "km/s"),
+        "theta": u.Q(0.01, "rad/s"),
+        "phi": u.Q(0.02, "rad/s"),
+    }
+
+    @staticmethod
+    def _td_op():
+        def delta(t):
+            s = t.ustrip("s")
+            return {
+                "r": u.Q(0.1, "km/s") * t,
+                "theta": u.Q(0.0, "rad"),
+                "phi": u.Q(0.02 * s, "rad"),
+            }
+
+        return cxfm.Translate(delta, chart=cxc.sph3d)
+
+    def test_td_velocity_matches_generic(self):
+        """Act on velocity equals the generic prolongation of the point action."""
+        op = self._td_op()
+        tau = u.Q(2.0, "s")
+        usys = u.unitsystems.si
+        fast = cxfm.act(
+            op, tau, self.sph_v, cxc.sph3d, cxr.coord_vel, at=self.sph_at, usys=usys
+        )
+        gen = prolong_jet(
+            op, tau, {0: self.sph_at, 1: self.sph_v}, cxc.sph3d, usys=usys
+        )
+        for k in fast:
+            unit = u.unit_of(gen[1][k])
+            assert jnp.allclose(u.ustrip(unit, fast[k]), gen[1][k].value, rtol=1e-6)
+
+    def test_static_velocity_not_identity(self):
+        """A static spherical-chart delta is not identity on velocities.
+
+        Its pushforward is base-point dependent, so velocities must NOT
+        pass through unchanged.
+        """
+        op = cxfm.Translate(
+            {"r": u.Q(0.2, "km"), "theta": u.Q(0.0, "rad"), "phi": u.Q(0.04, "rad")},
+            chart=cxc.sph3d,
+        )
+        usys = u.unitsystems.si
+        out = cxfm.act(
+            op, None, self.sph_v, cxc.sph3d, cxr.coord_vel, at=self.sph_at, usys=usys
+        )
+        # the phi-offset rotates the frame axes at the point: r-vel changes
+        assert not jnp.allclose(u.ustrip("km/s", out["r"]), 0.3)
+
+    def test_td_velocity_requires_at(self):
+        """The generic fallback demands the base point."""
+        op = self._td_op()
+        with pytest.raises(TypeError, match="requires the base point"):
+            cxfm.act(
+                op,
+                u.Q(2.0, "s"),
+                self.sph_v,
+                cxc.sph3d,
+                cxr.coord_vel,
+                usys=u.unitsystems.si,
+            )
+
+    def test_cartesian_ladder_unaffected(self):
+        """Cartesian-chart deltas keep the componentwise fast path (no at)."""
+        op = cxfm.Translate(
+            lambda t: {
+                "x": u.Q(3.0, "km/s") * t,
+                "y": u.Q(0.0, "km"),
+                "z": u.Q(0.0, "km"),
+            },
+            chart=cxc.cart3d,
+        )
+        v = {"x": u.Q(1.0, "km/s"), "y": u.Q(0.0, "km/s"), "z": u.Q(0.0, "km/s")}
+        out = cxfm.act(op, u.Q(2.0, "s"), v, cxc.cart3d, cxr.coord_vel)
+        assert jnp.allclose(u.ustrip("km/s", out["x"]), 4.0)

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -584,3 +584,72 @@ class TestFibreKickProlong:
         assert jnp.allclose(u.ustrip("km", out[0]["x"]), 4.0)  # x + dv*tau
         assert jnp.allclose(u.ustrip("km/s", out[1]["x"]), 1.5)  # v + dv
         assert jnp.allclose(u.ustrip("km/s2", out[2]["x"]), 0.1)  # a unchanged
+
+
+# ============================================================================
+# Unit preservation and tau=None semantics (PR review)
+
+
+class TestUnitPreservation:
+    """Outputs preserve the data's own units; tau=None is passed through."""
+
+    def test_pushforward_preserves_time_units(self):
+        """A kpc/Myr velocity pushes forward to kpc/Myr, not kpc/s."""
+        op = cxfm.Scale.from_factors([2.0, 2.0, 2.0])
+        v = {k: u.Q(x, "kpc/Myr") for k, x in zip("xyz", (1.0, 0.0, 0.0), strict=False)}
+        at = {k: u.Q(x, "kpc") for k, x in zip("xyz", (1.0, 0.0, 0.0), strict=False)}
+        out = cxfm.pushforward(op, None, v, cxc.cart3d, cxr.coord_vel, at=at)
+        assert out["x"].unit == u.unit("kpc/Myr")
+        assert jnp.allclose(out["x"].value, 2.0)
+
+    def test_prolong_preserves_time_units(self):
+        """Jet slots come back in the data's own time base."""
+        op = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+        jet = {
+            0: {k: u.Q(x, "kpc") for k, x in zip("xyz", (1.0, 0.0, 0.0), strict=False)},
+            1: {
+                k: u.Q(x, "kpc/Myr")
+                for k, x in zip("xyz", (1.0, 0.0, 0.0), strict=False)
+            },
+        }
+        out = cxfm.prolong(op, None, jet, cxc.cart3d)
+        assert out[1]["y"].unit == u.unit("kpc/Myr")
+        assert jnp.allclose(out[1]["y"].value, 1.0)
+
+    def test_prolong_chain_consistent_across_tau_units(self):
+        """Chain rule stays unit-consistent across differing tau units.
+
+        The result must not depend on whether tau is given in seconds or
+        Myr when the data's time base is Myr.
+        """
+        g = u.Q(1.0, "kpc/Myr2")
+        moving = cxfm.Translate(
+            lambda t: {"x": 0.5 * g * t**2, "y": u.Q(0.0, "kpc"), "z": u.Q(0.0, "kpc")},
+            chart=cxc.cart3d,
+        )
+        jet = {
+            0: {k: u.Q(0.0, "kpc") for k in "xyz"},
+            1: {
+                k: u.Q(v, "kpc/Myr")
+                for k, v in zip("xyz", (1.0, 0.0, 0.0), strict=False)
+            },
+        }
+        out_myr = cxfm.prolong(moving, u.Q(2.0, "Myr"), jet, cxc.cart3d)
+        out_s = cxfm.prolong(moving, u.Q(2.0, "Myr").uconvert("s"), jet, cxc.cart3d)
+        # v' = v + g*tau = 1 + 2 = 3 kpc/Myr, regardless of tau's unit
+        assert jnp.allclose(u.ustrip("kpc/Myr", out_myr[1]["x"]), 3.0)
+        assert jnp.allclose(u.ustrip("kpc/Myr", out_s[1]["x"]), 3.0, atol=1e-6)
+
+    def test_prolong_tau_none_passes_through_to_point_action(self):
+        """tau=None is not replaced by a dummy time.
+
+        A point action that genuinely requires tau (Boost) raises its own
+        informative error even on the generic autodiff path.
+        """
+        boost = cxfm.Boost(q3(1.0, 0.0, 0.0, "km/s"), chart=cxc.cart3d)
+        jet = {0: q3(1.0, 0.0, 0.0, "km"), 1: q3(0.0, 0.0, 0.0, "km/s")}
+        generic = cxfm.prolong.invoke(
+            cxfm.AbstractTransform, object, dict, cxc.AbstractChart
+        )
+        with pytest.raises(TypeError, match="requires a time parameter"):
+            generic(boost, None, jet, cxc.cart3d)

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -1055,3 +1055,25 @@ class TestLinearOpsUnderNewVerbs:
         v_ref = cxfm.act(op, None, v, cxc.cart3d, cxr.coord_vel, at=at)
         assert allclose_cdict(jet[0], p_ref, "m", atol=1e-8)
         assert allclose_cdict(jet[1], v_ref, "m/s", atol=1e-8)
+
+    def test_kick_cross_chart_in_jet(self):
+        """Prolong supplies at=jet[0], so cross-chart kicks work in jets."""
+        usys = u.unitsystems.si
+        dv = {k: u.Q(x, "km/s") for k, x in zip("xyz", (1.0, 0.0, 0.0), strict=False)}
+        kick = cxfm.Translate(dv, chart=cxc.cart3d, semantic_kind=cxr.vel)
+        jet = {
+            0: {"r": u.Q(5.0, "km"), "theta": u.Q(1.0, "rad"), "phi": u.Q(0.5, "rad")},
+            1: {
+                "r": u.Q(0.3, "km/s"),
+                "theta": u.Q(0.01, "rad/s"),
+                "phi": u.Q(0.02, "rad/s"),
+            },
+        }
+        out = cxfm.prolong(kick, None, jet, cxc.sph3d, usys=usys)
+        ref = cxfm.act(
+            kick, None, jet[1], cxc.sph3d, cxr.coord_vel, at=jet[0], usys=usys
+        )
+        for k, refk in ref.items():
+            unit = u.unit_of(refk)
+            assert jnp.allclose(u.ustrip(unit, out[1][k]), refk.value, rtol=1e-6)
+        assert jnp.allclose(u.ustrip("km", out[0]["r"]), 5.0)  # point untouched

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -1088,3 +1088,26 @@ class TestLinearOpsUnderNewVerbs:
         v_extra = q3(1.0, 0.0, 0.0, "m/s") | {"w": u.Q(0.0, "m/s")}
         with pytest.raises(TypeError, match=r"unexpected \['w'\]"):
             cxfm.pushforward(op, None, v_extra, cxc.cart3d, cxr.coord_vel, at=at)
+
+    def test_rotate_raw_tau_unitful_data(self):
+        """Raw (unitless) tau with unitful data works and is consistent.
+
+        The closed form interprets d/dtau in the data's own time base,
+        matching the generic engine's raw-tau convention.
+        """
+
+        def rot_z_raw(t) -> Real[Array, "3 3"]:
+            st_, ct = jnp.sin(t), jnp.cos(t)
+            return jnp.array([[ct, -st_, 0.0], [st_, ct, 0.0], [0.0, 0.0, 1.0]])
+
+        op = cxfm.Rotate.from_(rot_z_raw)
+        at = q3(1.0, 0.0, 0.0, "m")
+        v = q3(0.0, 0.0, 0.0, "m/s")
+        tau = jnp.asarray(0.0)
+        out = cxfm.act(op, tau, v, cxc.cart3d, cxr.tangent_geom, cxr.coord_vel, at=at)
+        gen = prolong_jet(op, tau, {0: at, 1: v}, cxc.cart3d)
+        for k in out:
+            unit = u.unit_of(gen[1][k])
+            assert jnp.allclose(u.ustrip(unit, out[k]), gen[1][k].value, atol=1e-7)
+        # omega = 1 per data-time-base; z-hat x x-hat = y-hat
+        assert jnp.allclose(u.ustrip("m/s", out["y"]), 1.0, atol=1e-7)

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -1,0 +1,476 @@
+"""Tests for the jet-prolongation engine and kinematic `act` semantics.
+
+The keystone property tested throughout: every hand-written fast path must
+equal the generic autodiff prolongation of the operator's point action.
+"""
+
+from jaxtyping import Array, Real
+
+import jax
+import pytest
+from hypothesis import given, settings, strategies as st
+
+import quaxed.numpy as jnp
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.main as cx
+import coordinax.representations as cxr
+import coordinax.transforms as cxfm
+
+# ============================================================================
+# Helpers
+
+
+def q3(x, y, z, unit):
+    return {"x": u.Q(x, unit), "y": u.Q(y, unit), "z": u.Q(z, unit)}
+
+
+def allclose_cdict(a, b, unit, atol=1e-10):
+    return all(
+        jnp.allclose(u.ustrip(unit, a[k]), u.ustrip(unit, b[k]), atol=atol) for k in a
+    )
+
+
+def rot_z(t) -> Real[Array, "3 3"]:
+    """Uniform rotation about z at 1 rad/s."""
+    th = t.ustrip("s")
+    st_, ct = jnp.sin(th), jnp.cos(th)
+    return jnp.array([[ct, -st_, 0.0], [st_, ct, 0.0], [0.0, 0.0, 1.0]])
+
+
+# ============================================================================
+# tau_derivative
+
+
+class TestTauDerivative:
+    """Unit tests for `tau_derivative`."""
+
+    def test_linear(self):
+        delta = lambda t: {"x": u.Q(3.0, "km/s") * t, "y": u.Q(0.0, "km")}
+        out = cxfm.tau_derivative(delta, u.Q(5.0, "s"))
+        assert jnp.allclose(u.ustrip("km/s", out["x"]), 3.0)
+        assert jnp.allclose(u.ustrip("km/s", out["y"]), 0.0)
+
+    def test_second_derivative(self):
+        delta = lambda t: {"x": u.Q(0.5, "m/s2") * t**2}
+        out = cxfm.tau_derivative(delta, u.Q(4.0, "s"), n=2)
+        assert jnp.allclose(u.ustrip("m/s2", out["x"]), 1.0)
+
+    def test_n_zero_is_evaluation(self):
+        delta = lambda t: {"x": u.Q(2.0, "m/s") * t}
+        out = cxfm.tau_derivative(delta, u.Q(3.0, "s"), n=0)
+        assert jnp.allclose(u.ustrip("m", out["x"]), 6.0)
+
+    def test_raw_array_output(self):
+        f = lambda t: jnp.array([1.0, 2.0]) * t.ustrip("s")
+        out = cxfm.tau_derivative(f, u.Q(7.0, "s"))
+        assert jnp.allclose(out, jnp.array([1.0, 2.0]))
+
+    def test_negative_n_raises(self):
+        with pytest.raises(ValueError, match="n >= 0"):
+            cxfm.tau_derivative(lambda t: t, u.Q(1.0, "s"), n=-1)
+
+    def test_nonsi_time_units(self):
+        delta = lambda t: {"x": u.Q(2.0, "km") * t.ustrip("Myr")}
+        out = cxfm.tau_derivative(delta, u.Q(3.0, "Myr"))
+        assert jnp.allclose(u.ustrip("km/Myr", out["x"]), 2.0)
+
+
+# ============================================================================
+# is_time_dependent
+
+
+class TestIsTimeDependent:
+    """Unit tests for `is_time_dependent`."""
+
+    def test_static(self):
+        assert not cxfm.is_time_dependent(cxfm.Translate.from_([1, 2, 3], "km"))
+        assert not cxfm.is_time_dependent(cxfm.Identity())
+        assert not cxfm.is_time_dependent(cxfm.Scale.from_factors([1.0, 2.0, 3.0]))
+
+    def test_callable_delta(self):
+        op = cxfm.Translate(
+            lambda t: q3(t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
+        )
+        assert cxfm.is_time_dependent(op)
+
+    def test_composed(self):
+        static = cxfm.Translate.from_([1, 2, 3], "km")
+        moving = cxfm.Translate(
+            lambda t: q3(t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
+        )
+        assert cxfm.is_time_dependent(static | moving)
+        assert not cxfm.is_time_dependent(static | cxfm.Identity())
+
+    def test_inverse_of_time_dependent(self):
+        moving = cxfm.Translate(
+            lambda t: q3(t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
+        )
+        assert cxfm.is_time_dependent(moving.inverse)
+
+
+# ============================================================================
+# Physics acid tests
+
+
+class TestPhysics:
+    """Analytic closed forms the prolongation must reproduce exactly."""
+
+    def test_falling_frame(self):
+        """Delta = 1/2 g t^2 => vel += g t, acc += g."""
+        g = u.Q(9.8, "m/s2")
+        op = cxfm.Translate(
+            lambda t: {"x": 0.5 * g * t**2, "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")},
+            chart=cxc.cart3d,
+        )
+        tau = u.Q(2.0, "s")
+        v = q3(1.0, 2.0, 3.0, "m/s")
+        a = q3(0.0, 0.0, 0.0, "m/s2")
+
+        out_v = cxfm.act(op, tau, v, cxc.cart3d, cxr.coord_vel)
+        assert jnp.allclose(u.ustrip("m/s", out_v["x"]), 1.0 + 9.8 * 2.0)
+        assert jnp.allclose(u.ustrip("m/s", out_v["y"]), 2.0)
+
+        out_a = cxfm.act(op, tau, a, cxc.cart3d, cxr.coord_acc)
+        assert jnp.allclose(u.ustrip("m/s2", out_a["x"]), 9.8)
+
+    def test_rotating_frame_velocity(self):
+        """V' = R v + dR/dt x; at t=0: v + omega x_perp."""
+        op = cxfm.Rotate.from_(rot_z)
+        tau = u.Q(0.0, "s")
+        at = q3(1.0, 0.0, 0.0, "m")
+        v = q3(0.0, 0.0, 0.0, "m/s")
+        out = cxfm.act(op, tau, v, cxc.cart3d, cxr.tangent_geom, cxr.coord_vel, at=at)
+        # omega z-hat cross x-hat = y-hat
+        assert jnp.allclose(u.ustrip("m/s", out["y"]), 1.0, atol=1e-8)
+        assert jnp.allclose(u.ustrip("m/s", out["x"]), 0.0, atol=1e-8)
+
+    def test_rotating_frame_acceleration_coriolis_centrifugal(self):
+        """A' = R a + 2 dR v + ddR x; at t=0: a + 2 omega z x v - omega^2 x_perp."""
+        op = cxfm.Rotate.from_(rot_z)
+        tau = u.Q(0.0, "s")
+        at = q3(1.0, 0.0, 0.0, "m")
+        at_vel = q3(0.0, 1.0, 0.0, "m/s")
+        a = q3(0.0, 0.0, 0.0, "m/s2")
+        out = cxfm.act(
+            op,
+            tau,
+            a,
+            cxc.cart3d,
+            cxr.tangent_geom,
+            cxr.coord_acc,
+            at=at,
+            at_vel=at_vel,
+        )
+        # 2*Omega x v = 2 * (z-hat x y-hat) = -2 x-hat; ddR x = -x-hat
+        assert jnp.allclose(u.ustrip("m/s2", out["x"]), -3.0, atol=1e-6)
+        assert jnp.allclose(u.ustrip("m/s2", out["y"]), 0.0, atol=1e-6)
+
+    def test_boost_equals_prolonged_translate(self):
+        """Boost(dv) == prolongation of Translate(dpl, lambda t: dv*t)."""
+        dv = q3(1.5, -0.5, 2.0, "km/s")
+        boost = cxfm.Boost(dv, chart=cxc.cart3d)
+        td = cxfm.Translate(
+            lambda t: {k: c * t for k, c in dv.items()}, chart=cxc.cart3d
+        )
+        tau = u.Q(3.0, "s")
+        jet = {
+            0: q3(1.0, 2.0, 3.0, "km"),
+            1: q3(0.1, 0.2, 0.3, "km/s"),
+            2: q3(0.0, 0.0, 0.0, "km/s2"),
+        }
+        out_td = cxfm.prolong(td, tau, jet, cxc.cart3d)
+        out_p = cxfm.act(boost, tau, jet[0], cxc.cart3d, cxr.point)
+        out_v = cxfm.act(boost, tau, jet[1], cxc.cart3d, cxr.coord_vel)
+        out_a = cxfm.act(boost, tau, jet[2], cxc.cart3d, cxr.coord_acc)
+        assert allclose_cdict(out_p, out_td[0], "km")
+        assert allclose_cdict(out_v, out_td[1], "km/s")
+        assert allclose_cdict(out_a, out_td[2], "km/s2")
+
+
+# ============================================================================
+# Keystone: hand fast paths == generic autodiff prolongation
+
+
+class TestFastPathEqualsGeneric:
+    """Hand-written fast paths must equal the generic autodiff rule."""
+
+    @given(
+        c0=st.floats(-5, 5),
+        c1=st.floats(-5, 5),
+        c2=st.floats(-5, 5),
+        tau=st.floats(0.1, 10),
+    )
+    @settings(max_examples=20, deadline=None)
+    def test_translate_polynomial_delta(self, c0, c1, c2, tau):
+        """Hand ladder rule == generic prolongation for polynomial delta."""
+
+        def delta(t):
+            ts = t.ustrip("s")
+            val = c0 + c1 * ts + c2 * ts**2
+            return {"x": u.Q(val, "km"), "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")}
+
+        op = cxfm.Translate(delta, chart=cxc.cart3d)
+        tq = u.Q(tau, "s")
+        jet = {
+            0: q3(1.0, 2.0, 3.0, "km"),
+            1: q3(0.5, -0.5, 0.0, "km/s"),
+            2: q3(0.1, 0.0, -0.1, "km/s2"),
+        }
+        out_gen = cxfm.prolong(op, tq, jet, cxc.cart3d)
+        out_v = cxfm.act(op, tq, jet[1], cxc.cart3d, cxr.coord_vel)
+        out_a = cxfm.act(op, tq, jet[2], cxc.cart3d, cxr.coord_acc)
+        assert allclose_cdict(out_v, out_gen[1], "km/s", atol=1e-6)
+        assert allclose_cdict(out_a, out_gen[2], "km/s2", atol=1e-6)
+
+    @given(tau=st.floats(0.0, 6.0))
+    @settings(max_examples=20, deadline=None)
+    def test_rotate_closed_form_vs_generic(self, tau):
+        """Rotate's Cartesian vel closed form == generic prolongation."""
+        op = cxfm.Rotate.from_(rot_z)
+        tq = u.Q(tau, "s")
+        at = q3(1.0, -2.0, 0.5, "m")
+        v = q3(0.3, 0.1, -0.2, "m/s")
+        out_hand = cxfm.act(
+            op, tq, v, cxc.cart3d, cxr.tangent_geom, cxr.coord_vel, at=at
+        )
+        out_gen = cxfm.prolong(op, tq, {0: at, 1: v}, cxc.cart3d)
+        assert allclose_cdict(out_hand, out_gen[1], "m/s", atol=1e-6)
+
+    def test_vel_kick_translate_vs_generic_fibre_law(self):
+        """TD vel-kick Translate: acc gains delta-dot (hand rule)."""
+        kick = cxfm.Translate(
+            lambda t: {
+                "x": u.Q(5.0, "km/s2") * t,
+                "y": u.Q(0.0, "km/s"),
+                "z": u.Q(0.0, "km/s"),
+            },
+            chart=cxc.cart3d,
+            semantic_kind=cxr.vel,
+        )
+        tau = u.Q(2.0, "s")
+        a = q3(1.0, 1.0, 1.0, "km/s2")
+        out = cxfm.act(kick, tau, a, cxc.cart3d, cxr.coord_acc)
+        assert jnp.allclose(u.ustrip("km/s2", out["x"]), 6.0)
+        assert jnp.allclose(u.ustrip("km/s2", out["y"]), 1.0)
+
+
+# ============================================================================
+# Structural properties
+
+
+class TestStructure:
+    """Structural identities of the prolongation calculus."""
+
+    def test_pushforward_equals_act_for_static(self):
+        op = cxfm.Rotate.from_euler("z", u.Q(37.0, "deg"))
+        v = q3(1.0, 2.0, 3.0, "m/s")
+        out_act = cxfm.act(op, None, v, cxc.cart3d, cxr.tangent_geom, cxr.coord_vel)
+        out_pf = cxfm.pushforward(op, None, v, cxc.cart3d, cxr.coord_vel)
+        assert allclose_cdict(out_act, out_pf, "m/s")
+
+    def test_dpl_invariant_under_translates(self):
+        d = q3(1.0, 2.0, 3.0, "km")
+        tau = u.Q(2.0, "s")
+        ops = [
+            cxfm.Translate.from_([1, 2, 3], "km"),
+            cxfm.Translate(
+                lambda t: q3(t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
+            ),
+            cxfm.Boost(q3(1.0, 0.0, 0.0, "km/s"), chart=cxc.cart3d),
+        ]
+        for op in ops:
+            out = cxfm.act(op, tau, d, cxc.cart3d, cxr.coord_disp)
+            assert allclose_cdict(out, d, "km")
+
+    def test_prolong_inverse_roundtrip(self):
+        moving = cxfm.Translate(
+            lambda t: q3(3.0 * t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
+        )
+        tau = u.Q(2.0, "s")
+        jet = {0: q3(1.0, 2.0, 3.0, "km"), 1: q3(0.5, -0.5, 0.0, "km/s")}
+        fwd = cxfm.prolong(moving, tau, jet, cxc.cart3d)
+        back = cxfm.prolong(moving.inverse, tau, fwd, cxc.cart3d)
+        assert allclose_cdict(back[0], jet[0], "km", atol=1e-6)
+        assert allclose_cdict(back[1], jet[1], "km/s", atol=1e-6)
+
+    def test_prolong_composed_equals_sequential(self):
+        opA = cxfm.Boost(q3(1.0, 0.0, 0.0, "km/s"), chart=cxc.cart3d)
+        opB = cxfm.Translate(
+            lambda t: q3(0.0, 2.0 * t.ustrip("s"), 0.0, "km"), chart=cxc.cart3d
+        )
+        tau = u.Q(2.0, "s")
+        jet = {0: q3(1.0, 2.0, 3.0, "km"), 1: q3(0.5, -0.5, 0.0, "km/s")}
+        out_pipe = cxfm.prolong(opA | opB, tau, jet, cxc.cart3d)
+        out_seq = cxfm.prolong(
+            opB, tau, cxfm.prolong(opA, tau, jet, cxc.cart3d), cxc.cart3d
+        )
+        assert allclose_cdict(out_pipe[0], out_seq[0], "km")
+        assert allclose_cdict(out_pipe[1], out_seq[1], "km/s")
+
+
+# ============================================================================
+# Units
+
+
+class TestUnits:
+    """Unit-handling through the prolongation engine."""
+
+    def test_spherical_chart_mixed_units(self):
+        """Prolongation in a spherical chart handles mixed (m, rad) units."""
+        moving = cxfm.Translate(
+            lambda t: q3(3.0 * t.ustrip("s"), 0.0, 0.0, "m"), chart=cxc.cart3d
+        )
+        tau = u.Q(2.0, "s")
+        jet = {
+            0: {
+                "r": u.Q(1.0, "m"),
+                "theta": u.Q(jnp.pi / 2, "rad"),
+                "phi": u.Q(0.0, "rad"),
+            },
+            1: {
+                "r": u.Q(0.0, "m/s"),
+                "theta": u.Q(0.0, "rad/s"),
+                "phi": u.Q(0.0, "rad/s"),
+            },
+        }
+        out = cxfm.prolong(moving, tau, jet, cxc.sph3d)
+        # point at (1+6, 0, 0) cartesian -> r = 7
+        assert jnp.allclose(u.ustrip("m", out[0]["r"]), 7.0, atol=1e-6)
+        # velocity gains delta-dot = 3 m/s radially (point on +x axis)
+        assert jnp.allclose(u.ustrip("m/s", out[1]["r"]), 3.0, atol=1e-6)
+        assert u.dimension_of(out[1]["theta"]) == u.dimension_of(u.Q(1, "rad/s"))
+
+    def test_tau_in_myr(self):
+        moving = cxfm.Translate(
+            lambda t: q3(2.0 * t.ustrip("Myr"), 0.0, 0.0, "kpc"), chart=cxc.cart3d
+        )
+        tau = u.Q(3.0, "Myr")
+        v = q3(0.0, 0.0, 0.0, "kpc/Myr")
+        out = cxfm.act(moving, tau, v, cxc.cart3d, cxr.coord_vel)
+        assert jnp.allclose(u.ustrip("kpc/Myr", out["x"]), 2.0)
+
+
+# ============================================================================
+# Batching / JAX transforms
+
+
+class TestBatchingAndJit:
+    """jit/vmap/batching compatibility."""
+
+    def test_jit_prolong(self):
+        moving = cxfm.Translate(
+            lambda t: q3(3.0 * t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
+        )
+        jet = {0: q3(0.0, 0.0, 0.0, "km"), 1: q3(0.0, 0.0, 0.0, "km/s")}
+        f = jax.jit(lambda tau, jet: cxfm.prolong(moving, tau, jet, cxc.cart3d))
+        out = f(u.Q(2.0, "s"), jet)
+        assert jnp.allclose(u.ustrip("km/s", out[1]["x"]), 3.0)
+
+    def test_vmap_over_tau(self):
+        g = u.Q(2.0, "m/s2")
+        moving = cxfm.Translate(
+            lambda t: {"x": 0.5 * g * t**2, "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")},
+            chart=cxc.cart3d,
+        )
+        jet = {0: q3(0.0, 0.0, 0.0, "m"), 1: q3(0.0, 0.0, 0.0, "m/s")}
+        f = jax.jit(lambda tau: cxfm.prolong(moving, tau, jet, cxc.cart3d)[1]["x"])
+        taus = u.Q(jnp.array([1.0, 2.0, 3.0]), "s")
+        out = jax.vmap(f)(taus)
+        assert jnp.allclose(u.ustrip("m/s", out), jnp.array([2.0, 4.0, 6.0]))
+
+    def test_batched_data(self):
+        moving = cxfm.Translate(
+            lambda t: q3(3.0 * t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
+        )
+        v = {
+            "x": u.Q(jnp.zeros(4), "km/s"),
+            "y": u.Q(jnp.ones(4), "km/s"),
+            "z": u.Q(jnp.zeros(4), "km/s"),
+        }
+        out = cxfm.act(moving, u.Q(2.0, "s"), v, cxc.cart3d, cxr.coord_vel)
+        assert out["x"].shape == (4,)
+        assert jnp.allclose(u.ustrip("km/s", out["x"]), 3.0)
+
+
+# ============================================================================
+# Error paths
+
+
+class TestErrors:
+    """Informative errors when required jet slots are missing."""
+
+    def test_td_rotate_lone_vel_requires_at(self):
+        op = cxfm.Rotate.from_(rot_z)
+        v = q3(1.0, 0.0, 0.0, "m/s")
+        with pytest.raises(TypeError, match="requires the base point"):
+            cxfm.act(op, u.Q(1.0, "s"), v, cxc.cart3d, cxr.tangent_geom, cxr.coord_vel)
+
+    def test_td_rotate_acc_requires_at_vel(self):
+        op = cxfm.Rotate.from_(rot_z)
+        a = q3(1.0, 0.0, 0.0, "m/s2")
+        at = q3(1.0, 0.0, 0.0, "m")
+        with pytest.raises(TypeError, match="at_vel"):
+            cxfm.act(
+                op, u.Q(1.0, "s"), a, cxc.cart3d, cxr.tangent_geom, cxr.coord_acc, at=at
+            )
+
+    def test_td_translate_tangent_requires_tau(self):
+        moving = cxfm.Translate(
+            lambda t: q3(t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
+        )
+        v = q3(1.0, 0.0, 0.0, "km/s")
+        with pytest.raises(TypeError, match="tau=None"):
+            cxfm.act(moving, None, v, cxc.cart3d, cxr.coord_vel)
+
+    def test_prolong_missing_slot(self):
+        moving = cxfm.Translate(
+            lambda t: q3(t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
+        )
+        jet = {0: q3(0.0, 0.0, 0.0, "km"), 2: q3(0.0, 0.0, 0.0, "km/s2")}
+        with pytest.raises(TypeError, match="slot 1 is missing"):
+            cxfm.prolong(moving, u.Q(1.0, "s"), jet, cxc.cart3d)
+
+    def test_static_scale_vel_requires_at(self):
+        op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
+        v = q3(1.0, 1.0, 1.0, "m/s")
+        with pytest.raises(TypeError, match="base point"):
+            cxfm.act(op, None, v, cxc.cart3d, cxr.coord_vel)
+
+
+# ============================================================================
+# Coordinate bundles
+
+
+class TestCoordinateBundle:
+    """Joint prolongation of Coordinate bundles."""
+
+    def test_td_translate_bundle(self):
+        point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+        vel = cx.Tangent(q3(1.0, 0.0, 0.0, "m/s"), cxc.cart3d, cxr.coord_basis, cxr.vel)
+        pv = cx.Coordinate(point=point, velocity=vel)
+        op = cx.Translate(
+            lambda t: q3(3.0 * t.ustrip("s"), 0.0, 0.0, "m"), chart=cxc.cart3d
+        )
+        out = cx.act(op, u.Q(2.0, "s"), pv)
+        assert jnp.allclose(u.ustrip("m", out.point.data["x"]), 7.0)
+        assert jnp.allclose(u.ustrip("m/s", out["velocity"].data["x"]), 4.0)
+
+    def test_td_rotate_bundle(self):
+        point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+        vel = cx.Tangent(q3(0.0, 0.0, 0.0, "m/s"), cxc.cart3d, cxr.coord_basis, cxr.vel)
+        pv = cx.Coordinate(point=point, velocity=vel)
+        op = cx.Rotate.from_(rot_z)
+        out = cx.act(op, u.Q(0.0, "s"), pv)
+        # v' = Rv + dR x = omega z-hat cross x-hat = y-hat
+        assert jnp.allclose(u.ustrip("m/s", out["velocity"].data["y"]), 1.0, atol=1e-8)
+
+    def test_static_bundle_unchanged_behavior(self):
+        point = cx.Point.from_([1.0, 0.0, 0.0], "m")
+        vel = cx.Tangent(q3(1.0, 0.0, 0.0, "m/s"), cxc.cart3d, cxr.coord_basis, cxr.vel)
+        pv = cx.Coordinate(point=point, velocity=vel)
+        op = cx.Translate.from_([1, 0, 0], "m")
+        out = cx.act(op, None, pv)
+        assert jnp.allclose(u.ustrip("m", out.point.data["x"]), 2.0)
+        assert jnp.allclose(u.ustrip("m/s", out["velocity"].data["x"]), 1.0)

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -754,3 +754,48 @@ class TestNonCartesianOpChart:
         assert is_flat_chart(cxc.cart3d)
         assert not is_flat_chart(cxc.sph3d)
         assert not is_flat_chart(cxc.PoincarePolar6D())
+
+    def test_flat_delta_nonflat_data_chart_matches_generic(self):
+        """Fast path equals generic when the data's chart is non-flat.
+
+        A Cartesian delta acting on spherical-chart tangent data is
+        nonlinear in the data's coordinates.
+        """
+        usys = u.unitsystems.si
+        v = {
+            "r": u.Q(0.3, "km/s"),
+            "theta": u.Q(0.0, "rad/s"),
+            "phi": u.Q(0.0, "rad/s"),
+        }
+        # static: NOT identity in spherical components
+        op = cxfm.Translate.from_([100.0, 0.0, 0.0], "km")
+        out = cxfm.act(op, None, v, cxc.sph3d, cxr.coord_vel, at=self.sph_at, usys=usys)
+        assert not jnp.allclose(u.ustrip("km/s", out["r"]), 0.3)
+        # TD: computes (previously raised ValueError) and equals generic
+        op_td = cxfm.Translate(
+            lambda t: {
+                "x": u.Q(3.0, "km/s") * t,
+                "y": u.Q(0.0, "km"),
+                "z": u.Q(0.0, "km"),
+            },
+            chart=cxc.cart3d,
+        )
+        tau = u.Q(2.0, "s")
+        fast = cxfm.act(
+            op_td, tau, v, cxc.sph3d, cxr.coord_vel, at=self.sph_at, usys=usys
+        )
+        gen = prolong_jet(op_td, tau, {0: self.sph_at, 1: v}, cxc.sph3d, usys=usys)
+        for k in fast:
+            unit = u.unit_of(gen[1][k])
+            assert jnp.allclose(u.ustrip(unit, fast[k]), gen[1][k].value, rtol=1e-6)
+
+    def test_order2_unit_preservation(self):
+        """Acceleration units survive the exact rational time-unit root."""
+        op = cxfm.Scale.from_factors([2.0, 2.0, 2.0])
+        a = {
+            k: u.Q(x, "kpc/Myr2") for k, x in zip("xyz", (1.0, 0.0, 0.0), strict=False)
+        }
+        at = {k: u.Q(x, "kpc") for k, x in zip("xyz", (1.0, 0.0, 0.0), strict=False)}
+        out = cxfm.pushforward(op, None, a, cxc.cart3d, cxr.coord_acc, at=at)
+        assert out["x"].unit == u.unit("kpc/Myr2")
+        assert jnp.allclose(out["x"].value, 2.0)

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -814,3 +814,40 @@ class TestNonCartesianOpChart:
         }
         with pytest.raises(TypeError, match=r"slot 1 .*missing \['z'\]"):
             cxfm.prolong(op, None, jet, cxc.cart3d)
+
+    def test_boost_nonflat_chart_acceleration_not_identity(self):
+        """Static Boost on spherical-chart accelerations is not identity.
+
+        It defers to the generic engine (previously silently identity) and
+        forwards the anchors.
+        """
+        usys = u.unitsystems.si
+        dv = {k: u.Q(x, "km/s") for k, x in zip("xyz", (1.0, 0.0, 0.0), strict=False)}
+        boost = cxfm.Boost(dv, chart=cxc.cart3d)
+        a = {
+            "r": u.Q(0.0, "km/s2"),
+            "theta": u.Q(0.0, "rad/s2"),
+            "phi": u.Q(0.0, "rad/s2"),
+        }
+        v = {
+            "r": u.Q(0.3, "km/s"),
+            "theta": u.Q(0.0, "rad/s"),
+            "phi": u.Q(0.0, "rad/s"),
+        }
+        tau = u.Q(2.0, "s")
+        with pytest.raises(TypeError, match="requires the base point"):
+            cxfm.act(boost, tau, a, cxc.sph3d, cxr.coord_acc, usys=usys)
+        fast = cxfm.act(
+            boost, tau, a, cxc.sph3d, cxr.coord_acc, at=self.sph_at, at_vel=v, usys=usys
+        )
+        td = cxfm.Translate(
+            lambda t: {k: c * t for k, c in dv.items()}, chart=cxc.cart3d
+        )
+        gen = prolong_jet(td, tau, {0: self.sph_at, 1: v, 2: a}, cxc.sph3d, usys=usys)
+        for k in fast:
+            unit = u.unit_of(gen[2][k])
+            assert jnp.allclose(
+                u.ustrip(unit, fast[k]), gen[2][k].value, rtol=1e-5, atol=1e-9
+            )
+        # the true result is nonzero: it was previously silently identity
+        assert not jnp.allclose(u.ustrip("km/s2", fast["r"]), 0.0)


### PR DESCRIPTION
## Summary

This PR makes `act` physically complete for time-dependent transforms and puts it to work in the astro frames.

### 1. `act` as jet prolongation (`coordinax.transforms`)

`act` on order-m tangent data is now the m-th **jet prolongation** of the transform's point action φ(τ, x): if x'(τ) = φ(τ, x(τ)) then

- v' = ∂τφ + ∂ₓφ·v
- a' = ∂ττφ + 2∂τ∂ₓφ·v + ∂ₓₓφ(v,v) + ∂ₓφ·a

so time-dependent transforms couple across the time-derivative ladder: a translation δ(τ) adds δ̇ to velocities and δ̈ to accelerations; a rotation R(τ) gives v' = Rv + Ṙx and the full Coriolis/centrifugal acceleration law.

- **Generic engine** (`actions/prolong.py`): nested `jax.jvp` through `materialize_transform` — correct for arbitrary time dependence and compositions by the chain rule. Unit-aware, jit/vmap-safe (jets are integer-keyed pytrees `{0: point, 1: vel, 2: acc, …}`).
- **New verbs**: `pushforward` (frozen-τ spatial differential — the transformation law for `Displacement` data, which is a same-τ point difference and never gains ∂τ terms) and `prolong` (joint jet action, used by `Coordinate` bundles). Plus `is_time_dependent` and `tau_derivative`.
- **Closed-form fast paths** override the generic rule by plum specificity: `Translate` gets a unified ladder rule (an order-k offset adds d^(m−k)δ/dτ^(m−k) to order-m data — one jvp on δ only, never on x); `Rotate` gets Rv + Ṙx; `Composed` threads the evolving jet (`at`, `at_vel`) through sub-operators.
- **`Boost` is redefined as the true Galilean boost** (x ↦ x + Δv·τ, requires τ for point data). The old fibre-only velocity kick is `Translate(semantic_kind=vel)`; the example `Bob` frame migrates to it with unchanged behavior. Property-tested: `Boost(Δv)` ≡ prolongation of `Translate(dpl, λτ: Δv·τ)`.
- **No silent physics loss**: a time-dependent transform acting on lone tangent data without the lower jet slots raises a precise `TypeError` pointing at `at=`/`at_vel=` or `Coordinate`.
- Static transforms never enter the jvp path — their dispatch is unchanged, zero performance regression. jit steady-state benchmarks added.

**Testing**: the keystone property — every hand-written fast path equals the generic autodiff rule — is hypothesis-tested, plus physics acid tests (δ = ½gτ² ⇒ v += gτ, a += g; uniform rotation reproduces a' = Ra + 2Ṙv + R̈x exactly), inverse/composition structure, mixed-unit spherical charts, τ in non-SI units, batching/jit/vmap, and error paths.

### 2. Phase-space astro frames (`coordinax.astro`, `coordinax.interop.astropy`)

- **Galactocentric velocities**: the `galcen_v_sun` field is enabled and the ICRS↔Galactocentric chain gains the solar-velocity offset (`R | offset_q | H | offset_v`, with `offset_v` a fibre-only velocity kick — the frame transform is a fixed-epoch snapshot, so positions are not advected). One operator applied to a `Coordinate` bundle now transforms positions **and** velocities, validated against astropy `SkyCoord` transforms to 1e-6 in both.
- **New `Galactic` frame**: parameter-free, related to ICRS by astropy's effective rotation matrix (FK4-B1950-derived, precessed to J2000, including the ~25 mas ICRS/FK5 frame bias — a matrix built from the bare J2000 NGP Euler angles would disagree with astropy at the sub-arcsecond level). `Galactic↔Galactocentric` composes for free via the generic route through ICRS and matches astropy end-to-end.
- Interop: `Tangent ↔ CartesianDifferential` converters; `galcen_v_sun` and `Galactic` wired through the astropy frame conversions.

### Behavior changes

- dpl-`Translate` with time-dependent δ now shifts velocities (δ̇) and accelerations (δ̈); was identity.
- `Boost` now moves points by Δv·τ; the old fibre-kick behavior is `Translate(semantic_kind=vel)`.
- Time-dependent `Rotate` on a lone velocity requires `at=` (result was previously silently missing the Ṙx term).
- ICRS↔Galactocentric transforms now affect velocity data (was position-only).

Also fixes a flaky hypothesis tolerance in the TransformedReferenceFrame roundtrip test (roundoff scales with |q|).

## Test plan

- Full suite: 6,713 passed, 0 failed (core + coordinax.astro + coordinax.interop.astropy, including sybil doctests).
- New: `tests/unit/transforms/test_prolongation.py` (34 tests), velocity/Galactic tests in `packages/coordinax.astro/tests/unit/test_frame_transforms.py` (13 new), `tests/benchmark/test_act_prolong.py`.
- Lint (ruff/ty/codespell via prek hooks) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)