### PR TITLE
♻️ refactor(transforms): shared AbstractLinearTransform base for Rotate/Scale/Shear/Reflect (#538)

### DIFF
--- a/src/coordinax/transforms/_src/actions/__init__.py
+++ b/src/coordinax/transforms/_src/actions/__init__.py
@@ -8,6 +8,7 @@ from .composite import *
 from .constants import *
 from .custom_types import *
 from .identity import *
+from .linear import *
 from .prolong import *
 from .reflect import *
 from .register_apply import *

--- a/src/coordinax/transforms/_src/actions/linear.py
+++ b/src/coordinax/transforms/_src/actions/linear.py
@@ -15,7 +15,6 @@ from jaxtyping import Array, ArrayLike
 from typing import Any, cast
 
 import equinox as eqx
-import jax.tree as jtu
 import plum
 
 import quaxed.numpy as jnp
@@ -228,7 +227,7 @@ def act(
         return cast("CDict", out)
 
     mapped_parts = tuple(
-        _maybe(f, p, **jtu.map(lambda seq, i=i: seq[i], ats))
+        _maybe(f, p, **{k: splits[i] for k, splits in ats.items()})
         for i, (f, p) in enumerate(zip(chart.factors, parts, strict=True))
     )
     return chart.merge_components(mapped_parts)

--- a/src/coordinax/transforms/_src/actions/linear.py
+++ b/src/coordinax/transforms/_src/actions/linear.py
@@ -1,0 +1,234 @@
+"""Shared base for pure linear (matrix) transforms.
+
+`Rotate`, `Scale`, `Shear`, and `Reflect` all act as ``x -> M x`` in the
+canonical Cartesian chart. This module owns that shared machinery — matrix
+validation, the point-action kernel (chart -> cartesian -> einsum -> back), the
+Array / Quantity fast paths, and the Cartesian-product factorwise dispatch — so
+each operator only supplies its matrix via `_raw_matrix`.
+"""
+
+__all__ = ("AbstractLinearTransform",)
+
+from abc import abstractmethod
+
+from jaxtyping import Array, ArrayLike
+from typing import Any, cast
+
+import equinox as eqx
+import jax.tree as jtu
+import plum
+
+import quaxed.numpy as jnp
+from unxt import AbstractQuantity as AbcQ
+
+import coordinax.api.transforms as cxfmapi
+import coordinax.charts as cxc
+import coordinax.representations as cxr
+from .base import AbstractTransform, materialize_transform
+from .custom_types import CDict, HasShape, OptUSys
+from coordinax.internal import pack_uniform_unit
+
+
+class AbstractLinearTransform(AbstractTransform):
+    r"""Base for pure Cartesian linear maps :math:`x \mapsto M x`.
+
+    A subclass provides its matrix via the `_raw_matrix` property (which may be
+    a callable of ``tau`` for a time-dependent map); this base owns the matrix
+    validation and every point-geometry ``act`` path.
+    """
+
+    @property
+    @abstractmethod
+    def _raw_matrix(self) -> Any:
+        """The matrix parameter (an array, or a callable of ``tau``)."""
+        raise NotImplementedError  # pragma: no cover
+
+    def _validate_square(self, matrix: HasShape, /) -> Array:
+        """Check the matrix is square (N x N)."""
+        shape = matrix.shape
+        return eqx.error_if(
+            matrix,
+            len(shape) != 2 or shape[0] != shape[1],
+            f"{type(self).__name__} requires a square matrix; got shape {shape!r}.",
+        )
+
+    def _validate_shape_match(
+        self, matrix: Array, cart: cxc.AbstractChart[Any, Any, Any], /
+    ) -> Array:
+        """Check the matrix dimension matches the Cartesian chart dimension."""
+        n = matrix.shape[0]
+        return eqx.error_if(
+            matrix,
+            cart.ndim != n or len(cart.components) != n,
+            f"{type(self).__name__}: matrix dimension {n} does not match the "
+            f"canonical Cartesian chart {type(cart).__name__} (ndim={cart.ndim!r}).",
+        )
+
+    def _matrix(
+        self, cart: cxc.AbstractChart[Any, Any, Any], tau: Any = None, /
+    ) -> Array:
+        """Return the validated matrix for ``cart``, materialized at ``tau``."""
+        op_eval = materialize_transform(self, tau)
+        matrix = op_eval._raw_matrix
+        matrix = eqx.error_if(
+            matrix, callable(matrix), "need to call `materialize_transform`."
+        )
+        matrix = self._validate_square(matrix)
+        return self._validate_shape_match(matrix, cart)
+
+
+# ============================================================================
+# act — point geometry (shared by every linear transform)
+
+
+@plum.dispatch
+def act(
+    op: AbstractLinearTransform,
+    tau: Any,
+    x: ArrayLike,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+    **kw: Any,
+) -> Array:
+    """Apply a linear transform to an Array(like) object."""
+    del kw  # Does not require an anchoring base-point.
+
+    x_arr = jnp.asarray(x)
+    chart = cxc.guess_chart(x_arr)  # ty: ignore[invalid-assignment]
+    if chart != chart.cartesian:
+        msg = (
+            f"act for {type(op).__name__} with ArrayLike x requires a Cartesian chart."
+        )
+        raise ValueError(msg)
+    if rep != cxr.point:
+        msg = (
+            f"act for {type(op).__name__} with ArrayLike x requires a "
+            "point representation."
+        )
+        raise TypeError(msg)
+
+    matrix = op._matrix(chart, tau)
+    return jnp.einsum("ij,...j->...i", matrix, x_arr)
+
+
+@plum.dispatch
+def act(
+    op: AbstractLinearTransform,
+    tau: Any,
+    x: AbcQ,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+    **kw: Any,
+) -> AbcQ:
+    """Apply a linear transform to a PointGeometry-roled Quantity."""
+    del rep, kw
+
+    cart = chart.cartesian
+    if chart != cart:
+        msg = (
+            f"act({type(op).__name__}, ..., Quantity) requires Cartesian "
+            f"components. chart {type(chart).__name__} is not its cartesian_chart."
+        )
+        raise ValueError(msg)
+
+    matrix = op._matrix(cart, tau)
+    return jnp.einsum("ij,...j->...i", matrix, x)  # ty: ignore[invalid-return-type]
+
+
+@plum.dispatch
+def act(
+    op: AbstractLinearTransform,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+    *,
+    usys: OptUSys = None,
+    **kw: Any,
+) -> CDict:
+    """Redispatch a CDict to the geometry-specific implementation."""
+    out = cxfmapi.act(op, tau, x, chart, rep.geom_kind, rep, usys=usys, **kw)
+    return cast("CDict", out)
+
+
+@plum.dispatch
+def act(
+    op: AbstractLinearTransform,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractChart,
+    geom: cxr.PointGeometry,
+    rep: cxr.Representation,
+    /,
+    *,
+    usys: OptUSys = None,
+    **kw: Any,
+) -> CDict:
+    """Apply a linear map to a Point-valued coordinate dictionary.
+
+    The point is mapped by converting to the chart's canonical Cartesian chart,
+    applying the matrix in Cartesian components, then converting back. Units are
+    handled by packing Cartesian components into a common unit before the map
+    and restoring it afterward.
+    """
+    del geom, rep, kw  # Does not require an anchoring base-point.
+
+    cart = chart.cartesian
+    comps_cart = cart.components
+    matrix = op._matrix(cart, tau)
+
+    p_cart = cxc.pt_map(x, chart, cart, usys=usys)
+
+    v, unit = pack_uniform_unit(p_cart, keys=comps_cart)  # ty: ignore[no-matching-overload]
+    v_out = jnp.einsum("ij,...j->...i", matrix, v)
+    p_cart_out = cxc.cdict(v_out, unit, comps_cart)
+
+    out = cxc.pt_map(p_cart_out, cart, chart, usys=usys)
+    return cast("CDict", out)
+
+
+@plum.dispatch
+def act(
+    op: AbstractLinearTransform,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractCartesianProductChart,
+    geom: cxr.PointGeometry,
+    rep: cxr.Representation,
+    /,
+    *,
+    usys: OptUSys = None,
+    **kw: Any,
+) -> CDict:
+    """Apply a linear map factorwise on Cartesian-product charts."""
+    n = op._validate_square(materialize_transform(op, tau)._raw_matrix).shape[-1]
+
+    n_factors = len(chart.factors)
+    parts = chart.split_components(x)
+    ats = {
+        k: chart.split_components(v) if v is not None else [None] * n_factors
+        for k, v in kw.items()
+        if k.startswith("at")
+    }
+
+    def _maybe(
+        factor_chart: cxc.AbstractChart[Any, Any, Any],
+        part: CDict,
+        /,
+        **ats: CDict | None,
+    ) -> CDict:
+        cart = factor_chart.cartesian
+        if cart.ndim != n or len(cart.components) != n:
+            return part
+
+        out = cxfmapi.act(op, tau, part, factor_chart, geom, rep, usys=usys, **ats)
+        return cast("CDict", out)
+
+    mapped_parts = tuple(
+        _maybe(f, p, **jtu.map(lambda seq, i=i: seq[i], ats))
+        for i, (f, p) in enumerate(zip(chart.factors, parts, strict=True))
+    )
+    return chart.merge_components(mapped_parts)

--- a/src/coordinax/transforms/_src/actions/reflect.py
+++ b/src/coordinax/transforms/_src/actions/reflect.py
@@ -4,9 +4,8 @@ __all__ = ("Reflect",)
 
 
 from jaxtyping import Array, Shaped
-from typing import Any, Final, TypeAlias, cast, final
+from typing import Any, Final, TypeAlias, final
 
-import jax.tree as jtu
 import plum
 from jax.typing import ArrayLike
 
@@ -14,33 +13,18 @@ import quaxed.numpy as jnp
 import unxt as u
 from unxt import AbstractQuantity as AbcQ
 
-import coordinax.api.transforms as cxfmapi
-import coordinax.charts as cxc
-import coordinax.representations as cxr
 from .base import AbstractTransform
-from .custom_types import CDict, HasShape, OptUSys
 from .identity import identity
-from coordinax.internal import pack_uniform_unit
+from .linear import AbstractLinearTransform
 from coordinax.transforms._src import groups
 
 HMatrix: TypeAlias = Shaped[Array, " N N"]
-
-_MSG_H_SHAPE: Final = (
-    "Reflect requires a square reflection matrix; got shape={shape!r}."
-)
-
-_MSG_H_X_SHAPE_MISMATCH: Final = (
-    "Reflect() requires the chart's canonical Cartesian chart "
-    "to have dimension matching the reflection matrix. "
-    "Got H.shape={H.shape} and cartesian_chart={cart.__class__.__name__} "
-    "with ndim={cart.ndim!r}."
-)
 
 _MSG_ZERO_NORMAL: Final = "Reflect.from_normal requires a nonzero normal vector."
 
 
 @final
-class Reflect(AbstractTransform):
+class Reflect(AbstractLinearTransform):
     r"""Operator for Euclidean hyperplane reflections.
 
     A reflection across the hyperplane orthogonal to a nonzero normal vector $n$
@@ -103,25 +87,9 @@ class Reflect(AbstractTransform):
         """The inverse of a reflection is the reflection itself."""
         return self
 
-    @staticmethod
-    def _validate_square(H: HasShape, /) -> HMatrix:
-        shape = H.shape
-        if len(shape) != 2 or shape[0] != shape[1]:
-            raise ValueError(_MSG_H_SHAPE.format(shape=shape))
-        return cast("HMatrix", H)
-
-    @staticmethod
-    def _validate_shape_match(
-        H: HMatrix, cart: cxc.AbstractChart[Any, Any, Any], /
-    ) -> HMatrix:
-        n = H.shape[0]
-        if cart.ndim != n or len(cart.components) != n:
-            raise ValueError(_MSG_H_X_SHAPE_MISMATCH.format(H=H, cart=cart))
-        return H
-
-    def _get_H(self, cart: cxc.AbstractChart[Any, Any, Any], /) -> HMatrix:
-        H = self._validate_square(self.H)
-        return self._validate_shape_match(H, cart)
+    @property
+    def _raw_matrix(self) -> Any:
+        return self.H
 
 
 @Reflect.from_.dispatch  # ty: ignore[unresolved-attribute]
@@ -148,146 +116,3 @@ def simplify(op: Reflect, /, **kw: Any) -> AbstractTransform:
     if jnp.allclose(op.H, jnp.eye(op.H.shape[0], dtype=op.H.dtype), **kw):
         return identity
     return op
-
-
-@plum.dispatch
-def act(
-    op: Reflect,
-    tau: Any,
-    x: ArrayLike,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    **kw: Any,
-) -> Array:
-    """Apply Reflect to an Array(like) object."""
-    del tau, kw
-
-    x_arr = jnp.asarray(x)
-    chart = cxc.guess_chart(x_arr)  # ty: ignore[invalid-assignment]
-    if chart != chart.cartesian:
-        msg = "act for Reflect with ArrayLike x requires a Cartesian chart."
-        raise ValueError(msg)
-    if rep != cxr.point:
-        msg = "act for Reflect with ArrayLike x requires a point representation."
-        raise TypeError(msg)
-
-    H = op._get_H(chart)
-    return jnp.einsum("ij,...j->...i", H, x_arr)
-
-
-@plum.dispatch
-def act(
-    op: Reflect,
-    tau: Any,
-    x: AbcQ,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    **kw: Any,
-) -> AbcQ:
-    """Apply Reflect to a PointGeometry-roled Quantity."""
-    del tau, rep, kw
-
-    cart = chart.cartesian
-    if chart != cart:
-        msg = (
-            "act(Reflect, ..., Quantity) requires Cartesian components. "
-            f"chart {type(chart).__name__} is not its cartesian_chart."
-        )
-        raise ValueError(msg)
-
-    H = op._get_H(chart)
-    return jnp.einsum("ij,...j->...i", H, x)  # ty: ignore[invalid-return-type]
-
-
-@plum.dispatch
-def act(
-    op: Reflect,
-    tau: Any,
-    x: CDict,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    *,
-    usys: OptUSys = None,
-    **kw: Any,
-) -> CDict:
-    """Apply Reflect to a coordinate dictionary."""
-    out = cxfmapi.act(op, tau, x, chart, rep.geom_kind, rep, usys=usys, **kw)
-    return cast("CDict", out)
-
-
-@plum.dispatch
-def act(
-    op: Reflect,
-    tau: Any,
-    x: CDict,
-    chart: cxc.AbstractChart,
-    geom: cxr.PointGeometry,
-    rep: cxr.Representation,
-    /,
-    *,
-    usys: OptUSys = None,
-    **kw: Any,
-) -> CDict:
-    """Apply a hyperplane reflection to a Point-valued coordinate dictionary."""
-    del tau, geom, rep, kw
-
-    cart = chart.cartesian
-    comps_cart = cart.components
-    H = op._get_H(cart)
-
-    p_cart = cxc.pt_map(x, chart, cart, usys=usys)
-
-    v, unit = pack_uniform_unit(p_cart, keys=comps_cart)  # ty: ignore[no-matching-overload]
-    v_ref = jnp.einsum("ij,...j->...i", H, v)
-    p_cart_ref = cxc.cdict(v_ref, unit, comps_cart)
-
-    out = cxc.pt_map(p_cart_ref, cart, chart, usys=usys)
-    return cast("CDict", out)
-
-
-@plum.dispatch
-def act(
-    op: Reflect,
-    tau: Any,
-    x: CDict,
-    chart: cxc.AbstractCartesianProductChart,
-    geom: cxr.PointGeometry,
-    rep: cxr.Representation,
-    /,
-    *,
-    usys: OptUSys = None,
-    **kw: Any,
-) -> CDict:
-    """Apply a reflection factorwise on Cartesian-product charts."""
-    del tau
-    n = op._validate_square(op.H).shape[-1]
-
-    n_factors = len(chart.factors)
-    parts = chart.split_components(x)
-    ats = {
-        k: chart.split_components(v) if v is not None else [None] * n_factors
-        for k, v in kw.items()
-        if k.startswith("at")
-    }
-
-    def _maybe(
-        factor_chart: cxc.AbstractChart[Any, Any, Any],
-        part: CDict,
-        /,
-        **ats: CDict | None,
-    ) -> CDict:
-        cart = factor_chart.cartesian
-        if cart.ndim != n or len(cart.components) != n:
-            return part
-
-        out = cxfmapi.act(op, None, part, factor_chart, geom, rep, usys=usys, **ats)
-        return cast("CDict", out)
-
-    reflected_parts = tuple(
-        _maybe(f, p, **jtu.map(lambda seq, i=i: seq[i], ats))
-        for i, (f, p) in enumerate(zip(chart.factors, parts, strict=True))
-    )
-    return chart.merge_components(reflected_parts)

--- a/src/coordinax/transforms/_src/actions/rotate.py
+++ b/src/coordinax/transforms/_src/actions/rotate.py
@@ -20,7 +20,7 @@ from unxt import AbstractQuantity as AbcQ
 
 import coordinax.charts as cxc
 import coordinax.representations as cxr
-from .base import AbstractTransform, materialize_transform
+from .base import AbstractTransform
 from .custom_types import CDict, OptUSys
 from .identity import identity
 from .linear import AbstractLinearTransform
@@ -498,8 +498,7 @@ def _rotate_pushforward_cdict(
 
     """
     cart = chart.cartesian
-    op_eval = materialize_transform(op, tau)
-    R = op_eval._matrix(cart)
+    R = op._matrix(cart, tau)
 
     if chart is cart:
         # Cartesian chart: Jacobian is the identity — simple linear map.

--- a/src/coordinax/transforms/_src/actions/rotate.py
+++ b/src/coordinax/transforms/_src/actions/rotate.py
@@ -4,16 +4,13 @@ __all__ = ("Rotate",)
 
 
 from dataclasses import replace
-from operator import itemgetter
 
 from collections.abc import Callable
 from jaxtyping import Array, Shaped
-from typing import Any, Final, TypeAlias, cast, final, get_type_hints
+from typing import Any, TypeAlias, cast, final, get_type_hints
 
-import equinox as eqx
 import jax
 import jax.scipy.spatial.transform as jtransform
-import jax.tree as jtu
 import plum
 from jax.typing import ArrayLike
 
@@ -21,12 +18,12 @@ import quaxed.numpy as jnp
 import unxt as u
 from unxt import AbstractQuantity as AbcQ
 
-import coordinax.api.transforms as cxfmapi
 import coordinax.charts as cxc
 import coordinax.representations as cxr
 from .base import AbstractTransform, materialize_transform
-from .custom_types import CDict, HasShape, OptUSys
+from .custom_types import CDict, OptUSys
 from .identity import identity
+from .linear import AbstractLinearTransform
 from .prolong import _attach_leaf, _strip_leaf, _tau_value_unit, prolong_slot
 from .utils import Neg
 from coordinax.internal import pack_uniform_unit
@@ -34,18 +31,9 @@ from coordinax.transforms._src import groups
 
 RMatrix: TypeAlias = Shaped[Array, " N N"]
 
-_MSG_R_SHAPE: Final = "Rotate requires a square rotation matrix; got shape={shape!r}."
-
-_MSG_R_X_SHAPE_MISMATCH: Final = (
-    "Rotate() requires the chart's canonical Cartesian chart "
-    "to have dimension matching the rotation matrix. "
-    "Got R.shape={R.shape} and cartesian_chart={cart.__class__.__name__} "
-    "with ndim={cart.ndim!r}."
-)
-
 
 @final
-class Rotate(AbstractTransform):
+class Rotate(AbstractLinearTransform):
     r"""Operator for Galilean rotations.
 
     The coordinate transform is given by:
@@ -224,29 +212,9 @@ class Rotate(AbstractTransform):
 
     # -----------------------------------------------------
 
-    @staticmethod
-    def _validate_square(R: HasShape, /) -> RMatrix:
-        shape = R.shape
-        return eqx.error_if(
-            R, len(shape) != 2 or shape[0] != shape[1], _MSG_R_SHAPE.format(shape=shape)
-        )
-
-    @staticmethod
-    def _validate_shape_match(
-        R: HasShape, cart: cxc.AbstractChart[Any, Any, Any], /
-    ) -> RMatrix:
-        n = R.shape[0]
-        return eqx.error_if(
-            R,
-            cart.ndim != n or len(cart.components) != n,
-            _MSG_R_X_SHAPE_MISMATCH.format(R=R, cart=cart),
-        )
-
-    def _get_R(self, cart: cxc.AbstractChart[Any, Any, Any], /) -> RMatrix:
-        R = self.R
-        R = eqx.error_if(R, callable(R), "need to call `materialize_transform`.")
-        R = self._validate_square(R)
-        return self._validate_shape_match(R, cart)
+    @property
+    def _raw_matrix(self) -> Any:
+        return self.R
 
     # -----------------------------------------------------
     # Arithmetic operations
@@ -470,147 +438,9 @@ def simplify(op: Rotate, /, **kw: Any) -> AbstractTransform:
 # act
 
 # -----------------------------------------------
-# Special dispatches for Array.
-# These are interpreted as Cartesian coordinates in a Euclidean metric
-
-
-@plum.dispatch
-def act(
-    op: Rotate,
-    tau: Any,
-    x: ArrayLike,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    **kw: Any,
-) -> Array:
-    """Apply Rotate to an Array(like) object."""
-    del kw  # Does not require an anchoring base-point.
-
-    # Process Value
-    x_arr = jnp.asarray(x)
-    chart = cxc.guess_chart(x_arr)  # ty: ignore[invalid-assignment]
-    if chart != chart.cartesian:
-        msg = "act for Rotate with ArrayLike x requires a Cartesian chart."
-        raise ValueError(msg)
-    if rep != cxr.point:
-        msg = "act for Rotate with ArrayLike x requires a point representation."
-        raise TypeError(msg)
-
-    # Process rotation
-    op_eval = materialize_transform(op, tau)
-    R = op_eval._get_R(chart)
-
-    return jnp.einsum("ij,...j->...i", R, x_arr)
-
-
-# -----------------------------------------------
-# Special dispatches for Quantity.
-# These are interpreted as Cartesian coordinates in a Euclidean metric
-# The role is inferred from the dimensions.
-
-_MSG_NOT_CART: Final = (
-    "act({op}, ..., Quantity) requires Cartesian components. "
-    "chart {name} is not its cartesian_chart."
-)
-
-
-@plum.dispatch
-def act(
-    op: Rotate,
-    tau: Any,
-    x: AbcQ,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    **kw: Any,
-) -> AbcQ:
-    """Apply Rotate to a PointGeometry-roled Quantity."""
-    del rep, kw
-
-    # Process Value
-    cart = chart.cartesian
-    if chart != cart:
-        msg = _MSG_NOT_CART.format(op=type(op).__name__, name=type(chart).__name__)
-        raise ValueError(msg)
-
-    # Rotation matrix
-    op_eval = materialize_transform(op, tau)
-    R = op_eval._get_R(chart)
-    return jnp.einsum("ij,...j->...i", R, x)  # ty: ignore[invalid-return-type]
-
-
-# -----------------------------------------------
-# On CDict
-
-
-@plum.dispatch
-def act(
-    op: Rotate,
-    tau: Any,
-    x: CDict,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    *,
-    usys: OptUSys = None,
-    **kw: Any,
-) -> CDict:
-    # Redispatch to geom-specific dispatch.
-    out = cxfmapi.act(op, tau, x, chart, rep.geom_kind, rep, usys=usys, **kw)
-    return cast("CDict", out)
-
-
-@plum.dispatch
-def act(
-    op: Rotate,
-    tau: Any,
-    x: CDict,
-    chart: cxc.AbstractChart,
-    geom: cxr.PointGeometry,
-    rep: cxr.Representation,
-    /,
-    *,
-    usys: OptUSys = None,
-    **kw: Any,
-) -> CDict:
-    """Apply a spatial rotation to a Point-valued coordinate dictionary.
-
-    The point is rotated by converting to the chart's canonical Cartesian chart,
-    applying the rotation in Cartesian components, then converting back.
-
-    Notes
-    -----
-    - This dispatch is for non-product charts; Cartesian-product charts have a
-      separate dispatch that rotates only matching spatial factors.
-    - The rotation matrix must be square and its dimension must match the
-      canonical Cartesian chart dimension.
-    - Units are handled by packing Cartesian components into a common unit before
-      rotation and restoring that unit afterward.
-
-    """
-    del geom, rep, kw  # Does not require an anchoring base-point.
-
-    cart = chart.cartesian
-    # print("CART", cart.__class__, chart.__class__)
-    comps_cart = cart.components
-
-    op_eval = materialize_transform(op, tau)
-    R = op_eval._get_R(cart)
-
-    # Convert point to canonical Cartesian chart.
-    p_cart = cxc.pt_map(x, chart, cart, usys=usys)
-
-    # Pack -> rotate -> unpack (batch-safe)
-    v, unit = pack_uniform_unit(
-        p_cart, keys=comps_cart
-    )  # (..., n)  # ty: ignore[no-matching-overload]
-    v_rot = jnp.einsum("ij,...j->...i", R, v)  # (..., n)
-    p_cart_rot = cxc.cdict(v_rot, unit, comps_cart)
-
-    # Convert back to original chart.
-    out = cxc.pt_map(p_cart_rot, cart, chart, usys=usys)
-    return cast("CDict", out)
+# Tangent geometry (pushforward + kinematic prolongation). The point-geometry
+# act paths (Array / Quantity / CDict / product charts) are inherited from
+# AbstractLinearTransform.
 
 
 def _rotate_pushforward_cdict(
@@ -669,7 +499,7 @@ def _rotate_pushforward_cdict(
     """
     cart = chart.cartesian
     op_eval = materialize_transform(op, tau)
-    R = op_eval._get_R(cart)
+    R = op_eval._matrix(cart)
 
     if chart is cart:
         # Cartesian chart: Jacobian is the identity — simple linear map.
@@ -829,70 +659,3 @@ def act(
     # General case (acceleration, or non-Cartesian chart): generic prolongation
     # (which also owns the missing-tau / missing-anchor errors).
     return prolong_slot(op, tau, x, chart, m, at=at, at_vel=at_vel, usys=usys)
-
-
-# -----------------------------------------------
-# On CDict with Cartesian-product charts
-
-
-@plum.dispatch
-def act(
-    op: Rotate,
-    tau: Any,
-    x: CDict,
-    chart: cxc.AbstractCartesianProductChart,
-    geom: cxr.PointGeometry,
-    rep: cxr.Representation,
-    /,
-    *,
-    usys: OptUSys = None,
-    **kw: Any,
-) -> CDict:
-    """Apply a spatial rotation to a coordinate dictionary.
-
-    For Cartesian-product charts, this applies the rotation factorwise: each
-    factor is rotated in its canonical Cartesian chart *iff* that Cartesian
-    chart's dimension matches the rotation matrix. Factors that do not match
-    (e.g. Time1D) are left unchanged.
-
-    Notes
-    -----
-    - The rotation matrix must be square.
-    - Units are handled by packing Cartesian components into a shared unit
-      before rotation and restoring that unit afterward.
-    - Kwarg requirements depend on role; eg. Points do not require an anchoring
-      base-point.
-
-    """
-    op_eval = materialize_transform(op, tau)
-    n = op_eval._validate_square(op_eval.R).shape[-1]
-
-    # Factorize the inputs
-    n_factors = len(chart.factors)
-    parts = chart.split_components(x)
-    ats = {
-        k: chart.split_components(v) if v is not None else [None] * n_factors
-        for k, v in kw.items()
-        if k.startswith("at")
-    }
-
-    def _maybe(
-        factor_chart: cxc.AbstractChart[Any, Any, Any],
-        part: CDict,
-        /,
-        **ats: CDict | None,
-    ) -> CDict:
-        # Determine if this factor's chart should be rotated.
-        cart = factor_chart.cartesian
-        if cart.ndim != n or len(cart.components) != n:
-            return part
-
-        # Apply rotation
-        out = cxfmapi.act(op_eval, tau, part, factor_chart, geom, rep, usys=usys, **ats)
-        return cast("CDict", out)
-
-    rotated_parts = tuple(
-        _maybe(f, p, **jtu.map(itemgetter(i), ats))
-        for i, (f, p) in enumerate(zip(chart.factors, parts, strict=True))
-    )
-    return chart.merge_components(rotated_parts)

--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -4,9 +4,8 @@
 __all__ = ("Scale",)
 
 
-from typing import Any, Final, TypeAlias, cast, final
+from typing import Any, Final, TypeAlias, final
 
-import jax.tree as jtu
 import plum
 from jax.typing import ArrayLike
 from jaxtyping import Array, Shaped
@@ -15,13 +14,9 @@ import quaxed.numpy as jnp
 import unxt as u
 from unxt import AbstractQuantity as AbcQ
 
-import coordinax.api.transforms as cxfmapi
-import coordinax.charts as cxc
-import coordinax.representations as cxr
 from .base import AbstractTransform
-from .custom_types import CDict, HasShape, OptUSys
 from .identity import identity
-from coordinax.internal import pack_uniform_unit
+from .linear import AbstractLinearTransform
 from coordinax.transforms._src import groups
 
 SMatrix: TypeAlias = Shaped[Array, " N N"]
@@ -37,7 +32,7 @@ _MSG_S_X_SHAPE_MISMATCH: Final = (
 
 
 @final
-class Scale(AbstractTransform):
+class Scale(AbstractLinearTransform):
     r"""Operator for Cartesian linear scaling.
 
     A scaling transform applies
@@ -79,25 +74,9 @@ class Scale(AbstractTransform):
         """Return the inverse scaling transform."""
         return type(self)(jnp.linalg.inv(self.S))
 
-    @staticmethod
-    def _validate_square(S: HasShape, /) -> SMatrix:
-        shape = S.shape
-        if len(shape) != 2 or shape[0] != shape[1]:
-            raise ValueError(_MSG_S_SHAPE.format(shape=shape))
-        return cast("SMatrix", S)
-
-    @staticmethod
-    def _validate_shape_match(
-        S: SMatrix, cart: cxc.AbstractChart[Any, Any, Any], /
-    ) -> SMatrix:
-        n = S.shape[0]
-        if cart.ndim != n or len(cart.components) != n:
-            raise ValueError(_MSG_S_X_SHAPE_MISMATCH.format(S=S, cart=cart))
-        return S
-
-    def _get_S(self, cart: cxc.AbstractChart[Any, Any, Any], /) -> SMatrix:
-        S = self._validate_square(self.S)
-        return self._validate_shape_match(S, cart)
+    @property
+    def _raw_matrix(self) -> Any:
+        return self.S
 
 
 @Scale.from_.dispatch  # ty: ignore[unresolved-attribute]
@@ -124,146 +103,3 @@ def simplify(op: Scale, /, **kw: Any) -> AbstractTransform:
     if jnp.allclose(op.S, jnp.eye(op.S.shape[0], dtype=op.S.dtype), **kw):
         return identity
     return op
-
-
-@plum.dispatch
-def act(
-    op: Scale,
-    tau: Any,
-    x: ArrayLike,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    **kw: Any,
-) -> Array:
-    """Apply Scale to an Array(like) object."""
-    del tau, kw
-
-    x_arr = jnp.asarray(x)
-    chart = cxc.guess_chart(x_arr)  # ty: ignore[invalid-assignment]
-    if chart != chart.cartesian:
-        msg = "act for Scale with ArrayLike x requires a Cartesian chart."
-        raise ValueError(msg)
-    if rep != cxr.point:
-        msg = "act for Scale with ArrayLike x requires a point representation."
-        raise TypeError(msg)
-
-    S = op._get_S(chart)
-    return jnp.einsum("ij,...j->...i", S, x_arr)
-
-
-@plum.dispatch
-def act(
-    op: Scale,
-    tau: Any,
-    x: AbcQ,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    **kw: Any,
-) -> AbcQ:
-    """Apply Scale to a PointGeometry-roled Quantity."""
-    del tau, rep, kw
-
-    cart = chart.cartesian
-    if chart != cart:
-        msg = (
-            "act(Scale, ..., Quantity) requires Cartesian components. "
-            f"chart {type(chart).__name__} is not its cartesian_chart."
-        )
-        raise ValueError(msg)
-
-    S = op._get_S(chart)
-    return jnp.einsum("ij,...j->...i", S, x)  # ty: ignore[invalid-return-type]
-
-
-@plum.dispatch
-def act(
-    op: Scale,
-    tau: Any,
-    x: CDict,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    *,
-    usys: OptUSys = None,
-    **kw: Any,
-) -> CDict:
-    """Apply Scale to a coordinate dictionary."""
-    out = cxfmapi.act(op, tau, x, chart, rep.geom_kind, rep, usys=usys, **kw)
-    return cast("CDict", out)
-
-
-@plum.dispatch
-def act(
-    op: Scale,
-    tau: Any,
-    x: CDict,
-    chart: cxc.AbstractChart,
-    geom: cxr.PointGeometry,
-    rep: cxr.Representation,
-    /,
-    *,
-    usys: OptUSys = None,
-    **kw: Any,
-) -> CDict:
-    """Apply Scale to a Point-valued coordinate dictionary."""
-    del tau, geom, rep, kw
-
-    cart = chart.cartesian
-    comps_cart = cart.components
-    S = op._get_S(cart)
-
-    p_cart = cxc.pt_map(x, chart, cart, usys=usys)
-
-    v, unit = pack_uniform_unit(p_cart, keys=comps_cart)  # ty: ignore[no-matching-overload]
-    v_scaled = jnp.einsum("ij,...j->...i", S, v)
-    p_cart_scaled = cxc.cdict(v_scaled, unit, comps_cart)
-
-    out = cxc.pt_map(p_cart_scaled, cart, chart, usys=usys)
-    return cast("CDict", out)
-
-
-@plum.dispatch
-def act(
-    op: Scale,
-    tau: Any,
-    x: CDict,
-    chart: cxc.AbstractCartesianProductChart,
-    geom: cxr.PointGeometry,
-    rep: cxr.Representation,
-    /,
-    *,
-    usys: OptUSys = None,
-    **kw: Any,
-) -> CDict:
-    """Apply a scaling factorwise on Cartesian-product charts."""
-    del tau
-    n = op._validate_square(op.S).shape[-1]
-
-    n_factors = len(chart.factors)
-    parts = chart.split_components(x)
-    ats = {
-        k: chart.split_components(v) if v is not None else [None] * n_factors
-        for k, v in kw.items()
-        if k.startswith("at")
-    }
-
-    def _maybe(
-        factor_chart: cxc.AbstractChart[Any, Any, Any],
-        part: CDict,
-        /,
-        **ats: CDict | None,
-    ) -> CDict:
-        cart = factor_chart.cartesian
-        if cart.ndim != n or len(cart.components) != n:
-            return part
-
-        out = cxfmapi.act(op, None, part, factor_chart, geom, rep, usys=usys, **ats)
-        return cast("CDict", out)
-
-    scaled_parts = tuple(
-        _maybe(f, p, **jtu.map(lambda seq, i=i: seq[i], ats))
-        for i, (f, p) in enumerate(zip(chart.factors, parts, strict=True))
-    )
-    return chart.merge_components(scaled_parts)

--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -21,14 +21,7 @@ from coordinax.transforms._src import groups
 
 SMatrix: TypeAlias = Shaped[Array, " N N"]
 
-_MSG_S_SHAPE: Final = "Scale requires a square scaling matrix; got shape={shape!r}."
 _MSG_SINGULAR: Final = "Scale matrix must be invertible."
-_MSG_S_X_SHAPE_MISMATCH: Final = (
-    "Scale() requires the chart's canonical Cartesian chart "
-    "to have dimension matching the scaling matrix. "
-    "Got S.shape={S.shape} and cartesian_chart={cart.__class__.__name__} "
-    "with ndim={cart.ndim!r}."
-)
 
 
 @final

--- a/src/coordinax/transforms/_src/actions/shear.py
+++ b/src/coordinax/transforms/_src/actions/shear.py
@@ -4,9 +4,8 @@
 __all__ = ("Shear",)
 
 
-from typing import Any, Final, TypeAlias, cast, final
+from typing import Any, TypeAlias, final
 
-import jax.tree as jtu
 import plum
 from jax.typing import ArrayLike
 from jaxtyping import Array, Shaped
@@ -15,28 +14,16 @@ import quaxed.numpy as jnp
 import unxt as u
 from unxt import AbstractQuantity as AbcQ
 
-import coordinax.api.transforms as cxfmapi
-import coordinax.charts as cxc
-import coordinax.representations as cxr
 from .base import AbstractTransform
-from .custom_types import CDict, HasShape, OptUSys
 from .identity import identity
-from coordinax.internal import pack_uniform_unit
+from .linear import AbstractLinearTransform
 from coordinax.transforms._src import groups
 
 HMatrix: TypeAlias = Shaped[Array, " N N"]
 
-_MSG_H_SHAPE: Final = "Shear requires a square shear matrix; got shape={shape!r}."
-_MSG_H_X_SHAPE_MISMATCH: Final = (
-    "Shear() requires the chart's canonical Cartesian chart "
-    "to have dimension matching the shear matrix. "
-    "Got H.shape={H.shape} and cartesian_chart={cart.__class__.__name__} "
-    "with ndim={cart.ndim!r}."
-)
-
 
 @final
-class Shear(AbstractTransform):
+class Shear(AbstractLinearTransform):
     r"""Operator for Cartesian linear shear.
 
     A shear transform applies
@@ -66,25 +53,9 @@ class Shear(AbstractTransform):
         """Return the inverse shear transform."""
         return type(self)(jnp.linalg.inv(self.H))
 
-    @staticmethod
-    def _validate_square(H: HasShape, /) -> HMatrix:
-        shape = H.shape
-        if len(shape) != 2 or shape[0] != shape[1]:
-            raise ValueError(_MSG_H_SHAPE.format(shape=shape))
-        return cast("HMatrix", H)
-
-    @staticmethod
-    def _validate_shape_match(
-        H: HMatrix, cart: cxc.AbstractChart[Any, Any, Any], /
-    ) -> HMatrix:
-        n = H.shape[0]
-        if cart.ndim != n or len(cart.components) != n:
-            raise ValueError(_MSG_H_X_SHAPE_MISMATCH.format(H=H, cart=cart))
-        return H
-
-    def _get_H(self, cart: cxc.AbstractChart[Any, Any, Any], /) -> HMatrix:
-        H = self._validate_square(self.H)
-        return self._validate_shape_match(H, cart)
+    @property
+    def _raw_matrix(self) -> Any:
+        return self.H
 
 
 @Shear.from_.dispatch  # ty: ignore[unresolved-attribute]
@@ -111,146 +82,3 @@ def simplify(op: Shear, /, **kw: Any) -> AbstractTransform:
     if jnp.allclose(op.H, jnp.eye(op.H.shape[0], dtype=op.H.dtype), **kw):
         return identity
     return op
-
-
-@plum.dispatch
-def act(
-    op: Shear,
-    tau: Any,
-    x: ArrayLike,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    **kw: Any,
-) -> Array:
-    """Apply Shear to an Array(like) object."""
-    del tau, kw
-
-    x_arr = jnp.asarray(x)
-    chart = cxc.guess_chart(x_arr)  # ty: ignore[invalid-assignment]
-    if chart != chart.cartesian:
-        msg = "act for Shear with ArrayLike x requires a Cartesian chart."
-        raise ValueError(msg)
-    if rep != cxr.point:
-        msg = "act for Shear with ArrayLike x requires a point representation."
-        raise TypeError(msg)
-
-    H = op._get_H(chart)
-    return jnp.einsum("ij,...j->...i", H, x_arr)
-
-
-@plum.dispatch
-def act(
-    op: Shear,
-    tau: Any,
-    x: AbcQ,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    **kw: Any,
-) -> AbcQ:
-    """Apply Shear to a PointGeometry-roled Quantity."""
-    del tau, rep, kw
-
-    cart = chart.cartesian
-    if chart != cart:
-        msg = (
-            "act(Shear, ..., Quantity) requires Cartesian components. "
-            f"chart {type(chart).__name__} is not its cartesian_chart."
-        )
-        raise ValueError(msg)
-
-    H = op._get_H(chart)
-    return jnp.einsum("ij,...j->...i", H, x)  # ty: ignore[invalid-return-type]
-
-
-@plum.dispatch
-def act(
-    op: Shear,
-    tau: Any,
-    x: CDict,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    *,
-    usys: OptUSys = None,
-    **kw: Any,
-) -> CDict:
-    """Apply Shear to a coordinate dictionary."""
-    out = cxfmapi.act(op, tau, x, chart, rep.geom_kind, rep, usys=usys, **kw)
-    return cast("CDict", out)
-
-
-@plum.dispatch
-def act(
-    op: Shear,
-    tau: Any,
-    x: CDict,
-    chart: cxc.AbstractChart,
-    geom: cxr.PointGeometry,
-    rep: cxr.Representation,
-    /,
-    *,
-    usys: OptUSys = None,
-    **kw: Any,
-) -> CDict:
-    """Apply Shear to a Point-valued coordinate dictionary."""
-    del tau, geom, rep, kw
-
-    cart = chart.cartesian
-    comps_cart = cart.components
-    H = op._get_H(cart)
-
-    p_cart = cxc.pt_map(x, chart, cart, usys=usys)
-
-    v, unit = pack_uniform_unit(p_cart, keys=comps_cart)  # ty: ignore[no-matching-overload]
-    v_sheared = jnp.einsum("ij,...j->...i", H, v)
-    p_cart_sheared = cxc.cdict(v_sheared, unit, comps_cart)
-
-    out = cxc.pt_map(p_cart_sheared, cart, chart, usys=usys)
-    return cast("CDict", out)
-
-
-@plum.dispatch
-def act(
-    op: Shear,
-    tau: Any,
-    x: CDict,
-    chart: cxc.AbstractCartesianProductChart,
-    geom: cxr.PointGeometry,
-    rep: cxr.Representation,
-    /,
-    *,
-    usys: OptUSys = None,
-    **kw: Any,
-) -> CDict:
-    """Apply a shear factorwise on Cartesian-product charts."""
-    del tau
-    n = op._validate_square(op.H).shape[-1]
-
-    n_factors = len(chart.factors)
-    parts = chart.split_components(x)
-    ats = {
-        k: chart.split_components(v) if v is not None else [None] * n_factors
-        for k, v in kw.items()
-        if k.startswith("at")
-    }
-
-    def _maybe(
-        factor_chart: cxc.AbstractChart[Any, Any, Any],
-        part: CDict,
-        /,
-        **ats: CDict | None,
-    ) -> CDict:
-        cart = factor_chart.cartesian
-        if cart.ndim != n or len(cart.components) != n:
-            return part
-
-        out = cxfmapi.act(op, None, part, factor_chart, geom, rep, usys=usys, **ats)
-        return cast("CDict", out)
-
-    sheared_parts = tuple(
-        _maybe(f, p, **jtu.map(lambda seq, i=i: seq[i], ats))
-        for i, (f, p) in enumerate(zip(chart.factors, parts, strict=True))
-    )
-    return chart.merge_components(sheared_parts)


### PR DESCRIPTION
Closes the quadruplication #538 identifies. Rotate, Scale, Shear, and Reflect all act as `x -> M x` in the canonical Cartesian chart, and each hand-copied the same machinery: matrix validation, the point-action kernel (chart → cartesian → einsum → back), the Array/Quantity fast paths, and the Cartesian-product factorwise dispatch.

## What this does

Introduces **`AbstractLinearTransform(AbstractTransform)`** (`linear.py`) that owns all of the above. A subclass supplies only its matrix via the **`_raw_matrix`** property; the base's `_matrix(cart, tau)` materializes it and validates (uniform `eqx.error_if` — fixing the drift where Rotate used `error_if` and the others used plain `raise`).

- **Scale / Shear / Reflect** become thin parameter classes: matrix field + `_raw_matrix` + `groups`/`inverse`/`from_`/`simplify`/ctor. Their five `act` methods and `_validate_square`/`_validate_shape_match`/`_get_*` trios are deleted (inherited).
- **Rotate** keeps everything genuinely its own — `from_euler`, `__matmul__`/`__neg__`, `inverse`, and the tangent-geometry paths (frozen-τ pushforward + time-dependent kinematic-prolongation closed forms) — and drops its point `act` methods to the base.

## Results

- **`act` methods 44 → 29** (the four operators' ~20 point methods collapse to 5 shared ones).
- **Net −521 lines** across the four operator files *including* the new base module (`rotate` 898→661, `scale` 269→98, `shear` 256→84, `reflect` 293→118, `linear.py` +234).
- A new linear operator is now ~30 lines of parameter class — no `act` machinery.
- The base's `_matrix` materializes uniformly, giving one kernel with no static/TD split. (Exposing time-dependent Scale/Shear/Reflect to users is a trivial follow-up — it only needs callable-aware constructors + `inverse`/`simplify` guards, deliberately out of scope here to keep this refactor behavior-preserving.)

## Verification (behavior-preserving)

- Full transforms suite (240), rotate/linear doctests (121).
- Downstream sweeps: frames + usage + vectors (272), coordinax.astro Galactocentric/Galactic frame transforms (92).
- ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)