### PR TITLE
🐛 fix(representations): anchor basis change at destination chart in cross-representation tangent_map

### DIFF
--- a/src/coordinax/representations/_src/tangent_map.py
+++ b/src/coordinax/representations/_src/tangent_map.py
@@ -264,6 +264,10 @@ def tangent_map(
 
     """
     v = cxrapi.tangent_map(v, from_chart, from_rep, to_chart, at=at, usys=usys)
+    # Unchanged basis: the pushforward already lives in the target basis, so
+    # skip the identity change_basis (and its base-point mapping).
+    if from_rep.basis == to_rep.basis:
+        return v  # ty: ignore[invalid-return-type]
     # After the pushforward v lives in ``to_chart``; the basis change must be
     # evaluated at the base point expressed in ``to_chart`` coordinates.
     at_to = (

--- a/src/coordinax/representations/_src/tangent_map.py
+++ b/src/coordinax/representations/_src/tangent_map.py
@@ -264,5 +264,14 @@ def tangent_map(
 
     """
     v = cxrapi.tangent_map(v, from_chart, from_rep, to_chart, at=at, usys=usys)
-    v = cxrapi.change_basis(v, to_chart, from_rep.basis, to_rep.basis, at=at, usys=usys)
+    # After the pushforward v lives in ``to_chart``; the basis change must be
+    # evaluated at the base point expressed in ``to_chart`` coordinates.
+    at_to = (
+        at
+        if (at is None or from_chart is to_chart)
+        else cxc.pt_map(at, from_chart, to_chart, usys=usys)
+    )
+    v = cxrapi.change_basis(
+        v, to_chart, from_rep.basis, to_rep.basis, at=at_to, usys=usys
+    )
     return v  # noqa: RET504  # ty: ignore[invalid-return-type]

--- a/src/coordinax/representations/_src/tangent_map.py
+++ b/src/coordinax/representations/_src/tangent_map.py
@@ -125,7 +125,7 @@ def tangent_map(
 
     """
     # Same-chart optimization: identity transform
-    if from_chart is to_chart:
+    if from_chart == to_chart:
         return v
 
     J = cxc.jac_pt_map(at, from_chart, to_chart, usys=usys)
@@ -174,7 +174,7 @@ def tangent_map(
 
     """
     # Same-chart optimization: identity transform
-    if from_chart is to_chart:
+    if from_chart == to_chart:
         return v
 
     # TODO: direct routes
@@ -268,7 +268,7 @@ def tangent_map(
     # evaluated at the base point expressed in ``to_chart`` coordinates.
     at_to = (
         at
-        if (at is None or from_chart is to_chart)
+        if (at is None or from_chart == to_chart)
         else cxc.pt_map(at, from_chart, to_chart, usys=usys)
     )
     v = cxrapi.change_basis(

--- a/tests/unit/representations/test_tangent_map.py
+++ b/tests/unit/representations/test_tangent_map.py
@@ -57,6 +57,18 @@ class TestTangentMapSameChart:
         np.testing.assert_allclose(result["theta"], v["theta"])
         np.testing.assert_allclose(result["phi"], v["phi"])
 
+    def test_equal_but_distinct_chart_instances(self) -> None:
+        """Charts are non-singleton: equal-but-distinct instances take the same path."""
+        fresh = type(cxc.cart3d)(M=cxc.cart3d.M)
+        assert fresh == cxc.cart3d
+        assert fresh is not cxc.cart3d
+        v = {"x": jnp.array(1), "y": jnp.array(2), "z": jnp.array(3)}
+        at = {"x": jnp.array(0.5), "y": jnp.array(0.5), "z": jnp.array(0)}
+        result = cxr.tangent_map(v, fresh, cxr.coord_disp, cxc.cart3d, at=at, usys=usys)
+        np.testing.assert_allclose(result["x"], v["x"])
+        np.testing.assert_allclose(result["y"], v["y"])
+        np.testing.assert_allclose(result["z"], v["z"])
+
 
 class TestTangentMapCart3dToSph3d:
     """Cart3D → Sph3D CoordinateBasis: Jacobian pushforward at (x=1, y=0, z=0).

--- a/tests/unit/representations/test_tangent_map.py
+++ b/tests/unit/representations/test_tangent_map.py
@@ -256,6 +256,8 @@ class TestTangentMapPhysicalBasis:
         )
 
         for k in ("r", "theta", "phi"):
+            # Physical-basis output must match in both magnitude and unit.
+            assert one_shot[k].unit == ref[k].unit
             np.testing.assert_allclose(one_shot[k].value, ref[k].value, atol=1e-6)
 
 

--- a/tests/unit/representations/test_tangent_map.py
+++ b/tests/unit/representations/test_tangent_map.py
@@ -211,6 +211,41 @@ class TestTangentMapPhysicalBasis:
             via_cc_cdict["phi"].value, direct["phi"].value, atol=1e-6
         )
 
+    def test_cross_chart_and_basis_one_shot(self) -> None:
+        """One call changing both chart and basis matches the two-step result.
+
+        Converting a Cartesian coordinate-basis vector to a spherical
+        physical-basis vector in a single ``tangent_map`` call must equal
+        first pushing the chart forward (keeping the basis) and then changing
+        the basis at the *destination-chart* base point.
+        """
+        v = {
+            "x": u.Q(jnp.array(1.0), "m/s"),
+            "y": u.Q(jnp.array(2.0), "m/s"),
+            "z": u.Q(jnp.array(0.5), "m/s"),
+        }
+        at = {
+            "x": u.Q(jnp.array(2.0), "m"),
+            "y": u.Q(jnp.array(1.0), "m"),
+            "z": u.Q(jnp.array(0.5), "m"),
+        }
+
+        one_shot = cxr.tangent_map(
+            v, cxc.cart3d, cxr.coord_disp, cxc.sph3d, cxr.phys_disp, at=at, usys=usys
+        )
+
+        # Reference: chart pushforward (keeps coord basis) then basis change.
+        mid = cxr.tangent_map(
+            v, cxc.cart3d, cxr.coord_disp, cxc.sph3d, at=at, usys=usys
+        )
+        at_sph = cxc.pt_map(at, cxc.cart3d, cxc.sph3d, usys=usys)
+        ref = cxr.change_basis(
+            mid, cxc.sph3d, cxr.coord_basis, cxr.phys_basis, at=at_sph, usys=usys
+        )
+
+        for k in ("r", "theta", "phi"):
+            np.testing.assert_allclose(one_shot[k].value, ref[k].value, atol=1e-6)
+
 
 class TestTangentMapCart2dToPolar2d:
     """Cart2D → Polar2D CoordinateBasis: Jacobian pushforward at (x=1, y=0).


### PR DESCRIPTION
## Problem

The 5-argument cross-representation `tangent_map` (and the `cconvert` path that delegates to it) does two things: push the tangent vector forward from `from_chart` into `to_chart` via the Jacobian, then change the basis. But it evaluated the basis change with `at` still expressed in **source-chart** coordinates:

```python
v = tangent_map(v, from_chart, from_rep, to_chart, at=at, usys=usys)   # now in to_chart
v = change_basis(v, to_chart, from_rep.basis, to_rep.basis, at=at, ...) # BUG: at still in from_chart
```

`change_basis` for a non-Cartesian target chart indexes `at` by the target chart's component names (`at["r"]`, …), so any single call that changes **both** chart and basis — e.g. "Cartesian coordinate-basis velocity → spherical physical-basis" — raised `KeyError: 'r'`. It only worked when `from_chart is to_chart` or the basis was unchanged, which is why the existing docstrings (which only exercise those cases) didn't catch it. The sibling physical-basis path already handled this correctly.

## Fix

Map `at` into `to_chart` (via `pt_map`) before the basis change, guarding the `at is None` / same-chart cases. This mirrors the existing correct path.

## Tests

Added `test_cross_chart_and_basis_one_shot` (RED before, GREEN after): asserts the one-shot Cartesian-coord → spherical-phys result equals the two-step reference (chart pushforward keeping basis, then `change_basis` at the destination base point). Full representations suite (306 tests) and source doctests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)