### PR TITLE
🚨 fix(lint): burn down coordinaxs.{api,curveframes,hypothesis} lint debt

### DIFF
--- a/packages/coordinaxs.api/pyproject.toml
+++ b/packages/coordinaxs.api/pyproject.toml
@@ -69,19 +69,3 @@ version_tuple = {version_tuple!r}
 
 [tool.ruff]
 extend = "../../pyproject.toml"
-
-[tool.ruff.lint]
-# Pre-existing lint debt, surfaced now that this package inherits the root
-# ruff config (previously it shadowed the root and silently ran ruff's
-# default rule set, so the root's import-convention aliases were never
-# enforced here). Ignored to keep this packaging change reviewable;
-# TODO: burn these down in a follow-up.
-ignore = [
-  "INP001",  # coordinaxs.api is an implicit namespace package (PEP 420)
-  "E501",
-  "PLC0415",
-  "S101",
-]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/**" = ["FBT001"]

--- a/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
+++ b/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
@@ -95,8 +95,14 @@ def angle_between(
     ...     "theta": u.Angle(jnp.pi / 2, "rad"),
     ...     "phi": u.Angle(0.0, "rad"),
     ... }
-    >>> u_tan = {"r": u.Q(0.0, "m"), "theta": u.Angle(1.0, "rad"), "phi": u.Angle(0.0, "rad")}
-    >>> v_tan = {"r": u.Q(0.0, "m"), "theta": u.Angle(0.0, "rad"), "phi": u.Angle(1.0, "rad")}
+    >>> u_tan = {
+    ...     "r": u.Q(0.0, "m"), "theta": u.Angle(1.0, "rad"),
+    ...     "phi": u.Angle(0.0, "rad"),
+    ... }
+    >>> v_tan = {
+    ...     "r": u.Q(0.0, "m"), "theta": u.Angle(0.0, "rad"),
+    ...     "phi": u.Angle(1.0, "rad"),
+    ... }
     >>> cxm.angle_between(cxc.sph3d, u_tan, v_tan, at=at_sph)
     Angle(1.57079633, 'rad')
 

--- a/packages/coordinaxs.curveframes/pyproject.toml
+++ b/packages/coordinaxs.curveframes/pyproject.toml
@@ -63,14 +63,6 @@ packages = ["src/coordinaxs"]
 [tool.ruff]
 extend = "../../pyproject.toml"
 
-[tool.ruff.lint]
-# Pre-existing lint debt, surfaced now that this package inherits the root
-# ruff config (previously it shadowed the root and silently ran ruff's
-# default rule set, so the root's import-convention aliases were never
-# enforced here). Ignored to keep this packaging change reviewable;
-# TODO: burn these down in a follow-up.
-ignore = ["D401", "PLC0415", "RUF002"]
-
 [tool.ruff.lint.isort]
 combine-as-imports = true
 known-first-party = ["dataclassish", "quaxed", "unxt", "coordinax"]

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_setup_package.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_setup_package.py
@@ -1,6 +1,6 @@
 """Package setup: runtime type-checking import hook for ``coordinaxs.curveframes``.
 
-This module configures `jaxtyping <https://docs.kidger.site/jaxtyping/>`_’s
+This module configures `jaxtyping <https://docs.kidger.site/jaxtyping/>`_'s
 import hook, which optionally checks array shape/dtype annotations at
 runtime.  The behaviour is controlled by the environment variable
 ``COORDINAX_ENABLE_RUNTIME_TYPECHECKING``:

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -276,7 +276,7 @@ class AbstractParallelTransportTransform(cxfm.AbstractCompositeTransform):
         return R(tau) if callable(R) else R  # ty: ignore[call-top-callable]
 
     def tangent(self, tau: u.AbstractQuantity, /) -> Any:
-        r"""Unit tangent vector $\mathbf{T}(\tau)$ (row 0 of R).
+        r"""Return the unit tangent vector $\mathbf{T}(\tau)$ (row 0 of R).
 
         Parameters
         ----------

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
@@ -129,7 +129,7 @@ class FrenetSerretTransform(AbstractParallelTransportTransform):
     # Convenience accessors (tangent inherited from ABC)
 
     def normal(self, tau: Any) -> u.Q:
-        r"""Unit normal vector $\mathbf{N}(\tau)$ (row 1 of R).
+        r"""Return the unit normal vector $\mathbf{N}(\tau)$ (row 1 of R).
 
         The principal normal lies in the osculating plane and points towards the
         centre of curvature.  It is obtained by Gram--Schmidt rejection of
@@ -168,7 +168,7 @@ class FrenetSerretTransform(AbstractParallelTransportTransform):
         return u.Q(R[1], "")
 
     def binormal(self, tau: Any) -> u.Q:
-        r"""Unit binormal vector $\mathbf{B}(\tau)$ (row 2 of R).
+        r"""Return the unit binormal vector $\mathbf{B}(\tau)$ (row 2 of R).
 
         The binormal completes the right-handed triad: $\mathbf{B} = \mathbf{T}
         \times \mathbf{N}$.

--- a/packages/coordinaxs.hypothesis/pyproject.toml
+++ b/packages/coordinaxs.hypothesis/pyproject.toml
@@ -64,36 +64,16 @@ packages = ["src/coordinaxs"]
 extend = "../../pyproject.toml"
 
 [tool.ruff.lint]
-# Pre-existing lint debt, surfaced now that this package inherits the root
-# ruff config (previously it shadowed the root and silently ran ruff's
-# default rule set, so the root's import-convention aliases were never
-# enforced here). Ignored to keep this packaging change reviewable;
-# TODO: burn these down in a follow-up.
 ignore = [
-  "ANN002",
-  "ANN201",
-  "ANN202",
-  "ANN206",
-  "D102",
-  "D205",
-  "D400",
-  "D415",
-  "D417",
-  "E501",
-  "FBT001",
+  # `hypothesis.assume()` takes its condition positionally, so `assume(False)`
+  # (a common idiom to reject a generated case) trips FBT003 across strategies.
   "FBT003",
-  "INP001",
-  "S101",
-  "SIM103",
 ]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
 known-first-party  = ["coordinax"]
 known-local-folder = ["coordinaxs.hypothesis"]
-
-[tool.ruff.lint.per-file-ignores]
-"**/__init__.py" = ["F403"]
 
 [tool.uv.sources]
 coordinax = { workspace = true }

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
@@ -31,7 +31,7 @@ xps = make_strategies_namespace(jnp)
 
 
 @plum.dispatch.abstract
