### PR TITLE
👷 build: publish coordinaxs.curveframes via the release automation

### DIFF
--- a/.github/workflows/cd-coordinaxs-curveframes.yml
+++ b/.github/workflows/cd-coordinaxs-curveframes.yml
@@ -1,0 +1,88 @@
+name: CD - coordinaxs.curveframes
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - "coordinaxs-curveframes-v*"
+    paths:
+      - "packages/coordinaxs.curveframes/**"
+      - ".github/workflows/cd-coordinaxs-curveframes.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  FORCE_COLOR: 3
+
+jobs:
+  build:
+    name: Build & inspect package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Build runs for manual dispatch, main pushes, and direct package tag pushes.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v5.5.0
+        with:
+          # Required for hatch-vcs to determine version from git tags.
+          # Can be removed if switching to hardcoded versions.
+          fetch-depth: 0
+          persist-credentials: false
+          # This workflow only runs on trusted `push` and `workflow_dispatch` events.
+          ref: ${{ github.ref }}
+
+      - name: Validate git tag (for tagged releases)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_REF_VAR: ${{ github.ref }}
+        run: |
+          TAG="${GITHUB_REF_VAR#refs/tags/}"
+          python scripts/validate_tag.py "$TAG" "coordinaxs.curveframes"
+        shell: bash
+
+      - name: Emit release metadata
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          HEAD_SHA=$(git rev-parse HEAD)
+
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          else
+            TAG=""
+          fi
+          TRIGGER_EVENT="${EVENT_NAME}"
+
+          jq -n \
+            --arg package "coordinaxs.curveframes" \
+            --arg package_tag "${TAG}" \
+            --arg head_sha "${HEAD_SHA}" \
+            --arg trigger_event "${TRIGGER_EVENT}" \
+            '{"package": $package, "package_tag": $package_tag, "head_sha": $head_sha, "trigger_event": $trigger_event}' \
+            > release-metadata.json
+
+          echo "Release metadata:"
+          cat release-metadata.json
+        shell: bash
+
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+        with:
+          path: packages/coordinaxs.curveframes
+          upload-name-suffix: -coordinaxs.curveframes
+          attest-build-provenance-github: false
+
+      - name: Upload release metadata artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-metadata-coordinaxs-curveframes
+          path: release-metadata.json
+          retention-days: 7

--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -14,6 +14,7 @@ on:
       - "CD - coordinax"
       - "CD - coordinaxs.api"
       - "CD - coordinaxs.astro"
+      - "CD - coordinaxs.curveframes"
       - "CD - coordinaxs.hypothesis"
       - "CD - coordinaxs.interop.astropy"
     types:

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -54,6 +54,7 @@ jobs:
             echo "  - coordinax-v${VERSION}"
             echo "  - coordinaxs-api-v${VERSION}"
             echo "  - coordinaxs-astro-v${VERSION}"
+            echo "  - coordinaxs-curveframes-v${VERSION}"
             echo "  - coordinaxs-hypothesis-v${VERSION}"
             echo "  - coordinaxs-interop-astropy-v${VERSION}"
             exit 1
@@ -83,6 +84,7 @@ jobs:
             "coordinax"
             "coordinaxs-api"
             "coordinaxs-astro"
+            "coordinaxs-curveframes"
             "coordinaxs-hypothesis"
             "coordinaxs-interop-astropy"
           )
@@ -91,6 +93,7 @@ jobs:
           COORDINAX_TAG_CREATED="false"
           COORDINAX_API_TAG_CREATED="false"
           COORDINAX_ASTRO_TAG_CREATED="false"
+          COORDINAX_CURVEFRAMES_TAG_CREATED="false"
           COORDINAX_HYPOTHESIS_TAG_CREATED="false"
           COORDINAX_INTEROP_ASTROPY_TAG_CREATED="false"
 
@@ -133,6 +136,9 @@ jobs:
               if [ "$PACKAGE" = "coordinaxs-astro" ]; then
                 COORDINAX_ASTRO_TAG_CREATED="true"
               fi
+              if [ "$PACKAGE" = "coordinaxs-curveframes" ]; then
+                COORDINAX_CURVEFRAMES_TAG_CREATED="true"
+              fi
               if [ "$PACKAGE" = "coordinaxs-hypothesis" ]; then
                 COORDINAX_HYPOTHESIS_TAG_CREATED="true"
               fi
@@ -158,6 +164,10 @@ jobs:
             echo "trigger_coordinax_astro_cd=false" >> "$GITHUB_OUTPUT"
             echo "coordinaxs_astro_tag=coordinaxs-astro-v${VERSION}" >> "$GITHUB_OUTPUT"
             echo "coordinaxs_astro_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
+
+            echo "trigger_coordinax_curveframes_cd=false" >> "$GITHUB_OUTPUT"
+            echo "coordinaxs_curveframes_tag=coordinaxs-curveframes-v${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "coordinaxs_curveframes_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
 
             echo "trigger_coordinax_hypothesis_cd=false" >> "$GITHUB_OUTPUT"
             echo "coordinaxs_hypothesis_tag=coordinaxs-hypothesis-v${VERSION}" >> "$GITHUB_OUTPUT"
