### PR TITLE
🐛 fix(transforms): make Boost's geometry-form act match its 5-arg act

### DIFF
--- a/src/coordinax/transforms/_src/actions/boost.py
+++ b/src/coordinax/transforms/_src/actions/boost.py
@@ -209,3 +209,29 @@ def act(
     if tau is None:
         raise TypeError(_MSG_TAU_REQUIRED_TANGENT.format(m=m))
     return delegate()
+
+
+@plum.dispatch
+def act(
+    op: Boost,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractChart,
+    geom: cxr.TangentGeometry,
+    rep: cxr.Representation,
+    /,
+    *,
+    usys: OptUSys = None,
+    **kw: Any,
+) -> CDict:
+    """Boost tangent action (geometry-form): defer to the 5-arg ``act``.
+
+    The generic geometry-form funnel routes on ``is_time_dependent``, which is
+    ``False`` for a Boost with constant ``delta`` even though the boost's point
+    action ``x + dv*tau`` is tau-dependent; it would misroute to ``pushforward``
+    and drop the kinematic velocity shift. Boost's 5-arg ``act`` implements the
+    correct kinematic prolongation, so the geometry-form delegates to it,
+    keeping the two ``act`` forms identical by construction.
+    """
+    del geom
+    return cast("CDict", cxfmapi.act(op, tau, x, chart, rep, usys=usys, **kw))

--- a/tests/unit/transforms/test_boost.py
+++ b/tests/unit/transforms/test_boost.py
@@ -116,6 +116,36 @@ class TestBoostOnVelocity:
         for k in vel_cdict:
             assert jnp.allclose(result[k], vel_cdict[k] + delta_v[k])
 
+    def test_geom_form_matches_5arg_act(self, boost, vel_cdict):
+        """6-arg geometry-form ``act`` must equal the 5-arg ``act``.
+
+        The generic geom-form funnel routes on ``is_time_dependent`` (False for
+        a static boost), which would misroute to ``pushforward`` and drop the
+        velocity shift. The two ``act`` forms must agree.
+        """
+        at = {"x": jnp.array(1.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
+        tau = jnp.array(0.0)
+        for rep in (cxr.coord_vel, cxr.coord_disp, cxr.coord_acc):
+            five = cxfm.act(boost, tau, vel_cdict, cxc.cart3d, rep, at=at)
+            six = cxfm.act(
+                boost, tau, vel_cdict, cxc.cart3d, cxr.tangent_geom, rep, at=at
+            )
+            for k in vel_cdict:
+                assert jnp.allclose(six[k], five[k]), f"{rep} component {k}"
+
+    def test_pushforward_is_frozen_tau_identity(self, boost, vel_cdict):
+        """``pushforward`` is the frozen-tau spatial map: velocity is unchanged.
+
+        This differs from ``act`` for a boost (Δv is a kinematic-prolongation
+        effect, not a pushforward effect); guard against an over-fix.
+        """
+        at = {"x": jnp.array(1.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
+        out = cxfm.pushforward(
+            boost, jnp.array(0.0), vel_cdict, cxc.cart3d, cxr.coord_vel, at=at
+        )
+        for k in vel_cdict:
+            assert jnp.allclose(out[k], vel_cdict[k])
+
     def test_right_add_true(self, delta_v, vel_cdict):
         boost_r = cxfm.Boost(delta_v, chart=cxc.cart3d, right_add=True)
         result = cxfm.act(boost_r, None, vel_cdict, cxc.cart3d, cxr.coord_vel)


### PR DESCRIPTION
## Problem

`Boost` has two ways to transform tangent (velocity) data that **disagreed**:

```python
boost = cxfm.Boost({"x": u.Q(1,"km/s"), ...}, chart=cxc.cart3d)
v = {"x": u.Q(2,"km/s"), ...}
cxfm.act(boost, tau, v, cxc.cart3d, cxr.coord_vel)                         # -> 3.0 (correct)
cxfm.act(boost, tau, v, cxc.cart3d, cxr.tangent_geom, cxr.coord_vel, at=…) # -> 2.0 (dv dropped)
```

A boost's point action `x ↦ x + Δv·τ` is τ-dependent, but its *parameters* are constant, so `is_time_dependent(Boost)` is `False`. The generic geometry-form `act` funnel routes on that flag and sent a static Boost to `pushforward` — which correctly applies only the frozen-τ spatial Jacobian (identity for a boost) and so drops the `Δv` shift. The 5-arg `act` funnels into the 6-arg form for every other operator, so the two `act` forms are supposed to agree; Boost is the unique operator that `is_time_dependent` misclassifies.

**`pushforward` itself is correct and is left unchanged** — for a boost the `Δv` shift is a *kinematic-prolongation* effect (a ∂τ effect), not a pushforward one. (A time-dependent `Translate` shows the same `pushforward` vs `act` split, and it's intended.)

## Fix

Register a Boost-specific 6-arg geometry-form `act` that delegates to Boost's own (correct) 5-arg `act`, so the two forms are identical by construction and can't diverge again. This keeps `is_time_dependent` in sync with `materialize_transform`'s partition rule (rather than special-casing the funnel).

## Tests

Added geom-form/5-arg parity tests for velocity, displacement, and acceleration (RED before: 2.0 vs 3.0), and a test pinning `pushforward` as the frozen-τ identity so a future over-fix can't silently change it. Full transforms suite (261) + boost doctests pass.

_Root-cause analysis credit: dispatch trace across `prolong.py` (funnel + `is_time_dependent`), `boost.py`, and `add.py`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)