### PR TITLE
🎨 test(hypothesis): harden the py.typed marker check

### DIFF
--- a/packages/coordinaxs.hypothesis/tests/test_packaging.py
+++ b/packages/coordinaxs.hypothesis/tests/test_packaging.py
@@ -4,22 +4,23 @@ __all__: tuple[str, ...] = ()
 
 import pathlib
 
+import pytest
+
 import coordinaxs.hypothesis.main as cxst
 
 
-def _distribution_portion_dir() -> pathlib.Path:
-    """Return this distribution's ``coordinaxs/hypothesis`` directory.
+def _portion_dir_for(main_file: str) -> pathlib.Path:
+    """Resolve the ``coordinaxs/hypothesis`` directory from ``main``'s file.
 
     ``coordinaxs.hypothesis`` is a namespace package split across distributions,
-    so anchor on ``main`` (only this distribution provides it) and resolve the
-    enclosing directory. ``__file__`` is ``.../hypothesis/main/__init__.py`` for
-    a package (→ parents[1]) or ``.../hypothesis/main.py`` for a module
-    (→ parents[0]); handle both so the check is robust to the layout.
+    so anchor on ``main`` (only this distribution provides it). ``main`` may be
+    a package (``.../hypothesis/main/__init__.py`` → ``.parent.parent``) or a
+    module (``.../hypothesis/main.py`` → ``.parent``); handle both.
     """
-    main_path = pathlib.Path(cxst.__file__).resolve()
+    main_path = pathlib.Path(main_file)
     if main_path.name == "__init__.py":
-        return main_path.parents[1]
-    return main_path.parents[0]
+        return main_path.parent.parent
+    return main_path.parent
 
 
 def test_ships_py_typed_marker() -> None:
@@ -28,6 +29,18 @@ def test_ships_py_typed_marker() -> None:
     The check is scoped to *this* distribution's own namespace portion, not the
     shared ``coordinaxs.hypothesis`` namespace as a whole.
     """
-    portion_dir = _distribution_portion_dir()
+    portion_dir = _portion_dir_for(str(pathlib.Path(cxst.__file__).resolve()))
     marker = portion_dir / "py.typed"
     assert marker.is_file(), f"py.typed marker missing from {portion_dir}"
+
+
+@pytest.mark.parametrize(
+    "main_file",
+    [
+        "/pkg/src/coordinaxs/hypothesis/main/__init__.py",  # main as package
+        "/pkg/src/coordinaxs/hypothesis/main.py",  # main as module
+    ],
+)
+def test_portion_dir_handles_both_layouts(main_file: str) -> None:
+    """Both the package and module layouts resolve to ``coordinaxs/hypothesis``."""
+    assert _portion_dir_for(main_file) == pathlib.Path("/pkg/src/coordinaxs/hypothesis")

--- a/packages/coordinaxs.hypothesis/tests/test_packaging.py
+++ b/packages/coordinaxs.hypothesis/tests/test_packaging.py
@@ -6,13 +6,21 @@ import pathlib
 
 import coordinaxs.hypothesis.main as cxst
 
+# ``coordinaxs.hypothesis`` is a namespace package split across distributions,
+# so anchor the check on ``main`` (only this distribution provides it) and
+# resolve the enclosing ``coordinaxs/hypothesis`` directory. ``__file__`` is
+# ``.../hypothesis/main/__init__.py`` when ``main`` is a package (→ parents[1])
+# or ``.../hypothesis/main.py`` when it is a module (→ parents[0]); handle both
+# so the check is robust to the layout.
+_MAIN = pathlib.Path(cxst.__file__).resolve()
+_PORTION = _MAIN.parents[1] if _MAIN.name == "__init__.py" else _MAIN.parents[0]
+
 
 def test_ships_py_typed_marker() -> None:
     """The package declares ``Typing :: Typed`` so it must ship ``py.typed``.
 
-    ``coordinaxs.hypothesis`` is a namespace package split across two
-    distributions, so anchor the check to *this* distribution's portion (the
-    one containing the ``main`` subpackage) rather than the namespace as a whole.
+    The check is scoped to *this* distribution's own namespace portion, not the
+    shared ``coordinaxs.hypothesis`` namespace as a whole.
     """
-    portion = pathlib.Path(cxst.__file__).parent.parent  # coordinaxs/hypothesis
-    assert (portion / "py.typed").is_file()
+    marker = _PORTION / "py.typed"
+    assert marker.is_file(), f"py.typed marker missing from {_PORTION}"

--- a/packages/coordinaxs.hypothesis/tests/test_packaging.py
+++ b/packages/coordinaxs.hypothesis/tests/test_packaging.py
@@ -6,14 +6,20 @@ import pathlib
 
 import coordinaxs.hypothesis.main as cxst
 
-# ``coordinaxs.hypothesis`` is a namespace package split across distributions,
-# so anchor the check on ``main`` (only this distribution provides it) and
-# resolve the enclosing ``coordinaxs/hypothesis`` directory. ``__file__`` is
-# ``.../hypothesis/main/__init__.py`` when ``main`` is a package (→ parents[1])
-# or ``.../hypothesis/main.py`` when it is a module (→ parents[0]); handle both
-# so the check is robust to the layout.
-_MAIN = pathlib.Path(cxst.__file__).resolve()
-_PORTION = _MAIN.parents[1] if _MAIN.name == "__init__.py" else _MAIN.parents[0]
+
+def _distribution_portion_dir() -> pathlib.Path:
+    """Return this distribution's ``coordinaxs/hypothesis`` directory.
+
+    ``coordinaxs.hypothesis`` is a namespace package split across distributions,
+    so anchor on ``main`` (only this distribution provides it) and resolve the
+    enclosing directory. ``__file__`` is ``.../hypothesis/main/__init__.py`` for
+    a package (→ parents[1]) or ``.../hypothesis/main.py`` for a module
+    (→ parents[0]); handle both so the check is robust to the layout.
+    """
+    main_path = pathlib.Path(cxst.__file__).resolve()
+    if main_path.name == "__init__.py":
+        return main_path.parents[1]
+    return main_path.parents[0]
 
 
 def test_ships_py_typed_marker() -> None:
@@ -22,5 +28,6 @@ def test_ships_py_typed_marker() -> None:
     The check is scoped to *this* distribution's own namespace portion, not the
     shared ``coordinaxs.hypothesis`` namespace as a whole.
     """
-    marker = _PORTION / "py.typed"
-    assert marker.is_file(), f"py.typed marker missing from {_PORTION}"
+    portion_dir = _distribution_portion_dir()
+    marker = portion_dir / "py.typed"
+    assert marker.is_file(), f"py.typed marker missing from {portion_dir}"

--- a/packages/coordinaxs.hypothesis/tests/test_packaging.py
+++ b/packages/coordinaxs.hypothesis/tests/test_packaging.py
@@ -15,10 +15,11 @@ def _portion_dir_for(main_file: str) -> pathlib.Path:
     ``coordinaxs.hypothesis`` is a namespace package split across distributions,
     so anchor on ``main`` (only this distribution provides it). ``main`` may be
     a package (``.../hypothesis/main/__init__.py`` → ``.parent.parent``) or a
-    module (``.../hypothesis/main.py`` → ``.parent``); handle both.
+    module (``.../hypothesis/main.py`` → ``.parent``); handle both. Match on the
+    stem so a compiled ``__init__.pyc`` resolves like its ``.py`` source.
     """
     main_path = pathlib.Path(main_file)
-    if main_path.name == "__init__.py":
+    if main_path.stem == "__init__":
         return main_path.parent.parent
     return main_path.parent
 
@@ -38,6 +39,7 @@ def test_ships_py_typed_marker() -> None:
     "main_file",
     [
         "/pkg/src/coordinaxs/hypothesis/main/__init__.py",  # main as package
+        "/pkg/src/coordinaxs/hypothesis/main/__init__.pyc",  # compiled package
         "/pkg/src/coordinaxs/hypothesis/main.py",  # main as module
     ],
 )

--- a/packages/coordinaxs.hypothesis/tests/test_packaging.py
+++ b/packages/coordinaxs.hypothesis/tests/test_packaging.py
@@ -15,10 +15,15 @@ def _portion_dir_for(main_file: str) -> pathlib.Path:
     ``coordinaxs.hypothesis`` is a namespace package split across distributions,
     so anchor on ``main`` (only this distribution provides it). ``main`` may be
     a package (``.../hypothesis/main/__init__.py`` → ``.parent.parent``) or a
-    module (``.../hypothesis/main.py`` → ``.parent``); handle both. Match on the
-    stem so a compiled ``__init__.pyc`` resolves like its ``.py`` source.
+    module (``.../hypothesis/main.py`` → ``.parent``); handle both. Compiled
+    forms — a plain ``__init__.pyc`` or a ``__pycache__/name.cpython-XY.pyc``
+    cache file — are normalised back to their source location first.
     """
     main_path = pathlib.Path(main_file)
+    if main_path.parent.name == "__pycache__":
+        # .../X/__pycache__/name.cpython-XY.pyc → .../X/name.py
+        source_stem = main_path.name.split(".", 1)[0]
+        main_path = main_path.parent.parent / f"{source_stem}.py"
     if main_path.stem == "__init__":
         return main_path.parent.parent
     return main_path.parent
@@ -40,7 +45,11 @@ def test_ships_py_typed_marker() -> None:
     [
         "/pkg/src/coordinaxs/hypothesis/main/__init__.py",  # main as package
         "/pkg/src/coordinaxs/hypothesis/main/__init__.pyc",  # compiled package
+        # cached compiled package (CPython __pycache__ layout)
+        "/pkg/src/coordinaxs/hypothesis/main/__pycache__/__init__.cpython-312.pyc",
         "/pkg/src/coordinaxs/hypothesis/main.py",  # main as module
+        # cached compiled module (CPython __pycache__ layout)
+        "/pkg/src/coordinaxs/hypothesis/__pycache__/main.cpython-312.pyc",
     ],
 )
 def test_portion_dir_handles_both_layouts(main_file: str) -> None:


### PR DESCRIPTION
Follow-up to #562 (merged), addressing the remaining Copilot review comments on the `py.typed` test.

## Changes

- **Path robustness** — the portion derivation now handles both layouts of `coordinaxs.hypothesis.main`: `parents[1]` when it's a package (`main/__init__.py`), `parents[0]` when it's a module (`main.py`). It always resolves to `coordinaxs/hypothesis`, never `coordinaxs`.
- **Assertion message** — includes the resolved portion path, so a CI failure (editable installs / alternate layouts) is diagnosable.
- **Scope clarity** — the docstring states the check is scoped to *this* distribution's own namespace portion, not the shared `coordinaxs.hypothesis` namespace.

(`importlib.metadata.files("coordinaxs.hypothesis")` was considered but returns no `py.typed` entry under the editable dev install, so it isn't a reliable check here.)

## Verification

Passes with the marker present; with the marker removed it fails with `AssertionError: py.typed marker missing from …/coordinaxs/hypothesis`. ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)