### PR TITLE
♻️ refactor(interop): drop private CPython attr; record failures instead

### DIFF
--- a/src/coordinax/__init__.py
+++ b/src/coordinax/__init__.py
@@ -193,14 +193,16 @@ from coordinax.vectors import Coordinate, Point, Tangent, ToUnitsOptions
 # loader runs while the sibling is only partially initialized and its types are
 # not yet resolvable, so the interop import fails.
 #
-# Because interop is an *optional* extra, that failure must never break
-# `import coordinax`. Rather than classifying failures, the loader records every
-# failure (in `_OPTIONAL_INTEROP_STATE["failed"]`) and never raises. A transient
-# cyclic failure recovers on a later call — packages that participate in such a
-# cycle re-invoke this once their own symbols exist (see
-# `coordinaxs.astro.__init__`), and the retry succeeds and clears the failure. A
-# genuine failure simply stays recorded. This needs no inspection of
+# Because interop is an *optional* extra, a failed entry-point *load* must never
+# break `import coordinax`. Rather than classifying failures, the loader records
+# each load failure (in `_OPTIONAL_INTEROP_STATE["failed"]`) and does not
+# re-raise it. A transient cyclic failure recovers on a later call — packages
+# that participate in such a cycle re-invoke this once their own symbols exist
+# (see `coordinaxs.astro.__init__`), and the retry succeeds and clears the
+# failure. A genuine failure simply stays recorded. This needs no inspection of
 # import-machinery state and behaves identically in every import order.
+# (Errors from entry-point *discovery* itself — e.g. corrupt distribution
+# metadata — indicate a broken environment and are left to propagate.)
 
 _INTEROP_ENTRYPOINT_GROUP: Final = "coordinaxs.interop"
 #: Pre-rename group name, still honoured so third-party interop
@@ -221,10 +223,13 @@ def _load_optional_interop() -> None:
     """Import interop packages registered in the ``coordinaxs.interop`` group.
 
     Interop distributions register their conversions and chart transitions as an
-    import side effect. Because interop is an *optional* extra, a load failure
-    must never break ``import coordinax``: this function never raises. Each entry
-    point is loaded at most once; a load that fails is recorded in
-    ``_OPTIONAL_INTEROP_STATE["failed"]`` and retried on the next call.
+    import side effect. Because interop is an *optional* extra, an entry point
+    that fails to *load* must never break ``import coordinax``: each entry point
+    is loaded at most once, and a load that raises is recorded in
+    ``_OPTIONAL_INTEROP_STATE["failed"]`` (with its traceback cleared) and retried
+    on the next call rather than propagated. Errors from entry-point *discovery*
+    itself — e.g. corrupt distribution metadata — are a broken environment and
+    are left to propagate.
 
     Retryability is what makes registration import-order independent. Interop
     participates in a cycle — ``coordinaxs.interop.astropy`` references
@@ -276,10 +281,13 @@ def _load_optional_interop() -> None:
             try:
                 ep.load()  # importing the module performs the registration
             except Exception as exc:  # noqa: BLE001
-                # Optional extra: never break `import coordinax`. Record the
-                # failure (retryable) instead of raising. A transient cyclic
-                # failure recovers on a later call; a genuine one persists here.
-                state["failed"][ep.name] = exc
+                # Optional extra: a failed load must never break `import
+                # coordinax`. Record the failure (retryable) instead of raising.
+                # Clear the traceback first: this dict lives for the process
+                # lifetime, and a retained traceback pins its stack frames and
+                # their locals. A transient cyclic failure recovers on a later
+                # call; a genuine one persists here.
+                state["failed"][ep.name] = exc.with_traceback(None)
             else:
                 state["loaded"].add(ep.name)
                 state["failed"].pop(ep.name, None)

--- a/src/coordinax/__init__.py
+++ b/src/coordinax/__init__.py
@@ -88,7 +88,6 @@ __all__ = (  # distances
     "ToUnitsOptions",
 )
 
-import sys
 import warnings
 from importlib.metadata import entry_points
 
@@ -203,42 +202,44 @@ _INTEROP_ENTRYPOINT_GROUP: Final = "coordinaxs.interop"
 #: Pre-rename group name, still honoured so third-party interop
 #: distributions published against it are not silently dropped.
 _LEGACY_INTEROP_ENTRYPOINT_GROUP: Final = "coordinax.interop"
-_OPTIONAL_INTEROP_STATE: dict[str, Any] = {"loading": False, "loaded": set()}
-
-
-def _coordinaxs_is_initializing() -> bool:
-    """Whether any ``coordinaxs`` module is still executing its module body."""
-    for name in list(sys.modules):
-        if name != "coordinaxs" and not name.startswith("coordinaxs."):
-            continue
-        spec = getattr(sys.modules.get(name), "__spec__", None)
-        if getattr(spec, "_initializing", False):
-            return True
-    return False
+#: ``loaded``: names of entry points whose module imported successfully.
+#: ``failed``: name -> the last exception raised while loading it (retryable;
+#: cleared on a later successful load). Inspect ``failed`` to diagnose an
+#: installed-but-broken interop.
+_OPTIONAL_INTEROP_STATE: dict[str, Any] = {
+    "loading": False,
+    "loaded": set(),
+    "failed": {},
+}
 
 
 def _load_optional_interop() -> None:
     """Import interop packages registered in the ``coordinaxs.interop`` group.
 
