### PR TITLE
🐛 fix(transforms): make Scale/Reflect constructors jit-safe

### DIFF
--- a/src/coordinax/transforms/_src/actions/reflect.py
+++ b/src/coordinax/transforms/_src/actions/reflect.py
@@ -6,6 +6,7 @@ __all__ = ("Reflect",)
 from jaxtyping import Array, Shaped
 from typing import Any, Final, TypeAlias, final
 
+import equinox as eqx
 import plum
 from jax.typing import ArrayLike
 
@@ -75,8 +76,9 @@ class Reflect(AbstractLinearTransform):
             raise ValueError(msg)
 
         norm = jnp.linalg.norm(n)
-        if bool(jnp.allclose(norm, 0)):
-            raise ValueError(_MSG_ZERO_NORMAL)
+        # Defer the zero-normal check so it survives jit (a plain `bool` on a
+        # traced value raises TracerBoolConversionError).
+        n = eqx.error_if(n, jnp.allclose(norm, 0), _MSG_ZERO_NORMAL)
 
         n_hat = n / norm
         H = jnp.eye(n.shape[0], dtype=n_hat.dtype) - 2 * jnp.outer(n_hat, n_hat)

--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -6,6 +6,7 @@ __all__ = ("Scale",)
 
 from typing import Any, Final, TypeAlias, final
 
+import equinox as eqx
 import plum
 from jax.typing import ArrayLike
 from jaxtyping import Array, Shaped
@@ -58,8 +59,9 @@ class Scale(AbstractLinearTransform):
         if s.ndim != 1:
             msg = f"Scale.from_factors requires a vector; got shape={s.shape!r}."
             raise ValueError(msg)
-        if bool(jnp.any(jnp.isclose(s, 0))):
-            raise ValueError(_MSG_SINGULAR)
+        # Defer the singular check so it survives jit (a plain `bool` on a
+        # traced value raises TracerBoolConversionError).
+        s = eqx.error_if(s, jnp.any(jnp.isclose(s, 0)), _MSG_SINGULAR)
         return cls(jnp.diag(s))
 
     @property

--- a/tests/unit/transforms/test_reflect.py
+++ b/tests/unit/transforms/test_reflect.py
@@ -4,14 +4,24 @@ __all__: tuple[str, ...] = ()
 
 from typing import Any, cast
 
+import equinox as eqx
+import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 import unxt as u
 
 import coordinax as cx
 import coordinax.transforms as cxfm
 from .conftest import EXPECTED_IDENTITY, EXPECTED_REFLECT
+
+
+def test_reflect_from_normal_zero_raises_under_jit() -> None:
+    """A zero normal is rejected even under jit (no tracer bool)."""
+    build = eqx.filter_jit(cxfm.Reflect.from_normal)
+    with pytest.raises(eqx.EquinoxRuntimeError, match="nonzero normal"):
+        jax.block_until_ready(build(jnp.asarray([0.0, 0.0, 0.0])).H)
 
 
 def _extract_xyz(result: Any) -> tuple[float, float, float]:

--- a/tests/unit/transforms/test_spatial_linear_transforms.py
+++ b/tests/unit/transforms/test_spatial_linear_transforms.py
@@ -2,7 +2,10 @@
 
 __all__: tuple[str, ...] = ()
 
+import equinox as eqx
+import jax
 import numpy as np
+import pytest
 
 import quaxed.numpy as jnp
 import unxt as u
@@ -13,6 +16,19 @@ import coordinax.transforms as cxfm
 def _to_np(x: object, unit: str) -> np.ndarray:
     assert isinstance(x, u.AbstractQuantity)
     return np.asarray(u.ustrip(unit, x), dtype=float)
+
+
+def test_scale_from_factors_singular_raises_under_jit() -> None:
+    """A zero scale factor is rejected even under jit (no tracer bool)."""
+    build = eqx.filter_jit(cxfm.Scale.from_factors)
+    with pytest.raises(eqx.EquinoxRuntimeError, match="invertible"):
+        jax.block_until_ready(build(jnp.asarray([2.0, 0.0, 4.0])).S)
+
+
+def test_scale_from_factors_nonsingular_jits() -> None:
+    """A valid Scale builds cleanly under jit."""
+    op = eqx.filter_jit(cxfm.Scale.from_factors)(jnp.asarray([2.0, 3.0, 4.0]))
+    np.testing.assert_allclose(np.asarray(jnp.diag(op.S)), [2.0, 3.0, 4.0])
 
 
 def test_public_surface_includes_scale_and_shear() -> None:


### PR DESCRIPTION
## Problem

`Scale.from_factors` and `Reflect.from_normal` validate their input with `if bool(jnp.any(...)): raise ValueError(...)`. Calling `bool()` on a traced array raises `TracerBoolConversionError`, so building either transform inside a jitted function fails:

```python
eqx.filter_jit(cxfm.Scale.from_factors)(jnp.asarray([2., 0., 4.]))
# TracerBoolConversionError
```

## Fix

Replace the eager `bool` checks with `eqx.error_if`, threading the checked array into the constructed matrix so the guard survives tracing (and still raises on concrete bad input, now as `EquinoxRuntimeError` — consistent with the `Distance`/`Parallax` checks). The `jnp.eye(shape[0])` dimension-agnostic simplify issue flagged in the audit was already fixed upstream in the `AbstractLinearTransform` refactor.

## Tests

Added jit-construction tests for both `Scale.from_factors` (singular → raises; valid → builds) and `Reflect.from_normal` (zero normal → raises). Full transforms unit suite (262) and source doctests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)