### PR TITLE
✨ fix(charts): guess_chart accepts NumPy arrays (+ act numpy-input guards)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1117,13 +1117,14 @@ The `coordinax.charts` module provides the chart-facing API for representing poi
 
     - Input `frozenset[str]` (component names): infer a chart whose `components` set matches exactly. The results are cached; repeated calls with the same key set return the same chart object instance.
     - Input `CDict`/mapping: infer from `frozenset(obj.keys())`.
-    - Input array-like or quantity-like with trailing axis length 1, 2, or 3: infer Cartesian chart by that trailing size.
-    - Mapping for shaped inputs: trailing `...x1 -> cart1d`, `...x2 -> cart2d`, `...x3 -> cart3d`.
+    - Input array-like or quantity-like with trailing axis length 1, 2, or 3: infer the matching low-dimensional Cartesian chart (`cart1d`/`cart2d`/`cart3d`) by that trailing size.
+    - Input array-like or quantity-like with any other trailing axis length: infer the arbitrary-dimension Cartesian chart `cartnd` (`CartND`).
+    - Mapping for shaped inputs: trailing `...x1 -> cart1d`, `...x2 -> cart2d`, `...x3 -> cart3d`, any other `...xN -> cartnd`.
 
     Failure semantics:
 
     - If no chart matches a provided key set, raise `ValueError`.
-    - Inputs outside registered dispatches (for example trailing axis sizes other than 1/2/3) are not inferred by this API.
+    - Inputs with no registered dispatch — neither a component-name set / mapping nor an array-like or quantity-like value — are not inferred by this API.
 
     Notes:
 

