### PR TITLE
⚡️ perf(transforms): restore plum dispatch caching on the hot paths

### DIFF
--- a/packages/coordinax.api/src/coordinax/api/_custom_types.py
+++ b/packages/coordinax.api/src/coordinax/api/_custom_types.py
@@ -1,13 +1,17 @@
 __all__ = ("CKey", "CDict")
 
-from typing import TypeAlias
+from typing import Any, TYPE_CHECKING, TypeAlias
 
 # Component key type: string for all charts (including dot-delimited product keys)
 CKey: TypeAlias = str
 
 # Parameter dictionary type alias
-# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
-# annotation makes every plum signature that uses CDict "unfaithful",
-# which disables plum's method cache and forces a full (~200x slower)
-# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
-CDict: TypeAlias = dict
+if TYPE_CHECKING:
+    # Typed for static checkers only.
+    CDict: TypeAlias = dict[CKey, Any]
+else:
+    # A parametric `dict[...]` annotation makes every plum signature
+    # using CDict "unfaithful", disabling plum's method cache (a full
+    # ~200x slower resolution per call). The bare `dict` keeps the cache;
+    # the TYPE_CHECKING branch above preserves the static type.
+    CDict: TypeAlias = dict

--- a/packages/coordinax.api/src/coordinax/api/_custom_types.py
+++ b/packages/coordinax.api/src/coordinax/api/_custom_types.py
@@ -1,9 +1,13 @@
 __all__ = ("CKey", "CDict")
 
-from typing import Any, TypeAlias
+from typing import TypeAlias
 
 # Component key type: string for all charts (including dot-delimited product keys)
 CKey: TypeAlias = str
 
 # Parameter dictionary type alias
-CDict: TypeAlias = dict[CKey, Any]
+# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
+# annotation makes every plum signature that uses CDict "unfaithful",
+# which disables plum's method cache and forces a full (~200x slower)
+# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
+CDict: TypeAlias = dict

--- a/packages/coordinax.curveframes/src/coordinax/curveframes/_src/custom_types.py
+++ b/packages/coordinax.curveframes/src/coordinax/curveframes/_src/custom_types.py
@@ -5,7 +5,11 @@ __all__ = (
     "CDict",
 )
 
-from typing import Any, TypeAlias
+from typing import TypeAlias
 
 CKey: TypeAlias = str
-CDict: TypeAlias = dict[CKey, Any]
+# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
+# annotation makes every plum signature that uses CDict "unfaithful",
+# which disables plum's method cache and forces a full (~200x slower)
+# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
+CDict: TypeAlias = dict

--- a/packages/coordinax.curveframes/src/coordinax/curveframes/_src/custom_types.py
+++ b/packages/coordinax.curveframes/src/coordinax/curveframes/_src/custom_types.py
@@ -5,11 +5,15 @@ __all__ = (
     "CDict",
 )
 
-from typing import TypeAlias
+from typing import Any, TYPE_CHECKING, TypeAlias
 
 CKey: TypeAlias = str
-# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
-# annotation makes every plum signature that uses CDict "unfaithful",
-# which disables plum's method cache and forces a full (~200x slower)
-# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
-CDict: TypeAlias = dict
+if TYPE_CHECKING:
+    # Typed for static checkers only.
+    CDict: TypeAlias = dict[CKey, Any]
+else:
+    # A parametric `dict[...]` annotation makes every plum signature
+    # using CDict "unfaithful", disabling plum's method cache (a full
+    # ~200x slower resolution per call). The bare `dict` keeps the cache;
+    # the TYPE_CHECKING branch above preserves the static type.
+    CDict: TypeAlias = dict

--- a/packages/coordinax.hypothesis/src/coordinax/hypothesis/utils/_src/custom_types.py
+++ b/packages/coordinax.hypothesis/src/coordinax/hypothesis/utils/_src/custom_types.py
@@ -6,7 +6,7 @@ __all__ = (
     "CDict",
 )
 
-from typing import Any, TypeAlias
+from typing import Any, TYPE_CHECKING, TypeAlias
 
 # =========================================================
 # Array-related Types
