### PR TITLE
♻️ refactor(act): collapse the input funnel; guarantee cross-input consistency (#535)

### DIFF
--- a/src/coordinax/transforms/_src/actions/register_apply.py
+++ b/src/coordinax/transforms/_src/actions/register_apply.py
@@ -3,7 +3,7 @@
 __all__: tuple[str, ...] = ()
 
 from jaxtyping import Array, ArrayLike
-from typing import Any, Final, TypeAlias, cast
+from typing import Any, TypeAlias, cast
 
 import plum
 
@@ -17,11 +17,6 @@ import coordinax.representations as cxr
 from .base import AbstractTransform
 from .custom_types import CDict
 from coordinax.internal import QMatrix, pack_nonuniform_unit, pack_uniform_unit
-
-_MSG_CHARTS_MATCH: Final = (
-    "inferred chart guess_chart(x)={0.__class__.__name__} "
-    "does not match provided chart {1.__class__.__name__}"
-)
 
 # A "point-like" input the entry funnel accepts. Faithful (each member and the
 # union), so the normalizer methods below stay in plum's method cache.

--- a/src/coordinax/transforms/_src/actions/register_apply.py
+++ b/src/coordinax/transforms/_src/actions/register_apply.py
@@ -36,6 +36,14 @@ PointLike: TypeAlias = ArrayLike | AbcQ | QMatrix | CDict
 # role is guessed from them.
 
 
+# NB: the return type is ``Any`` on purpose. plum performs runtime return-type
+# *conversion*, and a concrete `cxr.Representation` return trips the class's
+# invariant generic (``cxr.point`` is ``Representation[PointGeometry, ...]``),
+# while a `[Any, Any, Any]`-parametrized return breaks plum's converter. Both
+# were verified to fail; ``Any`` is the only annotation that is correct at
+# runtime and clean under the type checker.
+
+
 @plum.dispatch
 def _default_rep(x: ArrayLike, /) -> Any:
     return cxr.point
@@ -65,6 +73,11 @@ def _default_rep(x: CDict, /) -> Any:
 # generic coercion fallback for operators without a typed fast path. This
 # replaces the former per-input-type × arity boilerplate (and its ``-1``
 # precedence tier).
+#
+# The return type is ``Any``: these methods return the SAME container type they
+# receive (Array->Array, Quantity->Quantity, ...), which the type system can't
+# express, and because plum converts return values at runtime a `PointLike`
+# union return coerces/mangles the result (verified against the test suite).
 
 
 @plum.dispatch

--- a/src/coordinax/transforms/_src/actions/register_apply.py
+++ b/src/coordinax/transforms/_src/actions/register_apply.py
@@ -7,6 +7,7 @@ from typing import Any, Final, TypeAlias, cast
 
 import plum
 
+import quaxed.numpy as jnp
 import unxt as u
 from unxt import AbstractQuantity as AbcQ
 
@@ -25,6 +26,25 @@ _MSG_CHARTS_MATCH: Final = (
 # A "point-like" input the entry funnel accepts. Faithful (each member and the
 # union), so the normalizer methods below stay in plum's method cache.
 PointLike: TypeAlias = ArrayLike | AbcQ | QMatrix | CDict
+
+
+# ===================================================================
+# Input coercion
+#
+# `guess_chart` only dispatches on JAX arrays, Quantities, and CDicts, so a bare
+# `ArrayLike` (a list, a NumPy array, a scalar) must be coerced to a JAX array
+# before chart inference. Quantity / QMatrix / CDict are passed through
+# unchanged (they already carry the structure `guess_chart` needs).
+
+
+@plum.dispatch
+def _as_data(x: PointLike, /) -> Any:
+    return x
+
+
+@plum.dispatch
+def _as_data(x: ArrayLike, /) -> Any:
+    return jnp.asarray(x)
 
 
 # ===================================================================
@@ -113,6 +133,7 @@ def act(op: AbstractTransform, tau: Any, x: PointLike, /, **kw: Any) -> Any:
     Q([0., 1., 0.], 'km')
 
     """
+    x = _as_data(x)
     chart = cxc.guess_chart(x)
     return cxfmapi.act(op, tau, x, chart, _default_rep(x), **kw)
 
@@ -139,6 +160,7 @@ def act(
     Q([0., 1., 0.], 'km')
 
     """
+    x = _as_data(x)
     return cxfmapi.act(op, tau, x, chart, _default_rep(x), **kw)
 
 
@@ -169,9 +191,9 @@ def act(
     >>> import coordinax.main as cx
 
     >>> op = cx.Rotate.from_euler("z", u.Q(90, "deg"))
-    >>> q = u.Q([1, 0, 0], "km")
-    >>> cx.act(op, None, q, cx.cart3d, cx.point).round(3)
-    Q([0., 1., 0.], 'km')
+    >>> x = jnp.asarray([1.0, 0.0, 0.0])
+    >>> cx.act(op, None, x, cx.cart3d, cx.point).round(3)
+    Array([0., 1., 0.], dtype=float64)
 
     """
     out = cxfmapi.act(op, tau, x, chart, rep.geom_kind, rep, **kw)

--- a/src/coordinax/transforms/_src/actions/register_apply.py
+++ b/src/coordinax/transforms/_src/actions/register_apply.py
@@ -3,11 +3,10 @@
 __all__: tuple[str, ...] = ()
 
 from jaxtyping import Array, ArrayLike
-from typing import Any, Final, cast
+from typing import Any, Final, TypeAlias, cast
 
 import plum
 
-import quaxed.numpy as jnp
 import unxt as u
 from unxt import AbstractQuantity as AbcQ
 
@@ -23,17 +22,57 @@ _MSG_CHARTS_MATCH: Final = (
     "does not match provided chart {1.__class__.__name__}"
 )
 
+# A "point-like" input the entry funnel accepts. Faithful (each member and the
+# union), so the normalizer methods below stay in plum's method cache.
+PointLike: TypeAlias = ArrayLike | AbcQ | QMatrix | CDict
+
+
 # ===================================================================
-# On Array(like) inputs
+# Per-input-type representation default
+#
+# When ``rep`` is omitted the default depends only on the INPUT TYPE, not the
+# operator: a bare array / QMatrix carries no unit information to infer a role
+# from, so it defaults to ``point``; a Quantity / CDict carries units, so the
+# role is guessed from them.
 
 
 @plum.dispatch
-def act(op: AbstractTransform, tau: Any, x: ArrayLike, /, **kw: Any) -> Array:
-    """Apply an operator to an Array(like) object.
+def _default_rep(x: ArrayLike, /) -> Any:
+    return cxr.point
 
-    The Array is interpreted as equivalent to the data for a ``Vector``
-    with a Cartesian chart (e.g. `coordinax.charts.Cartesian3D`) and
-    `coordinax.representations.PointGeometry` geometry.
+
+@plum.dispatch
+def _default_rep(x: QMatrix, /) -> Any:
+    return cxr.point
+
+
+@plum.dispatch
+def _default_rep(x: AbcQ, /) -> Any:
+    return cxr.guess_rep(x)
+
+
+@plum.dispatch
+def _default_rep(x: CDict, /) -> Any:
+    return cxr.guess_rep(x)
+
+
+# ===================================================================
+# Normalize-once entry funnel
+#
+# One pair of arity-3 / arity-4 methods fills in the missing ``chart`` (guessed
+# once) and ``rep`` (per-type default), then redispatches to the arity-5 typed
+# ``act`` — the per-(operator, input-type) JAX fast paths, or the arity-5
+# generic coercion fallback for operators without a typed fast path. This
+# replaces the former per-input-type × arity boilerplate (and its ``-1``
+# precedence tier).
+
+
+@plum.dispatch
+def act(op: AbstractTransform, tau: Any, x: PointLike, /, **kw: Any) -> Any:
+    """Infer the chart and representation, then apply the operator.
+
+    A bare input is interpreted as the data for a `coordinax.Point` in its
+    guessed (Cartesian) chart.
 
     >>> import jax.numpy as jnp
     >>> import unxt as u
@@ -54,52 +93,48 @@ def act(op: AbstractTransform, tau: Any, x: ArrayLike, /, **kw: Any) -> Array:
     >>> cxfm.act(op, None, x, usys=usys).round(3)
     Array([1000.,    1.,    0.], dtype=float64)
 
+    A Quantity carries units, so its role is inferred from them:
+
+    >>> q = u.Q([1, 0, 0], "km")
+    >>> cxfm.act(R, None, q).round(3)
+    Q([0., 1., 0.], 'km')
+
     """
-    x_arr = jnp.asarray(x)  # Ensure array type
-    chart = cxc.guess_chart(x_arr)  # extract chart
-    # Redispatch (op, tau, x) -> (op, tau, x, chart, rep)
-    out = cxfmapi.act(op, tau, x, chart, cxr.point, **kw)
-    return cast("Array", out)
+    chart = cxc.guess_chart(x)
+    return cxfmapi.act(op, tau, x, chart, _default_rep(x), **kw)
 
 
 @plum.dispatch
 def act(
     op: AbstractTransform,
     tau: Any,
-    x: ArrayLike,
+    x: PointLike,
     chart: cxc.AbstractChart,
     /,
     **kw: Any,
-) -> Array:
-    """Apply an operator to an Array(like) object.
-
-    The Array is interpreted as equivalent to the data for a ``Vector``
-    with a Cartesian chart (e.g. `coordinax.charts.Cartesian3D`) and
-    `coordinax.representations.PointGeometry` geometry.
+) -> Any:
+    """Infer the representation, then apply the operator.
 
     >>> import jax.numpy as jnp
     >>> import unxt as u
-    >>> import coordinax.main as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.transforms as cxfm
 
-    >>> usys = u.unitsystems.si
-    >>> x = jnp.asarray([1, 0, 0])  # [m]
-
-    >>> T = cx.Translate.from_([1, 0, 0], "km")
-    >>> cx.act(T, None, x, cxc.cart3d, usys=usys).round(3)  # needs usys
-    Array([1001.,    0.,    0.], dtype=float64)
-
-    >>> R = cx.Rotate.from_euler("z", u.Q(90, "deg"))
-    >>> cx.act(R, None, x, cx.cart3d).round(3) # no usys required
-    Array([0., 1., 0.], dtype=float64)
-
-    >>> op = R | T  # rotate then translate
-    >>> cx.act(op, None, x, cx.cart3d, usys=usys).round(3)
-    Array([1000.,    1.,    0.], dtype=float64)
+    >>> R = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+    >>> q = u.Q([1, 0, 0], "km")
+    >>> cxfm.act(R, None, q, cxc.cart3d).round(3)
+    Q([0., 1., 0.], 'km')
 
     """
-    # (op, tau, x, chart) -> (op, tau, x, chart, rep)
-    out = cxfmapi.act(op, tau, x, chart, cxr.point, **kw)
-    return cast("Array", out)
+    return cxfmapi.act(op, tau, x, chart, _default_rep(x), **kw)
+
+
+# ===================================================================
+# Arity-5 typed fallbacks: coerce non-CDict inputs to a Cartesian CDict, act,
+# and repack. Operators with a typed arity-5 fast path (rotate.py, translate.py,
+# ...) override these by concrete-type specificity; these serve the rest.
+#
+# On Array(like) inputs
 
 
 @plum.dispatch
@@ -114,9 +149,7 @@ def act(
 ) -> Array:
     """Apply an operator to an Array(like) object.
 
-    The Array is interpreted as equivalent to the data for a ``Vector``
-    with a Cartesian chart (e.g. `coordinax.charts.Cartesian3D`) and
-    `coordinax.representations.PointGeometry` geometry.
+    The Array is interpreted as Cartesian point coordinates.
 
     >>> import jax.numpy as jnp
     >>> import unxt as u
@@ -136,68 +169,6 @@ def act(
 # On Quantity inputs
 
 
-# Precedence=-1 so it's easily overridden, like by `Identity`.
-@plum.dispatch(precedence=-1)  # ty: ignore[no-matching-overload]
-def act(op: AbstractTransform, tau: Any, x: AbcQ, /, **kw: Any) -> AbcQ:
-    """Apply an operator to a Quantity.
-
-    The Quantity is interpreted as equivalent to the data for a
-    `coordinax.Point` with a Cartesian chart (e.g.
-    `coordinax.charts.Cartesian3D`) and
-    `coordinax.representations.PointGeometry` geometry.
-
-    >>> import jax.numpy as jnp
-    >>> import unxt as u
-    >>> import coordinax.main as cx
-
-    >>> op = cx.Rotate.from_euler("z", u.Q(90, "deg"))
-    >>> q = u.Q([1, 0, 0], "km")
-    >>> cx.act(op, None, q).round(3)
-    Q([0., 1., 0.], 'km')
-
-    """
-    # Redispatch based on the inferred role & chart
-    chart = cxc.guess_chart(x)
-    rep = cxr.guess_rep(x)
-    out = cxfmapi.act(op, tau, x, chart, rep, **kw)
-    return cast("AbcQ", out)
-
-
-@plum.dispatch
-def act(
-    op: AbstractTransform,
-    tau: Any,
-    x: AbcQ,
-    chart: cxc.AbstractChart,
-    /,
-    **kw: Any,
-) -> AbcQ:
-    """Apply operator, routing through dictionary-based implementation.
-
-    >>> import jax.numpy as jnp
-    >>> import unxt as u
-    >>> import coordinax.transforms as cxfm
-
-    >>> op = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
-    >>> q = u.Q([1, 0, 0], "km")
-
-    Directly access this registered method, bypassing more efficient methods.
-
-    >>> func = cxfm.act.invoke(cxfm.Rotate, None, u.Q, cxc.Cart3D)
-    >>> func(op, None, q, cxc.cart3d).round(3)
-    Q([0., 1., 0.], 'km')
-
-    """
-    # Get the Cartesian CDict of the input Quantity
-    v = cxc.cdict(x, chart)
-    # Apply the operator to the CDict representation
-    rep = cxr.guess_rep(v)
-    nv = cxfmapi.act(op, tau, v, chart, rep, **kw)
-    # Stack back to a Quantity (homogeneous unit since Cartesian)
-    nva, unit = pack_uniform_unit(nv, keys=chart.components)  # ty: ignore[no-matching-overload]
-    return u.Q(jnp.stack(nva, axis=-1), unit)
-
-
 @plum.dispatch
 def act(
     op: AbstractTransform,
@@ -208,7 +179,7 @@ def act(
     /,
     **kw: Any,
 ) -> AbcQ:
-    """Apply operator, routing through dictionary-based implementation.
+    """Apply operator, routing through the CDict-based implementation.
 
     >>> import jax.numpy as jnp
     >>> import unxt as u
@@ -238,76 +209,11 @@ def act(
 # ===================================================================
 # On QMatrix inputs
 #
-# Precedence=2 on all QMatrix dispatches so they are preferred over
-# the (SpecificTransform, AbstractQuantity) dispatches in rotate.py,
-# translate.py, and composed.py (precedence=0) AND over the Identity
-# catch-all (precedence=1). Without this, plum sees e.g.
-# (Composed, tau, QM) as ambiguous between (Composed, tau, AbcQ) and
-# (AbstractTransform, tau, QM).
-
-
-@plum.dispatch(precedence=2)  # ty: ignore[no-matching-overload]
-def act(op: AbstractTransform, tau: Any, x: QMatrix, /, **kw: Any) -> QMatrix:
-    """Apply an operator to a ``QMatrix``.
-
-    The chart is inferred from the matrix size and the representation defaults
-    to ``point``.
-
-    >>> import jax.numpy as jnp
-    >>> import unxt as u
-    >>> import coordinax.transforms as cxfm
-    >>> from coordinax.internal import QMatrix
-
-    >>> op = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
-    >>> qm = QMatrix(
-    ...     jnp.array([1.0, 0.0, 0.0]),
-    ...     unit=(u.unit("km"), u.unit("km"), u.unit("km")),
-    ... )
-    >>> result = cxfm.act(op, None, qm)
-    >>> result.value.round(3)
-    Array([0., 1., 0.], dtype=float64)
-
-    """
-    chart = cxc.guess_chart(x)
-    out = cxfmapi.act(op, tau, x, chart, cxr.point, **kw)
-    return cast("QMatrix", out)
-
-
-@plum.dispatch(precedence=2)  # ty: ignore[no-matching-overload]
-def act(
-    op: AbstractTransform,
-    tau: Any,
-    x: QMatrix,
-    chart: cxc.AbstractChart,
-    /,
-    **kw: Any,
-) -> QMatrix:
-    """Apply an operator to a ``QMatrix`` with explicit chart.
-
-    >>> import jax.numpy as jnp
-    >>> import unxt as u
-    >>> import coordinax.charts as cxc
-    >>> import coordinax.transforms as cxfm
-    >>> from coordinax.internal import QMatrix
-
-    >>> qm = QMatrix(
-    ...     jnp.array([1.0, 0.0, 0.0]),
-    ...     unit=("km", "km", "km"),
-    ... )
-
-    >>> op = cxfm.Translate.from_([1, 0, 0], "km")
-    >>> result = cxfm.act(op, None, qm, cxc.cart3d)
-    >>> result.value.round(3)
-    Array([2., 0., 0.], dtype=float64)
-
-    >>> op = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
-    >>> result = cxfm.act(op, None, qm, cxc.cart3d)
-    >>> result.value.round(3)
-    Array([0., 1., 0.], dtype=float64)
-
-    """
-    out = cxfmapi.act(op, tau, x, chart, cxr.point, **kw)
-    return cast("QMatrix", out)
+# Precedence=2 so QMatrix (a subclass of AbstractQuantity) prefers this typed
+# path over the (SpecificTransform, AbstractQuantity) fast paths in rotate.py /
+# translate.py / composed.py (precedence 0) AND over the Identity catch-all
+# (precedence 1). Without it, e.g. (Composed, tau, QMatrix) is ambiguous between
+# (Composed, tau, AbcQ) and (AbstractTransform, tau, QMatrix).
 
 
 @plum.dispatch(precedence=2)  # ty: ignore[no-matching-overload]
@@ -349,55 +255,3 @@ def act(
     # Repack CDict → QMatrix
     arr, units = pack_nonuniform_unit(nv, keys=chart.components)
     return QMatrix(arr, unit=units)
-
-
-# ===================================================================
-# On CDict inputs
-
-
-@plum.dispatch
-def act(op: AbstractTransform, tau: Any, x: CDict, /, **kw: Any) -> CDict:
-    """Apply operator to a CDict representation of a vector.
-
-    >>> import jax.numpy as jnp
-    >>> import unxt as u
-    >>> import coordinax.transforms as cxfm
-
-    >>> op = cxfm.Rotate([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
-    >>> data = {"x": u.Q(1, "km"), "y": u.Q(0, "km"), "z": u.Q(0, "km")}
-    >>> cxfm.act(op, None, data)
-    {'x': Q(0, 'km'), 'y': Q(1, 'km'), 'z': Q(0, 'km')}
-
-    """
-    # Infer rep and chart from the CDict
-    chart = cxc.guess_chart(x)
-    rep = cxr.guess_rep(x)
-
-    # Redispatch to the main implementation
-    out = cxfmapi.act(op, tau, x, chart, rep, **kw)
-    return cast("CDict", out)
-
-
-@plum.dispatch
-def act(
-    op: AbstractTransform, tau: Any, x: CDict, chart: cxc.AbstractChart, /, **kw: Any
-) -> CDict:
-    """Apply operator to a CDict representation of a vector.
-
-    >>> import jax.numpy as jnp
-    >>> import unxt as u
-    >>> import coordinax.transforms as cxfm
-    >>> import coordinax.charts as cxc
-
-    >>> op = cxfm.Rotate([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
-    >>> data = {"x": u.Q(1, "km"), "y": u.Q(0, "km"), "z": u.Q(0, "km")}
-    >>> cxfm.act(op, None, data, cxc.cart3d)
-    {'x': Q(0, 'km'), 'y': Q(1, 'km'), 'z': Q(0, 'km')}
-
-    """
-    # Infer rep from the CDict
-    rep = cxr.guess_rep(x)
-
-    # Redispatch to the main implementation
-    out = cxfmapi.act(op, tau, x, chart, rep, **kw)
-    return cast("CDict", out)

--- a/tests/unit/transforms/test_act.py
+++ b/tests/unit/transforms/test_act.py
@@ -1,13 +1,17 @@
-"""Red/Green TDD tests for ``coordinax.frames.act`` dispatches.
+"""Tests for ``coordinax.transforms.act`` dispatches.
 
-Tests every combination of {Identity, Rotate, Translate, Composed} ×
-{Array, Quantity, QMatrix, CDict, Vector, Point+Frame, Point+XfmFrame}.
-
-Each class tests:
-  - correctness: known-value checks
+The dispatch matrix — {Identity, Rotate, Reflect, Translate, Composed} ×
+{Array, Quantity, QMatrix, CDict, Vector, Point+Frame, Point+XfmFrame} — is
+covered by parametrized tests for:
+  - correctness: known-value checks (also serves as cross-level consistency,
+    since every level is compared to the same expected result)
   - return type: output matches input type
   - roundtrip:  act(op.inverse, None, act(op, None, x)) ≈ x
-  - jit compat: jax.jit wrapping works
+  - jit compat: wrapping in jit works
+
+Level-specific structural checks (frame/chart preservation, mixed-unit
+QMatrix) and the non-Cartesian tangent-geometry paths follow as their own
+tests.
 """
 
 __all__: tuple[str, ...] = ()
@@ -77,521 +81,128 @@ def _assert_close(actual_xyz, expected_xyz, atol=ATOL):
 
 
 # ===================================================================
-# Level 1: Array(like)
+# Dispatch matrix: {operator} × {input level}
+#
+# Every operator/level pair is compared against the same EXPECTED_* tuple, so
+# this parametrized correctness test doubles as the cross-level consistency
+# check (all input types represent the same fundamental action).
 # ===================================================================
 
+USYS = u.unitsystem("km", "s", "kg", "rad")
+
+# (input fixture, expected isinstance type). A bare array carries no units, so
+# translate/composed need `usys` supplied at that level only.
+INPUT_LEVELS = [
+    ("array_3d", jax.Array),
+    ("quantity_3d", u.AbstractQuantity),
+    ("qmatrix_3d", QMatrix),
+    ("cdict_3d", dict),
+    ("vector_3d", cx.Point),
+    ("coord_3d", cx.Point),
+    ("coord_xfm_3d", cx.Point),
+]
+LEVEL_FIXTURES = [name for name, _ in INPUT_LEVELS]
+LEVEL_IDS = [name.removesuffix("_3d") for name, _ in INPUT_LEVELS]
+
+# (op fixture, expected xyz, needs usys at the bare-array level)
+OPS = [
+    ("identity_op", EXPECTED_IDENTITY, False),
+    ("rotate_op", EXPECTED_ROTATE, False),
+    ("reflect_op", EXPECTED_REFLECT, False),
+    ("translate_op", EXPECTED_TRANSLATE, True),
+    ("composed_op", EXPECTED_COMPOSED, True),
+]
+OP_IDS = [name.removesuffix("_op") for name, _, _ in OPS]
+
+# Operators with a non-trivial inverse worth round-tripping.
+ROUNDTRIP_OPS = [("rotate_op", False), ("translate_op", True), ("composed_op", True)]
+
+# Levels that accept an explicit chart / (chart, rep) as extra positional args.
+CHART_LEVELS = ["quantity_3d", "qmatrix_3d", "cdict_3d"]
+
+
+def _usys_kw(level_fixture, needs_usys):
+    """`usys` is only required for the unit-less bare-array level."""
+    return {"usys": USYS} if (needs_usys and level_fixture == "array_3d") else {}
+
+
+@pytest.mark.parametrize("level_fixture", LEVEL_FIXTURES, ids=LEVEL_IDS)
+@pytest.mark.parametrize(("op_fixture", "expected", "needs_usys"), OPS, ids=OP_IDS)
+def test_act_matches_expected(request, op_fixture, expected, needs_usys, level_fixture):
+    """Each operator gives its known result on every input level."""
+    op = request.getfixturevalue(op_fixture)
+    x = request.getfixturevalue(level_fixture)
+    result = cxfm.act(op, None, x, **_usys_kw(level_fixture, needs_usys))
+    _assert_close(_extract_xyz(result), expected)
+
+
+@pytest.mark.parametrize(("level_fixture", "return_type"), INPUT_LEVELS, ids=LEVEL_IDS)
+def test_act_returns_input_type(request, rotate_op, level_fixture, return_type):
+    """The output type mirrors the input type."""
+    x = request.getfixturevalue(level_fixture)
+    assert isinstance(cxfm.act(rotate_op, None, x), return_type)
+
+
+@pytest.mark.parametrize("level_fixture", LEVEL_FIXTURES, ids=LEVEL_IDS)
+@pytest.mark.parametrize(
+    ("op_fixture", "needs_usys"), ROUNDTRIP_OPS, ids=["rotate", "translate", "composed"]
+)
+def test_act_inverse_roundtrip(request, op_fixture, needs_usys, level_fixture):
+    """act(op.inverse, act(op, x)) recovers x on every input level."""
+    op = request.getfixturevalue(op_fixture)
+    x = request.getfixturevalue(level_fixture)
+    kw = _usys_kw(level_fixture, needs_usys)
+    fwd = cxfm.act(op, None, x, **kw)
+    back = cxfm.act(op.inverse, None, fwd, **kw)
+    _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
+
+
+@pytest.mark.parametrize(
+    "level_fixture", CHART_LEVELS, ids=["quantity", "qmatrix", "cdict"]
+)
+def test_act_with_explicit_chart_and_rep(request, rotate_op, level_fixture):
+    """A chart, and a (chart, rep) pair, may be passed as extra positionals."""
+    x = request.getfixturevalue(level_fixture)
+    _assert_close(
+        _extract_xyz(cxfm.act(rotate_op, None, x, cxc.cart3d)), EXPECTED_ROTATE
+    )
+    _assert_close(
+        _extract_xyz(cxfm.act(rotate_op, None, x, cxc.cart3d, cxr.point)),
+        EXPECTED_ROTATE,
+    )
+
+
+@pytest.mark.parametrize("level_fixture", LEVEL_FIXTURES, ids=LEVEL_IDS)
+def test_act_under_jit(request, rotate_op, level_fixture):
+    """Wrapping act in jit works at every input level."""
+    x = request.getfixturevalue(level_fixture)
+    result = eqx.filter_jit(lambda y: cxfm.act(rotate_op, None, y))(x)
+    _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
+
+
+# Level-specific structural checks that don't generalize across input types.
+
+
+def test_qmatrix_heterogeneous_units_identity(identity_op):
+    """A QMatrix with mixed units passes through Identity unchanged."""
+    qm = QMatrix(jnp.array([1, 2, 3]), unit=(u.unit("km"), u.unit("km"), u.unit("km")))
+    result = cxfm.act(identity_op, None, qm)
+    assert isinstance(result, QMatrix)
+    _assert_close(_extract_xyz(result), (1, 2, 3))
 
-class TestActOnArray:
-    """Apply transforms to bare JAX arrays."""
 
-    def test_identity(self, identity_op, array_3d):
-        result = cxfm.act(identity_op, None, array_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_IDENTITY)
+def test_vector_preserves_chart(rotate_op, vector_3d):
+    assert cxfm.act(rotate_op, None, vector_3d).chart == vector_3d.chart
 
-    def test_rotate(self, rotate_op, array_3d):
-        result = cxfm.act(rotate_op, None, array_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
 
-    def test_translate(self, translate_op, array_3d):
-        # Bare arrays require usys because there's no unit info on the array.
-        # The translate delta is in km, so with SI usys the array is in meters.
-        # We use a km-based usys so both array and delta are in km.
-        usys = u.unitsystem("km", "s", "kg", "rad")
-        result = cxfm.act(translate_op, None, array_3d, usys=usys)
-        _assert_close(_extract_xyz(result), EXPECTED_TRANSLATE)
+def test_coordinate_preserves_frame(rotate_op, coord_3d):
+    result = cxfm.act(rotate_op, None, coord_3d)
+    assert isinstance(result.frame, type(coord_3d.frame))
 
-    def test_composed(self, composed_op, array_3d):
-        usys = u.unitsystem("km", "s", "kg", "rad")
-        result = cxfm.act(composed_op, None, array_3d, usys=usys)
-        _assert_close(_extract_xyz(result), EXPECTED_COMPOSED)
 
-    def test_rotate_returns_array(self, rotate_op, array_3d):
-        result = cxfm.act(rotate_op, None, array_3d)
-        assert isinstance(result, jax.Array)
-
-    def test_rotate_roundtrip(self, rotate_op, array_3d):
-        fwd = cxfm.act(rotate_op, None, array_3d)
-        back = cxfm.act(rotate_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_translate_roundtrip(self, translate_op, array_3d):
-        usys = u.unitsystem("km", "s", "kg", "rad")
-        fwd = cxfm.act(translate_op, None, array_3d, usys=usys)
-        back = cxfm.act(translate_op.inverse, None, fwd, usys=usys)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_composed_roundtrip(self, composed_op, array_3d):
-        usys = u.unitsystem("km", "s", "kg", "rad")
-        fwd = cxfm.act(composed_op, None, array_3d, usys=usys)
-        back = cxfm.act(composed_op.inverse, None, fwd, usys=usys)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-
-# ===================================================================
-# Level 2: Quantity
-# ===================================================================
-
-
-class TestActOnQuantity:
-    """Apply transforms to ``unxt.Quantity``."""
-
-    def test_identity(self, identity_op, quantity_3d):
-        result = cxfm.act(identity_op, None, quantity_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_IDENTITY)
-
-    def test_rotate(self, rotate_op, quantity_3d):
-        result = cxfm.act(rotate_op, None, quantity_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_translate(self, translate_op, quantity_3d):
-        result = cxfm.act(translate_op, None, quantity_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_TRANSLATE)
-
-    def test_composed(self, composed_op, quantity_3d):
-        result = cxfm.act(composed_op, None, quantity_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_COMPOSED)
-
-    def test_returns_quantity(self, rotate_op, quantity_3d):
-        result = cxfm.act(rotate_op, None, quantity_3d)
-        assert isinstance(result, u.AbstractQuantity)
-
-    def test_rotate_roundtrip(self, rotate_op, quantity_3d):
-        fwd = cxfm.act(rotate_op, None, quantity_3d)
-        back = cxfm.act(rotate_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_translate_roundtrip(self, translate_op, quantity_3d):
-        fwd = cxfm.act(translate_op, None, quantity_3d)
-        back = cxfm.act(translate_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_composed_roundtrip(self, composed_op, quantity_3d):
-        fwd = cxfm.act(composed_op, None, quantity_3d)
-        back = cxfm.act(composed_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_rotate_with_explicit_chart(self, rotate_op, quantity_3d):
-        result = cxfm.act(rotate_op, None, quantity_3d, cxc.cart3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_rotate_with_chart_and_rep(self, rotate_op, quantity_3d):
-        result = cxfm.act(rotate_op, None, quantity_3d, cxc.cart3d, cxr.point)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-
-# ===================================================================
-# Level 3: QMatrix
-# ===================================================================
-
-
-class TestActOnQMatrix:
-    """Apply transforms to ``QMatrix``.
-
-    This is expected to be RED initially — no dispatches exist.
-    """
-
-    def test_identity(self, identity_op, qmatrix_3d):
-        result = cxfm.act(identity_op, None, qmatrix_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_IDENTITY)
-
-    def test_rotate(self, rotate_op, qmatrix_3d):
-        result = cxfm.act(rotate_op, None, qmatrix_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_translate(self, translate_op, qmatrix_3d):
-        result = cxfm.act(translate_op, None, qmatrix_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_TRANSLATE)
-
-    def test_composed(self, composed_op, qmatrix_3d):
-        result = cxfm.act(composed_op, None, qmatrix_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_COMPOSED)
-
-    def test_returns_quantity_matrix(self, rotate_op, qmatrix_3d):
-        result = cxfm.act(rotate_op, None, qmatrix_3d)
-        assert isinstance(result, QMatrix)
-
-    def test_rotate_roundtrip(self, rotate_op, qmatrix_3d):
-        fwd = cxfm.act(rotate_op, None, qmatrix_3d)
-        back = cxfm.act(rotate_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_translate_roundtrip(self, translate_op, qmatrix_3d):
-        fwd = cxfm.act(translate_op, None, qmatrix_3d)
-        back = cxfm.act(translate_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_composed_roundtrip(self, composed_op, qmatrix_3d):
-        fwd = cxfm.act(composed_op, None, qmatrix_3d)
-        back = cxfm.act(composed_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_rotate_with_explicit_chart(self, rotate_op, qmatrix_3d):
-        result = cxfm.act(rotate_op, None, qmatrix_3d, cxc.cart3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_rotate_with_chart_and_rep(self, rotate_op, qmatrix_3d):
-        result = cxfm.act(rotate_op, None, qmatrix_3d, cxc.cart3d, cxr.point)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_heterogeneous_units_identity(self, identity_op):
-        """QMatrix with mixed units passes through Identity."""
-        qm = QMatrix(
-            jnp.array([1, 2, 3]), unit=(u.unit("km"), u.unit("km"), u.unit("km"))
-        )
-        result = cxfm.act(identity_op, None, qm)
-        assert isinstance(result, QMatrix)
-        _assert_close(_extract_xyz(result), (1, 2, 3))
-
-
-# ===================================================================
-# Level 4: CDict
-# ===================================================================
-
-
-class TestActOnCDict:
-    """Apply transforms to component dictionaries (CDict)."""
-
-    def test_identity(self, identity_op, cdict_3d):
-        result = cxfm.act(identity_op, None, cdict_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_IDENTITY)
-
-    def test_rotate(self, rotate_op, cdict_3d):
-        result = cxfm.act(rotate_op, None, cdict_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_translate(self, translate_op, cdict_3d):
-        result = cxfm.act(translate_op, None, cdict_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_TRANSLATE)
-
-    def test_composed(self, composed_op, cdict_3d):
-        result = cxfm.act(composed_op, None, cdict_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_COMPOSED)
-
-    def test_returns_dict(self, rotate_op, cdict_3d):
-        result = cxfm.act(rotate_op, None, cdict_3d)
-        assert isinstance(result, dict)
-
-    def test_rotate_roundtrip(self, rotate_op, cdict_3d):
-        fwd = cxfm.act(rotate_op, None, cdict_3d)
-        back = cxfm.act(rotate_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_translate_roundtrip(self, translate_op, cdict_3d):
-        fwd = cxfm.act(translate_op, None, cdict_3d)
-        back = cxfm.act(translate_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_composed_roundtrip(self, composed_op, cdict_3d):
-        fwd = cxfm.act(composed_op, None, cdict_3d)
-        back = cxfm.act(composed_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_rotate_with_explicit_chart(self, rotate_op, cdict_3d):
-        result = cxfm.act(rotate_op, None, cdict_3d, cxc.cart3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_rotate_with_chart_and_rep(self, rotate_op, cdict_3d):
-        result = cxfm.act(rotate_op, None, cdict_3d, cxc.cart3d, cxr.point)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-
-# ===================================================================
-# Level 5: Vector
-# ===================================================================
-
-
-class TestActOnVector:
-    """Apply transforms to ``coordinax.Point``."""
-
-    def test_identity(self, identity_op, vector_3d):
-        result = cxfm.act(identity_op, None, vector_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_IDENTITY)
-
-    def test_rotate(self, rotate_op, vector_3d):
-        result = cxfm.act(rotate_op, None, vector_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_translate(self, translate_op, vector_3d):
-        result = cxfm.act(translate_op, None, vector_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_TRANSLATE)
-
-    def test_composed(self, composed_op, vector_3d):
-        result = cxfm.act(composed_op, None, vector_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_COMPOSED)
-
-    def test_returns_vector(self, rotate_op, vector_3d):
-        result = cxfm.act(rotate_op, None, vector_3d)
-        assert isinstance(result, cx.Point)
-
-    def test_preserves_chart(self, rotate_op, vector_3d):
-        result = cxfm.act(rotate_op, None, vector_3d)
-        assert result.chart == vector_3d.chart
-
-    def test_rotate_roundtrip(self, rotate_op, vector_3d):
-        fwd = cxfm.act(rotate_op, None, vector_3d)
-        back = cxfm.act(rotate_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_translate_roundtrip(self, translate_op, vector_3d):
-        fwd = cxfm.act(translate_op, None, vector_3d)
-        back = cxfm.act(translate_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_composed_roundtrip(self, composed_op, vector_3d):
-        fwd = cxfm.act(composed_op, None, vector_3d)
-        back = cxfm.act(composed_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-
-# ===================================================================
-# Level 6: Point with a concrete frame
-# ===================================================================
-
-
-class TestActOnCoordinate:
-    """Apply transforms to ``coordinax.Point`` with a concrete frame."""
-
-    def test_identity(self, identity_op, coord_3d):
-        result = cxfm.act(identity_op, None, coord_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_IDENTITY)
-
-    def test_rotate(self, rotate_op, coord_3d):
-        result = cxfm.act(rotate_op, None, coord_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_translate(self, translate_op, coord_3d):
-        result = cxfm.act(translate_op, None, coord_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_TRANSLATE)
-
-    def test_composed(self, composed_op, coord_3d):
-        result = cxfm.act(composed_op, None, coord_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_COMPOSED)
-
-    def test_returns_coordinate(self, rotate_op, coord_3d):
-        result = cxfm.act(rotate_op, None, coord_3d)
-        assert isinstance(result, cx.Point)
-
-    def test_preserves_frame(self, rotate_op, coord_3d):
-        result = cxfm.act(rotate_op, None, coord_3d)
-        assert isinstance(result.frame, type(coord_3d.frame))
-
-    def test_rotate_roundtrip(self, rotate_op, coord_3d):
-        fwd = cxfm.act(rotate_op, None, coord_3d)
-        back = cxfm.act(rotate_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_translate_roundtrip(self, translate_op, coord_3d):
-        fwd = cxfm.act(translate_op, None, coord_3d)
-        back = cxfm.act(translate_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_composed_roundtrip(self, composed_op, coord_3d):
-        fwd = cxfm.act(composed_op, None, coord_3d)
-        back = cxfm.act(composed_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-
-# ===================================================================
-# Level 7: Point with a TransformedReferenceFrame
-# ===================================================================
-
-
-class TestActOnCoordinateXfm:
-    """Apply transforms to ``Point`` with a ``TransformedReferenceFrame``."""
-
-    def test_identity(self, identity_op, coord_xfm_3d):
-        result = cxfm.act(identity_op, None, coord_xfm_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_IDENTITY)
-
-    def test_rotate(self, rotate_op, coord_xfm_3d):
-        result = cxfm.act(rotate_op, None, coord_xfm_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_translate(self, translate_op, coord_xfm_3d):
-        result = cxfm.act(translate_op, None, coord_xfm_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_TRANSLATE)
-
-    def test_composed(self, composed_op, coord_xfm_3d):
-        result = cxfm.act(composed_op, None, coord_xfm_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_COMPOSED)
-
-    def test_returns_coordinate(self, rotate_op, coord_xfm_3d):
-        result = cxfm.act(rotate_op, None, coord_xfm_3d)
-        assert isinstance(result, cx.Point)
-
-    def test_preserves_transformed_frame(self, rotate_op, coord_xfm_3d):
-        result = cxfm.act(rotate_op, None, coord_xfm_3d)
-        assert isinstance(result.frame, cxf.TransformedReferenceFrame)
-
-    def test_rotate_roundtrip(self, rotate_op, coord_xfm_3d):
-        fwd = cxfm.act(rotate_op, None, coord_xfm_3d)
-        back = cxfm.act(rotate_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_translate_roundtrip(self, translate_op, coord_xfm_3d):
-        fwd = cxfm.act(translate_op, None, coord_xfm_3d)
-        back = cxfm.act(translate_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-    def test_composed_roundtrip(self, composed_op, coord_xfm_3d):
-        fwd = cxfm.act(composed_op, None, coord_xfm_3d)
-        back = cxfm.act(composed_op.inverse, None, fwd)
-        _assert_close(_extract_xyz(back), EXPECTED_IDENTITY)
-
-
-# ===================================================================
-# Cross-level consistency: same transform on all levels gives same answer
-# ===================================================================
-
-
-class TestCrossLevelConsistency:
-    """Verify that the same transform gives the same numerical result."""
-
-    def test_rotate_all_levels_agree(
-        self,
-        rotate_op,
-        array_3d,
-        quantity_3d,
-        qmatrix_3d,
-        cdict_3d,
-        vector_3d,
-        coord_3d,
-        coord_xfm_3d,
-    ):
-        results = []
-        # Level 1: Array
-        results.append(_extract_xyz(cxfm.act(rotate_op, None, array_3d)))
-        # Level 2: Quantity
-        results.append(_extract_xyz(cxfm.act(rotate_op, None, quantity_3d)))
-        # Level 3: QMatrix
-        results.append(_extract_xyz(cxfm.act(rotate_op, None, qmatrix_3d)))
-        # Level 4: CDict
-        results.append(_extract_xyz(cxfm.act(rotate_op, None, cdict_3d)))
-        # Level 5: Vector
-        results.append(_extract_xyz(cxfm.act(rotate_op, None, vector_3d)))
-        # Level 6: Coordinate
-        results.append(_extract_xyz(cxfm.act(rotate_op, None, coord_3d)))
-        # Level 7: Coordinate + XfmFrame
-        results.append(_extract_xyz(cxfm.act(rotate_op, None, coord_xfm_3d)))
-
-        for r in results:
-            _assert_close(r, EXPECTED_ROTATE, atol=ATOL)
-
-    def test_translate_all_levels_agree(
-        self,
-        translate_op,
-        array_3d,
-        quantity_3d,
-        qmatrix_3d,
-        cdict_3d,
-        vector_3d,
-        coord_3d,
-        coord_xfm_3d,
-    ):
-        usys = u.unitsystem("km", "s", "kg", "rad")
-        results = []
-        results.append(_extract_xyz(cxfm.act(translate_op, None, array_3d, usys=usys)))
-        results.append(_extract_xyz(cxfm.act(translate_op, None, quantity_3d)))
-        results.append(_extract_xyz(cxfm.act(translate_op, None, qmatrix_3d)))
-        results.append(_extract_xyz(cxfm.act(translate_op, None, cdict_3d)))
-        results.append(_extract_xyz(cxfm.act(translate_op, None, vector_3d)))
-        results.append(_extract_xyz(cxfm.act(translate_op, None, coord_3d)))
-        results.append(_extract_xyz(cxfm.act(translate_op, None, coord_xfm_3d)))
-
-        for r in results:
-            _assert_close(r, EXPECTED_TRANSLATE, atol=ATOL)
-
-    def test_reflect_all_levels_agree(
-        self,
-        reflect_op,
-        array_3d,
-        quantity_3d,
-        qmatrix_3d,
-        cdict_3d,
-        vector_3d,
-        coord_3d,
-        coord_xfm_3d,
-    ):
-        # A linear op: every input level is the same fundamental action.
-        for x in (
-            array_3d,
-            quantity_3d,
-            qmatrix_3d,
-            cdict_3d,
-            vector_3d,
-            coord_3d,
-            coord_xfm_3d,
-        ):
-            _assert_close(
-                _extract_xyz(cxfm.act(reflect_op, None, x)), EXPECTED_REFLECT, atol=ATOL
-            )
-
-    def test_composed_all_levels_agree(
-        self,
-        composed_op,
-        array_3d,
-        quantity_3d,
-        qmatrix_3d,
-        cdict_3d,
-        vector_3d,
-        coord_3d,
-        coord_xfm_3d,
-    ):
-        # Composed contains a Translate, so the bare-array level needs usys.
-        usys = u.unitsystem("km", "s", "kg", "rad")
-        results = [
-            _extract_xyz(cxfm.act(composed_op, None, array_3d, usys=usys)),
-            *(
-                _extract_xyz(cxfm.act(composed_op, None, x))
-                for x in (
-                    quantity_3d,
-                    qmatrix_3d,
-                    cdict_3d,
-                    vector_3d,
-                    coord_3d,
-                    coord_xfm_3d,
-                )
-            ),
-        ]
-        for r in results:
-            _assert_close(r, EXPECTED_COMPOSED, atol=ATOL)
-
-
-# ===================================================================
-# JIT compatibility
-# ===================================================================
-
-
-class TestActJIT:
-    """Verify act works under jax.jit / eqx.filter_jit for each level."""
-
-    def test_jit_array(self, rotate_op, array_3d):
-        result = jax.jit(lambda x: cxfm.act(rotate_op, None, x))(array_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_jit_quantity(self, rotate_op, quantity_3d):
-        result = jax.jit(lambda x: cxfm.act(rotate_op, None, x))(quantity_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_jit_qmatrix(self, rotate_op, qmatrix_3d):
-        result = eqx.filter_jit(lambda x: cxfm.act(rotate_op, None, x))(qmatrix_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_jit_cdict(self, rotate_op, cdict_3d):
-        result = jax.jit(lambda x: cxfm.act(rotate_op, None, x))(cdict_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_jit_vector(self, rotate_op, vector_3d):
-        result = eqx.filter_jit(lambda x: cxfm.act(rotate_op, None, x))(vector_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_jit_coordinate(self, rotate_op, coord_3d):
-        result = eqx.filter_jit(lambda x: cxfm.act(rotate_op, None, x))(coord_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
-
-    def test_jit_coordinate_xfm(self, rotate_op, coord_xfm_3d):
-        result = eqx.filter_jit(lambda x: cxfm.act(rotate_op, None, x))(coord_xfm_3d)
-        _assert_close(_extract_xyz(result), EXPECTED_ROTATE)
+def test_coordinate_xfm_preserves_transformed_frame(rotate_op, coord_xfm_3d):
+    result = cxfm.act(rotate_op, None, coord_xfm_3d)
+    assert isinstance(result.frame, cxf.TransformedReferenceFrame)
 
 
 # ===================================================================

--- a/tests/unit/transforms/test_act.py
+++ b/tests/unit/transforms/test_act.py
@@ -184,11 +184,13 @@ def test_act_under_jit(request, rotate_op, level_fixture):
 
 
 def test_qmatrix_heterogeneous_units_identity(identity_op):
-    """A QMatrix with mixed units passes through Identity unchanged."""
-    qm = QMatrix(jnp.array([1, 2, 3]), unit=(u.unit("km"), u.unit("km"), u.unit("km")))
+    """A QMatrix with per-component (heterogeneous) units passes through Identity."""
+    units = (u.unit("km"), u.unit("m"), u.unit("cm"))
+    qm = QMatrix(jnp.array([1.0, 2.0, 3.0]), unit=units)
     result = cxfm.act(identity_op, None, qm)
     assert isinstance(result, QMatrix)
-    _assert_close(_extract_xyz(result), (1, 2, 3))
+    np.testing.assert_allclose(np.asarray(result.value), [1.0, 2.0, 3.0])
+    assert result.unit == units
 
 
 def test_vector_preserves_chart(rotate_op, vector_3d):

--- a/tests/unit/transforms/test_act.py
+++ b/tests/unit/transforms/test_act.py
@@ -28,6 +28,7 @@ import coordinax.transforms as cxfm
 from .conftest import (
     EXPECTED_COMPOSED,
     EXPECTED_IDENTITY,
+    EXPECTED_REFLECT,
     EXPECTED_ROTATE,
     EXPECTED_TRANSLATE,
 )
@@ -499,6 +500,61 @@ class TestCrossLevelConsistency:
 
         for r in results:
             _assert_close(r, EXPECTED_TRANSLATE, atol=ATOL)
+
+    def test_reflect_all_levels_agree(
+        self,
+        reflect_op,
+        array_3d,
+        quantity_3d,
+        qmatrix_3d,
+        cdict_3d,
+        vector_3d,
+        coord_3d,
+        coord_xfm_3d,
+    ):
+        # A linear op: every input level is the same fundamental action.
+        for x in (
+            array_3d,
+            quantity_3d,
+            qmatrix_3d,
+            cdict_3d,
+            vector_3d,
+            coord_3d,
+            coord_xfm_3d,
+        ):
+            _assert_close(
+                _extract_xyz(cxfm.act(reflect_op, None, x)), EXPECTED_REFLECT, atol=ATOL
+            )
+
+    def test_composed_all_levels_agree(
+        self,
+        composed_op,
+        array_3d,
+        quantity_3d,
+        qmatrix_3d,
+        cdict_3d,
+        vector_3d,
+        coord_3d,
+        coord_xfm_3d,
+    ):
+        # Composed contains a Translate, so the bare-array level needs usys.
+        usys = u.unitsystem("km", "s", "kg", "rad")
+        results = [
+            _extract_xyz(cxfm.act(composed_op, None, array_3d, usys=usys)),
+            *(
+                _extract_xyz(cxfm.act(composed_op, None, x))
+                for x in (
+                    quantity_3d,
+                    qmatrix_3d,
+                    cdict_3d,
+                    vector_3d,
+                    coord_3d,
+                    coord_xfm_3d,
+                )
+            ),
+        ]
+        for r in results:
+            _assert_close(r, EXPECTED_COMPOSED, atol=ATOL)
 
 
 # ===================================================================


### PR DESCRIPTION
Part 1 of the transforms audit sequence — the funnel-normalization piece of #535, **recalibrated** after reading the method bodies (see "Scope note" below).

## What this does

**1. Collapse the arity-3/4 input funnel into one normalizer.**
`register_apply` registered a "guess chart/rep then redispatch" method for every (input-type × arity) — 8 near-identical arity-3/4 copies plus a `-1` precedence tier on the Quantity entry. These are replaced by a single pair of generic arity-3/4 `act` methods on a faithful `PointLike = ArrayLike | AbstractQuantity | QMatrix | CDict` union that:
- guess the chart **once** (not once per ladder hop), and
- default the representation per input-type via a small `_default_rep` dispatch (`array`/`QMatrix` → `point`; `quantity`/`CDict` → `guess_rep`),

then redispatch to the arity-5 typed `act` — the per-`(operator, input-type)` fast paths, or the arity-5 coercion fallback for operators without one.

**2. Guarantee "equivalent inputs → equivalent outputs" as a test.**
`TestCrossLevelConsistency` covered only Rotate/Translate; it now also covers Reflect (pure linear) and Composed (contains a Translate, so the bare-array level takes `usys`). This is the safety net for the per-type JAX fast paths.

## What this deliberately does NOT do

The per-`(operator, input-type)` methods at arity 5 (`rotate`/`translate`/… on `Array`/`Quantity`) are **kept untouched**. They are the point of the layered dispatch — they avoid CDict flatten/unflatten, a real eager-and-trace-time cost — so collapsing them to a single CDict dispatch would sacrifice performance. Only the redundant arity-3/4 boilerplate and the `-1` tier are removed.

## Scope note (correction to #535)

#535's headline ("collapse to one CDict dispatch, ~44 → ~15 methods, delete all precedence tiers") was written on the premise that the per-type methods are redundant fast paths. Reading the bodies shows they are deliberate JAX performance paths (and several carry distinct tested semantics, e.g. Translate's bare-array fibre-kick rejection). So:
- `act` methods: **44 → 38** (not ~15) — the remainder are the fast paths, kept.
- The `+2` (QMatrix) and `+1` (Identity) tiers are **structurally necessary**, not removable cleanly: `QMatrix <: AbstractQuantity` makes `(Op, QMatrix)` genuinely ambiguous with the per-op `AbcQ` fast paths, and Identity's `Any` catch-all overlaps the normalizer. Only the `-1` tier is removed.

The realizable win is a maintainability + consistency-guarantee cleanup (funnel dedup, `guess_*` once, one fewer tier), not a dramatic table cut.

## Verification

- Full transforms suite (242, incl. the new consistency tests), `register_apply` doctests (45), frames + usage (85), vectors (187) — all pass.
- `act._resolver.is_faithful` stays `True` (the `PointLike` union is faithful).
- ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)