--- a/src/coordinax/_src/charts/register_guess.py
+++ b/src/coordinax/_src/charts/register_guess.py
@@ -113,7 +113,7 @@ def guess_chart(
     """Infer a 1D Cartesian chart from last dimension of a value / quantity.
 
     >>> import unxt as u
-    >>> import coordinax.charts as cx
+    >>> import coordinax.charts as cxc
     >>> q = u.Q([1.0], "m")
     >>> cxc.guess_chart(q)
     Cart1D(M=Rn(1))
@@ -130,7 +130,7 @@ def guess_chart(
     """Infer a 2D Cartesian chart from last dimension of a value / quantity.
 
     >>> import unxt as u
-    >>> import coordinax.charts as cx
+    >>> import coordinax.charts as cxc
     >>> q = u.Q([1.0, 2.0], "m")
     >>> cxc.guess_chart(q)
     Cart2D(M=Rn(2))
@@ -147,7 +147,7 @@ def guess_chart(
     """Infer a 3D Cartesian chart from last dimension of a value / quantity.
 
     >>> import unxt as u
-    >>> import coordinax.charts as cx
+    >>> import coordinax.charts as cxc
     >>> q = u.Q([1.0, 2.0, 3.0], "m")
     >>> cxc.guess_chart(q)
     Cart3D(M=Rn(3))
@@ -164,7 +164,7 @@ def guess_chart(
     """Infer a N-dimensional Cartesian chart from last dimension of a value / quantity.
 
     >>> import unxt as u
-    >>> import coordinax.charts as cx
+    >>> import coordinax.charts as cxc
     >>> q = u.Q([1.0, 2.0, 3.0, 4.0], "m")
     >>> cxc.guess_chart(q)
     CartND(M=Rn(True))

--- a/src/coordinax/_src/charts/register_guess.py
+++ b/src/coordinax/_src/charts/register_guess.py
@@ -2,7 +2,7 @@
 
 __all__: tuple[str, ...] = ()
 
-from jaxtyping import Array, Shaped
+from jaxtyping import ArrayLike, Shaped
 from typing import Any, cast
 
 import plum
@@ -107,7 +107,7 @@ def guess_chart(obj: CDict, /) -> AbstractChart:
 
 @plum.dispatch
 def guess_chart(
-    _: Shaped[Array, "*batch 1"] | Shaped[u.AbstractQuantity, "*batch 1"],
+    _: Shaped[ArrayLike, "*batch 1"] | Shaped[u.AbstractQuantity, "*batch 1"],
     /,
 ) -> AbstractChart:
     """Infer a 1D Cartesian chart from last dimension of a value / quantity.
@@ -124,7 +124,8 @@ def guess_chart(
 
 @plum.dispatch
 def guess_chart(
-    _: Shaped[Array, "*batch 2"] | Shaped[u.AbstractQuantity, "*batch 2"], /
+    _: Shaped[ArrayLike, "*batch 2"] | Shaped[u.AbstractQuantity, "*batch 2"],
+    /,
 ) -> AbstractChart:
     """Infer a 2D Cartesian chart from last dimension of a value / quantity.
 
@@ -140,7 +141,8 @@ def guess_chart(
 
 @plum.dispatch
 def guess_chart(
-    _: Shaped[Array, "*batch 3"] | Shaped[u.AbstractQuantity, "*batch 3"], /
+    _: Shaped[ArrayLike, "*batch 3"] | Shaped[u.AbstractQuantity, "*batch 3"],
+    /,
 ) -> AbstractChart:
     """Infer a 3D Cartesian chart from last dimension of a value / quantity.
 
@@ -156,7 +158,8 @@ def guess_chart(
 
 @plum.dispatch(precedence=-1)  # ty: ignore[no-matching-overload]
 def guess_chart(
-    _: Shaped[Array, "*batch N"] | Shaped[u.AbstractQuantity, "*batch N"], /
+    _: Shaped[ArrayLike, "*batch N"] | Shaped[u.AbstractQuantity, "*batch N"],
+    /,
 ) -> AbstractChart:
     """Infer a N-dimensional Cartesian chart from last dimension of a value / quantity.
 

--- a/src/coordinax/transforms/_src/actions/register_apply.py
+++ b/src/coordinax/transforms/_src/actions/register_apply.py
@@ -27,9 +27,10 @@ PointLike: TypeAlias = ArrayLike | AbcQ | QMatrix | CDict
 # Input coercion
 #
 # `guess_chart` only dispatches on JAX arrays, Quantities, and CDicts, so a bare
-# `ArrayLike` (a list, a NumPy array, a scalar) must be coerced to a JAX array
-# before chart inference. Quantity / QMatrix / CDict are passed through
-# unchanged (they already carry the structure `guess_chart` needs).
+# `ArrayLike` (a NumPy array or a scalar) must be coerced to a JAX array before
+# chart inference. Quantity / QMatrix / CDict are passed through unchanged (they
+# already carry the structure `guess_chart` needs). A Python list is not an
+# `ArrayLike`, so it never reaches this funnel (see test_act_rejects_python_list).
 
 
 @plum.dispatch

--- a/src/coordinax/transforms/_src/actions/register_apply.py
+++ b/src/coordinax/transforms/_src/actions/register_apply.py
@@ -7,7 +7,6 @@ from typing import Any, TypeAlias, cast
 
 import plum
 
-import quaxed.numpy as jnp
 import unxt as u
 from unxt import AbstractQuantity as AbcQ
 
@@ -20,27 +19,10 @@ from coordinax.internal import QMatrix, pack_nonuniform_unit, pack_uniform_unit
 
 # A "point-like" input the entry funnel accepts. Faithful (each member and the
 # union), so the normalizer methods below stay in plum's method cache.
+# `guess_chart` accepts all of these directly (JAX and NumPy arrays, Quantities,
+# QMatrix, CDicts). A Python list is not an `ArrayLike`, so it never matches this
+# union at all (see test_act_rejects_python_list).
 PointLike: TypeAlias = ArrayLike | AbcQ | QMatrix | CDict
-
-
-# ===================================================================
-# Input coercion
-#
-# `guess_chart` only dispatches on JAX arrays, Quantities, and CDicts, so a bare
-# `ArrayLike` (a NumPy array or a scalar) must be coerced to a JAX array before
-# chart inference. Quantity / QMatrix / CDict are passed through unchanged (they
-# already carry the structure `guess_chart` needs). A Python list is not an
-# `ArrayLike`, so it never reaches this funnel (see test_act_rejects_python_list).
-
-
-@plum.dispatch
-def _as_data(x: PointLike, /) -> Any:
-    return x
-
-
-@plum.dispatch
-def _as_data(x: ArrayLike, /) -> Any:
-    return jnp.asarray(x)
 
 
 # ===================================================================
@@ -129,7 +111,6 @@ def act(op: AbstractTransform, tau: Any, x: PointLike, /, **kw: Any) -> Any:
     Q([0., 1., 0.], 'km')
 
     """
-    x = _as_data(x)
     chart = cxc.guess_chart(x)
     return cxfmapi.act(op, tau, x, chart, _default_rep(x), **kw)
 
@@ -156,7 +137,6 @@ def act(
     Q([0., 1., 0.], 'km')
 
     """
-    x = _as_data(x)
     return cxfmapi.act(op, tau, x, chart, _default_rep(x), **kw)
 
 

--- a/tests/unit/charts/test_guess_chart.py
+++ b/tests/unit/charts/test_guess_chart.py
@@ -16,6 +16,8 @@
 
 from typing import TypeAlias
 
+import numpy as np
+import pytest
 from hypothesis import given, strategies as st
 
 import unxt_hypothesis as ust
@@ -128,3 +130,14 @@ class TestGuessChartFromArrayLike:
         q = data.draw(ust.quantities("m", shape=self.draw_shape(data, ndim)))
         guessed = cxc.guess_chart(q)
         assert guessed == expected
+
+    @pytest.mark.parametrize("ndim", [1, 2, 3])
+    def test_numpy_array_trailing_dim_guesses_cartesian(self, ndim: int) -> None:
+        """A NumPy array (not only a JAX array) guesses to Cart[N]D."""
+        guessed = cxc.guess_chart(np.ones((2, ndim)))
+        assert guessed == SHAPE_CART_MAP[ndim]
+
+    def test_numpy_array_high_dim_guesses_cartnd(self) -> None:
+        """A NumPy array with trailing dim > 3 guesses to the N-D Cartesian chart."""
+        guessed = cxc.guess_chart(np.ones((2, 5)))
+        assert type(guessed) is cxc.CartND

--- a/tests/unit/transforms/test_act.py
+++ b/tests/unit/transforms/test_act.py
@@ -21,6 +21,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from plum import NotFoundLookupError
 
 import unxt as u
 
@@ -205,6 +206,43 @@ def test_coordinate_preserves_frame(rotate_op, coord_3d):
 def test_coordinate_xfm_preserves_transformed_frame(rotate_op, coord_xfm_3d):
     result = cxfm.act(rotate_op, None, coord_xfm_3d)
     assert isinstance(result.frame, cxf.TransformedReferenceFrame)
+
+
+# ===================================================================
+# Non-JAX ArrayLike inputs
+#
+# `jaxtyping.ArrayLike` covers NumPy arrays and scalars, not just JAX arrays.
+# The dispatch funnel must coerce them before chart inference (guess_chart only
+# dispatches on JAX arrays / Quantities / CDicts); these guard that path, which
+# the JAX-array fixtures above do not exercise.
+# ===================================================================
+
+
+@pytest.mark.parametrize(("op_fixture", "expected", "needs_usys"), OPS, ids=OP_IDS)
+def test_act_accepts_numpy_array(request, op_fixture, expected, needs_usys):
+    """A NumPy array is coerced and dispatched exactly like a JAX array."""
+    op = request.getfixturevalue(op_fixture)
+    x = np.asarray([1.0, 0.0, 0.0])
+    kw = {"usys": USYS} if needs_usys else {}
+    _assert_close(_extract_xyz(cxfm.act(op, None, x, **kw)), expected)
+
+
+def test_act_numpy_matches_jax_array(rotate_op):
+    """NumPy and JAX array inputs give identical results."""
+    data = [1.0, 2.0, 3.0]
+    out_np = np.asarray(cxfm.act(rotate_op, None, np.asarray(data)))
+    out_jax = np.asarray(cxfm.act(rotate_op, None, jnp.asarray(data)))
+    np.testing.assert_allclose(out_np, out_jax)
+
+
+def test_act_rejects_python_list(rotate_op):
+    """A Python list is not an ArrayLike, so it does not resolve.
+
+    This is the documented boundary: callers pass ``jnp.asarray(...)`` or a
+    Quantity, not a bare list.
+    """
+    with pytest.raises(NotFoundLookupError):
+        cxfm.act(rotate_op, None, [1.0, 0.0, 0.0])
 
 
 # ===================================================================

--- a/tests/unit/transforms/test_act.py
+++ b/tests/unit/transforms/test_act.py
@@ -211,16 +211,16 @@ def test_coordinate_xfm_preserves_transformed_frame(rotate_op, coord_xfm_3d):
 # ===================================================================
 # Non-JAX ArrayLike inputs
 #
-# `jaxtyping.ArrayLike` covers NumPy arrays and scalars, not just JAX arrays.
-# The dispatch funnel must coerce them before chart inference (guess_chart only
-# dispatches on JAX arrays / Quantities / CDicts); these guard that path, which
-# the JAX-array fixtures above do not exercise.
+# `jaxtyping.ArrayLike` covers NumPy arrays as well as JAX arrays, and both
+# dispatch equivalently through `guess_chart` and the act funnel. These guard
+# that path, which the JAX-array fixtures above do not exercise. (A Python list
+# is not an ArrayLike and is rejected — see test_act_rejects_python_list.)
 # ===================================================================
 
 
 @pytest.mark.parametrize(("op_fixture", "expected", "needs_usys"), OPS, ids=OP_IDS)
 def test_act_accepts_numpy_array(request, op_fixture, expected, needs_usys):
-    """A NumPy array is coerced and dispatched exactly like a JAX array."""
+    """A NumPy array dispatches equivalently to a JAX array."""
     op = request.getfixturevalue(op_fixture)
     x = np.asarray([1.0, 0.0, 0.0])
     kw = {"usys": USYS} if needs_usys else {}


### PR DESCRIPTION
Makes `guess_chart` — and therefore `act` — work for NumPy arrays, at the source.

## Background

#543 fixed a regression where `act(op, None, np.array(...))` raised `NotFoundLookupError` by coercing `ArrayLike -> jnp.asarray` in a `_as_data` shim before chart inference. That was a workaround: the real gap is that `guess_chart`'s shape dispatches only accepted JAX arrays.

## What this does

- **`guess_chart` accepts NumPy arrays.** Its shape-parametrized dispatches were annotated `Shaped[Array, "*batch K"]` (JAX only); widen to `Shaped[Array | np.ndarray, "*batch K"]` so a NumPy array guesses its Cartesian chart directly for 1/2/3/N-D — matching JAX arrays and Quantities.
- **Remove the `_as_data` workaround** (and the now-unused `quaxed.numpy` import) from the act funnel: the normalizer calls `guess_chart(x)` directly, and the arity-5 fast paths already coerce.
- **Tests**: a direct `guess_chart` NumPy test, plus the act-level guards — `act` on a NumPy array matches the JAX-array result, and a Python list (not an `ArrayLike`) is still correctly rejected (the documented boundary).

## Verification

- `guess_chart` NumPy tests pass (1/2/3/N-D); JAX arrays and Quantities unchanged.
- Transforms suite (249), charts suite (439), doctests, ruff + ty — all green.
- `act._resolver.is_faithful` stays `True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)