@@ -17,4 +17,12 @@ Shape: TypeAlias = tuple[int, ...]
 # Vector-related Types
 
 CKey: TypeAlias = str
-CDict: TypeAlias = dict[CKey, Any]
+if TYPE_CHECKING:
+    # Typed for static checkers only.
+    CDict: TypeAlias = dict[CKey, Any]
+else:
+    # A parametric `dict[...]` annotation makes every plum signature
+    # using CDict "unfaithful", disabling plum's method cache (a full
+    # ~200x slower resolution per call). The bare `dict` keeps the cache;
+    # the TYPE_CHECKING branch above preserves the static type.
+    CDict: TypeAlias = dict

--- a/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/custom_types.py
+++ b/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/custom_types.py
@@ -5,7 +5,11 @@ __all__ = (
     "CDict",
 )
 
-from typing import Any, TypeAlias
+from typing import TypeAlias
 
 CKey: TypeAlias = str
-CDict: TypeAlias = dict[CKey, Any]
+# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
+# annotation makes every plum signature that uses CDict "unfaithful",
+# which disables plum's method cache and forces a full (~200x slower)
+# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
+CDict: TypeAlias = dict

--- a/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/custom_types.py
+++ b/packages/coordinax.interop.astropy/src/coordinax/interop/astropy/_src/custom_types.py
@@ -5,11 +5,15 @@ __all__ = (
     "CDict",
 )
 
-from typing import TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 CKey: TypeAlias = str
-# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
-# annotation makes every plum signature that uses CDict "unfaithful",
-# which disables plum's method cache and forces a full (~200x slower)
-# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
-CDict: TypeAlias = dict
+if TYPE_CHECKING:
+    # Typed for static checkers only.
+    CDict: TypeAlias = dict[CKey, Any]
+else:
+    # A parametric `dict[...]` annotation makes every plum signature
+    # using CDict "unfaithful", disabling plum's method cache (a full
+    # ~200x slower resolution per call). The bare `dict` keeps the cache;
+    # the TYPE_CHECKING branch above preserves the static type.
+    CDict: TypeAlias = dict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "optional-dependencies>=0.3.2",
   "plum>=2.8.0; python_version < '3.14'",
   "plum>=2.9.0; python_version >= '3.14'",
-  "quax>=0.3.2",
+  "quax>=0.3.6",
   "quax-blocks>=0.4.1",
   "quaxed>=0.10.5",
   "typing-extensions>=4.13.2",

--- a/src/coordinax/_src/custom_types.py
+++ b/src/coordinax/_src/custom_types.py
@@ -12,7 +12,7 @@ __all__: tuple[str, ...] = (
     "Ds",
 )
 
-from typing import Any, Literal, TypeAlias
+from typing import Literal, TypeAlias
 from typing_extensions import TypeVar
 
 import unxt as u
@@ -32,7 +32,11 @@ OptUSys: TypeAlias = u.AbstractUnitSystem | None
 # Vector-related Types
 
 CKey: TypeAlias = str
-CDict: TypeAlias = dict[CKey, Any]
+# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
+# annotation makes every plum signature that uses CDict "unfaithful",
+# which disables plum's method cache and forces a full (~200x slower)
+# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
+CDict: TypeAlias = dict
 CDictT = TypeVar("CDictT", bound=CDict)
 
 Ks = TypeVar("Ks", bound=tuple[CKey, ...], default=tuple[str, ...])

--- a/src/coordinax/_src/custom_types.py
+++ b/src/coordinax/_src/custom_types.py
@@ -12,7 +12,7 @@ __all__: tuple[str, ...] = (
     "Ds",
 )
 
-from typing import Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 from typing_extensions import TypeVar
 
 import unxt as u
@@ -32,11 +32,15 @@ OptUSys: TypeAlias = u.AbstractUnitSystem | None
 # Vector-related Types
 
 CKey: TypeAlias = str
-# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
-# annotation makes every plum signature that uses CDict "unfaithful",
-# which disables plum's method cache and forces a full (~200x slower)
-# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
-CDict: TypeAlias = dict
+if TYPE_CHECKING:
+    # Typed for static checkers only.
+    CDict: TypeAlias = dict[CKey, Any]
+else:
+    # A parametric `dict[...]` annotation makes every plum signature
+    # using CDict "unfaithful", disabling plum's method cache (a full
+    # ~200x slower resolution per call). The bare `dict` keeps the cache;
+    # the TYPE_CHECKING branch above preserves the static type.
+    CDict: TypeAlias = dict
 CDictT = TypeVar("CDictT", bound=CDict)
 
 Ks = TypeVar("Ks", bound=tuple[CKey, ...], default=tuple[str, ...])

--- a/src/coordinax/_src/internal/custom_types.py
+++ b/src/coordinax/_src/internal/custom_types.py
@@ -17,7 +17,7 @@ __all__ = (
     "CDict",
 )
 
-from typing import Any, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 from typing_extensions import TypeVar
 
 import unxt as u
@@ -40,11 +40,15 @@ Shape: TypeAlias = tuple[int, ...]
 # Vector-related Types
 
 CKey: TypeAlias = str
-# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
-# annotation makes every plum signature that uses CDict "unfaithful",
-# which disables plum's method cache and forces a full (~200x slower)
-# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
-CDict: TypeAlias = dict
+if TYPE_CHECKING:
+    # Typed for static checkers only.
+    CDict: TypeAlias = dict[CKey, Any]
+else:
+    # A parametric `dict[...]` annotation makes every plum signature
+    # using CDict "unfaithful", disabling plum's method cache (a full
+    # ~200x slower resolution per call). The bare `dict` keeps the cache;
+    # the TYPE_CHECKING branch above preserves the static type.
+    CDict: TypeAlias = dict
 
 # Component Value Type
 V = TypeVar("V", default=Any)

--- a/src/coordinax/_src/internal/custom_types.py
+++ b/src/coordinax/_src/internal/custom_types.py
@@ -40,7 +40,11 @@ Shape: TypeAlias = tuple[int, ...]
 # Vector-related Types
 
 CKey: TypeAlias = str
-CDict: TypeAlias = dict[CKey, Any]
+# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
+# annotation makes every plum signature that uses CDict "unfaithful",
+# which disables plum's method cache and forces a full (~200x slower)
+# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
+CDict: TypeAlias = dict
 
 # Component Value Type
 V = TypeVar("V", default=Any)

--- a/src/coordinax/_src/internal/quantity_matrix.py
+++ b/src/coordinax/_src/internal/quantity_matrix.py
@@ -38,7 +38,7 @@ import functools as ft
 import operator
 
 from jaxtyping import Array, Shaped
-from typing import Any, NoReturn, TypeAlias, TypeVar, cast, final
+from typing import TYPE_CHECKING, Any, NoReturn, TypeAlias, TypeVar, cast, final
 
 import equinox as eqx
 import jax
@@ -55,11 +55,15 @@ from jax.interpreters import ad as jax_ad, batching as jax_batching, mlir as jax
 import unxt as u
 from unxt.quantity import AllowValue
 
-# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
-# annotation makes every plum signature that uses CDict "unfaithful",
-# which disables plum's method cache and forces a full (~200x slower)
-# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
-CDict: TypeAlias = dict
+if TYPE_CHECKING:
+    # Typed for static checkers only.
+    CDict: TypeAlias = dict[str, Any]
+else:
+    # A parametric `dict[...]` annotation makes every plum signature
+    # using CDict "unfaithful", disabling plum's method cache (a full
+    # ~200x slower resolution per call). The bare `dict` keeps the cache;
+    # the TYPE_CHECKING branch above preserves the static type.
+    CDict: TypeAlias = dict
 _DMLS = u.unit("")
 
 

--- a/src/coordinax/_src/internal/quantity_matrix.py
+++ b/src/coordinax/_src/internal/quantity_matrix.py
@@ -55,7 +55,11 @@ from jax.interpreters import ad as jax_ad, batching as jax_batching, mlir as jax
 import unxt as u
 from unxt.quantity import AllowValue
 
