### PR TITLE
📝 docs: integrate coordinaxs.curveframes into the docs site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ sd_hide_title: true
 coordinaxs.api <packages/coordinaxs.api/index.md>
 coordinax <self>
 coordinaxs.astro <packages/coordinaxs.astro/index.md>
+coordinaxs.curveframes <packages/coordinaxs.curveframes/index.md>
 coordinaxs.hypothesis <packages/coordinaxs.hypothesis/index.md>
 coordinaxs.interop.astropy <packages/coordinaxs.interop.astropy/index.md>
 ```
@@ -50,6 +51,7 @@ tutorials/*
 coordinaxs.api <packages/coordinaxs.api/api>
 coordinax <api/index.md>
 coordinaxs.astro <packages/coordinaxs.astro/api>
+coordinaxs.curveframes <packages/coordinaxs.curveframes/api>
 coordinaxs.hypothesis <packages/coordinaxs.hypothesis/api>
 coordinaxs.interop.astropy <packages/coordinaxs.interop.astropy/api>
 ```

--- a/docs/packages/coordinaxs.curveframes
+++ b/docs/packages/coordinaxs.curveframes
@@ -1,0 +1,1 @@
+../../packages/coordinaxs.curveframes/docs

--- a/packages/coordinaxs.curveframes/docs/api.md
+++ b/packages/coordinaxs.curveframes/docs/api.md
@@ -1,0 +1,14 @@
+# API Reference
+
+Complete API documentation for `coordinaxs.curveframes`.
+
+```{eval-rst}
+
+.. currentmodule:: coordinaxs.curveframes
+
+.. automodule:: coordinaxs.curveframes
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+```

--- a/packages/coordinaxs.curveframes/docs/index.md
+++ b/packages/coordinaxs.curveframes/docs/index.md
@@ -1,0 +1,50 @@
+# coordinaxs.curveframes
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+guide.md
+tutorial.md
+tutorial_circle_equivalence.md
+api.md
+spec.md
+```
+
+Curve-attached reference frames for [coordinax](https://github.com/GalacticDynamics/coordinax).
+
+This package implements Frenet–Serret and Bishop frames for τ-parameterized smooth curves in 3D Euclidean space, letting you transform coordinate data into and out of the moving frame that travels along a space curve.
+
+## Installation
+
+::::{tab-set}
+
+:::{tab-item} pip
+
+```bash
+pip install coordinaxs.curveframes
+```
+
+:::
+
+:::{tab-item} uv
+
+```bash
+uv add coordinaxs.curveframes
+```
+
+:::
+
+::::
+
+## Learn More
+
+- {doc}`Working With Curve Frames <guide>` — concepts, and a walkthrough of building a curve frame and transforming data through it.
+- {doc}`Tutorial: Frenet–Serret Curve Frames <tutorial>` — a complete worked example, including chaining frames and using JAX for JIT and vectorisation.
+- {doc}`Tutorial: Parallel Transport vs Corotating Frame on a Circle <tutorial_circle_equivalence>` — why the Frenet–Serret, Bishop, and rigid-rotation frames coincide on a circle.
+- {doc}`API Reference <api>` — complete API documentation.
+- {doc}`Specification <spec>` — the normative specification.
+
+## License
+
+MIT License. See [LICENSE](../../../LICENSE) for details.


### PR DESCRIPTION
## Problem

`coordinaxs.curveframes` ships a full guide, two tutorials, and a spec (`packages/coordinaxs.curveframes/docs/`), but they were never wired into the docs build — no `docs/packages/` symlink and no toctree entry — so they never appeared in the rendered documentation.

To be clear, **nothing was deleted**: the guide (349 lines), `tutorial.md` (442), `tutorial_circle_equivalence.md` (201), and `spec.md` (530) have been present since the #548 packaging split (moved verbatim from the old `coordinax.curveframes` path, modulo the namespace rename). They were simply never published.

## Fix

Mirror how the other packages integrate their docs:
- Add the `docs/packages/coordinaxs.curveframes` symlink → `../../packages/coordinaxs.curveframes/docs`.
- Add a package landing `index.md` (toctree over guide / tutorials / api / spec) and an `api.md` (automodule), matching `coordinaxs.astro`.
- Register `coordinaxs.curveframes` in the root `docs/index.md` **Packages** and **API Reference** toctrees.

## Verification

`nox -s docs` builds successfully and now renders the curveframes pages: `_build/html/packages/coordinaxs.curveframes/{index,guide,tutorial,tutorial_circle_equivalence,api,spec}.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)