### PR TITLE
🐛 fix(product): geometric-mean units for cross-factor metric off-diagonals

### DIFF
--- a/src/coordinax/_src/product/register_metric.py
+++ b/src/coordinax/_src/product/register_metric.py
@@ -117,8 +117,10 @@ def metric_matrix(
     dtype = jnp.result_type(*(block.value.dtype for block in factor_blocks))
     value = jnp.zeros((n, n), dtype=dtype)
 
-    # First pass: place each factor block and record its diagonal units.
-    diag_units: list[Any] = [u.unit("") for _ in range(n)]
+    # Place each factor's numeric block and its (intra-block) units; record the
+    # index range of each block for the cross-factor pass below.
+    units: list[list[Any]] = [[u.unit("") for _ in range(n)] for _ in range(n)]
+    block_ranges: list[range] = []
     offset = 0
     for block in factor_blocks:
         block_n = block.shape[0]
@@ -126,30 +128,25 @@ def metric_matrix(
             block.value
         )
         for i in range(block_n):
-            diag_units[offset + i] = block.unit[i, i]
-        offset += block_n
-
-    # Off-diagonal (i, j) entries are numerically zero across factors, but their
-    # units must be the geometric mean sqrt([g_ii]*[g_jj]) so that every term of
-    # the vᵀGv contraction converts to the row reference unit g[i,0]*v[0]. This
-    # mirrors DiagonalMetric.to_dense and keeps products of factors with
-    # non-dimensionless metrics (e.g. an embedded sphere with a radius)
-    # unit-consistent. It is a no-op when every factor metric is dimensionless.
-    units = [
-        [
-            diag_units[i] if i == j else (diag_units[i] * diag_units[j]) ** 0.5
-            for j in range(n)
-        ]
-        for i in range(n)
-    ]
-    # Second pass: restore genuine intra-block off-diagonals (dense factor metrics).
-    offset = 0
-    for block in factor_blocks:
-        block_n = block.shape[0]
-        for i in range(block_n):
             for j in range(block_n):
                 units[offset + i][offset + j] = block.unit[i, j]
+        block_ranges.append(range(offset, offset + block_n))
         offset += block_n
+
+    # Cross-factor (i, j) entries are numerically zero, but their units must be
+    # the geometric mean sqrt([g_ii]*[g_jj]) so that every term of the vᵀGv
+    # contraction converts to the row reference unit g[i,0]*v[0]. This mirrors
+    # DiagonalMetric.to_dense and keeps products of factors with non-
+    # dimensionless metrics (e.g. an embedded sphere with a radius) consistent.
+    # Only cross-block entries are computed (intra-block units are kept), so it
+    # is a no-op when every factor metric is dimensionless.
+    for a, ra in enumerate(block_ranges):
+        for rb in block_ranges[a + 1 :]:
+            for i in ra:
+                for j in rb:
+                    geo_mean = (units[i][i] * units[j][j]) ** 0.5
+                    units[i][j] = geo_mean
+                    units[j][i] = geo_mean
 
     unit_tup = tuple(tuple(row) for row in units)
     G = QMatrix(value=value, unit=UnitsMatrix(unit_tup))

--- a/src/coordinax/_src/product/register_metric.py
+++ b/src/coordinax/_src/product/register_metric.py
@@ -11,6 +11,8 @@ by recursively calling the standalone ``metric_matrix`` dispatch API.
 
 __all__: tuple[str, ...] = ()
 
+from typing import Any
+
 import jax.numpy as jnp
 import plum
 
@@ -114,14 +116,36 @@ def metric_matrix(
     n = sum(block.shape[0] for block in factor_blocks)
     dtype = jnp.result_type(*(block.value.dtype for block in factor_blocks))
     value = jnp.zeros((n, n), dtype=dtype)
-    units = [[u.unit("") for _ in range(n)] for _ in range(n)]
 
+    # First pass: place each factor block and record its diagonal units.
+    diag_units: list[Any] = [u.unit("") for _ in range(n)]
     offset = 0
     for block in factor_blocks:
         block_n = block.shape[0]
         value = value.at[offset : offset + block_n, offset : offset + block_n].set(
             block.value
         )
+        for i in range(block_n):
+            diag_units[offset + i] = block.unit[i, i]
+        offset += block_n
+
+    # Off-diagonal (i, j) entries are numerically zero across factors, but their
+    # units must be the geometric mean sqrt([g_ii]*[g_jj]) so that every term of
+    # the vᵀGv contraction converts to the row reference unit g[i,0]*v[0]. This
+    # mirrors DiagonalMetric.to_dense and keeps products of factors with
+    # non-dimensionless metrics (e.g. an embedded sphere with a radius)
+    # unit-consistent. It is a no-op when every factor metric is dimensionless.
+    units = [
+        [
+            diag_units[i] if i == j else (diag_units[i] * diag_units[j]) ** 0.5
+            for j in range(n)
+        ]
+        for i in range(n)
+    ]
+    # Second pass: restore genuine intra-block off-diagonals (dense factor metrics).
+    offset = 0
+    for block in factor_blocks:
+        block_n = block.shape[0]
         for i in range(block_n):
             for j in range(block_n):
                 units[offset + i][offset + j] = block.unit[i, j]

--- a/src/coordinax/_src/product/register_metric.py
+++ b/src/coordinax/_src/product/register_metric.py
@@ -11,6 +11,8 @@ by recursively calling the standalone ``metric_matrix`` dispatch API.
 
 __all__: tuple[str, ...] = ()
 
+from itertools import combinations, product
+
 from typing import Any
 
 import jax.numpy as jnp
@@ -138,15 +140,15 @@ def metric_matrix(
     # contraction converts to the row reference unit g[i,0]*v[0]. This mirrors
     # DiagonalMetric.to_dense and keeps products of factors with non-
     # dimensionless metrics (e.g. an embedded sphere with a radius) consistent.
-    # Only cross-block entries are computed (intra-block units are kept), so it
+    # Only cross-block entries are filled (intra-block units are kept), so it
     # is a no-op when every factor metric is dimensionless.
-    for a, ra in enumerate(block_ranges):
-        for rb in block_ranges[a + 1 :]:
-            for i in ra:
-                for j in rb:
-                    geo_mean = (units[i][i] * units[j][j]) ** 0.5
-                    units[i][j] = geo_mean
-                    units[j][i] = geo_mean
+    #
+    # The mean factorises as sqrt([g_ii]*[g_jj]) = sqrt([g_ii]) * sqrt([g_jj]),
+    # so the per-index sqrt is taken once (n roots, not one per pair).
+    sqrt_diag = [units[i][i] ** 0.5 for i in range(n)]
+    for ra, rb in combinations(block_ranges, 2):
+        for i, j in product(ra, rb):
+            units[i][j] = units[j][i] = sqrt_diag[i] * sqrt_diag[j]
 
     unit_tup = tuple(tuple(row) for row in units)
     G = QMatrix(value=value, unit=UnitsMatrix(unit_tup))

--- a/tests/unit/manifolds/test_norm.py
+++ b/tests/unit/manifolds/test_norm.py
@@ -573,7 +573,7 @@ class TestProductMetricInterBlockUnits:
         return cxmapi.metric_matrix(m, at, chart).matrix, chart
 
     def test_length_carrying_factor_gets_geometric_mean_offdiagonal(self):
-        """A radius-scaled sphere (metric m²/rad²) x line (dimensionless)."""
+        """A radius-scaled sphere (metric m²/rad²) x line (unitless g_xx = 1)."""
         radius, theta, phi = 2.0, jnp.pi / 3, 0.5
         v_theta, v_phi, v_x = 0.5, 0.3, 1.0
 

--- a/tests/unit/manifolds/test_norm.py
+++ b/tests/unit/manifolds/test_norm.py
@@ -12,6 +12,9 @@ import unxt as u
 
 import coordinax.charts as cxc
 import coordinax.manifolds as cxm
+import coordinaxs.api.manifolds as cxmapi
+from coordinax._src.internal import pack_nonuniform_unit
+from coordinax.internal import QMatrix
 
 # =============================================================================
 # cxm.norm() standalone function
@@ -555,3 +558,48 @@ class TestNormJAXCompatSphere:
 
         # sin(π/2) = 1 > sin(π/6) = 0.5
         assert u.ustrip("rad/s", norm_eq) > u.ustrip("rad/s", norm_30)
+
+
+class TestProductMetricInterBlockUnits:
+    """The block-diagonal product metric uses geometric-mean off-diagonal units.
+
+    Cross-factor off-diagonal entries are numerically zero, but their units must
+    be the geometric mean ``sqrt(g_ii * g_jj)`` so that the ``vᵀGv`` contraction
+    is unit-consistent for factors with non-dimensionless metrics.
+    """
+
+    def _metric(self, factors, names, at):
+        m = cxm.CartesianProductManifold(factors=factors, factor_names=names)
+        chart = m.atlas.default_chart()
+        return cxmapi.metric_matrix(m, at, chart).matrix, chart
+
+    def test_length_carrying_factor_gets_geometric_mean_offdiagonal(self):
+        """A radius-scaled sphere (metric m²/rad²) x line (dimensionless)."""
+        E = cxm.embedded_twosphere(u.Q(2.0, "m"))
+        at = {
+            "sph.theta": u.Q(jnp.pi / 3, "rad"),
+            "sph.phi": u.Q(0.5, "rad"),
+            "line.x": u.Q(1.0, "m"),
+        }
+        gm, chart = self._metric((E, cxm.R1), ("sph", "line"), at)
+        # sqrt(m²/rad² * dimensionless) = m/rad
+        assert gm.unit[0, 2] == u.unit("m / rad")
+        assert gm.unit[2, 0] == u.unit("m / rad")
+
+        # The assembled metric now yields a unit-consistent norm:
+        v = {
+            "sph.theta": u.Q(0.5, "rad/s"),
+            "sph.phi": u.Q(0.3, "rad/s"),
+            "line.x": u.Q(1.0, "m/s"),
+        }
+        vv, units = pack_nonuniform_unit(v, chart.components)
+        # |v|^2 = 4*0.5^2 + (4*sin^2(pi/3))*0.3^2 + 1*1^2 = 2.27
+        result = cxm.norm(gm, QMatrix(vv, unit=units))
+        assert qnp.allclose(result, u.Q(2.27**0.5, "m/s"), atol=u.Q(1e-5, "m/s"))
+
+    def test_all_dimensionless_factors_stay_dimensionless(self):
+        """No regression: dimensionless factors keep dimensionless off-diagonals."""
+        at = {"line0.x": u.Q(1.0, "m"), "line1.x": u.Q(2.0, "m")}
+        gm, _ = self._metric((cxm.R1, cxm.R1), ("line0", "line1"), at)
+        assert gm.unit[0, 1] == u.unit("")
+        assert gm.unit[1, 0] == u.unit("")

--- a/tests/unit/manifolds/test_norm.py
+++ b/tests/unit/manifolds/test_norm.py
@@ -574,10 +574,13 @@ class TestProductMetricInterBlockUnits:
 
     def test_length_carrying_factor_gets_geometric_mean_offdiagonal(self):
         """A radius-scaled sphere (metric m²/rad²) x line (dimensionless)."""
-        E = cxm.embedded_twosphere(u.Q(2.0, "m"))
+        radius, theta, phi = 2.0, jnp.pi / 3, 0.5
+        v_theta, v_phi, v_x = 0.5, 0.3, 1.0
+
+        E = cxm.embedded_twosphere(u.Q(radius, "m"))
         at = {
-            "sph.theta": u.Q(jnp.pi / 3, "rad"),
-            "sph.phi": u.Q(0.5, "rad"),
+            "sph.theta": u.Q(theta, "rad"),
+            "sph.phi": u.Q(phi, "rad"),
             "line.x": u.Q(1.0, "m"),
         }
         gm, chart = self._metric((E, cxm.R1), ("sph", "line"), at)
@@ -585,16 +588,22 @@ class TestProductMetricInterBlockUnits:
         assert gm.unit[0, 2] == u.unit("m / rad")
         assert gm.unit[2, 0] == u.unit("m / rad")
 
-        # The assembled metric now yields a unit-consistent norm:
+        # The assembled metric now yields a unit-consistent norm. The round
+        # metric on the radius-R sphere is diag(R², R² sin²θ); the line adds 1:
+        #   |v|² = R²·v_θ² + R²sin²θ·v_φ² + v_x²
         v = {
-            "sph.theta": u.Q(0.5, "rad/s"),
-            "sph.phi": u.Q(0.3, "rad/s"),
-            "line.x": u.Q(1.0, "m/s"),
+            "sph.theta": u.Q(v_theta, "rad/s"),
+            "sph.phi": u.Q(v_phi, "rad/s"),
+            "line.x": u.Q(v_x, "m/s"),
         }
         vv, units = pack_nonuniform_unit(v, chart.components)
-        # |v|^2 = 4*0.5^2 + (4*sin^2(pi/3))*0.3^2 + 1*1^2 = 2.27
+        expected_sq = (
+            radius**2 * v_theta**2 + radius**2 * jnp.sin(theta) ** 2 * v_phi**2 + v_x**2
+        )
         result = cxm.norm(gm, QMatrix(vv, unit=units))
-        assert qnp.allclose(result, u.Q(2.27**0.5, "m/s"), atol=u.Q(1e-5, "m/s"))
+        assert qnp.allclose(
+            result, u.Q(jnp.sqrt(expected_sq), "m/s"), atol=u.Q(1e-5, "m/s")
+        )
 
     def test_all_dimensionless_factors_stay_dimensionless(self):
         """No regression: dimensionless factors keep dimensionless off-diagonals."""

--- a/tests/unit/manifolds/test_norm.py
+++ b/tests/unit/manifolds/test_norm.py
@@ -13,8 +13,7 @@ import unxt as u
 import coordinax.charts as cxc
 import coordinax.manifolds as cxm
 import coordinaxs.api.manifolds as cxmapi
-from coordinax._src.internal import pack_nonuniform_unit
-from coordinax.internal import QMatrix
+from coordinax.internal import QMatrix, pack_nonuniform_unit
 
 # =============================================================================
 # cxm.norm() standalone function

--- a/tests/unit/manifolds/test_norm.py
+++ b/tests/unit/manifolds/test_norm.py
@@ -584,9 +584,12 @@ class TestProductMetricInterBlockUnits:
             "line.x": u.Q(1.0, "m"),
         }
         gm, chart = self._metric((E, cxm.R1), ("sph", "line"), at)
-        # sqrt(m²/rad² * dimensionless) = m/rad
-        assert gm.unit[0, 2] == u.unit("m / rad")
+        # Both sphere components (theta=0, phi=1) carry m²/rad², so every
+        # sphere<->line cross-block off-diagonal is sqrt(m²/rad² * 1) = m/rad.
+        assert gm.unit[0, 2] == u.unit("m / rad")  # theta <-> x
         assert gm.unit[2, 0] == u.unit("m / rad")
+        assert gm.unit[1, 2] == u.unit("m / rad")  # phi <-> x
+        assert gm.unit[2, 1] == u.unit("m / rad")
 
         # The assembled metric now yields a unit-consistent norm. The round
         # metric on the radius-R sphere is diag(R², R² sin²θ); the line adds 1:


### PR DESCRIPTION
## Problem

The block-diagonal product metric (`_src/product/register_metric.py`) initialised every off-diagonal to dimensionless and only filled the intra-block entries — so **cross-factor** off-diagonals stayed dimensionless. For a product whose factor metric carries real units (e.g. `embedded_twosphere(radius)` → metric `m²/rad²`), the `vᵀGv` contraction then couldn't convert the numerically-zero cross terms to the row reference unit `g[i,0]·v[0]`, raising a `UnitConversionError`.

## Fix

Assign cross-factor off-diagonal units the geometric mean `sqrt(g_ii·g_jj)`, mirroring `DiagonalMetric.to_dense` (which already does exactly this for its zero off-diagonals). Genuine intra-block off-diagonals from dense factor metrics are preserved, and the change is a **no-op** when every factor metric is dimensionless.

After the fix, a radius-scaled sphere × line assembles `m/rad` cross off-diagonals and the metric yields a unit-consistent norm (`1.50665 m/s`).

## Scope note

The originally-reported case — `norm` on a **bare unit-`S2`(angle) × `R1`(length)** — is *genuinely ill-defined*: the unit sphere's metric is dimensionless, so the squared norm would add `rad²/s²` and `m²/s²`. That needs a length scale on the sphere (`embedded_twosphere(radius)`), not a units-bookkeeping change; this PR does not paper over it.

Separately, the high-level `cxm.norm(v, chart, at=…)` still can't reach this fix for an *embedded* product because `chart.M` reconstructs the manifold from the **intrinsic** factor charts and drops the embedding radius (its metric comes back dimensionless). That's a distinct bug in `EmbeddedChart`/product `.M` reconstruction — flagged for a follow-up, out of scope here. This fix is verified at the metric-assembly level and via the low-level `norm(G, v)` path.

## Tests

- radius-scaled sphere × line → off-diagonals are `m/rad`; low-level `norm(G, v)` = `1.50665 m/s` (RED before the fix).
- all-dimensionless product → off-diagonals stay dimensionless (regression guard).
- Full manifolds suite (380) + product doctests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)