-def cdicts(*args: Any, **kwargs: Any) -> CDict:
+def cdicts(*args: Any, **kwargs: Any) -> CDict:  # noqa: D417
     """Generate a valid CDict matching chart components and role constraints.
 
     A CDict is a mapping from component-name strings to quantity-like values,

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
@@ -31,7 +31,7 @@ xps = make_strategies_namespace(jnp)
 
 
 @plum.dispatch.abstract
-def cdicts(*args: Any, **kwargs: Any) -> CDict:  # noqa: D417
+def cdicts(*args: Any, **kwargs: Any) -> CDict:
     """Generate a valid CDict matching chart components and role constraints.
 
     A CDict is a mapping from component-name strings to quantity-like values,
@@ -41,19 +41,8 @@ def cdicts(*args: Any, **kwargs: Any) -> CDict:  # noqa: D417
       have the same physical dimension (length, length/time, or length/time²)
     - For Point role, component dimensions follow `chart.coord_dimensions`
 
-    Parameters
-    ----------
-    draw
-        The Hypothesis draw function (provided automatically)
-    chart
-        Chart instance or strategy generating one, defining the component schema.
-    dtype
-        Data type for array components (default: jnp.float32)
-    shape
-        Shape for array components. Can be int, tuple of ints, or strategy.
-        Default is scalar (shape=())
-    elements
-        Strategy for generating individual float values. If None, uses finite floats.
+    This is the abstract dispatcher; see the concrete overloads below for the
+    accepted arguments (``chart``, ``dtype``, ``shape``, ``elements``).
 
     Returns
     -------