-    Idempotent and retryable: each entry point is loaded at most once, and any
-    that cannot be loaded yet (because a package it references is mid-import)
-    is left pending for a later call.
+    Interop distributions register their conversions and chart transitions as an
+    import side effect. Because interop is an *optional* extra, a load failure
+    must never break ``import coordinax``: this function never raises. Each entry
+    point is loaded at most once; a load that fails is recorded in
+    ``_OPTIONAL_INTEROP_STATE["failed"]`` and retried on the next call.
 
-    Contract for interop authors: a pending entry point is only retried when
-    something calls this function again. Core calls it once at the end of its
-    own import, and ``coordinaxs.astro`` re-invokes it at the end of *its* import
-    (so astro-first ordering works). If you write an interop that participates
-    in an import cycle through a *different* sibling package, that sibling must
-    likewise call ``coordinax._load_optional_interop()`` at the end of its
-    ``__init__`` once its public symbols exist — otherwise a sibling-first import
-    leaves your interop permanently pending and silently unregistered.
+    Retryability is what makes registration import-order independent. Interop
+    participates in a cycle — ``coordinaxs.interop.astropy`` references
+    ``coordinaxs.astro`` types, and ``coordinaxs.astro`` imports
+    ``coordinax.frames``, which (now that ``coordinax`` is a regular package)
+    runs this module. When the sibling is imported first, this loader runs while
+    the sibling is only partially initialized, so the interop import fails; it is
+    recorded and simply *succeeds on the retry* once the sibling finishes. No
+    inspection of import-machinery state is needed, and the behaviour is the same
+    whichever module is imported first.
 