-CDict: TypeAlias = dict[str, Any]
+# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
+# annotation makes every plum signature that uses CDict "unfaithful",
+# which disables plum's method cache and forces a full (~200x slower)
+# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
+CDict: TypeAlias = dict
 _DMLS = u.unit("")
 
 

--- a/src/coordinax/_src/internal/quantity_matrix/_utils.py
+++ b/src/coordinax/_src/internal/quantity_matrix/_utils.py
@@ -1,14 +1,18 @@
 """Shared utilities for the quantity_matrix package."""
 
-from typing import Any, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import unxt as u
 
-# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
-# annotation makes every plum signature that uses CDict "unfaithful",
-# which disables plum's method cache and forces a full (~200x slower)
-# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
-CDict: TypeAlias = dict
+if TYPE_CHECKING:
+    # Typed for static checkers only.
+    CDict: TypeAlias = dict[str, Any]
+else:
+    # A parametric `dict[...]` annotation makes every plum signature
+    # using CDict "unfaithful", disabling plum's method cache (a full
+    # ~200x slower resolution per call). The bare `dict` keeps the cache;
+    # the TYPE_CHECKING branch above preserves the static type.
+    CDict: TypeAlias = dict
 _DMLS = u.unit("")
 
 PackedUnitOutput: TypeAlias = tuple[u.AbstractUnit | None, ...]

--- a/src/coordinax/_src/internal/quantity_matrix/_utils.py
+++ b/src/coordinax/_src/internal/quantity_matrix/_utils.py
@@ -4,7 +4,11 @@ from typing import Any, TypeAlias, cast
 
 import unxt as u
 
-CDict: TypeAlias = dict[str, Any]
+# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
+# annotation makes every plum signature that uses CDict "unfaithful",
+# which disables plum's method cache and forces a full (~200x slower)
+# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
+CDict: TypeAlias = dict
 _DMLS = u.unit("")
 
 PackedUnitOutput: TypeAlias = tuple[u.AbstractUnit | None, ...]

--- a/src/coordinax/representations/_src/custom_types.py
+++ b/src/coordinax/representations/_src/custom_types.py
@@ -8,7 +8,7 @@ __all__ = (
     "CDict",
 )
 
-from typing import TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import unxt as u
 
@@ -22,8 +22,12 @@ OptUSys: TypeAlias = u.AbstractUnitSystem | None
 # Vector-related Types
 
 CKey: TypeAlias = str
-# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
-# annotation makes every plum signature that uses CDict "unfaithful",
-# which disables plum's method cache and forces a full (~200x slower)
-# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
-CDict: TypeAlias = dict
+if TYPE_CHECKING:
+    # Typed for static checkers only.
+    CDict: TypeAlias = dict[CKey, Any]
+else:
+    # A parametric `dict[...]` annotation makes every plum signature
+    # using CDict "unfaithful", disabling plum's method cache (a full
+    # ~200x slower resolution per call). The bare `dict` keeps the cache;
+    # the TYPE_CHECKING branch above preserves the static type.
+    CDict: TypeAlias = dict

--- a/src/coordinax/representations/_src/custom_types.py
+++ b/src/coordinax/representations/_src/custom_types.py
@@ -8,7 +8,7 @@ __all__ = (
     "CDict",
 )
 
-from typing import Any, TypeAlias
+from typing import TypeAlias
 
 import unxt as u
 
@@ -22,4 +22,8 @@ OptUSys: TypeAlias = u.AbstractUnitSystem | None
 # Vector-related Types
 
 CKey: TypeAlias = str
-CDict: TypeAlias = dict[CKey, Any]
+# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
+# annotation makes every plum signature that uses CDict "unfaithful",
+# which disables plum's method cache and forces a full (~200x slower)
+# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
+CDict: TypeAlias = dict

--- a/src/coordinax/transforms/_src/actions/custom_types.py
+++ b/src/coordinax/transforms/_src/actions/custom_types.py
@@ -2,7 +2,7 @@
 
 __all__ = ("Shape", "HasShape", "OptUSys", "CKey", "CDict")
 
-from typing import Protocol, TypeAlias, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, runtime_checkable
 
 import unxt as u
 
