### PR TITLE
🎨 style(tests): drop redundant PLC0415 noqa in make_nonnegative test

### DIFF
--- a/packages/coordinaxs.hypothesis/tests/unit/distances/test_make_nonnegative.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/distances/test_make_nonnegative.py
@@ -15,7 +15,7 @@ from coordinaxs.hypothesis.distances import make_nonnegative
 
 def test_public_import() -> None:
     """The helper is importable from the package public API and callable."""
-    from coordinaxs.hypothesis import distances as cxdst  # noqa: PLC0415
+    from coordinaxs.hypothesis import distances as cxdst
 
     assert "make_nonnegative" in cxdst.__all__
     assert cxdst.make_nonnegative is make_nonnegative


### PR DESCRIPTION
## What

Removes the now-redundant `# noqa: PLC0415` on line 18 of `packages/coordinaxs.hypothesis/tests/unit/distances/test_make_nonnegative.py`.

## Why

`PLC0415` (import-outside-top-level) is already ignored for `**/tests/**` in the root `pyproject.toml`, so the inline suppression is dead and trips **RUF100** (unused-noqa) under `ruff --fix`. This fails the **Format** check on *every* open PR — it surfaced on the Dependabot lockfile bump #555, but #555 is not the cause.

It's a merge-interaction artifact: #554 added this test file with the noqa, while #553 added `PLC0415` to the root test-ignores. Each PR was green on its own; once both landed on `main` the noqa became redundant.

## Verification

- `ruff check .` → clean (no RUF100)
- `pytest packages/coordinaxs.hypothesis/tests/unit/distances/test_make_nonnegative.py` → 6 passed (PLC0415 genuinely ignored, so removing the noqa doesn't re-flag the in-function import)
- Full pre-commit (`prek`) suite green locally

Merging this unblocks the Format check on #555 and all other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)