### PR TITLE
📝 docs: ignore private _src paths in nitpick reference checks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,10 +127,12 @@ nitpick_ignore_regex = [
     # Private ``coordinax``/``coordinaxs`` ``_src`` implementation paths (and
     # their TypeVars) leak into type signatures; the public re-exports (e.g.
     # ``coordinax.vectors.Point``) are the documented targets. Ignore the
-    # private forms rather than the public API. Anchored on the coordinax(s)
-    # prefix and built from dotted-segment groups (no greedy ``.*``) so third-
-    # party ``._src.`` targets are unaffected. Removes ~940 warnings.
-    (r"py:.*", r"coordinaxs?(\.\w+)*\._src(\.\w+)+"),
+    # private forms rather than the public API. Fully anchored (``^…$``) and
+    # built from dotted-segment groups (no greedy ``.*``) so third-party
+    # ``._src.`` targets are unaffected. ``py:.*`` covers every Python role
+    # (class/data/obj/…) since ``_src`` symbols are never intentionally
+    # documented in any role. Removes ~940 warnings.
+    (r"py:.*", r"^coordinaxs?(\.\w+)*\._src(\.\w+)+$"),
 ]
 
 # -- MyST Setting -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,6 +124,11 @@ nitpick_ignore_regex = [
     (r"py:class", r"jaxtyping\..*"),  # TODO: remove
     (r"py:class", r".*TypedNdArray.*"),
     (r"py:class", r"jax\._src\..*"),
+    # Private ``_src`` implementation paths (and their TypeVars) leak into type
+    # signatures; the public re-exports (e.g. ``coordinax.vectors.Point``) are
+    # the documented targets. Ignore the private forms rather than the public
+    # API. This removes ~940 nitpick warnings.
+    (r"py:.*", r".*\._src\..*"),
 ]
 
 # -- MyST Setting -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,9 +127,10 @@ nitpick_ignore_regex = [
     # Private ``coordinax``/``coordinaxs`` ``_src`` implementation paths (and
     # their TypeVars) leak into type signatures; the public re-exports (e.g.
     # ``coordinax.vectors.Point``) are the documented targets. Ignore the
-    # private forms rather than the public API. Scoped to (coordinax|coordinaxs)
-    # so third-party ``._src.`` targets are unaffected. Removes ~940 warnings.
-    (r"py:.*", r"coordinaxs?(\..*)?\._src\..*"),
+    # private forms rather than the public API. Anchored on the coordinax(s)
+    # prefix and built from dotted-segment groups (no greedy ``.*``) so third-
+    # party ``._src.`` targets are unaffected. Removes ~940 warnings.
+    (r"py:.*", r"coordinaxs?(\.\w+)*\._src(\.\w+)+"),
 ]
 
 # -- MyST Setting -------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,11 +124,12 @@ nitpick_ignore_regex = [
     (r"py:class", r"jaxtyping\..*"),  # TODO: remove
     (r"py:class", r".*TypedNdArray.*"),
     (r"py:class", r"jax\._src\..*"),
-    # Private ``_src`` implementation paths (and their TypeVars) leak into type
-    # signatures; the public re-exports (e.g. ``coordinax.vectors.Point``) are
-    # the documented targets. Ignore the private forms rather than the public
-    # API. This removes ~940 nitpick warnings.
-    (r"py:.*", r".*\._src\..*"),
+    # Private ``coordinax``/``coordinaxs`` ``_src`` implementation paths (and
+    # their TypeVars) leak into type signatures; the public re-exports (e.g.
+    # ``coordinax.vectors.Point``) are the documented targets. Ignore the
+    # private forms rather than the public API. Scoped to (coordinax|coordinaxs)
+    # so third-party ``._src.`` targets are unaffected. Removes ~940 warnings.
+    (r"py:.*", r"coordinaxs?(\..*)?\._src\..*"),
 ]
 
 # -- MyST Setting -------------------------------------------------


### PR DESCRIPTION
## What

Adds a `nitpick_ignore_regex` entry for `.*\._src\..*` in `docs/conf.py`.

Private implementation paths (`coordinax…._src.…`, `coordinaxs…._src.…`) and their TypeVars leak into rendered type signatures, so nitpicky mode reports **~940** unresolved cross-references to targets that have no public doc page — the real documented targets are the public re-exports (e.g. `coordinax.vectors.Point`). Ignoring the private forms is correct and cuts the doc build from **~1598 → ~656** warnings.

## Scope

This is the deterministic first step toward enabling warnings-as-errors (`-W`). It does **not** enable `-W` yet — the remaining ~656 warnings are dominated by:

- **~383** from plum-dispatch docstring aggregation on `metric_matrix`: autodoc concatenates all registered method docstrings with `.. py:function::` directives and a napoleon `Raises` section bleeds, turning every following example/prose line into a failed `:exc:` reference.
- **~152** malformed-RST `[docutils]` warnings (an inherited external `quax` member + a few coordinax docstrings).
- ~120 misc external-type refs + a handful of malformed docstrings.

A follow-up PR will resolve those and then enable `-W` in `noxfile.py` + `ci.yml` and add the `docs` job to the CI status gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)