@@ -185,6 +195,10 @@ jobs:
           echo "trigger_coordinax_astro_cd=${COORDINAX_ASTRO_TAG_CREATED}" >> "$GITHUB_OUTPUT"
           echo "coordinaxs_astro_tag=coordinaxs-astro-v${VERSION}" >> "$GITHUB_OUTPUT"
           echo "coordinaxs_astro_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
+
+          echo "trigger_coordinax_curveframes_cd=${COORDINAX_CURVEFRAMES_TAG_CREATED}" >> "$GITHUB_OUTPUT"
+          echo "coordinaxs_curveframes_tag=coordinaxs-curveframes-v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "coordinaxs_curveframes_tag_sha=${COORDINATOR_SHA}" >> "$GITHUB_OUTPUT"
 
           echo "trigger_coordinax_hypothesis_cd=${COORDINAX_HYPOTHESIS_TAG_CREATED}" >> "$GITHUB_OUTPUT"
           echo "coordinaxs_hypothesis_tag=coordinaxs-hypothesis-v${VERSION}" >> "$GITHUB_OUTPUT"
@@ -232,6 +246,19 @@ jobs:
           tag_ref: ${{ steps.create_tags.outputs.coordinaxs_astro_tag }}
           tag_sha: ${{ steps.create_tags.outputs.coordinaxs_astro_tag_sha }}
           trigger_cd: ${{ steps.create_tags.outputs.trigger_coordinax_astro_cd }}
+
+      - name: Trigger CD - coordinaxs.curveframes for auto-created coordinaxs-curveframes tag
+        if: |
+          steps.create_tags.outputs.trigger_coordinax_curveframes_cd == 'true' ||
+          (steps.create_tags.outputs.coordinaxs_curveframes_tag != '' &&
+          steps.create_tags.outputs.trigger_coordinax_curveframes_cd == 'false')
+        uses: ./.github/actions/dispatch-package-cd
+        with:
+          workflow_id: cd-coordinaxs-curveframes.yml
+          workflow_name: CD - coordinaxs.curveframes
+          tag_ref: ${{ steps.create_tags.outputs.coordinaxs_curveframes_tag }}
+          tag_sha: ${{ steps.create_tags.outputs.coordinaxs_curveframes_tag_sha }}
+          trigger_cd: ${{ steps.create_tags.outputs.trigger_coordinax_curveframes_cd }}
 
       - name: Trigger CD - coordinaxs.hypothesis for auto-created coordinaxs-hypothesis tag
         if: |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,14 +1,15 @@
 # Release Process for coordinax Workspace
 
-This workspace contains five packages that can be released:
+This workspace contains six packages that can be released:
 
 - `coordinax` - the main package
 - `coordinaxs.api` - abstract dispatch API
 - `coordinaxs.astro` - astronomy-specific reference frames
+- `coordinaxs.curveframes` - curve/streamline reference frames
 - `coordinaxs.hypothesis` - hypothesis testing strategies
 - `coordinaxs.interop.astropy` - Astropy interoperability package
 
-> **Note:** the workspace also contains `coordinaxs.curveframes`, which is **intentionally not part of the release automation** (no CD workflow, not in `create-package-tags.yml`, `cd-publish.yml`, or `validate_tag.py`). It is developed and tested in-tree but not yet published to PyPI. To release it, wire it in like the packages above **and** register its PyPI trusted publisher first (see the note in `validate_tag.py`).
+> **Note:** `coordinaxs.curveframes` requires a one-time PyPI setup before its first automated release: register its **PyPI (and TestPyPI) trusted publisher** for the `cd-publish.yml` workflow, exactly as done for the other packages. The release automation is already wired for it.
 
 All releases are automated via GitHub Actions.
 
@@ -53,6 +54,7 @@ Valid coordinator tags (synchronized releases):
   - `coordinax-v0.24.0`
   - `coordinaxs-api-v0.24.0`
   - `coordinaxs-astro-v0.24.0`
+  - `coordinaxs-curveframes-v0.24.0`
   - `coordinaxs-hypothesis-v0.24.0`
   - `coordinaxs-interop-astropy-v0.24.0`
 
@@ -76,6 +78,7 @@ All packages use `hatch-vcs` with package-specific tag matching:
 - `coordinax` matches `coordinax-v*`
 - `coordinaxs.api` matches `coordinaxs-api-v*`
 - `coordinaxs.astro` matches `coordinaxs-astro-v*`
+- `coordinaxs.curveframes` matches `coordinaxs-curveframes-v*`
 - `coordinaxs.hypothesis` matches `coordinaxs-hypothesis-v*`
 - `coordinaxs.interop.astropy` matches `coordinaxs-interop-astropy-v*`
 
@@ -83,7 +86,7 @@ All packages use `hatch-vcs` with package-specific tag matching:
 
 1. Push coordinator tag `vX.Y.0`:
 