@@ -138,6 +127,28 @@ def cdicts(
 ) -> CDict:
     """Generate a valid CDict matching chart components and role constraints.
 
+    Parameters
+    ----------
+    draw
+        The Hypothesis draw function (provided automatically).
+    chart
+        The chart instance defining the component schema.
+    dtype
+        Data type for array components (default: ``jnp.float32``).
+    shape
+        Shape for array components; int, tuple of ints, or a strategy. Default
+        is scalar (``shape=()``).
+    elements
+        Strategy for generating individual float values. If ``None``, uses
+        finite floats.
+
+    Returns
+    -------
+    dict[str, Any]
+        A mapping from component names to quantity-like values.
+
+    Examples
+    --------
     >>> import coordinaxs.hypothesis.main as cxst
     >>> from hypothesis import given
     >>> import coordinax.charts as cxc

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/charts_product.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/charts_product.py
@@ -233,6 +233,8 @@ def chart_init_kwargs(
 
     Parameters
     ----------
+    draw
+        Hypothesis draw function. Automatically provided by hypothesis.
     chart_class : type[cxc.CartesianProductChart]
         The `coordinax.charts.CartesianProductChart` class.
     ndim : int | None
@@ -278,6 +280,8 @@ def charts(
     ----------
     draw
         Hypothesis draw function. Automatically provided by hypothesis.
+    chart_cls
+        The product-chart class to generate instances of.
     factor_charts
         Fixed tuple of factor chart instances, or strategy generating one.  If
         None, generates random charts with count between min_factors and

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/utils.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/utils.py
@@ -42,9 +42,9 @@ def _param_filter(name: str, param: inspect.Parameter, /) -> bool:
         return False
     # Skip keyword-only params with defaults (e.g., the inherited `manifold`
     # field on AbstractChart) — these are metadata, not mathematical parameters.
-    if param.kind == inspect.Parameter.KEYWORD_ONLY and param.default is not EMPTY:
-        return False
-    return True
+    return not (
+        param.kind == inspect.Parameter.KEYWORD_ONLY and param.default is not EMPTY
+    )
 
 
 @ft.lru_cache(maxsize=256)

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
@@ -578,7 +578,8 @@ def atlases(
             chart = cls()
         except TypeError as exc:
             raise ValueError(
-                f"Required chart class {cls.__name__} must be zero-argument constructible."
+                f"Required chart class {cls.__name__} must be zero-argument "
+                "constructible."
             ) from exc
         if chart.ndim != custom_ndim:
             raise ValueError(

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/cdict.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/cdict.py
@@ -114,7 +114,11 @@ def cdicts(
     >>> @given(data=st.data())
     ... def test_invalid_point_basis_raises(data):
     ...     with pytest.raises(TypeError, match="NoBasis"):
-    ...         data.draw(cxrst.cdicts(cxc.cart3d, cxr.PointGeometry(), FakeBasis(), cxr.Location()))
+    ...         data.draw(
+    ...             cxrst.cdicts(
+    ...                 cxc.cart3d, cxr.PointGeometry(), FakeBasis(), cxr.Location()
+    ...             )
+    ...         )
 
     """
     if not isinstance(basis, cxr.NoBasis):

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/reps.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/reps.py
@@ -149,7 +149,7 @@ def representations(
     geom_kind = draw_if_strategy(draw, geom_kind)
     if geom_kind is None:
         geom_kind = draw(geometries())
-    assert isinstance(geom_kind, cxr.AbstractGeometry)
+    assert isinstance(geom_kind, cxr.AbstractGeometry)  # noqa: S101  # strategy invariant
 
     # Draw the basis kind
     basis_kind = draw_if_strategy(draw, basis_kind)

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/__init__.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/__init__.py
@@ -1,6 +1,7 @@
 """Coordinax Hypothesis Utilities.
 
-NOTE: these are internal utilities for the `coordinaxs.hypothesis` package and are not guaranteed to be stable. They may be changed without warning.
+NOTE: these are internal utilities for the `coordinaxs.hypothesis` package and are
+not guaranteed to be stable. They may be changed without warning.
 
 """
 

--- a/packages/coordinaxs.hypothesis/tests/test_composite_dispatch.py
+++ b/packages/coordinaxs.hypothesis/tests/test_composite_dispatch.py
@@ -1,5 +1,4 @@
-"""Integration tests: ``hypothesis.strategies.composite`` + ``plum`` multiple dispatch
-====================================================================================
+"""Integration tests: ``hypothesis.strategies.composite`` + ``plum`` multiple dispatch.
 
 How it works
 ------------
@@ -105,10 +104,13 @@ def annotated_draw(draw: Any, x: int):
 
 @pytest.mark.skipif(
     sys.version_info >= (3, 14),
-    reason="Python 3.14 changes annotation behaviour; @st.composite no longer strips draw from __annotations__ the same way",
+    reason=(
+        "Python 3.14 changes annotation behaviour; @st.composite no longer "
+        "strips draw from __annotations__ the same way"
+    ),
 )
 def test_draw_annotation_is_stripped():
-    """@composite removes draw from the public signature regardless of its annotation."""
+    """@composite removes draw from the public signature regardless of annotation."""
     fn = annotated_draw.invoke(int)
     assert "draw" not in fn.__annotations__, (
         "@composite should have stripped draw from annotations"

--- a/packages/coordinaxs.hypothesis/tests/unit/charts/test_cdicts.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/charts/test_cdicts.py
@@ -105,7 +105,7 @@ class TestCDictValueControl:
         )
     )
     def test_spherical_positive_elements(self, p):