-    Known limitation: a genuinely broken interop package whose import fails
-    *while* some ``coordinaxs`` module is still initializing is indistinguishable
-    from the expected cycle, so it is left pending rather than raised. In
-    practice that means a broken interop is reported when `coordinax` is
-    imported first (the common case, and the documented entry point) but is
-    silently skipped when the interop's sibling package is imported first.
+    Contract for interop authors: a failed/pending entry point is retried only
+    when something calls this again. Core calls it once at the end of its own
+    import, and ``coordinaxs.astro`` re-invokes it at the end of *its* import. An
+    interop that participates in a cycle through a *different* sibling should
+    have that sibling likewise call ``coordinax._load_optional_interop()`` at the
+    end of its ``__init__`` (once its public symbols exist), or a sibling-first
+    import leaves the interop recorded in ``failed`` and unregistered until the
+    next call. A genuinely broken interop stays in ``failed`` in every ordering.
     """
     state = _OPTIONAL_INTEROP_STATE
     if state["loading"]:  # guard against re-entrant loading
@@ -270,14 +271,14 @@ def _load_optional_interop() -> None:
                 continue
             try:
                 ep.load()  # importing the module performs the registration
-            except Exception:
-                # Only the known import cycle is tolerated; leave this entry
-                # point pending so a later call retries it. Anything else is a
-                # genuine failure in an installed interop package.
-                if not _coordinaxs_is_initializing():
-                    raise
+            except Exception as exc:  # noqa: BLE001
+                # Optional extra: never break `import coordinax`. Record the
+                # failure (retryable) instead of raising. A transient cyclic
+                # failure recovers on a later call; a genuine one persists here.
+                state["failed"][ep.name] = exc
             else:
                 state["loaded"].add(ep.name)
+                state["failed"].pop(ep.name, None)
     finally:
         state["loading"] = False
 

--- a/src/coordinax/__init__.py
+++ b/src/coordinax/__init__.py
@@ -191,12 +191,16 @@ from coordinax.vectors import Coordinate, Point, Tangent, ToUnitsOptions
 # sibling imports `coordinax.frames`, which — now that `coordinax` is a regular
 # package — runs this module. So when the sibling is imported *first*, this
 # loader runs while the sibling is only partially initialized and its types are
-# not yet resolvable. Rather than pre-guessing that state, the loader attempts
-# the import and classifies the failure: if any `coordinaxs.*` module is still
-# executing its body, the entry point is left pending for a later call;
-# otherwise the failure is real and propagates. Packages that participate in
-# such a cycle re-invoke this once their own symbols exist (see
-# `coordinaxs.astro.__init__`), which is what completes the registration.
+# not yet resolvable, so the interop import fails.
+#
+# Because interop is an *optional* extra, that failure must never break
+# `import coordinax`. Rather than classifying failures, the loader records every
+# failure (in `_OPTIONAL_INTEROP_STATE["failed"]`) and never raises. A transient
+# cyclic failure recovers on a later call — packages that participate in such a
+# cycle re-invoke this once their own symbols exist (see
+# `coordinaxs.astro.__init__`), and the retry succeeds and clears the failure. A
+# genuine failure simply stays recorded. This needs no inspection of
+# import-machinery state and behaves identically in every import order.
 
 _INTEROP_ENTRYPOINT_GROUP: Final = "coordinaxs.interop"
 #: Pre-rename group name, still honoured so third-party interop

--- a/tests/unit/test_interop_loader.py
+++ b/tests/unit/test_interop_loader.py
@@ -3,16 +3,13 @@
 `tests/integration/frames/test_interop_import_order.py` covers the real
 end-to-end behaviour, but it must spawn subprocesses (the session conftest
 preloads `coordinax`, so import order cannot be varied in-process). These
-in-process tests exercise the loader's branches directly: readiness detection,
-legacy-group handling, and the failure classification that decides whether an
-entry point is left pending or raised.
+in-process tests exercise the loader directly: it never raises (interop is an
+optional extra), records failures for inspection, retries pending/failed entry
+points, and honours the legacy group name.
 """
 
-import importlib
-import sys
 import warnings
 
-import types
 from typing import Any
 
 import pytest
@@ -24,10 +21,15 @@ import coordinax as cx
 def _reset_interop_state() -> Any:
     """Save/restore the loader's module-level state around a test."""
     state = cx._OPTIONAL_INTEROP_STATE
-    saved = {"loading": state["loading"], "loaded": set(state["loaded"])}
+    saved = {
+        "loading": state["loading"],
+        "loaded": set(state["loaded"]),
+        "failed": dict(state["failed"]),
+    }
     yield
     state["loading"] = saved["loading"]
     state["loaded"] = saved["loaded"]
+    state["failed"] = saved["failed"]
 
 
 class _FakeEntryPoint:
@@ -45,84 +47,27 @@ class _FakeEntryPoint:
         return object()
 
 
-def _initializing_module(name: str) -> types.ModuleType:
-    """A module object that reports itself as still executing its body."""
-    module = types.ModuleType(name)
-    spec = types.SimpleNamespace(_initializing=True)
-    module.__spec__ = spec  # type: ignore[assignment]
-    return module
+def _only_interop(ep: _FakeEntryPoint) -> Any:
+    """An `entry_points` stub returning ``[ep]`` for the interop group."""
+    return lambda group: [ep] if "interop" in group else []
 
 
 # =============================================================================
-# _coordinaxs_is_initializing
-
-
-def test_not_initializing_at_rest() -> None:
-    """With every coordinaxs module fully imported, nothing is initializing."""
-    assert cx._coordinaxs_is_initializing() is False
-
-
-def test_detects_partially_initialized_module(monkeypatch: Any) -> None:
-    """A coordinaxs module mid-import is detected."""
-    monkeypatch.setitem(
-        sys.modules, "coordinaxs.fake_pkg", _initializing_module("coordinaxs.fake_pkg")
-    )
-    assert cx._coordinaxs_is_initializing() is True
-
-
-def test_ignores_unrelated_initializing_module(monkeypatch: Any) -> None:
-    """A non-coordinaxs module mid-import is not mistaken for the cycle."""
-    monkeypatch.setitem(sys.modules, "unrelated", _initializing_module("unrelated"))
-    assert cx._coordinaxs_is_initializing() is False
-
-
-def test_importlib_marks_initializing_modules(tmp_path: Any) -> None:
-    """Pin the private importlib contract `_coordinaxs_is_initializing` uses.
-
-    `_coordinaxs_is_initializing` reads ``__spec__._initializing`` — a private,
-    undocumented CPython importlib attribute that is ``True`` only while a
-    module's body executes. Every other test in this module *fakes* that
-    attribute, so a Python release that removed or renamed it would leave the
-    faked tests green while the real cycle-tolerance silently broke (astro-first
-    import would start raising). This test imports a real module that captures
-    its own ``__spec__._initializing`` during execution, pinning the contract so
-    such a change is caught here instead.
-    """
-    probe = tmp_path / "_probe_initializing.py"
-    probe.write_text(
-        "import sys\n"
-        "_spec = sys.modules[__name__].__spec__\n"
-        "captured = getattr(_spec, '_initializing', 'MISSING')\n"
-    )
-    probe_dir = str(tmp_path)
-    sys.path.insert(0, probe_dir)
-    try:
-        module = importlib.import_module("_probe_initializing")
-        assert module.captured is True, (
-            "importlib no longer sets __spec__._initializing during module "
-            "execution; _coordinaxs_is_initializing() needs updating."
-        )
-    finally:
-        sys.path.remove(probe_dir)
-        sys.modules.pop("_probe_initializing", None)
-
-
-# =============================================================================
-# _load_optional_interop
+# _load_optional_interop: success and bookkeeping
 
 
 @pytest.mark.usefixtures("_reset_interop_state")
 def test_loads_entry_point_once(monkeypatch: Any) -> None:
     """An entry point is loaded once and then recorded as loaded."""
     ep = _FakeEntryPoint("fake")
-    monkeypatch.setattr(
-        cx, "entry_points", lambda group: [ep] if "interop" in group else []
-    )
+    monkeypatch.setattr(cx, "entry_points", _only_interop(ep))
     cx._OPTIONAL_INTEROP_STATE["loaded"] = set()
+    cx._OPTIONAL_INTEROP_STATE["failed"] = {}
 
     cx._load_optional_interop()
     assert ep.loaded
     assert "fake" in cx._OPTIONAL_INTEROP_STATE["loaded"]
+    assert cx._OPTIONAL_INTEROP_STATE["failed"] == {}
 
     ep.loaded = False
     cx._load_optional_interop()  # already recorded -> not re-loaded
