### PR TITLE
🐛 fix(manifolds): honor the ambient chart in embedded_twosphere / TwoSphereIn3D

### DIFF
--- a/src/coordinax/_src/embedded/chart.py
+++ b/src/coordinax/_src/embedded/chart.py
@@ -73,7 +73,7 @@ class EmbeddedChart(
     >>> import unxt as u
     >>> chart = cxm.EmbeddedChart(cxm.TwoSphereIn3D(radius=u.Q(2.0, "km")))
     >>> chart.embed_map
-    TwoSphereIn3D(radius=Q(2., 'km'))
+    TwoSphereIn3D(radius=Q(2., 'km'), ambient=Spherical3D(M=Rn(3)))
 
     """
 
@@ -93,7 +93,8 @@ class EmbeddedChart(
         >>> chart.M
         EmbeddedManifold(intrinsic=HyperSphericalManifold(ndim=2),
                          ambient=Rn(3),
-                         embed_map=TwoSphereIn3D(radius=Q(2., 'km')))
+                         embed_map=TwoSphereIn3D(radius=Q(2., 'km'),
+                                                 ambient=Spherical3D(M=Rn(3))))
 
         """
         return EmbeddedManifold(

--- a/src/coordinax/_src/embedded/manifold.py
+++ b/src/coordinax/_src/embedded/manifold.py
@@ -170,7 +170,7 @@ def pt_embed(
         p_intrinsic, from_intrinsic_chart, embed_map.intrinsic, usys=usys
     )
     # Step 2: embed from embedding's intrinsic chart to ambient chart
-    p_ambient = embed_map.embed(p_intrinsic_in_embedding_chart)
+    p_ambient = embed_map.embed(p_intrinsic_in_embedding_chart, usys=usys)
     # Step 3: point transition from embedding's ambient chart to target chart
     p_ambient_in_target_chart = cxcapi.pt_map(
         p_ambient, embed_map.ambient, to_ambient_chart, usys=usys
@@ -244,7 +244,7 @@ def pt_project(
         p_ambient, from_ambient_chart, embed_map.ambient, usys=usys
     )
     # Step 2: project from embedding's ambient chart to intrinsic chart
-    p_intrinsic = embed_map.project(p_ambient_in_embedding_chart)
+    p_intrinsic = embed_map.project(p_ambient_in_embedding_chart, usys=usys)
     # Step 3: point transition from embedding's intrinsic chart to target chart
     p_intrinsic_in_target_chart = cxcapi.pt_map(
         p_intrinsic, embed_map.intrinsic, to_intrinsic_chart, usys=usys

--- a/src/coordinax/_src/embedded/register_charts.py
+++ b/src/coordinax/_src/embedded/register_charts.py
@@ -39,7 +39,8 @@ def pt_map(
     >>> M
     EmbeddedManifold(intrinsic=HyperSphericalManifold(...),
                      ambient=Rn(3),
-                     embed_map=TwoSphereIn3D(radius=Q(1, 'kpc')))
+                     embed_map=TwoSphereIn3D(radius=Q(1, 'kpc'),
+                                             ambient=Spherical3D(M=Rn(3))))
     >>> x_cart = {"x": u.Q(1, "m"), "y": u.Q(2, "m"), "z": u.Q(3, "m")}
 
     >>> x_sph2 = cxc.pt_map(x_cart, M, cxc.cart3d, cxc.loncoslat_sph2)

--- a/src/coordinax/_src/spherical/embed.py
+++ b/src/coordinax/_src/spherical/embed.py
@@ -74,37 +74,45 @@ class TwoSphereIn3D(AbstractEmbeddingMap[IntrinsicT, AmbientT]):
     Embed/project through an ambient `{class}`~coordinax.charts.Cart3D` chart
     (routing via `{class}`~coordinax.charts.Spherical3D` internally)::
 
-    >>> chart = cxm.EmbeddedChart(cxm.TwoSphereIn3D(radius=u.Q(2.0, "km")))
+    >>> emb = cxm.TwoSphereIn3D(radius=u.Q(2.0, "km"), ambient=cxc.cart3d)
+    >>> chart = cxm.EmbeddedChart(emb)
     >>> xyz = cxm.pt_embed(p, chart)
-    >>> p3 = cxm.pt_project(xyz, chart)
-    >>> p3
-    {'theta': Angle(1.57079633, 'rad'), 'phi': Angle(0., 'rad')}
+    >>> sorted(xyz)
+    ['x', 'y', 'z']
+    >>> bool(jnp.allclose(u.ustrip("km", xyz["x"]), 2.0, atol=1e-6))
+    True
 
+    >>> p3 = cxm.pt_project(xyz, chart)
     >>> bool(jnp.allclose(u.ustrip("rad", p3["phi"]), u.ustrip("rad", p["phi"])))
     True
 
     """
 
     radius: u.AbstractQuantity | float | int = dataclasses.field()
+    ambient: cxc.AbstractChart[Any, Any, Any] = dataclasses.field(default=cxc.sph3d)
 
     @property
     def intrinsic(self) -> cxc.AbstractChart[Any, Any, Any]:
         """The intrinsic chart is always `coordinax.charts.SphericalTwoSphere`."""
         return cxc.sph2
 
-    @property
-    def ambient(self) -> cxc.AbstractChart[Any, Any, Any]:
-        """The ambient chart is always `coordinax.charts.Spherical3D`."""
-        return cxc.sph3d
-
     def embed(self, q: CDict, /, *, usys: OptUSys = None) -> CDict:
-        """Embed ``SphericalTwoSphere`` intrinsic coords into ``Spherical3D`` coords."""
-        del usys
-        return {"r": self.radius, "theta": q["theta"], "phi": q["phi"]}
+        """Embed ``SphericalTwoSphere`` intrinsic coords into the ambient chart."""
+        x_sph: CDict = {"r": self.radius, "theta": q["theta"], "phi": q["phi"]}
+        if self.ambient is cxc.sph3d:
+            return x_sph
+        out: CDict = cxc.pt_map(  # ty: ignore[invalid-assignment]
+            x_sph, cxc.sph3d, self.ambient, usys=usys
+        )
+        return out
 
-    def project(self, x_sph: CDict, /, *, usys: OptUSys = None) -> CDict:
-        """Project ``Spherical3D`` onto ``SphericalTwoSphere`` intrinsic coords."""
-        del usys
+    def project(self, x: CDict, /, *, usys: OptUSys = None) -> CDict:
+        """Project ambient coords onto ``SphericalTwoSphere`` intrinsic coords."""
+        x_sph: CDict = x
+        if self.ambient is not cxc.sph3d:
+            x_sph = cxc.pt_map(  # ty: ignore[invalid-assignment]
+                x, self.ambient, cxc.sph3d, usys=usys
+            )
         return {"theta": x_sph["theta"], "phi": x_sph["phi"]}
 
 
@@ -140,22 +148,26 @@ def embedded_twosphere(
     >>> M
     EmbeddedManifold(intrinsic=HyperSphericalManifold(...),
                      ambient=Rn(3),
-                     embed_map=TwoSphereIn3D(radius=Q(2., 'km')))
+                     embed_map=TwoSphereIn3D(radius=Q(2., 'km'),
+                                             ambient=Spherical3D(M=Rn(3))))
 
     >>> p = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0.0, "rad")}
     >>> sph = cxm.pt_embed(p, M)
     >>> sph
     {'r': Q(2., 'km'), 'theta': Angle(1.57079633, 'rad'), 'phi': Angle(0., 'rad')}
 
-    With Cartesian ambient::
+    With Cartesian ambient the embedding returns ``(x, y, z)``::
 
     >>> M = cxm.embedded_twosphere(radius=u.Q(2.0, "km"), ambient=cxc.cart3d)
     >>> xyz = cxm.pt_embed(p, M)
-    >>> p3 = cxm.pt_project(xyz, M)
-    >>> p3
-    {'theta': Angle(1.57079633, 'rad'), 'phi': Angle(0., 'rad')}
+    >>> sorted(xyz)
+    ['x', 'y', 'z']
+    >>> bool(jnp.allclose(u.ustrip("km", xyz["x"]), 2.0, atol=1e-6))
+    True
 
     """
     return EmbeddedManifold(
-        intrinsic=S2, ambient=R3, embed_map=TwoSphereIn3D(radius=radius)
+        intrinsic=S2,
+        ambient=R3,
+        embed_map=TwoSphereIn3D(radius=radius, ambient=ambient),
     )

--- a/src/coordinax/_src/spherical/embed.py
+++ b/src/coordinax/_src/spherical/embed.py
@@ -99,7 +99,9 @@ class TwoSphereIn3D(AbstractEmbeddingMap[IntrinsicT, AmbientT]):
     def embed(self, q: CDict, /, *, usys: OptUSys = None) -> CDict:
         """Embed ``SphericalTwoSphere`` intrinsic coords into the ambient chart."""
         x_sph: CDict = {"r": self.radius, "theta": q["theta"], "phi": q["phi"]}
-        if self.ambient is cxc.sph3d:
+        # A ``Spherical3D`` ambient (any instance — the chart is not a singleton)
+        # already uses ``(r, theta, phi)``, so no coordinate transform is needed.
+        if isinstance(self.ambient, cxc.Spherical3D):
             return x_sph
         out: CDict = cxc.pt_map(  # ty: ignore[invalid-assignment]
             x_sph, cxc.sph3d, self.ambient, usys=usys
@@ -109,7 +111,7 @@ class TwoSphereIn3D(AbstractEmbeddingMap[IntrinsicT, AmbientT]):
     def project(self, x: CDict, /, *, usys: OptUSys = None) -> CDict:
         """Project ambient coords onto ``SphericalTwoSphere`` intrinsic coords."""
         x_sph: CDict = x
-        if self.ambient is not cxc.sph3d:
+        if not isinstance(self.ambient, cxc.Spherical3D):
             x_sph = cxc.pt_map(  # ty: ignore[invalid-assignment]
                 x, self.ambient, cxc.sph3d, usys=usys
             )

--- a/tests/unit/manifolds/test_embedded_twosphere.py
+++ b/tests/unit/manifolds/test_embedded_twosphere.py
@@ -43,3 +43,16 @@ class TestEmbeddedTwosphereAmbient:
         np.testing.assert_allclose(
             u.ustrip("rad", back["phi"]), u.ustrip("rad", _P["phi"]), atol=1e-6
         )
+
+    def test_non_singleton_spherical_ambient_takes_spherical_path(self) -> None:
+        """A non-singleton Spherical3D ambient still embeds to spherical coords.
+
+        The ambient check is by type, not identity, so a freshly-constructed
+        ``Spherical3D`` (distinct from the ``sph3d`` instance) is handled too.
+        """
+        fresh = type(cxc.sph3d)(M=cxc.sph3d.M)
+        assert fresh is not cxc.sph3d  # a distinct instance
+        m = cxm.embedded_twosphere(radius=u.Q(2.0, "km"), ambient=fresh)
+        out = cxm.pt_embed(_P, m)
+        assert set(out) == {"r", "theta", "phi"}
+        np.testing.assert_allclose(u.ustrip("km", out["r"]), 2.0, atol=1e-6)

--- a/tests/unit/manifolds/test_embedded_twosphere.py
+++ b/tests/unit/manifolds/test_embedded_twosphere.py
@@ -44,6 +44,17 @@ class TestEmbeddedTwosphereAmbient:
             u.ustrip("rad", back["phi"]), u.ustrip("rad", _P["phi"]), atol=1e-6
         )
 
+    def test_usys_is_forwarded_to_embed(self) -> None:
+        """``pt_embed`` accepts and threads ``usys`` to the embedding.
+
+        Bare-array intrinsic coords embed through a Cartesian ambient.
+        """
+        m = cxm.embedded_twosphere(radius=u.Q(2.0, "m"), ambient=cxc.cart3d)
+        p = {"theta": jnp.asarray(jnp.pi / 2), "phi": jnp.asarray(0.0)}
+        out = cxm.pt_embed(p, m, usys=u.unitsystems.si)
+        assert set(out) == {"x", "y", "z"}
+        np.testing.assert_allclose(np.asarray(out["x"]), 2.0, atol=1e-6)
+
     def test_non_singleton_spherical_ambient_takes_spherical_path(self) -> None:
         """A non-singleton Spherical3D ambient still embeds to spherical coords.
 

--- a/tests/unit/manifolds/test_embedded_twosphere.py
+++ b/tests/unit/manifolds/test_embedded_twosphere.py
@@ -1,0 +1,45 @@
+"""Tests for the ``embedded_twosphere`` ambient-chart selection."""
+
+__all__: tuple[str, ...] = ()
+
+import jax.numpy as jnp
+import numpy as np
+
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+
+_P = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0.0, "rad")}
+
+
+class TestEmbeddedTwosphereAmbient:
+    """The ``ambient`` argument selects the ambient coordinate chart."""
+
+    def test_default_ambient_is_spherical(self) -> None:
+        """Default ambient embeds to spherical ``(r, theta, phi)``."""
+        m = cxm.embedded_twosphere(radius=u.Q(2.0, "km"))
+        out = cxm.pt_embed(_P, m)
+        assert set(out) == {"r", "theta", "phi"}
+        np.testing.assert_allclose(u.ustrip("km", out["r"]), 2.0, atol=1e-6)
+
+    def test_cartesian_ambient_embeds_to_xyz(self) -> None:
+        """``ambient=cart3d`` embeds to Cartesian ``(x, y, z)``."""
+        m = cxm.embedded_twosphere(radius=u.Q(2.0, "km"), ambient=cxc.cart3d)
+        out = cxm.pt_embed(_P, m)
+        # (r=2, theta=pi/2, phi=0) -> (x=2, y=0, z=0)
+        assert set(out) == {"x", "y", "z"}
+        np.testing.assert_allclose(u.ustrip("km", out["x"]), 2.0, atol=1e-6)
+        np.testing.assert_allclose(u.ustrip("km", out["y"]), 0.0, atol=1e-6)
+        np.testing.assert_allclose(u.ustrip("km", out["z"]), 0.0, atol=1e-6)
+
+    def test_cartesian_ambient_roundtrip(self) -> None:
+        """Embed then project through a Cartesian ambient recovers the point."""
+        m = cxm.embedded_twosphere(radius=u.Q(2.0, "km"), ambient=cxc.cart3d)
+        back = cxm.pt_project(cxm.pt_embed(_P, m), m)
+        np.testing.assert_allclose(
+            u.ustrip("rad", back["theta"]), u.ustrip("rad", _P["theta"]), atol=1e-6
+        )
+        np.testing.assert_allclose(
+            u.ustrip("rad", back["phi"]), u.ustrip("rad", _P["phi"]), atol=1e-6
+        )


### PR DESCRIPTION
## Problem

`embedded_twosphere(radius, ambient=...)` accepted an `ambient` argument but **discarded it** — it always built `TwoSphereIn3D(radius=radius)`. And `TwoSphereIn3D` had no `ambient` field at all: `.ambient` was hardcoded to `Spherical3D` and `embed` always returned spherical `(r, theta, phi)`.

So a caller asking for a Cartesian ambient silently got spherical output, contradicting the class/function docstrings which explicitly describe `ambient=cart3d` returning `(x, y, z)`:

```python
M = embedded_twosphere(radius=u.Q(2.0, "km"), ambient=cxc.cart3d)
pt_embed(p, M)   # -> {'r': ..., 'theta': ..., 'phi': ...}   (spherical, not xyz)
```

## Fix

Give `TwoSphereIn3D` an `ambient` field (default `Spherical3D`) and route `embed`/`project` through `Spherical3D` to/from the chosen ambient chart (via `pt_map`), exactly as the class docstring already describes. Thread `ambient` through from `embedded_twosphere`.

The added field changes `TwoSphereIn3D`'s repr, so the affected doctests (`embed.py`, `embedded/chart.py`, `embedded/register_charts.py`) are updated.

## Tests

New `tests/unit/manifolds/test_embedded_twosphere.py` (RED before, GREEN after): default ambient still embeds to spherical; `ambient=cart3d` embeds `(theta=π/2, phi=0), r=2 km` to `(x=2, y≈0, z≈0)`; and the Cartesian embed→project round-trips. Full manifolds suite (365) + all embedded-module doctests pass; `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)