### PR TITLE
📝 docs: make the Sphinx build warnings-clean and enable -W

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,16 +174,13 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v6
 
-      # TODO: fix this
-      # - name: Build docs (warnings as errors)
-      # run: uv run --frozen nox -s docs -- -W
-      - name: Build docs
+      - name: Build docs (warnings as errors)
         run: uv run --frozen nox -s docs
 
   status:
     name: CI Pass
     runs-on: ubuntu-latest
-    needs: [format, tests_linux, tests_nonlinux, check_oldest]
+    needs: [format, tests_linux, tests_nonlinux, check_oldest, docs]
     if: always()
     steps:
       - name: All required jobs passed

--- a/docs/api/angles.md
+++ b/docs/api/angles.md
@@ -5,7 +5,7 @@
 .. currentmodule:: coordinax.angles
 
 .. automodule:: coordinax.angles
-    :exclude-members: aval, default, materialise, enable_materialise
+    :exclude-members: Angle, aval, default, materialise, enable_materialise
 
 .. autoclass:: Angle
     :members:

--- a/docs/api/distances.md
+++ b/docs/api/distances.md
@@ -5,7 +5,7 @@
 .. currentmodule:: coordinax.distances
 
 .. automodule:: coordinax.distances
-    :exclude-members: aval, default, materialise, enable_materialise
+    :exclude-members: Distance, aval, default, materialise, enable_materialise
 
 .. autoclass:: Distance
     :members:

--- a/docs/api/manifolds.md
+++ b/docs/api/manifolds.md
@@ -88,7 +88,6 @@ ang = cxm.angle_between(cxc.cart3d, uvec, vvec, at=at)
 .. currentmodule:: coordinax.manifolds
 
 .. automodule:: coordinax.manifolds
-    :no-inherited-members:
     :exclude-members: aval, default, materialise, enable_materialise
 
 ```

--- a/docs/api/manifolds.md
+++ b/docs/api/manifolds.md
@@ -88,6 +88,7 @@ ang = cxm.angle_between(cxc.cart3d, uvec, vvec, at=at)
 .. currentmodule:: coordinax.manifolds
 
 .. automodule:: coordinax.manifolds
+    :no-inherited-members:
     :exclude-members: aval, default, materialise, enable_materialise
 
 ```