@@ -130,42 +75,67 @@ def test_loads_entry_point_once(monkeypatch: Any) -> None:
 
 
 @pytest.mark.usefixtures("_reset_interop_state")
-def test_failure_during_cycle_is_left_pending(monkeypatch: Any) -> None:
-    """A failure while a coordinaxs module is mid-import leaves it pending."""
-    ep = _FakeEntryPoint("fake", exc=AttributeError("no attribute 'Parallax'"))
-    monkeypatch.setattr(
-        cx, "entry_points", lambda group: [ep] if "interop" in group else []
-    )
-    monkeypatch.setitem(
-        sys.modules, "coordinaxs.fake_pkg", _initializing_module("coordinaxs.fake_pkg")
-    )
+def test_reentrant_call_is_a_noop(monkeypatch: Any) -> None:
+    """A re-entrant call returns immediately instead of double-loading."""
+    ep = _FakeEntryPoint("fake")
+    monkeypatch.setattr(cx, "entry_points", _only_interop(ep))
     cx._OPTIONAL_INTEROP_STATE["loaded"] = set()
+    cx._OPTIONAL_INTEROP_STATE["failed"] = {}
+    cx._OPTIONAL_INTEROP_STATE["loading"] = True
+
+    cx._load_optional_interop()
+
+    assert not ep.loaded
+
+
+# =============================================================================
+# _load_optional_interop: failures are recorded, never raised
+#
+# Interop is an optional extra, so a load failure must never break `import
+# coordinax`. Instead of classifying failures (which previously required reading
+# a private CPython import-state attribute), the loader records every failure
+# and retries it on the next call. A transient failure (a sibling still
+# mid-import in the astro->coordinax->interop->astro cycle) recovers on the
+# retry; a genuine failure stays recorded. Behaviour is identical regardless of
+# import order.
+
+
+@pytest.mark.usefixtures("_reset_interop_state")
+def test_failure_is_recorded_not_raised(monkeypatch: Any) -> None:
+    """A load failure is recorded rather than raised, and is not marked loaded."""
+    exc = RuntimeError("interop is broken")
+    ep = _FakeEntryPoint("fake", exc=exc)
+    monkeypatch.setattr(cx, "entry_points", _only_interop(ep))
+    cx._OPTIONAL_INTEROP_STATE["loaded"] = set()
+    cx._OPTIONAL_INTEROP_STATE["failed"] = {}
 
     cx._load_optional_interop()  # must not raise
 
     assert "fake" not in cx._OPTIONAL_INTEROP_STATE["loaded"]
+    assert cx._OPTIONAL_INTEROP_STATE["failed"]["fake"] is exc
 
 
 @pytest.mark.usefixtures("_reset_interop_state")
-def test_genuine_failure_propagates(monkeypatch: Any) -> None:
-    """A failure with nothing mid-import is real breakage and is raised."""
-    ep = _FakeEntryPoint("fake", exc=RuntimeError("interop is broken"))
-    monkeypatch.setattr(
-        cx, "entry_points", lambda group: [ep] if "interop" in group else []
-    )
+def test_import_error_is_also_recorded_not_raised(monkeypatch: Any) -> None:
+    """An ImportError (absent transitive dep) is recorded, not raised."""
+    ep = _FakeEntryPoint("fake", exc=ImportError("no module named 'astropy'"))
+    monkeypatch.setattr(cx, "entry_points", _only_interop(ep))
     cx._OPTIONAL_INTEROP_STATE["loaded"] = set()
+    cx._OPTIONAL_INTEROP_STATE["failed"] = {}
 
-    with pytest.raises(RuntimeError, match="interop is broken"):
-        cx._load_optional_interop()
+    cx._load_optional_interop()  # must not raise
+
+    assert "fake" not in cx._OPTIONAL_INTEROP_STATE["loaded"]
+    assert isinstance(cx._OPTIONAL_INTEROP_STATE["failed"]["fake"], ImportError)
 
 
 @pytest.mark.usefixtures("_reset_interop_state")