@@ -28,8 +28,12 @@ class HasShape(Protocol):
 OptUSys: TypeAlias = u.AbstractUnitSystem | None
 
 CKey: TypeAlias = str
-# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
-# annotation makes every plum signature that uses CDict "unfaithful",
-# which disables plum's method cache and forces a full (~200x slower)
-# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
-CDict: TypeAlias = dict
+if TYPE_CHECKING:
+    # Typed for static checkers only.
+    CDict: TypeAlias = dict[CKey, Any]
+else:
+    # A parametric `dict[...]` annotation makes every plum signature
+    # using CDict "unfaithful", disabling plum's method cache (a full
+    # ~200x slower resolution per call). The bare `dict` keeps the cache;
+    # the TYPE_CHECKING branch above preserves the static type.
+    CDict: TypeAlias = dict

--- a/src/coordinax/transforms/_src/actions/custom_types.py
+++ b/src/coordinax/transforms/_src/actions/custom_types.py
@@ -2,7 +2,7 @@
 
 __all__ = ("Shape", "HasShape", "OptUSys", "CKey", "CDict")
 
-from typing import Any, Protocol, TypeAlias, runtime_checkable
+from typing import Protocol, TypeAlias, runtime_checkable
 
 import unxt as u
 
@@ -28,4 +28,8 @@ class HasShape(Protocol):
 OptUSys: TypeAlias = u.AbstractUnitSystem | None
 
 CKey: TypeAlias = str
-CDict: TypeAlias = dict[CKey, Any]
+# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
+# annotation makes every plum signature that uses CDict "unfaithful",
+# which disables plum's method cache and forces a full (~200x slower)
+# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
+CDict: TypeAlias = dict

--- a/src/coordinax/vectors/_src/custom_types.py
+++ b/src/coordinax/vectors/_src/custom_types.py
@@ -2,12 +2,16 @@
 
 __all__ = ("Shape", "HasShape", "CKey", "CDict")
 
-from typing import Any, Protocol, TypeAlias, runtime_checkable
+from typing import Protocol, TypeAlias, runtime_checkable
 
 import unxt as u
 
 CKey: TypeAlias = str
-CDict: TypeAlias = dict[CKey, Any]
+# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
+# annotation makes every plum signature that uses CDict "unfaithful",
+# which disables plum's method cache and forces a full (~200x slower)
+# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
+CDict: TypeAlias = dict
 
 Shape: TypeAlias = tuple[int, ...]
 

--- a/src/coordinax/vectors/_src/custom_types.py
+++ b/src/coordinax/vectors/_src/custom_types.py
@@ -2,16 +2,20 @@
 
 __all__ = ("Shape", "HasShape", "CKey", "CDict")
 
-from typing import Protocol, TypeAlias, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, runtime_checkable
 
 import unxt as u
 
 CKey: TypeAlias = str
-# NOTE: deliberately the bare `dict`, not `dict[str, Any]`: a parametric
-# annotation makes every plum signature that uses CDict "unfaithful",
-# which disables plum's method cache and forces a full (~200x slower)
-# resolution on every call of `act`/`pt_map`/`cconvert`/etc.
-CDict: TypeAlias = dict
+if TYPE_CHECKING:
+    # Typed for static checkers only.
+    CDict: TypeAlias = dict[CKey, Any]
+else:
+    # A parametric `dict[...]` annotation makes every plum signature
+    # using CDict "unfaithful", disabling plum's method cache (a full
+    # ~200x slower resolution per call). The bare `dict` keeps the cache;
+    # the TYPE_CHECKING branch above preserves the static type.
+    CDict: TypeAlias = dict
 
 Shape: TypeAlias = tuple[int, ...]
 

--- a/tests/unit/transforms/test_dispatch_faithfulness.py
+++ b/tests/unit/transforms/test_dispatch_faithfulness.py
@@ -24,9 +24,9 @@ via::
 from jaxtyping import ArrayLike
 
 import jax
+import jax.numpy as jnp
 from plum import Signature
 