--- a/docs/api/vectors.md
+++ b/docs/api/vectors.md
@@ -79,8 +79,11 @@ Additional utilities:
 
 For design philosophy, architecture, and immutability details, see [Working With Vectors](../guides/vectors.md#motivation-why-a-separate-vector-class). For tangent-vector patterns (basis, semantic kind, Jacobian pushforward), see [Working With Tangent Vectors](../guides/tangents.md). For JAX integration patterns (PyTree, scalar-first design, vmap/jit/grad), see [Working With Vectors](../guides/vectors.md#jax-integration).
 
-```{automodule} coordinax.vectors
-:members:
-:undoc-members:
-:exclude-members: aval, default, materialise, enable_materialise
+```{eval-rst}
+
+.. currentmodule:: coordinax.vectors
+
+.. automodule:: coordinax.vectors
+    :exclude-members: aval, default, materialise, enable_materialise
+
 ```

--- a/docs/api/vectors.md
+++ b/docs/api/vectors.md
@@ -77,7 +77,7 @@ Additional utilities:
 
 ## Design & Integration
 
-For design philosophy, architecture, and immutability details, see [Working With Vectors](../guides/vectors.md#architecture--design-philosophy). For tangent-vector patterns (basis, semantic kind, Jacobian pushforward), see [Working With Tangent Vectors](../guides/tangents.md). For JAX integration patterns (PyTree, scalar-first design, vmap/jit/grad), see [Working With Vectors](../guides/vectors.md#jax-integration--scaling).
+For design philosophy, architecture, and immutability details, see [Working With Vectors](../guides/vectors.md#motivation-why-a-separate-vector-class). For tangent-vector patterns (basis, semantic kind, Jacobian pushforward), see [Working With Tangent Vectors](../guides/tangents.md). For JAX integration patterns (PyTree, scalar-first design, vmap/jit/grad), see [Working With Vectors](../guides/vectors.md#jax-integration).
 
 ```{automodule} coordinax.vectors
 :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,11 +91,6 @@ autodoc_default_options = {
     "inherited-members": True,
     "show-inheritance": True,
     "member-order": "bysource",
-    # These members are inherited from external ``quax._core.Value``; their
-    # upstream docstrings contain malformed RST we cannot fix in-repo, and they
-    # are implementation details of quax's materialisation machinery rather than
-    # part of coordinax's public API. Exclude them everywhere.
-    "exclude-members": "aval, default, materialise, enable_materialise",
 }
 
 always_document_param_types = True
@@ -189,7 +184,7 @@ nitpick_ignore_regex = [
     # Parametrized unxt Quantity aliases (``Quantity[PhysicalType('length')]``,
     # ``['angle']``, …) are emitted verbatim into signatures but are not
     # resolvable inventory targets.
-    (r"py:.*", r"unxt\._src\.quantity\.quantity\.Quantity\[PhysicalType\("),
+    (r"py:.*", r"unxt\._src\.quantity\.quantity\.Quantity\[PhysicalType\(.*"),
     # beartype-validator annotations (``typing.Annotated[..., beartype.vale.Is
     # [...]]``) are emitted verbatim into signatures and are not doc targets.
     (r"py:.*", r"typing\.Annotated\[.*"),
@@ -397,7 +392,51 @@ def _convert_dollar_math(
     lines[:] = text.split("\n")
 
 
+# Members inherited from the external ``quax.Value`` materialisation protocol
+# (defined on ``quax.Value`` and/or overridden without a docstring on
+# ``unxt.AbstractQuantity``). Their upstream docstrings are written in MkDocs
+# Markdown (autorefs, ``!!!`` admonitions, code fences) that Sphinx's RST parser
+# renders as raw text, so we document these inherited members with a concise RST
+# summary instead. See the quax docs for the full details.
+_QUAX_VALUE_DOCS: dict[str, str] = {
+    "aval": "Return the ``jax.core.AbstractValue`` this value presents to JAX.",
+    "default": (
+        "Default multiple-dispatch rule used when no rule is registered for a "
+        "primitive."
+    ),
+    "materialise": (
+        "Materialise this value into a concrete JAX type (usually an array)."
+    ),
+    "enable_materialise": "Whether this value may be materialised into a JAX type.",
+}
+_QUAX_VALUE_SOURCES = ("quax", "unxt")
+
+
+def _clean_quax_value_docstrings(
+    app: Sphinx,
+    what: str,
+    name: str,
+    obj: object,
+    options: object,
+    lines: list[str],
+) -> None:
+    """Replace the quax-materialisation members' MkDocs docstrings with clean RST.
+
+    Only rewrites the external inherited forms (defining module ``quax``/``unxt``,
+    or a docstring still carrying MkDocs markup); a coordinax-authored override of
+    the same name keeps its own docstring.
+    """
+    summary = _QUAX_VALUE_DOCS.get(name.rsplit(".", 1)[-1])
+    if summary is None:
+        return
+    is_external = (getattr(obj, "__module__", "") or "").startswith(_QUAX_VALUE_SOURCES)
+    has_mkdocs = any("!!!" in ln or "[`" in ln for ln in lines)
+    if is_external or has_mkdocs:
+        lines[:] = [summary, ""]
+
+
 def setup(app: Sphinx, /) -> None:
     app.connect("missing-reference", _resolve_short_names)
     app.connect("missing-reference", _resolve_internal_short_names)
     app.connect("autodoc-process-docstring", _convert_dollar_math)
+    app.connect("autodoc-process-docstring", _clean_quax_value_docstrings)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,6 @@ nitpick_ignore = [
     ("py:class", "unxt._src.quantity.base._QuantityIndexUpdateHelper"),
     ("py:class", "dataclassish._src.converters.PassThroughTs"),
     ("py:class", "dataclassish._src.converters.ArgT"),
-    ("py:class", "unxt._src.quantity.quantity.Quantity[PhysicalType('length')]"),
     ("py:class", "coordinax.vectors._src.core.Point"),
     ("py:class", "coordinax.representations._src.semantics.AbstractSemanticKind"),
     ("py:class", "coordinax.representations._src.geom.PointGeometry"),
@@ -184,6 +183,13 @@ nitpick_ignore_regex = [
     (r"py:.*", r"wadler_lindig\..*"),
     (r"py:.*", r"unxt_hypothesis\..*"),
     (r"py:.*", r"optype\..*"),
+    # quax-blocks mixins are private (``_src``) implementation details with no
+    # published inventory; they leak into base-class signatures.
+    (r"py:.*", r"quax_blocks\._src\..*"),
+    # Parametrized unxt Quantity aliases (``Quantity[PhysicalType('length')]``,
+    # ``['angle']``, …) are emitted verbatim into signatures but are not
+    # resolvable inventory targets.
+    (r"py:.*", r"unxt\._src\.quantity\.quantity\.Quantity\[PhysicalType\("),
     # beartype-validator annotations (``typing.Annotated[..., beartype.vale.Is
     # [...]]``) are emitted verbatim into signatures and are not doc targets.
     (r"py:.*", r"typing\.Annotated\[.*"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,12 +8,16 @@ list see the documentation:
 import importlib.metadata
 from datetime import datetime
 
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pytz
 from docutils.nodes import Element, Node, reference
 from sphinx.application import Sphinx
 from sphinx.environment import BuildEnvironment
+from sphinx.util.nodes import make_refnode
+
+if TYPE_CHECKING:
+    from sphinx.domains.python import PythonDomain
 
 # -- Project information -----------------------------------------------------
 
@@ -87,10 +91,24 @@ autodoc_default_options = {
     "inherited-members": True,
     "show-inheritance": True,
     "member-order": "bysource",
+    # These members are inherited from external ``quax._core.Value``; their
+    # upstream docstrings contain malformed RST we cannot fix in-repo, and they
+    # are implementation details of quax's materialisation machinery rather than
+    # part of coordinax's public API. Exclude them everywhere.
+    "exclude-members": "aval, default, materialise, enable_materialise",
 }
 
 always_document_param_types = True
 typehints_use_signature = True
+
+# -- Napoleon settings ---------------------------------------------------
+# Render class ``Attributes`` sections as ``:ivar:`` info fields rather than
+# standalone ``.. attribute::`` directives. With ``automodule``/``autoclass``
+# already documenting the real attributes and properties, the directive form
+# emits a second object description for the same name ("duplicate object
+# description"); the ``:ivar:`` form keeps the curated prose without a clashing
+# target.
+napoleon_use_ivar = True
 
 
 nitpick_ignore = [
@@ -116,6 +134,34 @@ nitpick_ignore = [
     ("py:class", "coordinax.representations._src.geom.PointGeometry"),
     ("py:class", "coordinax.representations._src.basis.AbstractBasis"),
     ("py:class", "coordinax._src.charts.d3.LonLatSpherical3D"),
+    # --- External types with no resolvable Sphinx inventory entry ---
+    # unxt's objects.inv does not expose these public names under these keys
+    # (it uses different qualified paths internally), so intersphinx cannot
+    # resolve them. The bare / import-alias forms leak in from hand-written
+    # docstrings and generated type signatures.
+    ("py:class", "AbstractQuantity"),
+    ("py:class", "Quantity"),
+    ("py:class", "unxt.AbstractQuantity"),
+    ("py:class", "unxt.Quantity"),
+    ("py:class", "u.AbstractUnit"),
+    ("py:class", "jnp.ndarray"),
+    # typing.TypeIs is only in the CPython inventory from 3.13; the pinned
+    # Python intersphinx target predates it.
+    ("py:class", "typing.TypeIs"),
+    # plum does not publish a Sphinx inventory entry for these names.
+    ("py:exc", "plum.NotFoundLookupError"),
+    ("py:func", "plum.dispatch"),
+    # TypeVars / jaxtyping shape fragments that leak verbatim into
+    # sphinx-autodoc-typehints-generated signatures (source ``<unknown>``);
+    # they are not documentable objects.
+    ("py:class", "Ts"),
+    ("py:class", "Rep"),
+    ("py:class", "StaticValue"),
+    ("py:class", "3"),
+    ("py:class", "'N N'"),
+    # A napoleon-misparsed prose word ("... the same ...") in an aggregated
+    # plum docstring; nothing is legitimately named ``same``.
+    ("py:obj", "same"),
 ]
 
 # TypedNdArray is a JAX-private type (jax._src.basearray) with no public docs.
@@ -133,6 +179,14 @@ nitpick_ignore_regex = [
     # (class/data/obj/…) since ``_src`` symbols are never intentionally
     # documented in any role. Removes ~940 warnings.
     (r"py:.*", r"^coordinaxs?(\.\w+)*\._src(\.\w+)+$"),
+    # External libraries without a resolvable Sphinx inventory (MkDocs sites or
+    # no published objects.inv): render their type references as plain text.
+    (r"py:.*", r"wadler_lindig\..*"),
+    (r"py:.*", r"unxt_hypothesis\..*"),
+    (r"py:.*", r"optype\..*"),
+    # beartype-validator annotations (``typing.Annotated[..., beartype.vale.Is
+    # [...]]``) are emitted verbatim into signatures and are not doc targets.
+    (r"py:.*", r"typing\.Annotated\[.*"),
 ]
 
 # -- MyST Setting -------------------------------------------------
@@ -251,5 +305,93 @@ def _resolve_short_names(
     return reference("", "", contnode, internal=False, refuri=url)
 
 
+def _resolve_internal_short_names(
+    app: Sphinx,
+    env: BuildEnvironment,
+    node: Element,
+    contnode: Element,
+) -> Node | None:
+    """Resolve a bare short name to a coordinax object of the same name.
+
+    Plum's combined ``__doc__`` and hand-written Napoleon ``Parameters`` /
+    ``Returns`` / ``See Also`` sections reference project objects by their short
+    name (e.g. ``Representation``, ``pt_map``, ``minkowski4d``) rather than the
+    fully-qualified path Sphinx indexes them under. Look the target up in this
+    project's own Python object inventory and, when it maps unambiguously to a
+    single public object, return a real internal cross-reference. External
+    names never appear in this inventory, so they fall through to the normal
+    (nitpick) handling.
+    """
+    if node.get("refdomain") != "py":
+        return None
+    target = node.get("reftarget", "")
+    if not target:
+        return None
+    pydomain = cast("PythonDomain", env.get_domain("py"))
+    matches = [
+        name
+        for name in pydomain.objects
+        if name == target or name.endswith(f".{target}")
+    ]
+    # Prefer public paths over private ``._src.`` implementation paths.
+    public = [name for name in matches if "._src." not in name]
+    candidates = public or matches
+    if len(candidates) != 1:
+        return None  # unknown or ambiguous → leave for normal handling
+    name = candidates[0]
+    obj = pydomain.objects[name]
+    return make_refnode(
+        app.builder, node["refdoc"], obj.docname, obj.node_id, contnode, name
+    )
+
+
+# -- Dollar-math in docstrings ----------------------------------------
+# The Markdown (MyST) pages render maths with the ``dollarmath`` extension, so
+# docstrings are written with the same ``$...$`` / ``$$...$$`` convention for
+# consistency. Autodoc, however, feeds docstrings to the *reStructuredText*
+# parser, which has no dollar-math support: inside ``$...$`` a LaTeX subscript
+# such as ``h_\theta`` is misread as an RST reference (``Unknown target name:
+# "h"``), ``|\nu|`` as a substitution, ``**`` as strong emphasis, and multi-line
+# ``$$``-blocks as block quotes (``Unexpected indentation``). Convert dollar-math
+# to the RST ``:math:`` role / ``.. math::`` directive before parsing so the
+# maths both renders correctly *and* stops emitting spurious warnings. Doctest
+# blocks in these docstrings never contain ``$``, so this is safe.
+import re  # noqa: E402
+
+_DISPLAY_MATH_RE = re.compile(r"\$\$(.+?)\$\$", re.DOTALL)
+# Inline maths may wrap across a line break (but not a blank line), so match any
+# run of non-``$`` characters that does not contain a blank line.
+_INLINE_MATH_RE = re.compile(r"\$(?!\$)((?:[^$]|\n(?!\s*\n))+?)\$")
+
+
+def _display_math_repl(match: "re.Match[str]") -> str:
+    """Replace a ``$$...$$`` block with an ``.. math::`` directive."""
+    body = "\n".join(
+        "   " + line.strip() for line in match.group(1).strip().splitlines()
+    )
+    return f"\n\n.. math::\n\n{body}\n\n"
+
+
+def _convert_dollar_math(
+    app: Sphinx,
+    what: str,
+    name: str,
+    obj: object,
+    options: object,
+    lines: list[str],
+) -> None:
+    """Rewrite ``$...$`` / ``$$...$$`` maths in docstrings to RST math."""
+    if not any("$" in line for line in lines):
+        return
+    text = "\n".join(lines)
+    text = _DISPLAY_MATH_RE.sub(_display_math_repl, text)
+    text = _INLINE_MATH_RE.sub(
+        lambda m: ":math:`" + " ".join(m.group(1).split()) + "`", text
+    )
+    lines[:] = text.split("\n")
+
+
 def setup(app: Sphinx, /) -> None:
     app.connect("missing-reference", _resolve_short_names)
+    app.connect("missing-reference", _resolve_internal_short_names)
+    app.connect("autodoc-process-docstring", _convert_dollar_math)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,6 +153,14 @@ nitpick_ignore = [
     ("py:class", "StaticValue"),
     ("py:class", "3"),
     ("py:class", "'N N'"),
+    # ``ChartT`` is a TypeVar; ``TypeIs`` leaks in bare and from typing_extensions
+    # (the pinned intersphinx Python target predates ``typing.TypeIs``).
+    ("py:class", "ChartT"),
+    ("py:class", "TypeIs"),
+    ("py:class", "typing_extensions.TypeIs"),
+    # AbstractVector's docstring references the ``AbstractCoordinate`` bundle base
+    # by a public path it is not (re-)exported under; not a documentable target.
+    ("py:obj", "coordinax.vectors.AbstractCoordinate"),
     # A napoleon-misparsed prose word ("... the same ...") in an aggregated
     # plum docstring; nothing is legitimately named ``same``.
     ("py:obj", "same"),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -306,6 +306,27 @@ def _resolve_short_names(
     return reference("", "", contnode, internal=False, refuri=url)
 
 
+def _py_suffix_index(
+    env: BuildEnvironment, pydomain: "PythonDomain"
+) -> dict[str, list[str]]:
+    """Map every dotted suffix of each py object name to the full names.
+
+    Built once per build and cached on ``env`` (missing-reference resolution runs
+    after reading, when the object inventory is complete and stable). A lookup by
+    ``target`` then returns exactly the names for which
+    ``name == target or name.endswith(f".{target}")``.
+    """
+    index: dict[str, list[str]] | None = getattr(env, "_coordinax_suffix_index", None)
+    if index is None:
+        index = {}
+        for name in pydomain.objects:
+            parts = name.split(".")
+            for i in range(len(parts)):
+                index.setdefault(".".join(parts[i:]), []).append(name)
+        env._coordinax_suffix_index = index  # ty: ignore[unresolved-attribute]
+    return index
+
+
 def _resolve_internal_short_names(
     app: Sphinx,
     env: BuildEnvironment,
@@ -329,14 +350,14 @@ def _resolve_internal_short_names(
     if not target:
         return None
     pydomain = cast("PythonDomain", env.get_domain("py"))
-    matches = [
-        name
-        for name in pydomain.objects
-        if name == target or name.endswith(f".{target}")
-    ]
+    # ``target`` matches an object when it equals the full name or a trailing
+    # dotted suffix of it (``name == target or name.endswith(f".{target}")``).
+    # Look that up in a per-build suffix index so each reference is O(1) rather
+    # than an O(N) scan of every documented object.
+    matches = _py_suffix_index(env, pydomain).get(target, ())
     # Prefer public paths over private ``._src.`` implementation paths.
     public = [name for name in matches if "._src." not in name]
-    candidates = public or matches
+    candidates = public or list(matches)
     if len(candidates) != 1:
         return None  # unknown or ambiguous → leave for normal handling
     name = candidates[0]
@@ -382,6 +403,11 @@ def _convert_dollar_math(
     lines: list[str],
 ) -> None:
     """Rewrite ``$...$`` / ``$$...$$`` maths in docstrings to RST math."""
+    # Restrict to this project's own docstrings: ``$`` reliably means math only
+    # in coordinax's controlled docstrings, so an external package entering the
+    # build (where ``$`` might be currency, a shell var, etc.) is left untouched.
+    if not name.startswith(("coordinax", "coordinaxs")):
+        return
     if not any("$" in line for line in lines):
         return
     text = "\n".join(lines)

--- a/docs/guides/frames.md
+++ b/docs/guides/frames.md
@@ -396,7 +396,7 @@ print(coord_cart.frame, coord_cart.chart)  # Alice(), Cart3D(M=Rn(3))
 print(coord_sph.frame, coord_sph.chart)  # Alice(), Spherical3D()
 ```
 
-For a full frame-oriented workflow (constructor patterns, frame+chart pipelines, and JAX batching), see [Working With Vectors](./vectors.md#coordinate-objects).
+For a full frame-oriented workflow (constructor patterns, frame+chart pipelines, and JAX batching), see [Working With Vectors](./vectors.md#combined-frame-and-chart-pipelines).
 
 ## Practical Workflow: Rotating Frame
 

--- a/docs/guides/manifolds.md
+++ b/docs/guides/manifolds.md
@@ -390,7 +390,7 @@ You can also call `norm` on a standalone metric object:
 Q(5., 'm / s')
 ```
 
-See [spec § norm](../spec.md#software-spec-norm) for the complete dispatch table and notes on curved-metric position dependence.
+See [spec § norm](#software-spec-norm) for the complete dispatch table and notes on curved-metric position dependence.
 
 ## Quick Reference
 

--- a/docs/guides/vectors.md
+++ b/docs/guides/vectors.md
@@ -138,7 +138,7 @@ For a full treatment of `Tangent`, basis kinds, and `Coordinate` bundles, see th
 | Change frame of whole bundle | `pv.to_frame(frame)` | frame of point + all fibres | chart, geometric point |
 | Convert units | `u.uconvert(units_dict, v)` | component values | chart, frame, geometric point |
 
-## Combined Frame + Chart Pipelines
+## Combined Frame and Chart Pipelines
 
 Operations chain naturally — each step is independent:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -194,6 +194,7 @@ def docs(s: nox.Session, /) -> None:
     shared_args = (
         "-n",  # nitpicky mode
         "-T",  # full tracebacks
+        "-W",  # turn warnings into errors
         f"-b={args.builder}",
         f"-d {args.output_dir}/doctrees",
         "-D",

--- a/packages/coordinaxs.api/src/coordinaxs/api/charts.py
+++ b/packages/coordinaxs.api/src/coordinaxs/api/charts.py
@@ -79,7 +79,7 @@ def cartesian_chart(obj: Any, /) -> "coordinax.charts.AbstractChart":
 
     See Also
     --------
-    pt_map : Transform coordinates between charts
+    coordinax.charts.pt_map : Transform coordinates between charts
     coordinax.charts.AbstractChart : Base class for coordinate charts
 
     Examples
@@ -132,7 +132,7 @@ def pt_map(*args: Any, **kwargs: Any) -> CDict:
     coordinate description.
 
     For charts in the same atlas on the same manifold, this reduces to the
-    ordinary chart transition map handled by `pt_map`. It is the
+    ordinary chart transition map handled by `coordinax.charts.pt_map`. It is the
     intrinsic coordinate-change operation: the underlying point on the manifold
     is unchanged, and only its coordinate representation is changed.
 
@@ -164,7 +164,7 @@ def pt_map(*args: Any, **kwargs: Any) -> CDict:
     More generally, if $\varphi_{\mathrm{from}} : U \subset M \to \mathbb{R}^n$
     and $\psi_{\mathrm{to}} : W \subset N \to \mathbb{R}^m$ are chart maps on
     manifolds $M$ and $N$, and there is a point map $F : M \supset U \to W
-    \subset N$, then `pt_map` represents the coordinate expression
+    \subset N$, then `coordinax.charts.pt_map` represents the coordinate expression
 
     $$ \psi_{\mathrm{to}} \circ F \circ \varphi_{\mathrm{from}}^{-1}. $$
 
@@ -199,7 +199,7 @@ def pt_map(*args: Any, **kwargs: Any) -> CDict:
 
     See Also
     --------
-    pt_map : transform position coordinates between charts on the
+    coordinax.charts.pt_map : transform position coordinates between charts on the
     same manifold.
 
     Examples

--- a/packages/coordinaxs.api/src/coordinaxs/api/frames.py
+++ b/packages/coordinaxs.api/src/coordinaxs/api/frames.py
@@ -34,8 +34,8 @@ def frame_transition(*args: Any, **kwargs: Any) -> Any:
 
     See Also
     --------
-    coordinax.frames.act : Apply a transform to coordinates
-    coordinax.frames.compose : Compose two transforms into one
+    coordinax.transforms.act : Apply a transform to coordinates
+    coordinax.transforms.compose : Compose two transforms into one
 
     Examples
     --------

--- a/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
+++ b/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
@@ -197,7 +197,6 @@ def pt_embed(
     --------
     pt_project : Inverse operation projecting ambient to intrinsic
         coordinates
-    embed_tangent : Embedding for tangent vector components
     coordinax.manifolds.EmbeddedChart : Container for embedded manifold
         charts
 
@@ -345,7 +344,6 @@ def pt_project(*args: object, usys: u.AbstractUnitSystem | None = None) -> CDict
     See Also
     --------
     pt_embed : Embed intrinsic chart coordinates into ambient space
-    project_tangent : Project ambient velocity/acceleration onto tangent space
 
     Examples
     --------
@@ -416,7 +414,7 @@ def pt_map(*args: Any, **kwargs: Any) -> CDict:
     coordinate description.
 
     For charts in the same atlas on the same manifold, this reduces to the
-    ordinary chart transition map handled by `pt_map`. It is the
+    ordinary chart transition map handled by `coordinax.charts.pt_map`. It is the
     intrinsic coordinate-change operation: the underlying point on the manifold
     is unchanged, and only its coordinate representation is changed.
 
@@ -448,7 +446,7 @@ def pt_map(*args: Any, **kwargs: Any) -> CDict:
     More generally, if $\varphi_{\mathrm{from}} : U \subset M \to \mathbb{R}^n$
     and $\psi_{\mathrm{to}} : W \subset N \to \mathbb{R}^m$ are chart maps on
     manifolds $M$ and $N$, and there is a point map $F : M \supset U \to W
-    \subset N$, then `pt_map` represents the coordinate expression
+    \subset N$, then `coordinax.charts.pt_map` represents the coordinate expression
 
     $$ \psi_{\mathrm{to}} \circ F \circ \varphi_{\mathrm{from}}^{-1}. $$
 
@@ -483,7 +481,7 @@ def pt_map(*args: Any, **kwargs: Any) -> CDict:
 
     See Also
     --------
-    pt_map : transform position coordinates between charts on the
+    coordinax.charts.pt_map : transform position coordinates between charts on the
     same manifold.
 
     Examples

--- a/packages/coordinaxs.api/src/coordinaxs/api/transforms.py
+++ b/packages/coordinaxs.api/src/coordinaxs/api/transforms.py
@@ -75,8 +75,8 @@ def act(*args: Any, **kwargs: Any) -> Any:
     See Also
     --------
     coordinax.transforms.act : Concrete dispatch entrypoint used in practice
-    coordinax.frames.compose : Compose two transforms into one
-    coordinax.frames.simplify : Simplify a transform to canonical form
+    coordinax.transforms.compose : Compose two transforms into one
+    coordinax.transforms.simplify : Simplify a transform to canonical form
 
     Examples
     --------
@@ -184,11 +184,9 @@ def prolong(*args: Any, **kwargs: Any) -> Any:
 
         prolong(op, tau, jet, chart, /, *, usys=None) -> jet
 
-    See Also
-    --------
-    act : per-slot application (delegates here for time-dependent transforms)
-    pushforward : the frozen-tau spatial differential
-
+    See also `act` (per-slot application, which delegates here for
+    time-dependent transforms) and `pushforward` (the frozen-$\tau$ spatial
+    differential).
     """
     raise NotImplementedError  # pragma: no cover
 

--- a/packages/coordinaxs.astro/docs/api.md
+++ b/packages/coordinaxs.astro/docs/api.md
@@ -10,5 +10,6 @@ Complete API documentation for `coordinaxs.astro`.
    :members:
    :undoc-members:
    :show-inheritance:
+   :exclude-members: aval, default, materialise, enable_materialise
 
 ```

--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/frame_transforms.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/frame_transforms.py
@@ -241,6 +241,18 @@ def frame_transition(from_frame: ICRS, to_frame: Galactocentric, /) -> cxfm.Comp
     3. Tilt correction for the Sun's height above the Galactic plane
     4. Velocity boost to the Galactocentric rest frame
 
+    Notes
+    -----
+    The transformation is composed of:
+
+    - R: Combined rotation matrix (longitude x latitude x roll)
+    - offset_q: Translation by the Galactic center distance
+    - H: Rotation to account for Sun's height above plane
+    - offset_v: Solar-velocity kick to the Galactocentric rest frame
+      (a fibre-only ``Translate(semantic_kind=vel)``)
+
+    The default Galactocentric frame uses parameters from the Astropy default
+    values (as of v4.0), which are based on various literature sources.
 
     Examples
     --------
@@ -302,19 +314,6 @@ def frame_transition(from_frame: ICRS, to_frame: Galactocentric, /) -> cxfm.Comp
     >>> print(gcf_q)
     <Point: chart=Cart3D (x, y, z) [pc]
         [-8112.898    21.798    29.015]>
-
-    Notes
-    -----
-    The transformation is composed of:
-
-    - R: Combined rotation matrix (longitude x latitude x roll)
-    - offset_q: Translation by the Galactic center distance
-    - H: Rotation to account for Sun's height above plane
-    - offset_v: Solar-velocity kick to the Galactocentric rest frame
-      (a fibre-only ``Translate(semantic_kind=vel)``)
-
-    The default Galactocentric frame uses parameters from the Astropy default
-    values (as of v4.0), which are based on various literature sources.
 
     """
     # rotation matrix to align x(ICRS) with the vector to the Galactic center

--- a/packages/coordinaxs.curveframes/docs/guide.md
+++ b/packages/coordinaxs.curveframes/docs/guide.md
@@ -2,7 +2,7 @@
 
 This guide introduces **curve-attached reference frames** provided by `coordinaxs.curveframes`. You will learn what a curve frame is, how to build one from a space curve, and how to transform coordinate data between curve frames and ordinary reference frames.
 
-For the mathematical specification see the [curveframes spec](spec.md). For API reference on the base frame system see [Working With Frames](../../../docs/guides/frames.md) and [Working With Transforms](../../../docs/guides/transforms.md).
+For the mathematical specification see the {doc}`curveframes spec <spec>`. For API reference on the base frame system see [Working With Frames](../../../docs/guides/frames.md) and [Working With Transforms](../../../docs/guides/transforms.md).
 
 ```python
 import jax

--- a/packages/coordinaxs.curveframes/docs/tutorial.md
+++ b/packages/coordinaxs.curveframes/docs/tutorial.md
@@ -2,7 +2,7 @@
 
 This tutorial walks through a complete example: define a space curve, attach a Frenet–Serret frame, transform points into and out of the curve frame, chain through multiple frames, and leverage JAX for JIT compilation and vectorisation.
 
-**Prerequisites**: [Working With Curve Frames](guide.md), [Working With Frames](../../../docs/guides/frames.md).
+**Prerequisites**: {doc}`Working With Curve Frames <guide>`, [Working With Frames](../../../docs/guides/frames.md).
 
 ```pycon
 >>> import jax
@@ -218,7 +218,7 @@ The key idea: **$\tau$ is not stored on the frame**. It is passed at evaluation 
 
 This tutorial shows how to use the **Bishop frame** — the rotation-minimising alternative to Frenet–Serret. You will see how it handles straight lines gracefully and how to compare both frames on the same curve.
 
-**Prerequisites**: [Working With Curve Frames](guide.md), the Frenet–Serret tutorial above.
+**Prerequisites**: {doc}`Working With Curve Frames <guide>`, the Frenet–Serret tutorial above.
 
 ```pycon
 >>> import coordinaxs.curveframes as cxfc

--- a/src/coordinax/_src/base/atlas.py
+++ b/src/coordinax/_src/base/atlas.py
@@ -32,7 +32,7 @@ class AbstractAtlas(metaclass=abc.ABCMeta):
 
     The atlas does **not** perform coordinate transformations itself. Those are
     implemented by chart-level transition maps and higher-level transformation
-    machinery (e.g. {func}`pt_map`).
+    machinery (e.g. :func:`coordinax.charts.pt_map`).
 
     Notes
     -----

--- a/src/coordinax/_src/charts/d3.py
+++ b/src/coordinax/_src/charts/d3.py
@@ -464,7 +464,7 @@ class ProlateSpheroidal3D(
 
     - $\Delta > 0$,
     - $\mu \ge \Delta^2$,
-    - $|\nu| \le \Delta^2$.
+    - $\lvert\nu\rvert \le \Delta^2$.
 
     The parameter $\Delta$ is stored as metadata on the representation.
 

--- a/src/coordinax/_src/charts/register_cdict.py
+++ b/src/coordinax/_src/charts/register_cdict.py
@@ -78,6 +78,7 @@ def cdict(obj: u.AbstractQuantity, keys: tuple[str, ...], /) -> CDict:
     splitting along that axis according to the provided keys.
 
     This function requires that:
+
     1. The last dimension of the quantity matches the number of chart components
     2. The chart has homogeneous coordinate dimensions (all components have the
        same physical dimension, like Cartesian charts)
@@ -155,6 +156,7 @@ def cdict(obj: u.AbstractQuantity, chart: AbstractChart, /) -> CDict:
     splitting along that axis according to the chart's component names.
 
     This function requires that:
+
     1. The last dimension of the quantity matches the number of chart components
     2. The chart has homogeneous coordinate dimensions (all components have the
        same physical dimension, like Cartesian charts)

--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -702,8 +702,8 @@ def pt_map(
 
     We calculate through cylindrical coordinates first:
 
-    $\rho = \sqrt{(\mu-\Delta^2)\left(1-\frac{|\nu|}{\Delta^2}\right)}$
-    $z = \sqrt{\mu\,\frac{|\nu|}{\Delta^2}}\;\mathrm{sign}(\nu)$
+    $\rho = \sqrt{(\mu-\Delta^2)\left(1-\frac{\lvert\nu\rvert}{\Delta^2}\right)}$
+    $z = \sqrt{\mu\,\frac{\lvert\nu\rvert}{\Delta^2}}\;\mathrm{sign}(\nu)$
     $\phi = \phi.$
 
     Then convert to Cartesian:
@@ -1122,12 +1122,12 @@ def pt_map(
 
     - $\Delta > 0$,
     - $\mu \ge \Delta^2$,
-    - $|\nu| \le \Delta^2$.
+    - $\lvert\nu\rvert \le \Delta^2$.
 
     The conversion proceeds via
 
-    $\rho = \sqrt{(\mu-\Delta^2)\left(1-\frac{|\nu|}{\Delta^2}\right)}$,
-    $z = \sqrt{\mu\,\frac{|\nu|}{\Delta^2}}\,\mathrm{sign}(\nu)$,
+    $\rho = \sqrt{(\mu-\Delta^2)\left(1-\frac{\lvert\nu\rvert}{\Delta^2}\right)}$,
+    $z = \sqrt{\mu\,\frac{\lvert\nu\rvert}{\Delta^2}}\,\mathrm{sign}(\nu)$,
     $\phi = \phi$.
 
     >>> import coordinax.manifolds as cxm
@@ -1189,9 +1189,9 @@ def pt_map(
     Then
 
     $\mu = \Delta^2 + \tfrac12(D + D_f)$ (with numerically-stable branches),
-    $|\nu| = \dfrac{2\Delta^2}{S + D}\,z^2$,
-    and $\nu = |\nu|\,\mathrm{sign}(z)$, with a stability fix when
-    $\Delta^2 - |\nu|$ is small.
+    $\lvert\nu\rvert = \dfrac{2\Delta^2}{S + D}\,z^2$,
+    and $\nu = \lvert\nu\rvert\,\mathrm{sign}(z)$, with a stability fix when
+    $\Delta^2 - \lvert\nu\rvert$ is small.
 
     >>> import coordinax.manifolds as cxm
     >>> import coordinax.charts as cxc
@@ -1653,6 +1653,8 @@ def pt_map(
         Array of shape ``(..., ndim)`` containing the transformed coordinates in
         ``to_chart``.
 
+    Examples
+    --------
     >>> import coordinax.charts as cxc
     >>> import unxt as u
     >>> import jax.numpy as jnp

--- a/src/coordinax/_src/embedded/embedmap.py
+++ b/src/coordinax/_src/embedded/embedmap.py
@@ -20,9 +20,9 @@ AmbientT = TypeVar("AmbientT", bound=AbstractChart[Any, Any, Any])
 class AbstractEmbeddingMap(Generic[IntrinsicT, AmbientT], metaclass=abc.ABCMeta):
     r"""Abstract base class representing a smooth embedding.
 
-    An embedding represents a smooth injective map $$ \iota : M \hookrightarrow
-    N $$ of an intrinsic manifold (with charts in `coordinax.charts`) into an
-    ambient manifold.
+    An embedding represents a smooth injective map
+    $\iota : M \hookrightarrow N$ of an intrinsic manifold (with charts in
+    `coordinax.charts`) into an ambient manifold.
 
     Conceptually, an embedding provides:
 

--- a/src/coordinax/_src/embedded/metric.py
+++ b/src/coordinax/_src/embedded/metric.py
@@ -142,7 +142,7 @@ class PullbackMetric(AbstractMetricField):
 
     @property
     def signature(self) -> tuple[int, ...]:
-        """Metric signature: ``(1,) * m`` where ``m`` is the intrinsic dimension.
+        """Metric signature ``(1,) * m`` where ``m`` is the intrinsic dimension.
 
         Embedding into a Riemannian ambient manifold always produces a
         Riemannian induced metric (``J^T g_M J`` is positive-definite when

--- a/src/coordinax/_src/metric/api.py
+++ b/src/coordinax/_src/metric/api.py
@@ -23,25 +23,14 @@ from coordinax._src.base import AbstractChart, AbstractManifold
 def metric_matrix(
     M: AbstractManifold, point: dict, chart: AbstractChart, /
 ) -> AbstractMetricMatrix:
-    """Fallback — raise with a helpful message for unregistered pairs.
+    """Fallback — raise `NotImplementedError` for unregistered pairs.
 
     Concrete ``(manifold, chart)`` pairs register their own dispatch rules in
     the relevant ``register_metric.py`` modules (loaded as part of Phase 2).
-
-    Parameters
-    ----------
-    M : AbstractManifold
-        The manifold carrying the metric field.
-    point : CDict
-        A component dictionary giving the coordinates in ``chart``.
-    chart : AbstractChart
-        The coordinate chart in which to express the metric.
-
-    Raises
-    ------
-    NotImplementedError
-        When no specific dispatch rule is registered for the given types.
-
+    This fallback raises `NotImplementedError` when no specific dispatch rule
+    is registered for the given manifold ``M``, point ``point`` and chart
+    ``chart`` types. See the abstract :func:`metric_matrix` for the full
+    parameter documentation.
     """
     del point
     msg = (

--- a/src/coordinax/_src/minkowski/manifold.py
+++ b/src/coordinax/_src/minkowski/manifold.py
@@ -35,7 +35,7 @@ class MinkowskiManifold(AbstractManifold):
     **Metric.** The manifold carries the flat Minkowski metric
     $\eta = \operatorname{diag}(-1, 1, 1, 1)$.
 
-    **Pre-built instance.** The module exports :obj:`minkowski4d` as a
+    **Pre-built instance.** The module exports ``minkowski4d`` as a
     ready-to-use instance.
 
     Parameters

--- a/src/coordinax/_src/minkowski/metric.py
+++ b/src/coordinax/_src/minkowski/metric.py
@@ -59,5 +59,5 @@ class MinkowskiMetric(AbstractDiagonalMetricField):
 
     @property
     def signature(self) -> tuple[int, ...]:
-        """Metric signature: ``(-1, 1, 1, 1)`` — Lorentzian pseudo-Riemannian."""
+        """Metric signature ``(-1, 1, 1, 1)``, Lorentzian pseudo-Riemannian."""
         return (-1, 1, 1, 1)

--- a/src/coordinax/_src/product/chart.py
+++ b/src/coordinax/_src/product/chart.py
@@ -67,7 +67,7 @@ class AbstractCartesianProductChart(AbstractChart[CartesianProductManifold, Ks, 
 
     @property
     def ndims(self) -> tuple[int, ...]:
-        """Total dimension: sum of factor dimensions."""
+        """Total dimension, the sum of factor dimensions."""
         return tuple(f.ndim for f in self.factors)
 
     def split_components(self, p: CDict, /) -> tuple[CDict, ...]:
@@ -144,7 +144,7 @@ class AbstractCartesianProductChart(AbstractChart[CartesianProductManifold, Ks, 
 
     @property
     def components(self) -> Ks:
-        """Component keys: dot-delimited strings ``"factor_name.component"``.
+        """Component keys are dot-delimited strings ``"factor_name.component"``.
 
         Components are dot-delimited string keys to avoid collisions:
             (f"{name_0}.{c}" for c in factors[0].components, ...)
@@ -165,7 +165,7 @@ class AbstractCartesianProductChart(AbstractChart[CartesianProductManifold, Ks, 
 
     @property
     def ndim(self) -> int:
-        """Total dimension: sum of factor dimensions."""
+        """Total dimension, the sum of factor dimensions."""
         return sum(f.ndim for f in self.factors)
 
     # ===============================================================
@@ -194,6 +194,7 @@ class AbstractFlatCartesianProductChart(AbstractCartesianProductChart[Ks, Ds]):
     collide.
 
     Normative requirements:
+
     - `factor_names` must be provided (abstract property)
     - `components` is the direct concatenation of factor components
       (must be collision-free)
@@ -258,7 +259,7 @@ class AbstractFlatCartesianProductChart(AbstractCartesianProductChart[Ks, Ds]):
 
     @property
     def components(self) -> Ks:
-        """Component keys: flat strings (collision-free concatenation of factors).
+        """Component keys are flat strings (collision-free concatenation of factors).
 
         Components are the direct concatenation of factor component strings
         (must be collision-free).

--- a/src/coordinax/_src/product/chart.py
+++ b/src/coordinax/_src/product/chart.py
@@ -67,7 +67,7 @@ class AbstractCartesianProductChart(AbstractChart[CartesianProductManifold, Ks, 
 
     @property
     def ndims(self) -> tuple[int, ...]:
-        """Total dimension, the sum of factor dimensions."""
+        """Per-factor dimensions, as a tuple aligned with ``factors``."""
         return tuple(f.ndim for f in self.factors)
 
     def split_components(self, p: CDict, /) -> tuple[CDict, ...]:

--- a/src/coordinax/_src/product/galilean_ct.py
+++ b/src/coordinax/_src/product/galilean_ct.py
@@ -88,7 +88,7 @@ class GalileanCT(AbstractFlatCartesianProductChart[Ks, Ds]):
     """
 
     spatial_chart: AbstractFixedComponentsChart[Any, Any, Any] = field(default=cart3d)  # pylint: disable=invalid-field-call
-    """Spatial part of the representation. Defaults: `coordinax.charts.cart3d`."""
+    """Spatial part of the representation (defaults to `coordinax.charts.cart3d`)."""
 
     _: KW_ONLY
     c: Float[u.StaticQuantity["speed"], ""] = field(default=C_DEFAULT)  # pylint: disable=invalid-field-call

--- a/src/coordinax/_src/spherical/embed.py
+++ b/src/coordinax/_src/spherical/embed.py
@@ -34,10 +34,10 @@ class TwoSphereIn3D(AbstractEmbeddingMap[IntrinsicT, AmbientT]):
     ({class}`~coordinax.charts.Spherical3D`), regardless of which ambient chart
     is selected. In particular:
 
-    - If ``ambient`` is `{class}`~coordinax.charts.Spherical3D`, then
+    - If ``ambient`` is :class:`~coordinax.charts.Spherical3D`, then
       {meth}`embed` returns spherical coordinates ``(r, theta, phi)`` and
       {meth}`project` expects the same.
-    - If ``ambient`` is `{class}`~coordinax.charts.Cart3D`, then {meth}`embed`
+    - If ``ambient`` is :class:`~coordinax.charts.Cart3D`, then {meth}`embed`
       performs ``SphericalTwoSphere -> Spherical3D -> Cart3D`` and returns Cartesian
       coordinates ``(x, y, z)``; {meth}`project` performs ``Cart3D ->
       Spherical3D -> SphericalTwoSphere``.
@@ -47,12 +47,12 @@ class TwoSphereIn3D(AbstractEmbeddingMap[IntrinsicT, AmbientT]):
     radius
         Sphere radius ``R``.
     ambient
-        Ambient chart. Defaults to `{class}`~coordinax.charts.Spherical3D`.
+        Ambient chart. Defaults to :class:`~coordinax.charts.Spherical3D`.
 
     Examples
     --------
-    Embed/project `{class}`~coordinax.charts.SphericalTwoSphere` through an ambient
-    `{class}`~coordinax.charts.Spherical3D` chart::
+    Embed/project :class:`~coordinax.charts.SphericalTwoSphere` through an ambient
+    :class:`~coordinax.charts.Spherical3D` chart:
 
     >>> import jax.numpy as jnp
     >>> import coordinax.charts as cxc
@@ -71,8 +71,8 @@ class TwoSphereIn3D(AbstractEmbeddingMap[IntrinsicT, AmbientT]):
     >>> jnp.allclose(p2["theta"].value, p["theta"].value)
     Array(True, dtype=bool)
 
-    Embed/project through an ambient `{class}`~coordinax.charts.Cart3D` chart
-    (routing via `{class}`~coordinax.charts.Spherical3D` internally)::
+    Embed/project through an ambient :class:`~coordinax.charts.Cart3D` chart
+    (routing via :class:`~coordinax.charts.Spherical3D` internally):
 
     >>> emb = cxm.TwoSphereIn3D(radius=u.Q(2.0, "km"), ambient=cxc.cart3d)
     >>> chart = cxm.EmbeddedChart(emb)
@@ -144,7 +144,7 @@ def embedded_twosphere(
     >>> import coordinax.manifolds as cxm
     >>> import unxt as u
 
-    Default ambient (Spherical3D)::
+    Default ambient (Spherical3D):
 
     >>> M = cxm.embedded_twosphere(radius=u.Q(2.0, "km"))
     >>> M

--- a/src/coordinax/_src/spherical/embed.py
+++ b/src/coordinax/_src/spherical/embed.py
@@ -158,7 +158,7 @@ def embedded_twosphere(
     >>> sph
     {'r': Q(2., 'km'), 'theta': Angle(1.57079633, 'rad'), 'phi': Angle(0., 'rad')}
 
-    With Cartesian ambient the embedding returns ``(x, y, z)``::
+    With Cartesian ambient the embedding returns ``(x, y, z)``:
 
     >>> M = cxm.embedded_twosphere(radius=u.Q(2.0, "km"), ambient=cxc.cart3d)
     >>> xyz = cxm.pt_embed(p, M)

--- a/src/coordinax/_src/spherical/metric.py
+++ b/src/coordinax/_src/spherical/metric.py
@@ -52,5 +52,5 @@ class RoundMetric(AbstractDiagonalMetricField):
 
     @property
     def signature(self) -> tuple[int, ...]:
-        """Metric signature: ``(1,) * ndim`` — the round sphere metric is Riemannian."""
+        """Metric signature ``(1,) * ndim``, the round sphere metric is Riemannian."""
         return (1,) * self.ndim

--- a/src/coordinax/_src/spherical/scale_factors.py
+++ b/src/coordinax/_src/spherical/scale_factors.py
@@ -21,7 +21,7 @@ def scale_factors(
     r"""Return round-metric diagonal directly without forming the nxn matrix.
 
     Computes the cumulative-sine diagonal $g_{kk} = \prod_{j<k} \sin^2\theta_j$
-    as a 1-D vector, avoiding the O(n^2) cost of :meth:`~.RoundMetric.metric_matrix`.
+    as a 1-D vector, avoiding the O(n^2) cost of ``RoundMetric.metric_matrix``.
 
     >>> import jax.numpy as jnp
     >>> import unxt as u

--- a/src/coordinax/frames/_src/register_pfxm.py
+++ b/src/coordinax/frames/_src/register_pfxm.py
@@ -17,7 +17,7 @@ from .null import NoFrame
 def frame_transition(from_frame: NoFrame, to_frame: NoFrame, /) -> cxfm.Identity:
     """Null-to-null frame transition is always the identity.
 
-    When both source and target frames are :obj:`noframe` (i.e. the vector is
+    When both source and target frames are ``noframe`` (i.e. the vector is
     frame-agnostic) there is nothing to transform, so the result is the
     identity operation.
 

--- a/src/coordinax/frames/_src/xfm.py
+++ b/src/coordinax/frames/_src/xfm.py
@@ -25,14 +25,12 @@ class AbstractTransformedReferenceFrame(AbstractReferenceFrame, Generic[FrameT])
     reference frame. The transformation from the base reference frame to this
     reference frame is stored as an `coordinax.operators.AbstractTransform`.
 
-    ```{warning}
+    .. warning::
 
-    The transformation operator ``ops`` is the transformation of the
-    points, not a passive re-labeling of coordinates. Frame transitions in
-    `coordinax` use active semantics: coordinates are transformed by direct
-    application of the operator.
-
-    ```
+        The transformation operator ``ops`` is the transformation of the
+        points, not a passive re-labeling of coordinates. Frame transitions in
+        `coordinax` use active semantics: coordinates are transformed by direct
+        application of the operator.
 
     Examples
     --------
@@ -81,14 +79,12 @@ class TransformedReferenceFrame(AbstractTransformedReferenceFrame[FrameT]):
     reference frame. The transformation from the base reference frame to this
     reference frame is stored as an `coordinax.operators.AbstractTransform`.
 
-    ```{warning}
+    .. warning::
 
-    The transformation operator ``ops`` is the transformation of the
-    points, not a passive re-labeling of coordinates. Frame transitions in
-    `coordinax` use active semantics: coordinates are transformed by direct
-    application of the operator.
-
-    ```
+        The transformation operator ``ops`` is the transformation of the
+        points, not a passive re-labeling of coordinates. Frame transitions in
+        `coordinax` use active semantics: coordinates are transformed by direct
+        application of the operator.
 
     Examples
     --------

--- a/src/coordinax/representations/_src/basis_change.py
+++ b/src/coordinax/representations/_src/basis_change.py
@@ -470,30 +470,32 @@ def change_basis(
 ) -> CDict:
     r"""Change from coordinate basis to physical basis in a 3-D spherical chart.
 
-    In spherical coordinates $(r, \theta, \phi)$ the scale factors are
+    In spherical coordinates :math:`(r, \theta, \phi)` the scale factors are
 
-    $$h_r = 1, \quad h_\theta = r, \quad h_\phi = r \sin\theta,$$
+    .. math::
+
+        h_r = 1, \quad h_\theta = r, \quad h_\phi = r \sin\theta,
 
     so the transformation matrix is
 
-    $$
-    H = \begin{pmatrix}
+    .. math::
+
+        H = \begin{pmatrix}
         1 & 0 & 0 \\
         0 & r & 0 \\
         0 & 0 & r\sin\theta
-    \end{pmatrix}.
-    $$
+        \end{pmatrix}.
 
-    Given coordinate-basis components $(v^r, v^\theta, v^\phi)$, the
+    Given coordinate-basis components :math:`(v^r, v^\theta, v^\phi)`, the
     physical-basis components are
 
-    $$
-    \hat{v} = H v
+    .. math::
+
+        \hat{v} = H v
         \implies
         \hat{v}^r = v^r, \quad
         \hat{v}^\theta = r\, v^\theta, \quad
         \hat{v}^\phi = r\sin\theta\, v^\phi.
-    $$
 
     Examples
     --------
@@ -574,27 +576,27 @@ def change_basis(
 ) -> CDict:
     r"""Change from physical basis to coordinate basis in a 3-D spherical chart.
 
-    In spherical coordinates $(r, \theta, \phi)$ the inverse transformation
+    In spherical coordinates :math:`(r, \theta, \phi)` the inverse transformation
     matrix is
 
-    $$
-    H^{-1} = \begin{pmatrix}
+    .. math::
+
+        H^{-1} = \begin{pmatrix}
         1 & 0 & 0 \\
         0 & 1/r & 0 \\
         0 & 0 & 1/(r\sin\theta)
-    \end{pmatrix}.
-    $$
+        \end{pmatrix}.
 
-    Given physical-basis components $(\hat{v}^r, \hat{v}^\theta, \hat{v}^\phi)$,
+    Given physical-basis components :math:`(\hat{v}^r, \hat{v}^\theta, \hat{v}^\phi)`,
     the coordinate-basis components are
 
-    $$
-    v = H^{-1} \hat{v}
+    .. math::
+
+        v = H^{-1} \hat{v}
         \implies
         v^r = \hat{v}^r, \quad
         v^\theta = \hat{v}^\theta / r, \quad
         v^\phi = \hat{v}^\phi / (r\sin\theta).
-    $$
 
     Examples
     --------

--- a/src/coordinax/transforms/_src/actions/composed.py
+++ b/src/coordinax/transforms/_src/actions/composed.py
@@ -73,15 +73,13 @@ class Composed(AbstractCompositeTransform, Generic[*Ts]):
     is equivalent to evaluating $g \circ f = g(f(x))$. Note the order of the
     transformations!
 
-    ```{note}
+    .. note::
 
-    The `|` operator works differently from the functional composition operator
-    $\circ$, which is sadly not supported in Python. The `|` operator is like
-    the Unix Shell pipe operator, where output is passed left-to-right. This
-    order can be seen in the indexing of the transformations in the `Composed`
-    object.
-
-    ```
+        The ``|`` operator works differently from the functional composition
+        operator $\circ$, which is sadly not supported in Python. The ``|``
+        operator is like the Unix Shell pipe operator, where output is passed
+        left-to-right. This order can be seen in the indexing of the
+        transformations in the `Composed` object.
 
     Parameters
     ----------

--- a/src/coordinax/transforms/_src/actions/rotate.py
+++ b/src/coordinax/transforms/_src/actions/rotate.py
@@ -89,7 +89,7 @@ class Rotate(AbstractLinearTransform):
         [0 1 0]>
 
     This also works for a batch of vectors (as a note, it is more efficient to
-    `jax.vmap` over the `jax.jit`ted operator):
+    `jax.vmap` over the `jax.jit`-ed operator):
 
     >>> v = cx.Point.from_([[1, 0, 0], [0, 1, 0]], "m")  # A Point vector
     >>> print(op(t, v))

--- a/src/coordinax/transforms/_src/actions/translate.py
+++ b/src/coordinax/transforms/_src/actions/translate.py
@@ -118,7 +118,7 @@ class Translate(AbstractAdd):
     semantic_kind: cxr.AbstractTangentSemanticKind = eqx.field(
         static=True, default=cxr.dpl
     )
-    """Semantic kind of tangent data this operator acts on. Default: Displacement."""
+    """Semantic kind of tangent data this operator acts on (default Displacement)."""
 
     # delta, chart, and right_add inherited from AbstractAdd
     @classmethod

--- a/src/coordinax/vectors/_src/base.py
+++ b/src/coordinax/vectors/_src/base.py
@@ -94,35 +94,6 @@ class AbstractVector(
     shape : tuple[int, ...]
         The batch shape of the vector (abstract; implemented by subclasses).
 
-    Methods
-    -------
-    from_(*args, **kwargs) -> AbstractVector
-        Multiple-dispatch constructor.  Dispatches are registered externally
-        via ``plum``; call ``.methods`` to inspect all overloads.
-    cconvert(*args, **kwargs) -> AbstractVector
-        Convert to another chart or representation, forwarding to
-        `coordinax.representations.cconvert`.
-    to_cartesian() -> AbstractVector
-        Shorthand for ``self.cconvert(self.chart.cartesian)``.
-    uconvert(*args, **kwargs) -> AbstractVector
-        Convert component units by forwarding to `unxt.uconvert`.
-    astype(dtype, **kwargs) -> AbstractVector
-        Cast all component leaves to a new dtype.
-    copy() -> Self
-        Shallow copy via `dataclasses.replace`.
-    flatten() -> Self
-        Flatten all component leaves.
-    ravel() -> Self
-        Return a flattened copy (alias of ``flatten``).
-    reshape(*shape) -> Self
-        Return a reshaped copy.
-    round(decimals=0) -> Self
-        Return a rounded copy.
-    to_device(device=None) -> Self
-        Move all leaves to the specified JAX device.
-    is_like(obj) -> TypeIs[Self]
-        Class method; return ``True`` if *obj* is an instance of this class.
-
     See Also
     --------
     coordinax.vectors.Point : Concrete default implementation.

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -836,7 +836,7 @@ def cconvert(
 ) -> Coordinate:
     """Convert a Coordinate to a new chart.
 
-    Delegates to {meth}`Coordinate.cconvert`.
+    Delegates to ``Coordinate.cconvert``.
 
     >>> import coordinax as cx
     >>> import coordinax.charts as cxc

--- a/src/coordinax/vectors/_src/tangent.py
+++ b/src/coordinax/vectors/_src/tangent.py
@@ -98,6 +98,8 @@ class Tangent(
     frame
         The reference frame. Defaults to ``cxf.noframe``.
 
+    Examples
+    --------
     Construct a **coordinate-basis velocity** in Cartesian 3D:
 
     >>> import coordinax as cx


### PR DESCRIPTION
## Summary

Drives the nitpicky (`-n`) HTML docs build from **~656 warnings to 0** and turns warnings into errors (`-W`) in nox and CI, so future warnings can't slip back in.

Builds on #569 (which added the `_src` `nitpick_ignore_regex` and cut the build from ~1598 → ~656 warnings).

## Root causes fixed (not suppressed)

- **Plum-dispatch docstring aggregation (~383 `[ref.exc]` + more).** Plum concatenates every registered method's docstring into the function's `__doc__`. A Napoleon `Raises`/`Returns`/`Parameters` section that is the *last* section of a method greedily consumes everything after it (the next methods' prose and doctests), turning each line into a failed `:exc:`/`:class:` reference. Restructured the offending fallback/abstract docstrings (`metric_matrix`, `pt_map`, `prolong`, `frame_transition`) so each ends in a non-consuming block (an `Examples` doctest block or plain prose).

- **Dollar-maths in docstrings (~90 `[docutils]`).** The Markdown pages render maths with MyST `dollarmath`, and docstrings follow the same `$...$` / `$$...$$` convention — but autodoc feeds docstrings to the *reStructuredText* parser, which has no dollar-math support. There, `h_\theta` is read as a phantom reference (`Unknown target name: "h"`), `|\nu|` as a substitution, `**` as strong emphasis and multi-line `$$`-blocks as block quotes. Added an `autodoc-process-docstring` hook that converts dollar-maths to the RST `:math:` role / `.. math::` directive, so the maths both renders correctly **and** stops emitting warnings.

- **Malformed RST in coordinax's own docstrings.** Fixed MyST `{note}` / `{warning}` fences and `{class}` roles used verbatim in docstrings, `Word: ...` one-liners misparsed as field lists, enumerated/bullet lists missing a preceding blank line, `::` literal-block/doctest conflicts, and inline-markup runs like `` `jax.jit`ted ``.

- **Bare / wrong cross-references.** Added a `missing-reference` resolver that maps bare short names (`Representation`, `AbstractBasis`, `pt_map`, …) to the project's own Python objects; qualified or relabelled the rest. Genuinely external targets with no resolvable inventory (`unxt`, `wadler_lindig`, `optype`, `plum`, `typing.TypeIs`, jaxtyping shape fragments, beartype validators) go to `nitpick_ignore`, each with a documented rationale.

- **Duplicate object descriptions (~77).** `napoleon_use_ivar = True` stops class `Attributes` sections emitting `.. attribute::` directives that clash with the autodoc-documented members; the sibling `automodule`/`autoclass` on the angles & distances pages now excludes the explicitly-`autoclass`'d class; `:no-inherited-members:` on the manifolds page stops inherited dataclass fields clashing with subclass property overrides. The malformed inherited external `quax._core.Value` members are excluded globally.

- **Broken MyST anchor links** in the guides/api Markdown (renamed/nonexistent section anchors).

## Enabling `-W`

- `noxfile.py`: add `-W` to the docs session's `shared_args` (alongside `-n`, `-T`).
- `.github/workflows/ci.yml`: run the warnings-as-errors docs build (removing the old `# TODO: fix this`), and add `docs` to the `status` gate's `needs` so a docs failure now blocks CI.

## Verification

Clean `-W` build exits 0 with 0 warnings:

```
uv run --group docs --with matplotlib jupytext --to notebook guides/perf.md --output guides/perf.ipynb
rm -rf _build/doctrees _build/html
uv run --group docs --with matplotlib sphinx-build -n -T -W --keep-going -b html -d _build/doctrees . _build/html
# build succeeded.  EXIT: 0
```

Doctests on the edited docstrings still pass; `ruff` and `ty` pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)