### PR TITLE
🐛 fix(vectors): account for chart and frame in vector equality

### DIFF
--- a/src/coordinax/vectors/_src/base.py
+++ b/src/coordinax/vectors/_src/base.py
@@ -371,8 +371,16 @@ class AbstractVector(
         if type(other) is not type(self):
             return NotImplemented
 
+        # Vectors in different charts or frames are not equal. Chart and frame
+        # are static metadata, so this comparison is a plain Python bool (safe
+        # under jit); it also avoids the component-key mismatch that comparing
+        # different-chart data dicts would otherwise raise.
+        other_vec = cast("AbstractVector", other)
+        if self.chart != other_vec.chart or self.frame != other_vec.frame:
+            return jnp.zeros((), dtype=bool)
+
         # Delegate to `quax` primitives
-        return jnp.equal(self, cast("AbstractVector", other))
+        return jnp.equal(self, other_vec)
 
     # ---------------------------------
     # methods

--- a/tests/unit/vectors/test_point.py
+++ b/tests/unit/vectors/test_point.py
@@ -3,6 +3,7 @@
 __all__: tuple[str, ...] = ()
 
 
+import quaxed.numpy as qnp
 import unxt as u
 
 import coordinax as cx
@@ -72,3 +73,25 @@ class TestPointFrame:
             frame=cxf.alice,
         )
         assert isinstance(p.frame, cxf.AbstractReferenceFrame)
+
+
+class TestPointEquality:
+    """``==`` accounts for the chart and frame, and never raises."""
+
+    def test_eq_different_chart_is_false(self):
+        """Points in different charts are unequal, not a key-mismatch error."""
+        p1 = cx.Point.from_([1, 2, 3], "m")
+        p2 = p1.cconvert(cxc.sph3d)
+        assert not bool(qnp.all(p1 == p2))
+
+    def test_eq_different_frame_is_false(self):
+        """Points with identical data but different frames are unequal."""
+        p1 = cx.Point.from_([1, 2, 3], "km", cxf.alice)
+        p2 = cx.Point.from_([1, 2, 3], "km", cxf.noframe)
+        assert not bool(qnp.all(p1 == p2))
+
+    def test_eq_same_chart_frame_and_data_is_true(self):
+        """Identical points remain equal."""
+        p1 = cx.Point.from_([1, 2, 3], "km", cxf.alice)
+        p2 = cx.Point.from_([1, 2, 3], "km", cxf.alice)
+        assert bool(qnp.all(p1 == p2))


### PR DESCRIPTION
## Problem

`AbstractVector.__eq__` only checked `type(other) is type(self)` and then delegated straight to `jnp.equal` over the component dicts, ignoring `chart` and `frame`:

- Comparing points in **different charts** (different component keys) raised `ValueError: Dict key mismatch` instead of returning "not equal" — `__eq__` should never raise on a valid comparison.
- Points with identical data but **different frames** compared **equal**, silently hiding a physically meaningful difference.

## Fix

Guard on `chart` and `frame` before delegating. Both are static metadata, so the comparison is a plain Python bool (safe under jit) — mismatched chart or frame returns a scalar `False` array; otherwise the existing `jnp.equal` path runs unchanged.

## Tests

Added `TestPointEquality`: different chart ⇒ False (no raise), different frame ⇒ False, identical ⇒ True. Full vectors suite (190), base doctests (58), and the integration/usage suites (178) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)