-        """elements= applies to all component values including angles in a sphere chart."""
+        """elements= applies to all component values, including sphere angles."""
         # r, theta, phi all have positive values when elements is positive
         assert float(p["r"].value) > 0
         assert float(p["theta"].value) > 0

--- a/packages/coordinaxs.hypothesis/tests/unit/representations/test_cdicts.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/representations/test_cdicts.py
@@ -58,13 +58,13 @@ def test_point_geometry_requires_location_semantic(data):
 
 @given(p=cxrst.cdicts(cxc.cart3d, cxr.coord_disp))
 def test_cdicts_tangent_coord_disp(p):
-    """Cdicts with coord_disp (TangentGeometry, CoordinateBasis, Displacement) returns chart components."""
+    """Cdicts with coord_disp returns chart components."""
     assert set(p.keys()) == {"x", "y", "z"}
 
 
 @given(p=cxrst.cdicts(cxc.sph3d, cxr.phys_vel))
 def test_cdicts_tangent_phys_vel(p):
-    """Cdicts with phys_vel (TangentGeometry, PhysicalBasis, Velocity) returns chart components."""
+    """Cdicts with phys_vel returns chart components."""
     assert set(p.keys()) == {"r", "theta", "phi"}
 
 
@@ -72,5 +72,5 @@ def test_cdicts_tangent_phys_vel(p):
     p=cxrst.cdicts(cxc.cart3d, cxst.representations(geom_kind=cxr.TangentGeometry()))
 )
 def test_cdicts_tangent_with_rep_strategy(p):
-    """Cdicts with a TangentGeometry representation strategy returns chart components."""
+    """Cdicts with a TangentGeometry strategy returns chart components."""
     assert set(p.keys()) == set(cxc.cart3d.components)

--- a/packages/coordinaxs.hypothesis/tests/unit/representations/test_geometry_classes.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/representations/test_geometry_classes.py
@@ -82,7 +82,7 @@ class TestGeometries:
 
     @given(geom=cxrst.geometries())
     def test_never_returns_abstract_class(self, geom: cxr.AbstractGeometry) -> None:
-        """Generated value is never an instance of the abstract base itself (only concrete)."""
+        """Generated value is never an instance of the abstract base itself."""
         # AbstractGeometry is abstract; so all instances are subclass instances
         assert type(geom) is not cxr.AbstractGeometry
 

--- a/packages/coordinaxs.interop.astropy/tests/test_package.py
+++ b/packages/coordinaxs.interop.astropy/tests/test_package.py
@@ -3,4 +3,4 @@
 
 def test_import() -> None:
     """Test that the package can be imported."""
-    import coordinaxs.interop.astropy  # noqa: F401, PLC0415
+    import coordinaxs.interop.astropy  # noqa: F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -402,13 +402,14 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "**/tests/**" = [
   "ANN",
-  "ARG002", # Unused method argument
-  "ARG005", # Unused lambda argument
+  "ARG002",  # Unused method argument
+  "ARG005",  # Unused lambda argument
   "D102",
-  "D401",   # First line of docstring should be in imperative mood
+  "D401",    # First line of docstring should be in imperative mood
   "FBT001",
   "INP001",
   "N803",
+  "PLC0415", # tests may import inside functions (e.g. import-smoke tests)
   "RUF002",
   "S101",
   "T20",

--- a/tests/unit/test_import_identity.py
+++ b/tests/unit/test_import_identity.py
@@ -20,7 +20,7 @@ def _is_workspace_module(module: ModuleType, /) -> bool:
 
 def test_canonical_chart_module_identity() -> None:
     """Chart classes resolve from canonical ``coordinax.*`` module paths."""
-    from coordinax._src.charts.d3 import Cart3D  # noqa: PLC0415
+    from coordinax._src.charts.d3 import Cart3D
 
     assert Cart3D is cxc.Cart3D
 

--- a/tests/unit/test_validate_tag.py
+++ b/tests/unit/test_validate_tag.py
@@ -24,7 +24,7 @@ def validate_tag(monkeypatch):
     monkeypatch.syspath_prepend(str(scripts_path))
 
     # Import inside fixture so path change is scoped
-    import validate_tag as vt  # noqa: PLC0415
+    import validate_tag as vt
 
     return vt
 


### PR DESCRIPTION
Closes #549. Follow-up to #548.

Those three packages carried blanket `ignore` lists (15 codes for hypothesis) added to keep the packaging PR reviewable, with a "burn these down" TODO. This removes them and fixes the underlying findings.

## Root cause of the ~830 "findings"

ruff's `extend` **replaces** `per-file-ignores` when the child config defines its own table. So each package's own `[tool.ruff.lint.per-file-ignores]` shadowed the root's `"**/tests/**"` ignores, surfacing ~830 test-file findings (`S101`, `ANN*`, `INP001`, ...) that the root already handles. Dropping the shadowing tables lets the root's test-ignores apply and eliminates the vast majority — no code change, just config.

## Real findings fixed (~24, not suppressed)

- **curveframes**: 3 `D401` (property docstrings → imperative), 1 `RUF002` (curly apostrophe → straight).
- **hypothesis**: 1 `SIM103`, `D400`/`D415` (auto-fixed), 2 `D417` (documented the real `chart_cls`/`draw` params), 13 `E501` (wrapped doctests/strings; concise test docstrings).
- Removed 3 now-redundant `# noqa: PLC0415`.

## Two narrow, justified ignores remain (not blanket debt)

- root `"**/tests/**"` += `PLC0415` — tests legitimately import inside functions (import-smoke tests).
- hypothesis += `FBT003` — the `hypothesis.assume(False)` idiom (`assume` takes its condition positionally). 10 occurrences across strategies.

One type-narrowing assert in a strategy keeps a scoped `# noqa: S101`.

## Verification

- All five trees ruff- and format-clean; ICN import-convention enforcement **preserved** (probe-verified in each tree).
- `ty` clean (one pre-existing unrelated `translate.py` warning).
- Tests for every touched file pass (269), including the reworded doctests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)