### PR TITLE
♻️ refactor(hypothesis): make make_nonnegative public; drop astro's private _src reach-in

### DIFF
--- a/packages/coordinaxs.astro/src/coordinaxs/hypothesis/astro/plx.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/hypothesis/astro/plx.py
@@ -11,7 +11,7 @@ import unxt as u
 import unxt_hypothesis as ust
 
 import coordinaxs.astro as cxastro
-from coordinaxs.hypothesis.distances._src.utils import make_nonnegative
+from coordinaxs.hypothesis.distances import make_nonnegative
 
 ANGLE = u.dimension("angle")
 

--- a/packages/coordinaxs.hypothesis/docs/spec.md
+++ b/packages/coordinaxs.hypothesis/docs/spec.md
@@ -75,7 +75,7 @@ This module provides general-purpose strategies for generating valid `coordinax`
 | Module | Objects |
 | --- | --- |
 | `coordinaxs.hypothesis.angles` | `angles` |
-| `coordinaxs.hypothesis.distances` | `distances` |
+| `coordinaxs.hypothesis.distances` | `distances`, `make_nonnegative` |
 | `coordinaxs.hypothesis.charts` | `chart_classes`, `chart_init_kwargs`, `charts`, `charts_like`, `cdicts` |
 | `coordinaxs.hypothesis.manifolds` | `atlas_classes`, `atlases`, `manifold_classes`, `manifolds` |
 | `coordinaxs.hypothesis.representations` | `geometry_classes`, `geometries`, `basis_classes`, `bases`, `semantic_classes`, `semantics`, `valid_basis_classes_for_geometry`, `valid_semantic_classes_for_geometry`, `representations`, `cdicts` |
@@ -151,6 +151,39 @@ This module provides general-purpose strategies for generating valid `coordinax`
     - `@given(d=cxst.distances())`
     - `@given(d=cxst.distances(check_negative=False))`
     - `@given(d=cxst.distances(unit="kpc", shape=(2, 3)))`
+
+!!! info `make_nonnegative`:
+
+    Adjust a quantity-strategy's keyword arguments to force non-negative
+    generated values. This is the shared helper behind the non-negativity of
+    `distances` and of the astro distance strategies
+    (`coordinaxs.hypothesis.astro.parallaxes`).
+
+    Source:
+    - `coordinaxs.hypothesis.distances.make_nonnegative` is implemented in
+          `coordinaxs.hypothesis.distances._src.utils`.
+
+    Signature:
+    - `make_nonnegative(draw, /, **kwargs) -> dict[str, Any]`
+
+    Parameters:
+    - `draw`: the Hypothesis draw function (provided automatically inside an
+          `@st.composite` strategy).
+    - `**kwargs`: keyword arguments destined for `unxt_hypothesis.quantities`.
+          Only the `elements` entry is inspected/adjusted; all other keys are
+          returned unchanged.
+
+    Contract:
+    - Returns a new/updated `kwargs` mapping whose `elements` entry generates
+          only non-negative values.
+    - If `elements` is a mapping, its `min_value` is raised to at least `0`.
+    - If `elements` is a `SearchStrategy`, its values are mapped with `abs`.
+    - If `elements` is absent, a default non-negative elements strategy is
+          created from `dtype` (defaulting to `jnp.float32`) with `min_value=0`.
+
+    Failure behavior:
+    - An `elements` value that is neither a mapping nor a `SearchStrategy`
+          triggers `assert_never` (a logic error, not a user-facing failure).
 
 ### `coordinaxs.hypothesis.charts`
 

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/distances/__init__.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/distances/__init__.py
@@ -1,5 +1,5 @@
 """Hypothesis strategies for coordinax."""
 
-__all__ = ("distances",)
+__all__ = ("distances", "make_nonnegative")
 
-from ._src import distances
+from ._src import distances, make_nonnegative

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/distances/_src/__init__.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/distances/_src/__init__.py
@@ -1,5 +1,6 @@
 """Hypothesis strategies for Distance quantities."""
 
-__all__ = ("distances",)
+__all__ = ("distances", "make_nonnegative")
 
 from .dist import distances
+from .utils import make_nonnegative