-def test_retry_completes_after_cycle_clears(monkeypatch: Any) -> None:
-    """A pending entry point loads on a later call once the cycle clears.
+def test_retry_recovers_after_transient_failure(monkeypatch: Any) -> None:
+    """An entry point that fails once then succeeds is recovered on the retry.
 
-    This is the whole point of the retryable design: fail while a sibling is
-    mid-import, then succeed on a later at-rest call. The astro-first ordering
-    relies on exactly this two-phase transition.
+    This is the mechanism the astro-first import ordering relies on: the first
+    load fails because a sibling is still mid-import, and a later call (from the
+    sibling's own re-invocation hook) succeeds.
     """
     calls = {"n": 0}
 
@@ -177,28 +147,23 @@ def test_retry_completes_after_cycle_clears(monkeypatch: Any) -> None:
 
         def load(self) -> object:
             calls["n"] += 1
-            if calls["n"] == 1:  # first attempt: fail as if mid-cycle
+            if calls["n"] == 1:  # first attempt fails, as if mid-cycle
                 raise AttributeError("partially initialized: no 'Parallax' yet")
             self.loaded = True
             return object()
 
     ep = _FlakyEntryPoint()
-    monkeypatch.setattr(
-        cx, "entry_points", lambda group: [ep] if "interop" in group else []
-    )
+    monkeypatch.setattr(cx, "entry_points", _only_interop(ep))
     cx._OPTIONAL_INTEROP_STATE["loaded"] = set()
+    cx._OPTIONAL_INTEROP_STATE["failed"] = {}
 
-    # Phase 1: a coordinaxs module is initializing -> the failure is tolerated
-    # and the entry point is left pending.
-    initializing = _initializing_module("coordinaxs.fake_pkg")
-    monkeypatch.setitem(sys.modules, "coordinaxs.fake_pkg", initializing)
+    # Phase 1: fails -> recorded, not loaded.
     cx._load_optional_interop()
     assert not ep.loaded
     assert "flaky" not in cx._OPTIONAL_INTEROP_STATE["loaded"]
+    assert "flaky" in cx._OPTIONAL_INTEROP_STATE["failed"]
 
-    # Phase 2: the sibling finished initializing; a later call retries and the
-    # entry point now loads and is recorded.
-    initializing.__spec__._initializing = False  # type: ignore[union-attr]
+    # Phase 2: a later call retries and now succeeds.
     cx._load_optional_interop()
     assert ep.loaded
     assert "flaky" in cx._OPTIONAL_INTEROP_STATE["loaded"]
@@ -206,44 +171,48 @@ def test_retry_completes_after_cycle_clears(monkeypatch: Any) -> None:
 
 
 @pytest.mark.usefixtures("_reset_interop_state")
-def test_genuine_error_is_swallowed_while_initializing(monkeypatch: Any) -> None:
-    """A genuinely broken interop is swallowed, not raised, while initializing.
+def test_success_clears_prior_failure(monkeypatch: Any) -> None:
+    """Recovering an entry point removes it from the recorded failures."""
+    calls = {"n": 0}
 
-    This pins the loader's documented limitation.
-    `_load_optional_interop` cannot distinguish a real failure from the expected
-    import cycle while a `coordinaxs` module is still initializing, so it leaves
-    the entry point pending instead of raising (see the loader docstring). This
-    test locks that intended-but-imperfect semantics so a future change to the
-    failure classification is caught.
-    """
-    ep = _FakeEntryPoint("fake", exc=RuntimeError("interop is genuinely broken"))
-    monkeypatch.setattr(
-        cx, "entry_points", lambda group: [ep] if "interop" in group else []
-    )
-    monkeypatch.setitem(
-        sys.modules, "coordinaxs.fake_pkg", _initializing_module("coordinaxs.fake_pkg")
-    )
+    class _FlakyEntryPoint:
+        name = "flaky"
+
+        def load(self) -> object:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("not yet")
+            return object()
+
+    ep = _FlakyEntryPoint()
+    monkeypatch.setattr(cx, "entry_points", _only_interop(ep))
     cx._OPTIONAL_INTEROP_STATE["loaded"] = set()
+    cx._OPTIONAL_INTEROP_STATE["failed"] = {}
 
-    # Swallowed, not raised, because a coordinaxs module is still initializing.
     cx._load_optional_interop()
+    assert "flaky" in cx._OPTIONAL_INTEROP_STATE["failed"]
 
-    assert "fake" not in cx._OPTIONAL_INTEROP_STATE["loaded"]
+    cx._load_optional_interop()
+    assert "flaky" not in cx._OPTIONAL_INTEROP_STATE["failed"]
+    assert "flaky" in cx._OPTIONAL_INTEROP_STATE["loaded"]
 
 
 @pytest.mark.usefixtures("_reset_interop_state")
-def test_reentrant_call_is_a_noop(monkeypatch: Any) -> None:
-    """A re-entrant call returns immediately instead of double-loading."""
-    ep = _FakeEntryPoint("fake")
+def test_one_failure_does_not_block_other_entry_points(monkeypatch: Any) -> None:
+    """A failing entry point does not prevent a sibling from loading."""
+    good = _FakeEntryPoint("good")
+    bad = _FakeEntryPoint("bad", exc=RuntimeError("broken"))
     monkeypatch.setattr(
-        cx, "entry_points", lambda group: [ep] if "interop" in group else []
+        cx, "entry_points", lambda group: [bad, good] if "interop" in group else []
     )
     cx._OPTIONAL_INTEROP_STATE["loaded"] = set()
-    cx._OPTIONAL_INTEROP_STATE["loading"] = True
+    cx._OPTIONAL_INTEROP_STATE["failed"] = {}
 
     cx._load_optional_interop()
 
-    assert not ep.loaded
+    assert good.loaded
+    assert "good" in cx._OPTIONAL_INTEROP_STATE["loaded"]
+    assert "bad" in cx._OPTIONAL_INTEROP_STATE["failed"]
 
 
 # =============================================================================
@@ -260,6 +229,7 @@ def test_legacy_group_is_honoured_with_deprecation_warning(monkeypatch: Any) -> 
 
     monkeypatch.setattr(cx, "entry_points", fake_entry_points)
     cx._OPTIONAL_INTEROP_STATE["loaded"] = set()
+    cx._OPTIONAL_INTEROP_STATE["failed"] = {}
 
     with pytest.warns(DeprecationWarning, match="legacy"):
         cx._load_optional_interop()
@@ -280,6 +250,7 @@ def test_current_group_wins_over_legacy_duplicate(monkeypatch: Any) -> None:
 
     monkeypatch.setattr(cx, "entry_points", fake_entry_points)
     cx._OPTIONAL_INTEROP_STATE["loaded"] = set()
+    cx._OPTIONAL_INTEROP_STATE["failed"] = {}
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)

--- a/tests/unit/test_interop_loader.py
+++ b/tests/unit/test_interop_loader.py
@@ -47,9 +47,17 @@ class _FakeEntryPoint:
         return object()
 
 
-def _only_interop(ep: _FakeEntryPoint) -> Any:
-    """An `entry_points` stub returning ``[ep]`` for the interop group."""
-    return lambda group: [ep] if "interop" in group else []
+def _only_interop(ep: Any) -> Any:
+    """An `entry_points` stub returning ``[ep]`` for the current interop group.
+
+    Mirrors `importlib.metadata.entry_points()`: `group` is keyword-only and
+    matched exactly, so a loader that queries the wrong group name gets nothing.
+    """
+
+    def entry_points(*, group: str) -> list[Any]:
+        return [ep] if group == cx._INTEROP_ENTRYPOINT_GROUP else []
+
+    return entry_points
 
 
 # =============================================================================
@@ -202,9 +210,11 @@ def test_one_failure_does_not_block_other_entry_points(monkeypatch: Any) -> None
     """A failing entry point does not prevent a sibling from loading."""
     good = _FakeEntryPoint("good")
     bad = _FakeEntryPoint("bad", exc=RuntimeError("broken"))
-    monkeypatch.setattr(
-        cx, "entry_points", lambda group: [bad, good] if "interop" in group else []
-    )
+
+    def entry_points(*, group: str) -> list[_FakeEntryPoint]:
+        return [bad, good] if group == cx._INTEROP_ENTRYPOINT_GROUP else []
+
+    monkeypatch.setattr(cx, "entry_points", entry_points)
     cx._OPTIONAL_INTEROP_STATE["loaded"] = set()
     cx._OPTIONAL_INTEROP_STATE["failed"] = {}
 

--- a/tests/unit/test_interop_loader.py
+++ b/tests/unit/test_interop_loader.py
@@ -120,7 +120,11 @@ def test_failure_is_recorded_not_raised(monkeypatch: Any) -> None:
     cx._load_optional_interop()  # must not raise
 
     assert "fake" not in cx._OPTIONAL_INTEROP_STATE["loaded"]
-    assert cx._OPTIONAL_INTEROP_STATE["failed"]["fake"] is exc
+    stored = cx._OPTIONAL_INTEROP_STATE["failed"]["fake"]
+    assert stored is exc
+    # The traceback is cleared so the long-lived `failed` dict does not pin the
+    # stack frames (and their locals) captured when the load failed.
+    assert stored.__traceback__ is None
 
 
 @pytest.mark.usefixtures("_reset_interop_state")


### PR DESCRIPTION
## Summary

Follow-up to #548. The interop entry-point loader read `__spec__._initializing`
— a private, undocumented CPython importlib attribute — to classify a failed
`ep.load()` as either the expected import cycle (tolerate + retry) or genuine
breakage (raise). This removes that dependency entirely.

**Interop is an optional extra, so a load failure should never hard-fail
`import coordinax` in the first place** — which means there is no need to
classify failures at all. The loader now:

- **never raises**: on any `ep.load()` failure it records the exception in
  `_OPTIONAL_INTEROP_STATE["failed"]` (name → exc) and moves on;
- **stays import-order independent** via the existing retry hooks: an entry
  point that failed because a sibling was half-imported (the
  `astro → coordinax → interop → astro` cycle) simply succeeds on the next call
  from the sibling's re-invocation hook, which also clears it from `failed`;
- keeps genuine failures **inspectable** in `failed` (previously they raised).

## Why this is better than a different private-attr replacement

- `_coordinaxs_is_initializing()` and the `import sys` it needed are **gone** —
  the whole class of import-machinery introspection is eliminated, not moved.
- The order-dependent quirk from #548's review (a genuinely broken interop
  raised only when `coordinax` was imported first — review finding #8)
  **disappears**: behaviour is now identical in every import order.
- A broken *optional* plugin no longer bricks the core library's import.

## Verification

- All **six** first-import orderings register the astropy conversions, with an
  empty `failed` dict in each (`import coordinaxs.astro` / `coordinax` /
  `coordinaxs.hypothesis.astro` / `coordinax.angles` /
  `coordinaxs.interop.astropy` / `coordinax.frames`).
- Loader unit tests rewritten to the new contract (record-not-raise, retry
  recovers, success clears prior failure, one failure doesn't block siblings);
  the tests that pinned the private attribute are dropped.
- `src/coordinax/__init__.py` stays at 100% line coverage (and shrinks 48 → 39
  statements). Full suite green (9061 passed); `ruff` / `ty` clean.

## Trade-off (stated plainly)

A genuinely-broken *installed* interop is now recorded rather than raised, so it
won't announce itself at import time — the missing conversion surfaces at
use-time, or via `coordinax._OPTIONAL_INTEROP_STATE["failed"]`. For an optional
extra this is the right default (and it retains the error, unlike the original
`contextlib.suppress` which discarded it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