-- `create-package-tags` workflow validates it and creates all five package tags.
+- `create-package-tags` workflow validates it and creates all six package tags.
 - Each package CD workflow runs from the created package tag and publishes.
 
 2. Push package tag `PACKAGE-vX.Y.Z`:
@@ -127,7 +130,7 @@ git push origin vX.Y.0
 Expected automation:
 
 1. `Create Package Tags` runs and creates all package tags.
-2. All five `cd-*` workflows run.
+2. All six `cd-*` workflows run.
 3. Packages are published to TestPyPI and PyPI.
 
 ### Scenario 2: Bug-fix Release (Single Package)

--- a/scripts/validate_tag.py
+++ b/scripts/validate_tag.py
@@ -19,15 +19,11 @@ import sys
 
 logger = logging.getLogger(__name__)
 
-# NOTE: `coordinaxs.curveframes` is intentionally omitted — it is developed
-# in-tree but not part of the release automation (see RELEASING.md). To release
-# it, add it here, add a `cd-coordinaxs-curveframes.yml` workflow, wire it into
-# `create-package-tags.yml` / `cd-publish.yml`, and register its PyPI trusted
-# publisher.
 PACKAGE_NAMES: tuple[str, ...] = (
     "coordinax",
     "coordinaxs.api",
     "coordinaxs.astro",
+    "coordinaxs.curveframes",
     "coordinaxs.hypothesis",
     "coordinaxs.interop.astropy",
 )

--- a/tests/unit/test_validate_tag.py
+++ b/tests/unit/test_validate_tag.py
@@ -301,6 +301,15 @@ class TestValidateTagForPackage:
         )
         assert is_valid is True
 
+    def test_curveframes_is_a_release_package(self, validate_tag):
+        """coordinaxs.curveframes is wired into the release automation."""
+        assert "coordinaxs.curveframes" in validate_tag.PACKAGE_NAMES
+        # Bug-fix patch tag (Z > 0) needs no coordinator tag.
+        is_valid, error = validate_tag.validate_tag_for_package(
+            "coordinaxs-curveframes-v2.0.99", "coordinaxs.curveframes"
+        )
+        assert is_valid is True, error
+
     def test_bugfix_release_subprocess_not_called(self, validate_tag):
         """Verify subprocess is not called for bugfix releases."""
         with patch("subprocess.run") as mock_subprocess:
@@ -344,16 +353,8 @@ class TestValidateTagForPackage:
         mock_result.stdout = "v1.0.0\n"
         mock_result.stderr = ""
 
-        packages = [
-            "coordinax",
-            "coordinaxs.api",
-            "coordinaxs.astro",
-            "coordinaxs.hypothesis",
-            "coordinaxs.interop.astropy",
-        ]
-
         with patch("subprocess.run", return_value=mock_result):
-            for package in packages:
+            for package in validate_tag.PACKAGE_NAMES:
                 tag_prefix = package.replace(".", "-")
                 is_valid, error = validate_tag.validate_tag_for_package(
                     f"{tag_prefix}-v1.0.0", package


### PR DESCRIPTION
## Problem

`coordinaxs.curveframes` is complete and tested in-tree, but it was deliberately excluded from the release automation — no CD workflow, absent from `create-package-tags.yml` / `cd-publish.yml` / `validate_tag.py`. As a result `pip install coordinax[curveframes]` (and `[workspace]`) could not resolve from PyPI, since the extra pointed at an unpublished package.

Per the plan, this **publishes** it (rather than dropping the extra).

## Changes

- **`cd-coordinaxs-curveframes.yml`** — new Stage A build workflow, identical to `cd-coordinaxs-astro.yml` modulo the package name (validates the `coordinaxs-curveframes-v*` tag, emits release metadata, builds/inspects the package).
- **`cd-publish.yml`** — register `CD - coordinaxs.curveframes` in the `workflow_run` trigger list (the privileged Stage B derives package identity from the workflow name).
- **`create-package-tags.yml`** — thread curveframes through the coordinator-tag fan-out: help text, `PACKAGES`, the created-flag, both `GITHUB_OUTPUT` branches, and a `Trigger CD` step.
- **`validate_tag.py`** — add `coordinaxs.curveframes` to `PACKAGE_NAMES` (removes the "intentionally omitted" note).
- **`RELEASING.md`** — six packages; documents the one remaining out-of-band step.

## Maintainer action required

Register the **PyPI + TestPyPI trusted publisher** for the new `cd-coordinaxs-curveframes.yml` → `cd-publish.yml` flow before the first release (as was done for the other packages). Noted in `RELEASING.md`. Everything else is wired.

## Verification

- `coordinaxs.curveframes` builds (sdist + wheel) via `uv build`.
- Its pyproject already matches `coordinaxs-curveframes-v*`.
- All three edited workflows are valid YAML; pre-commit's workflow validator passes.
- `test_validate_tag.py` now derives the valid-package list from `PACKAGE_NAMES` and asserts curveframes is a release package (29 tests pass).

Pairs with #565 (which pins the `curveframes` extra to `>=0.24`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)