--- a/packages/coordinaxs.hypothesis/tests/unit/distances/test_make_nonnegative.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/distances/test_make_nonnegative.py
@@ -1,0 +1,62 @@
+"""Tests for the public ``make_nonnegative`` helper.
+
+``make_nonnegative`` is part of the public API of
+``coordinaxs.hypothesis.distances`` (it is the shared non-negativity helper
+behind ``distances`` and the astro parallax strategies), so it is imported here
+via that public path.
+"""
+
+import hypothesis.strategies as st
+import jax.numpy as jnp
+from hypothesis import given
+
+from coordinaxs.hypothesis.distances import make_nonnegative
+
+
+def test_public_import() -> None:
+    """The helper is importable from the package public API and callable."""
+    from coordinaxs.hypothesis import distances as cxdst  # noqa: PLC0415
+
+    assert "make_nonnegative" in cxdst.__all__
+    assert cxdst.make_nonnegative is make_nonnegative
+    assert callable(make_nonnegative)
+
+
+@given(data=st.data())
+def test_mapping_elements_raises_min_value(data: st.DataObject) -> None:
+    """A mapping ``elements`` has its ``min_value`` raised to at least 0."""
+    out = make_nonnegative(data.draw, elements={"min_value": -10, "max_value": 100})
+    assert out["elements"]["min_value"] == 0
+    assert out["elements"]["max_value"] == 100  # other keys untouched
+
+
+@given(data=st.data())
+def test_mapping_elements_keeps_nonnegative_min(data: st.DataObject) -> None:
+    """A mapping ``elements`` with a non-negative ``min_value`` is preserved."""
+    out = make_nonnegative(data.draw, elements={"min_value": 5.0})
+    assert out["elements"]["min_value"] == 5.0
+
+
+@given(data=st.data())
+def test_strategy_elements_are_made_nonnegative(data: st.DataObject) -> None:
+    """A ``SearchStrategy`` ``elements`` yields only non-negative draws."""
+    out = make_nonnegative(data.draw, elements=st.floats(-100.0, 100.0))
+    value = data.draw(out["elements"])
+    assert value >= 0
+
+
+@given(data=st.data())
+def test_absent_elements_creates_nonnegative_default(data: st.DataObject) -> None:
+    """With no ``elements``, a default non-negative strategy is created."""
+    out = make_nonnegative(data.draw, dtype=jnp.float32)
+    assert "elements" in out
+    value = data.draw(out["elements"])
+    assert value >= 0
+
+
+@given(data=st.data())
+def test_other_kwargs_are_passed_through(data: st.DataObject) -> None:
+    """Keys other than ``elements`` are returned unchanged."""
+    out = make_nonnegative(data.draw, unit="kpc", shape=(2, 3), elements={})
+    assert out["unit"] == "kpc"
+    assert out["shape"] == (2, 3)


### PR DESCRIPTION
Closes #550.

The `coordinaxs.hypothesis.astro` strategy tree (shipped by the **astro** distribution) imported `make_nonnegative` from `coordinaxs.hypothesis.distances._src.utils` — a **private module of a different distribution**.

## Why "make the helper public" and not "move the tree"

#550 floated two options. Investigation shows one is clearly right:

- The base `coordinaxs.hypothesis` distribution is **deliberately astro-agnostic** (`dependencies = ["coordinax", "hypothesis", "unxt-hypothesis"]` — no astro).
- So astro's own strategies correctly live **with astro** (the dual tree, wired through astro's `[hypothesis]` extra from #548).
- Moving the tree into the hypothesis distribution would **invert that clean dependency** and force `coordinaxs.astro` onto every `coordinaxs.hypothesis` user — architecturally worse.

So the current layout is right; the only real smell is the cross-distribution `_src` reach-in.

## The fix

`make_nonnegative` already has an `__all__` and a full docstring, so it's promoted to the public API of `coordinaxs.hypothesis.distances`, and astro's `plx.py` imports the public name.

## Verification

- Zero cross-distribution `_src` reach-ins remain (grep-verified).
- `from coordinaxs.hypothesis.distances import make_nonnegative` works; `import coordinaxs.hypothesis.astro` works.
- Wheels rebuilt: astro still ships both trees (`coordinaxs/astro/*` + `coordinaxs/hypothesis/astro/*`) with no namespace `__init__` leak; `make_nonnegative` is exported from the hypothesis wheel.
- 45 astro-hypothesis / hypothesis-distances tests pass; ruff/format/ty clean.

Note: the remaining #550 observation — `import coordinaxs.hypothesis.astro` needs `pip install "coordinaxs.astro[hypothesis]"` — is by design (astro's strategies are an optional extra) and documented on that extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)