### PR TITLE
🐛 fix(distances): enforce Distance/Parallax non-negativity checks under jit

### DIFF
--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/parallax.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/parallax.py
@@ -71,12 +71,15 @@ class Parallax(cxd.AbstractDistance):
             msg = "Parallax must have angular dimensions."
             raise ValueError(msg)
 
-        if self.check_negative:  # pylint: disable=unreachable
-            eqx.error_if(
+        if self.check_negative:
+            # Store the checked value back so the guard survives jit (an
+            # unused `error_if` result is dead-code-eliminated under trace).
+            checked = eqx.error_if(
                 self.value,
                 jnp.any(jnp.less(self.value, 0)),
                 "Parallax must be non-negative.",
             )
+            object.__setattr__(self, "value", checked)
 
 
 @Parallax.from_.dispatch  # ty: ignore[unresolved-attribute]

--- a/packages/coordinaxs.astro/tests/unit/distances/test_parallax.py
+++ b/packages/coordinaxs.astro/tests/unit/distances/test_parallax.py
@@ -59,6 +59,18 @@ class TestParallaxConstruction:
         ):
             cxastro.Parallax(-1, "mas", check_negative=True)
 
+    def test_negative_raises_under_jit(self) -> None:
+        """The non-negativity check is not dead-code-eliminated under jit."""
+
+        @eqx.filter_jit
+        def build(v: jax.Array) -> jax.Array:
+            return cxastro.Parallax(v, "mas", check_negative=True).value
+
+        with pytest.raises(
+            eqx.EquinoxRuntimeError, match="Parallax must be non-negative"
+        ):
+            jax.block_until_ready(build(jnp.asarray(-1.0)))
+
     @given(plx=cxastrost.parallaxes())
     def test_has_value_and_unit(self, plx: cxastro.Parallax) -> None:
         """Generated parallaxes have value and unit attributes."""

--- a/src/coordinax/distances/_src/measures.py
+++ b/src/coordinax/distances/_src/measures.py
@@ -57,12 +57,15 @@ class Distance(AbstractDistance):
             msg = "Distance must have dimensions length."
             raise ValueError(msg)
 
-        if self.check_negative:  # pylint: disable=unreachable
-            eqx.error_if(
+        if self.check_negative:
+            # Store the checked value back so the guard survives jit (an
+            # unused `error_if` result is dead-code-eliminated under trace).
+            checked = eqx.error_if(
                 self.value,
                 jnp.any(jnp.less(self.value, 0)),
                 "Distance must be non-negative.",
             )
+            object.__setattr__(self, "value", checked)
 
 
 @Distance.from_.dispatch  # ty: ignore[unresolved-attribute]

--- a/tests/unit/distances/test_distance.py
+++ b/tests/unit/distances/test_distance.py
@@ -137,6 +137,18 @@ class TestDistanceConstruction:
         ):
             cxd.Distance(-1, "kpc", check_negative=True)
 
+    def test_negative_raises_under_jit(self) -> None:
+        """The non-negativity check is not dead-code-eliminated under jit."""
+
+        @eqx.filter_jit
+        def build(v: jax.Array) -> jax.Array:
+            return cxd.Distance(v, "kpc", check_negative=True).value
+
+        with pytest.raises(
+            eqx.EquinoxRuntimeError, match="Distance must be non-negative"
+        ):
+            jax.block_until_ready(build(jnp.asarray(-1.0)))
+
 
 class TestDistanceConversion:
     """Unit conversion preserves the Distance type and produces correct values."""


### PR DESCRIPTION
## Problem

`Distance.__check_init__` and `Parallax.__check_init__` guard against negative values with `eqx.error_if(...)` — but they **discard the return value**. `error_if` attaches its runtime check to the array it *returns*; since that array never flows into the stored `value`, XLA dead-code-eliminates the check under trace.

Result: the non-negativity invariant holds eagerly but is silently bypassed under `jax.jit`, which is the primary execution mode for this library:

```python
Distance(-5, "pc")                                  # eager: raises ✓
eqx.filter_jit(lambda v: Distance(v, "pc").value)(-5.0)   # returns -5.0, no error ✗
```

(The stray `# pylint: disable=unreachable` on both check blocks hinted the branch was already suspected of being odd.)

## Fix

Thread the checked array back into the stored field via `object.__setattr__(self, "value", checked)`, mirroring the codebase's own correct `error_if` usages (`checks.py`, `linear.py`, `translate.py`), which all keep the checked value in the data flow.

`DistanceModulus` was checked and has no such guard (it can legitimately be negative); these two were the only offenders.

## Tests

Added `test_negative_raises_under_jit` for both `Distance` and `Parallax` (RED before, GREEN after) constructing a negative value under `eqx.filter_jit` and asserting `EquinoxRuntimeError`. Full distances suites (core + astro) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)