### PR TITLE
♻️ refactor(transforms): consolidate audit cleanup findings

### DIFF
--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -261,13 +261,20 @@ def prolong(
 
     """
     import coordinax.api.transforms as cxfmapi  # noqa: PLC0415 - avoid cycle
-    from .prolong import prolong_jet  # noqa: PLC0415 - avoid cycle
+    from .prolong import (  # noqa: PLC0415 - avoid cycle
+        _MSG_JET_SLOT0_MISSING,
+        prolong_jet,
+    )
 
     if is_componentwise_offset(op, chart):
         # The jet supplies the base point, so fibre kicks (k >= 1) work even
         # cross-chart: `act` pushes the offset through the chart Jacobian at
         # jet[0] when needed. The anchor is only passed for tangent slots:
         # slot 0 IS the point, so a strict point dispatch need not accept it.
+        # Any tangent slot indexes jet[0], so require it explicitly here — a
+        # bare KeyError would otherwise mask the same guard prolong_jet gives.
+        if 0 not in jet and any(m != 0 for m in jet):
+            raise TypeError(_MSG_JET_SLOT0_MISSING)
         return {
             m: cxfmapi.act(
                 op,

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -2,6 +2,7 @@
 
 __all__ = ("AbstractAdd",)
 
+import functools as ft
 from dataclasses import KW_ONLY, replace
 
 from collections.abc import Callable
@@ -24,7 +25,7 @@ from .base import AbstractTransform
 from .composed import Composed
 from .custom_types import CDict
 from .identity import Identity, identity
-from .utils import Neg, is_flat_chart
+from .utils import Neg, is_componentwise_offset
 from coordinax.internal import jax_scalar_handler, pos_named_objs
 
 
@@ -210,8 +211,9 @@ def from_(cls: type[AbstractAdd], x: ArrayLike, unit: str) -> AbstractAdd:
 # prolong
 
 
+@ft.cache
 def _slot_rep(m: int, /) -> Any:
-    """Return the coordinate-basis representation for jet slot ``m``."""
+    """Return the coordinate-basis representation for jet slot ``m`` (cached)."""
     if m == 0:
         return cxr.point
     kind: cxr.AbstractTangentSemanticKind = cxr.vel
@@ -261,13 +263,11 @@ def prolong(
     import coordinax.api.transforms as cxfmapi  # noqa: PLC0415 - avoid cycle
     from .prolong import prolong_jet  # noqa: PLC0415 - avoid cycle
 
-    k = getattr(op, "semantic_kind", cxr.dpl).order
-    if k != 0 or (chart == op.chart and is_flat_chart(chart)):
-        # The jet always supplies the base point, so fibre kicks (k >= 1)
-        # work even cross-chart: `act` pushes the offset through the chart
-        # Jacobian at jet[0] when the charts differ.
-        # The base point anchors the tangent slots only: slot 0 IS the point,
-        # so it gets no 'at' (a strict point dispatch need not accept one).
+    if is_componentwise_offset(op, chart):
+        # The jet supplies the base point, so fibre kicks (k >= 1) work even
+        # cross-chart: `act` pushes the offset through the chart Jacobian at
+        # jet[0] when needed. The anchor is only passed for tangent slots:
+        # slot 0 IS the point, so a strict point dispatch need not accept it.
         return {
             m: cxfmapi.act(
                 op,
@@ -282,10 +282,7 @@ def prolong(
         }
 
     # A point-active offset (ladder order 0) outside the flat matching case
-    # is fully captured by the point action — whether the jet is in a
-    # different chart or the offset lives in a non-Cartesian chart (where the
-    # point action is base-point dependent and the slot-wise ladder rule does
-    # not apply) — so use the generic prolongation.
+    # is fully captured by the point action — use the generic prolongation.
     return prolong_jet(op, tau, jet, chart, usys=usys)
 
 
@@ -331,8 +328,7 @@ def pushforward(
     # A k=0 offset is a flat translation only when delta and the data live
     # in the same Cartesian-type chart; otherwise the differential is
     # base-point dependent. Defer to the generic engine.
-    k = getattr(op, "semantic_kind", cxr.dpl).order
-    if k == 0 and not (chart == op.chart and is_flat_chart(chart)):
+    if not is_componentwise_offset(op, chart):
         from .prolong import pushforward_generic  # noqa: PLC0415 - avoid cycle
 
         return pushforward_generic(op, tau, v, chart, rep, at=at, usys=usys)

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -19,12 +19,14 @@ import unxt as u
 from dataclassish import field_items
 from unxt.quantity import AllowValue, is_any_quantity
 
+import coordinax.api.transforms as cxfmapi
 import coordinax.charts as cxc
 import coordinax.representations as cxr
 from .base import AbstractTransform
 from .composed import Composed
 from .custom_types import CDict
 from .identity import Identity, identity
+from .prolong import _MSG_JET_SLOT0_MISSING, prolong_jet, pushforward_generic
 from .utils import Neg, is_componentwise_offset
 from coordinax.internal import jax_scalar_handler, pos_named_objs
 
@@ -260,12 +262,6 @@ def prolong(
     (Q(1., 'm'), Q(101., 'm / s'))
 
     """
-    import coordinax.api.transforms as cxfmapi  # noqa: PLC0415 - avoid cycle
-    from .prolong import (  # noqa: PLC0415 - avoid cycle
-        _MSG_JET_SLOT0_MISSING,
-        prolong_jet,
-    )
-
     if is_componentwise_offset(op, chart):
         # The jet supplies the base point, so fibre kicks (k >= 1) work even
         # cross-chart: `act` pushes the offset through the chart Jacobian at
@@ -336,8 +332,6 @@ def pushforward(
     # in the same Cartesian-type chart; otherwise the differential is
     # base-point dependent. Defer to the generic engine.
     if not is_componentwise_offset(op, chart):
-        from .prolong import pushforward_generic  # noqa: PLC0415 - avoid cycle
-
         return pushforward_generic(op, tau, v, chart, rep, at=at, usys=usys)
 
     del op, tau, chart, rep, at, usys

--- a/src/coordinax/transforms/_src/actions/base.py
+++ b/src/coordinax/transforms/_src/actions/base.py
@@ -415,6 +415,18 @@ def materialize_transform(op: OpT, tau: Any, /) -> OpT:
     # Partition into callable (tau-dependent) and static parameters
     dynamic, static = eqx.partition(params, filter_spec=callable)
 
+    # Materializing time-dependent parameters requires a time. Guarding here
+    # (the shared choke point) gives every operator an informative error
+    # instead of an arbitrary crash from inside the user's callable at
+    # p(None). Static operators have no dynamic leaves, so tau=None is fine.
+    if tau is None and any(leaf is not None for leaf in jtu.leaves(dynamic)):
+        msg = (
+            f"materialize_transform({type(op).__name__}, ...): the operator "
+            "has time-dependent (callable) parameters, which require a time "
+            "parameter; got tau=None."
+        )
+        raise TypeError(msg)
+
     # Evaluate the dynamic parameters at the given tau
     eval_dynamic = jtu.map(lambda p: p(tau), dynamic)
 

--- a/src/coordinax/transforms/_src/actions/boost.py
+++ b/src/coordinax/transforms/_src/actions/boost.py
@@ -16,7 +16,7 @@ import coordinax.charts as cxc
 import coordinax.representations as cxr
 from .add import AbstractAdd
 from .custom_types import CDict, OptUSys
-from .utils import is_flat_chart
+from .utils import is_componentwise_offset
 from coordinax.transforms._src.groups import AffineGroup, DiffeomorphismGroup
 
 if TYPE_CHECKING:
@@ -164,27 +164,29 @@ def act(
     {'x': Q(1., 'km / s2'), 'y': Q(0., 'km / s2'), 'z': Q(0., 'km / s2')}
 
     """
-    # --- Point input: x + dv * tau, via the Translate ladder machinery.
-    if rep == cxr.point:
-        if tau is None:
-            raise TypeError(_MSG_TAU_REQUIRED_POINT)
+
+    def delegate() -> CDict:
+        # The single delegation tail: the equivalent displacement Translate
+        # (delta(tau) = dv*tau) implements the ladder rule, the flat-chart
+        # gating, and the generic fallback with anchors (at=, at_vel=).
         return cast(
             "CDict",
             cxfmapi.act(_as_translate(op), tau, x, chart, rep, usys=usys, **kw),
         )
 
+    # --- Point input: x + dv * tau, via the Translate ladder machinery.
+    if rep == cxr.point:
+        if tau is None:
+            raise TypeError(_MSG_TAU_REQUIRED_POINT)
+        return delegate()
+
     # The closed forms below hold only when dv and the data live in the same
     # Cartesian-type (flat) chart, where the boost's point action is a flat
     # translation at each tau. Otherwise the action is base-point dependent
     # in the data's coordinates — delegate everything (including
-    # displacements) to the equivalent displacement Translate, whose generic
-    # fallback handles the anchors (at=, at_vel=) and raises informative
-    # errors when they are missing.
-    if not (chart == op.chart and is_flat_chart(chart)):
-        return cast(
-            "CDict",
-            cxfmapi.act(_as_translate(op), tau, x, chart, rep, usys=usys, **kw),
-        )
+    # displacements).
+    if not is_componentwise_offset(op, chart):
+        return delegate()
 
     # --- Tangent input of ladder order m, flat matching chart.
     m = rep.semantic_kind.order
@@ -210,6 +212,4 @@ def act(
     # whose ladder rule computes d^m (dv(tau) * tau) / dtau^m.
     if tau is None:
         raise TypeError(_MSG_TAU_REQUIRED_TANGENT.format(m=m))
-    return cast(
-        "CDict", cxfmapi.act(_as_translate(op), tau, x, chart, rep, usys=usys, **kw)
-    )
+    return delegate()

--- a/src/coordinax/transforms/_src/actions/boost.py
+++ b/src/coordinax/transforms/_src/actions/boost.py
@@ -2,7 +2,7 @@
 
 __all__ = ("Boost",)
 
-from typing import TYPE_CHECKING, Any, cast, final
+from typing import Any, cast, final
 
 import jax.tree as jtu
 import plum
@@ -16,11 +16,9 @@ import coordinax.charts as cxc
 import coordinax.representations as cxr
 from .add import AbstractAdd
 from .custom_types import CDict, OptUSys
+from .translate import Translate
 from .utils import is_componentwise_offset
 from coordinax.transforms._src.groups import AffineGroup, DiffeomorphismGroup
-
-if TYPE_CHECKING:
-    from .translate import Translate
 
 _MSG_TAU_REQUIRED_POINT = (
     "act(Boost, ...) on point data requires a time parameter: the Galilean "
@@ -111,10 +109,8 @@ def _boost_displacement(op: Boost, /) -> Any:
     return g
 
 
-def _as_translate(op: Boost, /) -> "Translate":
+def _as_translate(op: Boost, /) -> Translate:
     """Return the equivalent displacement Translate: delta = dv(tau) * tau."""
-    from .translate import Translate  # noqa: PLC0415 - avoid module cycle
-
     return Translate(_boost_displacement(op), chart=op.chart, right_add=op.right_add)
 
 

--- a/src/coordinax/transforms/_src/actions/composed.py
+++ b/src/coordinax/transforms/_src/actions/composed.py
@@ -290,13 +290,18 @@ def act(
     step_kw = dict(kw_rest)
     at_kw = {"at": current_at} if current_at is not None else {}
     result = x
-    for sub_op in op.transforms:
+    last = len(op.transforms) - 1
+    for i, sub_op in enumerate(op.transforms):
         if current_at is not None:
             step_kw["at"] = current_at
             at_kw["at"] = current_at
         if current_at_vel is not None:
             step_kw["at_vel"] = current_at_vel
         result = cxfmapi.act(sub_op, tau, result, chart, rep, **step_kw)
+        if i == last:
+            # The advanced anchors would never be read — skip the (eager-mode)
+            # dead work of transforming them through the final sub-op.
+            break
         # Advance the anchor jet (velocity first: it needs the old base point).
         if current_at_vel is not None:
             current_at_vel = cxfmapi.act(

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -148,6 +148,19 @@ def _jvp(fn: Callable[..., Any], primals: Any, tangents: Any, /) -> Any:
     return jax.jvp(fn, primals, tangents)
 
 
+def _eval_shape_or_call(f: Callable[..., Any], /, *args: Any) -> Any:
+    """Discover output structure/units via `jax.eval_shape`, else a real call.
+
+    Only `TypeError` (not abstractly traceable, e.g. concretization inside
+    the callable) triggers the real-call fallback; other errors (units,
+    shapes) propagate so genuine bugs are not masked.
+    """
+    try:
+        return jax.eval_shape(f, *args)
+    except TypeError:
+        return f(*args)
+
+
 # =============================================================================
 # tau_derivative: unit-aware d^n/dtau^n of a callable parameter
 
@@ -202,12 +215,7 @@ def tau_derivative(f: Callable[[Any], Any], tau: Any, /, *, n: int = 1) -> Any:
 
     # Discover the output structure and per-leaf units without a full
     # evaluation where possible (eval_shape preserves static unit metadata).
-    try:
-        y0 = jax.eval_shape(f, tau)
-    except TypeError:
-        # Not abstractly traceable (e.g. concretization inside f): fall back
-        # to a real call. Other errors (units, shapes) propagate.
-        y0 = f(tau)
+    y0 = _eval_shape_or_call(f, tau)
     leaves0, treedef = jtu.flatten(y0, is_leaf=is_any_quantity)
     units = [u.unit_of(leaf) for leaf in leaves0]
 
@@ -308,15 +316,9 @@ def _point_act_units(
     them without evaluating the action; a real evaluation is the fallback for
     non-traceable actions.
     """
-    try:
-        y0 = jax.eval_shape(
-            lambda q: cxfmapi.act(op, tau, q, chart, cxr.point, usys=usys), q0
-        )
-    except TypeError:
-        # Not abstractly traceable (e.g. concretization inside the point
-        # action): fall back to a real call. Other errors (units, shapes)
-        # propagate.
-        y0 = cxfmapi.act(op, tau, q0, chart, cxr.point, usys=usys)
+    y0 = _eval_shape_or_call(
+        lambda q: cxfmapi.act(op, tau, q, chart, cxr.point, usys=usys), q0
+    )
     return _cdict_units(cast("CDict", y0))
 
 

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -90,6 +90,7 @@ _MSG_AT_VEL_REQUIRED = (
 _MSG_JET_SLOT_MISSING = (
     "prolong({op}, ...) requires all jet slots 1..{m}; slot {k} is missing."
 )
+_MSG_JET_SLOT0_MISSING = "prolong requires the base point at jet slot 0."
 
 
 # =============================================================================
@@ -428,8 +429,7 @@ def prolong_jet(
 
     """
     if 0 not in jet:
-        msg = "prolong requires the base point at jet slot 0."
-        raise TypeError(msg)
+        raise TypeError(_MSG_JET_SLOT0_MISSING)
     q0 = jet[0]
     max_order = max(jet)
     for m in range(1, max_order + 1):

--- a/src/coordinax/transforms/_src/actions/rotate.py
+++ b/src/coordinax/transforms/_src/actions/rotate.py
@@ -27,7 +27,7 @@ import coordinax.representations as cxr
 from .base import AbstractTransform, materialize_transform
 from .custom_types import CDict, HasShape, OptUSys
 from .identity import identity
-from .prolong import _attach_leaf, _strip_leaf, prolong_slot
+from .prolong import _attach_leaf, _strip_leaf, _tau_value_unit, prolong_slot
 from .utils import Neg
 from coordinax.internal import pack_uniform_unit
 from coordinax.transforms._src import groups
@@ -428,18 +428,6 @@ def from_(cls: type[Rotate], obj: jtransform.Rotation, /) -> Rotate:
     return cls(obj.as_matrix())
 
 
-_MSG_TAU_REQUIRED_R = (
-    "act/pushforward(Rotate, ...) with a time-dependent (callable) rotation "
-    "matrix requires a time parameter; got tau=None."
-)
-
-
-def _check_tau(op: "Rotate", tau: Any, /) -> None:
-    """Raise an informative TypeError before materializing a callable R."""
-    if tau is None and callable(op.R):
-        raise TypeError(_MSG_TAU_REQUIRED_R)
-
-
 # ============================================================================
 # Simplification
 
@@ -510,7 +498,6 @@ def act(
         raise TypeError(msg)
 
     # Process rotation
-    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
     R = op_eval._get_R(chart)
 
@@ -548,7 +535,6 @@ def act(
         raise ValueError(msg)
 
     # Rotation matrix
-    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
     R = op_eval._get_R(chart)
     return jnp.einsum("ij,...j->...i", R, x)  # ty: ignore[invalid-return-type]
@@ -609,7 +595,6 @@ def act(
     # print("CART", cart.__class__, chart.__class__)
     comps_cart = cart.components
 
-    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
     R = op_eval._get_R(cart)
 
@@ -683,7 +668,6 @@ def _rotate_pushforward_cdict(
 
     """
     cart = chart.cartesian
-    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
     R = op_eval._get_R(cart)
 
@@ -812,11 +796,10 @@ def act(
     if m == 1 and chart == cart and tau is not None and at is not None:
         # Closed form in Cartesian components: v' = R v + dR/dtau x.
         # One jvp evaluates R(tau) and dR/dtau together.
-        tau_unit = u.unit_of(tau)
-        tau_val = u.ustrip(tau_unit, tau) if tau_unit is not None else jnp.asarray(tau)
+        tau_val, tau_unit = _tau_value_unit(tau)
         R_fn = op.R
         R, Rdot = jax.jvp(
-            lambda tv: R_fn(u.Q(tv, tau_unit) if tau_unit is not None else tv),  # ty: ignore[call-top-callable]
+            lambda tv: R_fn(_attach_leaf(tau_unit, tv)),  # ty: ignore[call-top-callable]
             (tau_val,),
             (jax.numpy.ones_like(tau_val),),
         )
@@ -881,7 +864,6 @@ def act(
       base-point.
 
     """
-    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
     n = op_eval._validate_square(op_eval.R).shape[-1]
 

--- a/src/coordinax/transforms/_src/actions/translate.py
+++ b/src/coordinax/transforms/_src/actions/translate.py
@@ -370,12 +370,12 @@ def act(
     if n == 0:
         delta = materialize_transform(op, tau).delta
     elif callable(op.delta):
+        # Differentiating the callable delta needs tau. Route the tau=None
+        # guard through materialize_transform (the shared choke point) so
+        # every callable-parameter tau error carries one consistent message
+        # instead of a Translate-specific one that can drift.
         if tau is None:
-            msg = (
-                "act(Translate, ...) with a time-dependent (callable) delta "
-                "requires a time parameter; got tau=None."
-            )
-            raise TypeError(msg)
+            materialize_transform(op, tau)  # raises the shared TypeError
         delta = tau_derivative(op.delta, tau, n=n)
     else:
         # Static delta: all tau-derivatives vanish.

--- a/src/coordinax/transforms/_src/actions/translate.py
+++ b/src/coordinax/transforms/_src/actions/translate.py
@@ -21,7 +21,7 @@ from .base import is_time_dependent, materialize_transform
 from .composed import Composed
 from .custom_types import CDict, OptUSys
 from .prolong import prolong_slot, tau_derivative
-from .utils import is_flat_chart
+from .utils import is_componentwise_offset
 from coordinax.internal import pack_uniform_unit
 from coordinax.transforms._src import groups
 
@@ -144,18 +144,6 @@ class Translate(AbstractAdd):
     # inverse and __neg__ inherited from AbstractAdd
 
 
-_MSG_TAU_REQUIRED = (
-    "act(Translate, ...) with a time-dependent (callable) delta requires a "
-    "time parameter; got tau=None."
-)
-
-
-def _check_tau(op: "Translate", tau: Any, /) -> None:
-    """Raise an informative TypeError before materializing a callable delta."""
-    if tau is None and callable(op.delta):
-        raise TypeError(_MSG_TAU_REQUIRED)
-
-
 # ============================================================================
 # act
 
@@ -228,7 +216,6 @@ def act(
     )
 
     # Process Translation
-    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
 
     # Convert delta to array using chart components and usys
@@ -290,7 +277,6 @@ def act(
         return x
 
     # Process Translation
-    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
 
     # Convert delta to array using chart components and usys
@@ -371,7 +357,7 @@ def act(
     # is nonlinear in the data's coordinates), the pushforward/prolongation
     # gains base-point-dependent coupling terms — defer to the generic
     # autodiff engine (which requires the base point 'at').
-    if k == 0 and not (chart == op.chart and is_flat_chart(chart)):
+    if not is_componentwise_offset(op, chart):
         return _act_translate_nonflat(op, tau, x, chart, rep, m, kw, usys)
 
     # Displacements are same-tau point differences (never gain dtau terms and
@@ -382,11 +368,14 @@ def act(
     # Contribution: d^(m-k) delta / dtau^(m-k).
     n = m - k
     if n == 0:
-        _check_tau(op, tau)
         delta = materialize_transform(op, tau).delta
     elif callable(op.delta):
         if tau is None:
-            raise TypeError(_MSG_TAU_REQUIRED)
+            msg = (
+                "act(Translate, ...) with a time-dependent (callable) delta "
+                "requires a time parameter; got tau=None."
+            )
+            raise TypeError(msg)
         delta = tau_derivative(op.delta, tau, n=n)
     else:
         # Static delta: all tau-derivatives vanish.
@@ -469,7 +458,6 @@ def _translate_point_cdict(
     usys: OptUSys = None,
 ) -> CDict:
     """Shift a point by the (materialized) delta, via the Cartesian chart."""
-    _check_tau(op, tau)
     op_eval = materialize_transform(op, tau)
 
     # Translate in Cartesian space, then map back.

--- a/src/coordinax/transforms/_src/actions/utils.py
+++ b/src/coordinax/transforms/_src/actions/utils.py
@@ -12,6 +12,9 @@ from typing import Any, final
 import jax.numpy as jnp
 import jax.tree as jtu
 
+import coordinax.representations as cxr
+from coordinax._src.exceptions import NoGlobalCartesianChartError
+
 
 def is_flat_chart(chart: Any, /) -> bool:
     """Whether ``chart`` is a Cartesian-type chart (its own canonical Cartesian).
@@ -25,10 +28,6 @@ def is_flat_chart(chart: Any, /) -> bool:
     flat: this predicate returns `False` rather than propagating
     `~coordinax.charts.NoGlobalCartesianChartError`.
     """
-    from coordinax._src.exceptions import (  # noqa: PLC0415 - avoid cycle
-        NoGlobalCartesianChartError,
-    )
-
     try:
         cart = chart.cartesian
     except NoGlobalCartesianChartError:
@@ -66,7 +65,5 @@ def is_componentwise_offset(op: Any, chart: Any, /) -> bool:
     `pushforward`, and `prolong` must all use it so the fast paths stay
     provably consistent with the generic prolongation.
     """
-    import coordinax.representations as cxr  # noqa: PLC0415 - avoid cycle
-
     k = getattr(op, "semantic_kind", cxr.dpl).order
     return k != 0 or (chart == op.chart and is_flat_chart(chart))

--- a/src/coordinax/transforms/_src/actions/utils.py
+++ b/src/coordinax/transforms/_src/actions/utils.py
@@ -3,7 +3,7 @@
 This module defines helpers for operator implementations.
 """
 
-__all__: tuple[str, ...] = ("Neg", "is_flat_chart")
+__all__: tuple[str, ...] = ("Neg", "is_componentwise_offset", "is_flat_chart")
 
 import dataclasses
 
@@ -51,3 +51,22 @@ class Neg:
     def __neg__(self) -> Any:
         """Return the original parameter."""
         return self.param
+
+
+def is_componentwise_offset(op: Any, chart: Any, /) -> bool:
+    """Whether an additive offset acts componentwise on data in ``chart``.
+
+    True for fibre-only offsets (ladder order k >= 1 — their point action is
+    the identity, so the componentwise rule is definitional), and for k = 0
+    offsets whose ``delta`` and data share the same Cartesian-type (flat)
+    chart (a true ambient translation). Everything else is base-point
+    dependent and must go through the generic engine.
+
+    This is THE routing predicate for the additive family — `act`,
+    `pushforward`, and `prolong` must all use it so the fast paths stay
+    provably consistent with the generic prolongation.
+    """
+    import coordinax.representations as cxr  # noqa: PLC0415 - avoid cycle
+
+    k = getattr(op, "semantic_kind", cxr.dpl).order
+    return k != 0 or (chart == op.chart and is_flat_chart(chart))

--- a/tests/benchmark/test_act_prolong.py
+++ b/tests/benchmark/test_act_prolong.py
@@ -124,3 +124,91 @@ def test_composed_five_ops_point(benchmark, jet):
     _bench_jitted(
         benchmark, lambda x: cxfm.act(op, None, x, cxc.cart3d, cxr.point), jet[0]
     )
+
+
+# ---------------------------------------------------------------------------
+# Eager-mode and trace-time benchmarks.
+#
+# The jitted steady-state guards above cannot detect regressions in the new
+# Python-side machinery (plum dispatch, materialization, anchor threading,
+# unit discovery): after compilation none of it runs, and XLA DCE removes
+# dead work from the compiled graph. These benchmarks measure where that
+# cost actually lives — per-call eager overhead and jit trace/lower time.
+
+
+class TestEagerOverhead:
+    """Eager (un-jitted) per-call cost of the dispatch + engine machinery."""
+
+    def test_eager_static_translate_point(self, benchmark):
+        op = cxfm.Translate.from_([1.0, 2.0, 3.0], "km")
+        p = q3(0.0, 0.0, 0.0, "km")
+        cxfm.act(op, None, p, cxc.cart3d, cxr.point)  # warm dispatch caches
+        benchmark(lambda: cxfm.act(op, None, p, cxc.cart3d, cxr.point))
+
+    def test_eager_td_translate_velocity(self, benchmark):
+        op = cxfm.Translate(
+            lambda t: {
+                "x": u.Q(3.0, "km/s") * t,
+                "y": u.Q(0.0, "km"),
+                "z": u.Q(0.0, "km"),
+            },
+            chart=cxc.cart3d,
+        )
+        tau = u.Q(2.0, "s")
+        v = q3(1.0, 0.0, 0.0, "km/s")
+        cxfm.act(op, tau, v, cxc.cart3d, cxr.coord_vel)
+        benchmark(lambda: cxfm.act(op, tau, v, cxc.cart3d, cxr.coord_vel))
+
+    def test_eager_composed_anchored_velocity(self, benchmark):
+        """The anchor-threading loop — the dominant eager tangent cost."""
+        shift = cxfm.Translate.from_([1.0, 0.0, 0.0], "km")
+        moving = cxfm.Translate(
+            lambda t: {
+                "x": u.Q(3.0, "km/s") * t,
+                "y": u.Q(0.0, "km"),
+                "z": u.Q(0.0, "km"),
+            },
+            chart=cxc.cart3d,
+        )
+        op = shift | moving | shift
+        tau = u.Q(2.0, "s")
+        at = q3(1.0, 2.0, 3.0, "km")
+        v = q3(1.0, 0.0, 0.0, "km/s")
+        cxfm.act(op, tau, v, cxc.cart3d, cxr.coord_vel, at=at)
+        benchmark(lambda: cxfm.act(op, tau, v, cxc.cart3d, cxr.coord_vel, at=at))
+
+
+class TestTraceTime:
+    """jit trace+lower cost — where per-op Python machinery lands under jit."""
+
+    def test_trace_composed5_point(self, benchmark):
+        ops = [cxfm.Translate.from_([float(i), 0.0, 0.0], "km") for i in range(5)]
+        op = ops[0] | ops[1] | ops[2] | ops[3] | ops[4]
+        p = q3(0.0, 0.0, 0.0, "km")
+
+        def trace():
+            return jax.jit(
+                lambda x: cxfm.act(op, None, x, cxc.cart3d, cxr.point)
+            ).lower(p)
+
+        trace()
+        benchmark(trace)
+
+    def test_trace_td_prolong_2jet(self, benchmark, jet):
+        op = cxfm.Translate(
+            lambda t: {
+                "x": 0.5 * u.Q(2.0, "km/s2") * t**2,
+                "y": u.Q(0.0, "km"),
+                "z": u.Q(0.0, "km"),
+            },
+            chart=cxc.cart3d,
+        )
+        tau = u.Q(2.0, "s")
+
+        def trace():
+            return jax.jit(lambda t, j: cxfm.prolong(op, t, j, cxc.cart3d)).lower(
+                tau, jet
+            )
+
+        trace()
+        benchmark(trace)

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -464,6 +464,19 @@ class TestErrors:
         with pytest.raises(TypeError, match="slot 1 is missing"):
             cxfm.prolong(op, u.Q(1.0, "s"), jet, cxc.cart3d)
 
+    def test_prolong_additive_missing_slot0(self):
+        # The componentwise (additive) path indexes jet[0] for tangent slots;
+        # a jet without slot 0 must raise the same TypeError as the generic
+        # engine, not a bare KeyError.
+        kick = cxfm.Translate(
+            {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+            chart=cxc.cart3d,
+            semantic_kind=cxr.vel,
+        )
+        jet = {1: q3(0.0, 0.0, 0.0, "m/s")}
+        with pytest.raises(TypeError, match="jet slot 0"):
+            cxfm.prolong(kick, None, jet, cxc.cart3d)
+
     def test_prolong_additive_skips_intermediate_slots(self):
         # Additive ops prolong slot-wise: no intermediate slots required.
         moving = cxfm.Translate(

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -424,9 +424,9 @@ class TestErrors:
         """Materializing a callable R without tau raises informatively."""
         op = cxfm.Rotate.from_(rot_z)
         d = q3(1.0, 0.0, 0.0, "m")
-        with pytest.raises(TypeError, match=r"time-dependent \(callable\) rotation"):
+        with pytest.raises(TypeError, match=r"time-dependent \(callable\) parameters"):
             cxfm.pushforward(op, None, d, cxc.cart3d, cxr.coord_disp)
-        with pytest.raises(TypeError, match=r"time-dependent \(callable\) rotation"):
+        with pytest.raises(TypeError, match=r"time-dependent \(callable\) parameters"):
             cxfm.act(op, None, d, cxc.cart3d, cxr.point)
 
     def test_td_translate_point_requires_tau(self):
@@ -435,7 +435,7 @@ class TestErrors:
             lambda t: q3(t.ustrip("s"), 0.0, 0.0, "km"), chart=cxc.cart3d
         )
         p = q3(0.0, 0.0, 0.0, "km")
-        with pytest.raises(TypeError, match=r"time-dependent \(callable\) delta"):
+        with pytest.raises(TypeError, match=r"time-dependent \(callable\) parameters"):
             cxfm.act(moving, None, p, cxc.cart3d, cxr.point)
 
     def test_td_vel_kick_matching_order_requires_tau(self):
@@ -446,7 +446,7 @@ class TestErrors:
             semantic_kind=cxr.vel,
         )
         v = q3(0.0, 0.0, 0.0, "km/s")
-        with pytest.raises(TypeError, match=r"time-dependent \(callable\) delta"):
+        with pytest.raises(TypeError, match=r"time-dependent \(callable\) parameters"):
             cxfm.act(kick, None, v, cxc.cart3d, cxr.coord_vel)
 
     def test_td_translate_tangent_requires_tau(self):


### PR DESCRIPTION
## Summary

The mechanical consolidation items deferred from the #532 pre-merge audit. Behavior-preserving throughout — the fast-path==generic keystone property tests guard every change — with one small capability gain that falls out of the unification.

**Stacked on** #532 → #533 → #540 (only the last commit is new here; review after those merge, or view the [top commit](https://github.com/GalacticDynamics/coordinax/compare/vecs/act-dispatch-caching...vecs/act-cleanup-consolidation) directly).

### One rule, one place

- **`is_componentwise_offset(op, chart)`** — the additive family's routing predicate ("does this offset act componentwise on data in this chart?") was spelled four slightly different ways across `Translate.act`, `AbstractAdd.pushforward`, `AbstractAdd.prolong`, and `Boost.act`, and was re-fixed twice in sequence during #532's review (362509f4, d55fbd67). It is now one function in `actions/utils.py` used by all four sites.
- **τ-guard in `materialize_transform`** — the "callable params require tau" check moves into the shared choke point, deleting the two per-operator `_check_tau` helpers and three drifting message wordings. Any future operator with callable parameters gets the informative error for free.
- **`_eval_shape_or_call`** — the duplicated eval_shape-with-TypeError-fallback blocks in `tau_derivative` and `_point_act_units` now share one helper, so the subtle fallback policy (only TypeError falls back; unit/shape errors propagate) lives in exactly one place.
- **Boost** — three copies of the Translate-delegation call collapse into one closure; **Rotate** — the closed-form velocity path reuses `_tau_value_unit`/`_attach_leaf` instead of inlining the None-unit convention.

### Capability gain

`AbstractAdd.prolong` now passes `at=jet[0]` to its slot-wise acts, so **fibre kicks work cross-chart inside jets** (the jet supplies the base point) — removing the last cross-chart `ValueError` in the additive family and matching `act`'s behavior from #532.

### Efficiency

- Composed's anchored tangent act skips advancing the anchors after the final sub-op (dead work in eager mode).
- `_slot_rep` is cached (it rebuilt `Representation` objects in a Python loop per slot per call).
- **Benchmarks that can actually catch regressions**: eager-mode and jit trace/lower-time benchmarks added. The audit found the existing jitted steady-state guards measure only cached XLA dispatch (~µs constant) — none of the Python-side machinery where this PR family's costs live runs after compilation, and XLA DCE removes dead work from the compiled graph.

### Deferred by design (tracked)

The jet-first anchor API (#536), shared-base linear-transform dedup (#538), pairwise simplify/affine collapse (#539), and declaring `semantic_kind` on `AbstractAdd` (#537/#538) — audit evidence recorded on each issue.

## Test plan

- Full sweep: 6,777 passed (core + curveframes + astro + usage), benchmarks smoke-tested with `--benchmark-disable`.
- ruff/ty clean; the three τ-guard tests updated to the new shared message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)