-import quaxed.numpy as jnp
 import unxt as u
 
 import coordinax.charts as cxc

--- a/tests/unit/transforms/test_dispatch_faithfulness.py
+++ b/tests/unit/transforms/test_dispatch_faithfulness.py
@@ -1,0 +1,74 @@
+"""Guard plum dispatch-cache faithfulness of the hot-path generic functions.
+
+plum only uses its (fast, type-keyed) method cache when every registered
+signature of a generic function is "faithful". Two things can silently break
+that and force a full (~200x slower) resolution on every call:
+
+1. A **parametric** annotation such as ``dict[str, Any]`` — hence ``CDict`` is
+   the bare ``dict`` (see ``custom_types.py``).
+2. An **unfaithful class**: ``jax.Array``'s metaclass overrides
+   ``__instancecheck__``, so plum treats it — and every ``ArrayLike`` union
+   containing it — as unfaithful *unless* ``jax.Array.__faithful__`` is set.
+   ``quax >= 0.3.6`` sets it (in ``quax._compat``), which is why plain
+   ``ArrayLike`` / ``jax.Array`` annotations are safe in dispatch signatures.
+
+The first test pins the upstream ``quax`` guarantee directly; the rest exercise
+each hot-path function once (resolvers populate lazily) and assert the whole
+resolver is faithful, so a future registration or dependency regression cannot
+silently degrade dispatch performance. If one fails, find the offending method
+via::
+
+    [m for m in fn._resolver.methods if not m.signature.is_faithful]
+"""
+
+import jax
+from jax.typing import ArrayLike
+from plum import Signature
+
+import quaxed.numpy as jnp
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.representations as cxr
+import coordinax.transforms as cxfm
+
+
+def _point():
+    return {"x": u.Q(1.0, "km"), "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")}
+
+
+def test_jax_array_and_arraylike_are_faithful():
+    # Provided by quax >= 0.3.6 (`jax.Array.__faithful__ = True`). If this
+    # fails, the quax floor regressed and every ArrayLike/jax.Array dispatch
+    # signature below silently loses the method cache.
+    assert Signature(jax.Array).is_faithful
+    assert Signature(ArrayLike).is_faithful
+
+
+def test_act_dispatch_is_faithful():
+    op = cxfm.Translate.from_([1, 2, 3], "km")
+    cxfm.act(op, None, _point(), cxc.cart3d, cxr.point)
+    cxfm.act(op, None, _point())
+    cxfm.act(op, None, u.Q([1.0, 0.0, 0.0], "km"))
+    cxfm.act(op, None, jnp.array([1.0, 0.0, 0.0]), usys=u.unitsystems.si)
+    assert cxfm.act._resolver.is_faithful
+
+
+def test_pushforward_dispatch_is_faithful():
+    op = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+    v = {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")}
+    cxfm.pushforward(op, None, v, cxc.cart3d, cxr.coord_vel)
+    assert cxfm.pushforward._resolver.is_faithful
+
+
+def test_prolong_dispatch_is_faithful():
+    op = cxfm.Translate.from_([1, 2, 3], "km")
+    jet = {0: _point()}
+    cxfm.prolong(op, None, jet, cxc.cart3d)
+    assert cxfm.prolong._resolver.is_faithful
+
+
+def test_pt_map_dispatch_is_faithful():
+    cxc.pt_map(_point(), cxc.cart3d, cxc.sph3d)
+    cxc.pt_map(jnp.array([1.0, 0.0, 0.0]), cxc.cart3d, cxc.sph3d, usys=u.unitsystems.si)
+    assert cxc.pt_map._resolver.is_faithful

--- a/tests/unit/transforms/test_dispatch_faithfulness.py
+++ b/tests/unit/transforms/test_dispatch_faithfulness.py
@@ -21,8 +21,9 @@ via::
     [m for m in fn._resolver.methods if not m.signature.is_faithful]
 """
 
+from jaxtyping import ArrayLike
+
 import jax
-from jax.typing import ArrayLike
 from plum import Signature
 
 import quaxed.numpy as jnp
@@ -38,6 +39,9 @@ def _point():
 
 
 def test_jax_array_and_arraylike_are_faithful():
+    # `ArrayLike` here is `jaxtyping.ArrayLike` — the exact type the hot-path
+    # dispatch signatures annotate with (e.g. register_apply / translate) — so
+    # this pins the type that actually matters, not merely `jax.typing`'s.
     # Provided by quax >= 0.3.6 (`jax.Array.__faithful__ = True`). If this
     # fails, the quax floor regressed and every ArrayLike/jax.Array dispatch
     # signature below silently loses the method cache.

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -581,7 +581,7 @@ requires-dist = [
     { name = "plum", marker = "python_full_version < '3.14'", specifier = ">=2.8.0" },
     { name = "plum", marker = "python_full_version >= '3.14'", specifier = ">=2.9.0" },
     { name = "pytest-benchmark", marker = "extra == 'benchmark'", specifier = ">=5.2.3" },
-    { name = "quax", specifier = ">=0.3.2" },
+    { name = "quax", specifier = ">=0.3.6" },
     { name = "quax-blocks", specifier = ">=0.4.1" },
     { name = "quaxed", specifier = ">=0.10.5" },
     { name = "typing-extensions", specifier = ">=4.13.2" },
@@ -911,8 +911,8 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "plum-dispatch", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "plum-dispatch" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/ba/2bfe199ce28195b1d5460ad1cb731661f7c3979a323cda569bf33f114e0d/dataclassish-0.8.0.tar.gz", hash = "sha256:15e9443f4bd6527112ca63a8512f9d7b147cf078ffd13b98e5e72737ee21ab5e", size = 54993, upload-time = "2025-02-14T23:51:28.752Z" }
 wheels = [
@@ -929,9 +929,9 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "optype", version = "0.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "plum-dispatch", marker = "python_full_version >= '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "optype", version = "0.17.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "plum-dispatch" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/67/835a8f06347fe630a030fa079028b1984ad81b7369b31dfbbfd4e2877750/dataclassish-0.9.0.tar.gz", hash = "sha256:310b0d6d00442ca93dbc9b3742a91e25e157582d10fd3e9e453d35767f5d9347", size = 73210, upload-time = "2026-03-22T14:34:52.156Z" }
 wheels = [
@@ -1853,7 +1853,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/7f/daa32a35b2a6a564a79723da49c0ddc464c462e67a906fc2b66a0d64f28e/optype-0.13.4.tar.gz", hash = "sha256:131d8e0f1c12d8095d553e26b54598597133830983233a6a2208886e7a388432", size = 99547, upload-time = "2025-08-19T19:52:44.242Z" }
 wheels = [
@@ -1870,7 +1870,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version == '3.12.*'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/9f/3b13bab05debf685678b8af004e46b8c67c6f98ffa08eaf5d33bcf162c16/optype-0.17.0.tar.gz", hash = "sha256:31351a1e64d9eba7bf67e14deefb286e85c66458db63c67dd5e26dd72e4664e5", size = 53484, upload-time = "2026-03-08T23:03:12.594Z" }
 wheels = [
@@ -2383,7 +2383,7 @@ wheels = [
 
 [[package]]
 name = "quax"
-version = "0.3.2"
+version = "0.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "equinox" },
@@ -2392,9 +2392,9 @@ dependencies = [
     { name = "packaging" },
     { name = "plum-dispatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/15/66c9a1a32168726ba0f4adeb158e737a012e2a2ec19c638dfa24f7d4b0ab/quax-0.3.2.tar.gz", hash = "sha256:94a1656c55f813ca5f6e76b69f085c8dcc701673928f7616af1f2536da158f62", size = 171557, upload-time = "2026-05-04T13:43:07.09Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/09/7d59f59e558f2fb573abef5a15d107f845d59f2b42cf9c40d7d92f7b13cf/quax-0.3.6.tar.gz", hash = "sha256:f879f9c9945393281cf219b76d4e531ef3b50e88b864041ab159c95305eef451", size = 175831, upload-time = "2026-06-29T20:22:28.982Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/08/ef6ff182c14090127dcb1cb0a7724e327b5a2ef0c0e3e8afcd1c5672441b/quax-0.3.2-py3-none-any.whl", hash = "sha256:d63ea1f6af06711ee256cfd38d19e980b9ded760c58c49a5ccb668d5f2a5c6c3", size = 39313, upload-time = "2026-05-04T13:43:05.48Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/8d/c3fd4c78ba0a128b79053a279bc5de4db6b81bcf8476726d45c64ff46b8b/quax-0.3.6-py3-none-any.whl", hash = "sha256:dbe08ddca8d6df4383feffa5943f7bceaa4d273fd588901d2a5819e36ffce815", size = 40887, upload-time = "2026-06-29T20:22:27.473Z" },
 ]
 
 [[package]]
@@ -2729,23 +2729,23 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.12'" },
-    { name = "babel", marker = "python_full_version < '3.12'" },
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version < '3.12'" },
-    { name = "imagesize", marker = "python_full_version < '3.12'" },
-    { name = "jinja2", marker = "python_full_version < '3.12'" },
-    { name = "packaging", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "requests", marker = "python_full_version < '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version < '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -2762,23 +2762,23 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -2811,7 +2811,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/f6/bdd93582b2aaad2cfe9eb5695a44883c8bc44572dd3c351a947acbb13789/sphinx_autodoc_typehints-3.6.1.tar.gz", hash = "sha256:fa0b686ae1b85965116c88260e5e4b82faec3687c2e94d6a10f9b36c3743e2fe", size = 37563, upload-time = "2026-01-02T15:23:46.543Z" }
 wheels = [
@@ -2828,7 +2828,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/75/75/9a5695b3d3b848a43cfe91c7d7d3c5ab543eb3bc5c2a12ffaf5003a2a4f6/sphinx_autodoc_typehints-3.10.2.tar.gz", hash = "sha256:34db651eb14343ba16bd9c03e0f5093971f9bbd3cc6b0a1470adecd578940b9c", size = 74241, upload-time = "2026-04-15T22:09:48.87Z" }
 wheels = [


### PR DESCRIPTION
> **Stacked on #534** — only the last commit is new relative to the merged base.

Part 1 of #535 (the funnel collapse is the remaining part).

## Summary

Restore plum's method cache on the transform/chart hot paths. plum only caches dispatch when **every** registered signature of a generic function is *faithful*; one unfaithful signature forces a full (~200 µs) resolution on every call — paid eagerly and re-paid at every jit retrace. `act`, `pushforward`, `prolong`, and `pt_map` were all unfaithful.

Two independent causes, two fixes:

1. **Parametric `CDict = dict[str, Any]`** is unfaithful. Make `CDict` the bare `dict` (membership is a plain `isinstance`, cacheable), across every `custom_types.py` that defines a `CDict`.
2. **`jax.Array`'s metaclass overrides `__instancecheck__`**, so plum treats it — and every `ArrayLike` union — as unfaithful. Fixed **upstream**: [quax v0.3.6](https://github.com/nstarman/quax/releases/tag/v0.3.6) sets `jax.Array.__faithful__ = True` (in `quax._compat`), so plain `ArrayLike`/`jax.Array` dispatch signatures are cacheable again. Bump the `quax` floor to `>=0.3.6` — **no coordinax-side wrapper needed**.

## Result

- `act._resolver.is_faithful` → **True**
- warm dispatch resolution: **~220 µs → ~0.4 µs (~580×)**

## Testing

`tests/unit/transforms/test_dispatch_faithfulness.py`:
- asserts the upstream `jax.Array`/`ArrayLike` faithfulness directly (guards against a quax-floor regression);
- exercises each hot-path function once and asserts its resolver stays faithful, so a future registration can't silently kill the cache.

Broad sweep green (1574 transforms/vectors tests).

## Note

An earlier revision added a coordinax-side `FaithfulArrayLike`/`FaithfulJaxArray` wrapper to work around the `jax.Array` metaclass issue. That's now unnecessary — quax v0.3.6 fixes it at the source for the whole ecosystem — so the wrapper is dropped; only the `CDict = dict` change and the `quax` floor bump remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)