### PR TITLE
✨ feat(vectors): add chart- and unit-invariant `equivalent`

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -183,6 +183,24 @@ $$
 
 for the inverse transition map.
 
+(math-spec-equivalence)=
+
+### Same-Point Equivalence
+
+[Software Spec](#software-spec-equivalence)
+
+A point $p \in M$ has a coordinate representation $q = \varphi_C(p)$ in every chart $C$ whose domain contains it. Two coordinate tuples therefore describe the **same geometric point** precisely when they are related by the appropriate [transition map](#math-spec-transition-maps): $q_1 \in \varphi_{C_1}(U)$ and $q_2 \in \varphi_{C_2}(V)$ represent the same point iff
+
+$$
+q_2 = \tau_{C_1\to C_2}(q_1)
+\quad\Longleftrightarrow\quad
+\varphi_{C_1}^{-1}(q_1) = \varphi_{C_2}^{-1}(q_2).
+$$
+
+This is an **equivalence relation** on coordinate tuples across all charts of the atlas — reflexive, symmetric (transition maps are invertible), and transitive (they compose). It is coarser than **coordinate equality**, which additionally demands that the two tuples lie in the _same_ chart and be numerically identical: coordinate equality implies same-point equivalence, but not conversely. For example, the Cartesian tuple $(0, 1, 0)$ and the spherical tuple $(1, \tfrac{\pi}{2}, \tfrac{\pi}{2})$ describe the same point yet are not coordinate-equal.
+
+When representations additionally carry a reference frame (an extra transformation-group axis; see Frame Transforms), same-point equivalence is taken **within a fixed frame**: tuples in different frames denote different physical points.
+
 (math-spec-embedded-manifolds)=
 
 ### Embedded Manifolds
@@ -2263,10 +2281,9 @@ Separating semantics from geometry provides two advantages:
       - ``(V, *args, **kwargs) -> uconvert(*args, V, **kwargs)`` redispatch
       - ``(V, u.AbstractUnitSystem) -> uconvert(u.AbstractUnitSystem, V)`` redispatch
     - ``__array_namespace__``: the array API namespace -- `quax.numpy`. This delegates to `quax` primitives.
-    - ``__eq__``: strict equality — requires the same type, chart, and frame, then compares component data via the `quax` equality primitive.
+    - ``__eq__``: strict equality — requires the same type, chart, and frame, then compares component data via the `quax` equality primitive. See [Comparison and Equivalence](#software-spec-equivalence) for the strict-vs-relaxed relations.
       - Chart and frame are static metadata, so they are compared with ordinary Python ``!=`` (safe under `jit`).
       - When they differ, ``__eq__`` short-circuits and returns a 0-d boolean array (``jnp.zeros((), dtype=bool)``) instead of comparing the component dicts, which also avoids raising on their differing keys.
-    - ``equivalent(a, b, *, rtol, atol)``: the relaxed, coordinate-free counterpart to ``__eq__`` — whether two vectors denote the *same geometric point*, invariant to the chart and component units but frame-strict. Compared in a common Cartesian chart, tolerance-based, and never raising (mismatched frame, manifold, or unit-vs-unitless leaves ⇒ ``False``). Registered on the global `plum` ``dispatch`` (shared with `unxt`'s quantity-level ``equivalent``).
     - ``copy()``: call `dataclass.replace`.
     - ``flatten()``: flatten the vector.
     - ``ravel()``: return a flattened vector.
@@ -2292,6 +2309,27 @@ Separating semantics from geometry provides two advantages:
     - ``__int__``
     - ``__setitem__`` : vectors are immutable.
     - ``__hash__()``: hash the vector by its field items. In general this raises an error.
+
+(software-spec-equivalence)=
+
+### Comparison and Equivalence
+
+[Math Spec](#math-spec-equivalence)
+
+Vectors support two comparison relations — a strict one and a coordinate-free one — realising the [same-point equivalence](#math-spec-equivalence) discussed in the math spec.
+
+`==` (`AbstractVector.__eq__`) is **strict**: two vectors are equal only when they share the same type, chart, frame, and component data. It is the software form of _coordinate equality_.
+
+!!! info `equivalent`
+
+    ``equivalent(a, b, *, rtol=..., atol=...)`` is the **coordinate-free** relation: it tests whether two vectors denote the [same geometric point](#math-spec-equivalence). It is the relaxed counterpart to ``==`` — invariant to the chart and to the component units, but **frame-strict** (vectors in different frames denote different physical points).
+
+    Semantics:
+
+    - **Chart-invariant.** The operands are compared in a common Cartesian chart, so the result does not depend on the chart each is expressed in.
+    - **Tolerance-based.** Closeness is controlled by ``rtol``/``atol`` (chart transitions are trigonometric/√-heavy, so exact equality is fragile); the comparison is evaluated element-wise over the batch, mirroring ``==``.
+    - **Never raises.** A differing frame, a differing manifold (Cartesian chart), or a per-component unitful-vs-unitless or incompatible-dimension mismatch all yield ``False`` rather than an error.
+    - **`plum` registration.** ``equivalent`` is registered on the global `plum` ``dispatch`` _without_ importing `unxt`'s ``equivalent``, so the vector overload and `unxt`'s quantity-level ``equivalent`` coexist on one multiply-dispatched function; the vector overload also works standalone when `unxt` provides none.
 
 !!! info `Point`
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2326,9 +2326,10 @@ Vectors support two comparison relations — a strict one and a coordinate-free 
 
     Semantics:
 
+    - **Point-geometry only.** As a same-*point* relation it applies to point-geometry vectors (a `Point`, a `Coordinate`); a `Tangent` denotes a displacement, not a point. Any non-point or cross-geometry pair yields scalar ``False`` (never the same point, and never raising — a `Tangent` cannot re-chart to Cartesian without a base point).
     - **Chart-invariant.** The operands are compared in a common Cartesian chart, so the result does not depend on the chart each is expressed in.
     - **Tolerance-based.** Closeness is controlled by ``rtol``/``atol`` (chart transitions are trigonometric/√-heavy, so exact equality is fragile); the comparison is evaluated element-wise over the batch, mirroring ``==``.
-    - **Never raises.** A differing frame, a differing manifold (Cartesian chart), or a per-component unitful-vs-unitless or incompatible-dimension mismatch all yield ``False`` rather than an error.
+    - **Never raises.** A non-point/cross-geometry operand, a differing frame, a differing manifold (Cartesian chart), or a per-component unitful-vs-unitless or incompatible-dimension mismatch all yield ``False`` rather than an error.
     - **`plum` registration.** ``equivalent`` is registered on the global `plum` ``dispatch`` _without_ importing `unxt`'s ``equivalent``, so the vector overload and `unxt`'s quantity-level ``equivalent`` coexist on one multiply-dispatched function; the vector overload also works standalone when `unxt` provides none.
 
 !!! info `Point`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2266,6 +2266,7 @@ Separating semantics from geometry provides two advantages:
     - ``__eq__``: strict equality — requires the same type, chart, and frame, then compares component data via the `quax` equality primitive.
       - Chart and frame are static metadata, so they are compared with ordinary Python ``!=`` (safe under `jit`).
       - When they differ, ``__eq__`` short-circuits and returns a 0-d boolean array (``jnp.zeros((), dtype=bool)``) instead of comparing the component dicts, which also avoids raising on their differing keys.
+    - ``equivalent(a, b, *, rtol, atol)``: the relaxed, coordinate-free counterpart to ``__eq__`` — whether two vectors denote the *same geometric point*, invariant to the chart and component units but frame-strict. Compared in a common Cartesian chart, tolerance-based, and never raising (mismatched frame, manifold, or unit-vs-unitless leaves ⇒ ``False``). Registered on the global `plum` ``dispatch`` (shared with `unxt`'s quantity-level ``equivalent``).
     - ``copy()``: call `dataclass.replace`.
     - ``flatten()``: flatten the vector.
     - ``ravel()``: return a flattened vector.

--- a/src/coordinax/__init__.py
+++ b/src/coordinax/__init__.py
@@ -86,6 +86,7 @@ __all__ = (  # distances
     "Coordinate",
     "Tangent",
     "ToUnitsOptions",
+    "equivalent",
 )
 
 import warnings
@@ -174,7 +175,13 @@ from coordinax.transforms import (
     identity,
     simplify,
 )
-from coordinax.vectors import Coordinate, Point, Tangent, ToUnitsOptions
+from coordinax.vectors import (
+    Coordinate,
+    Point,
+    Tangent,
+    ToUnitsOptions,
+    equivalent,
+)
 
 # ============================================================================
 # Optional interop registration

--- a/src/coordinax/vectors/__init__.py
+++ b/src/coordinax/vectors/__init__.py
@@ -2,6 +2,7 @@
 
 __all__ = (
     "cconvert",
+    "equivalent",
     "AbstractVector",
     "Point",
     "Coordinate",
@@ -12,7 +13,14 @@ __all__ = (
 from ._setup_package import install_import_hook
 
 with install_import_hook("coordinax.vectors"):
-    from ._src import AbstractVector, Coordinate, Point, Tangent, ToUnitsOptions
+    from ._src import (
+        AbstractVector,
+        Coordinate,
+        Point,
+        Tangent,
+        ToUnitsOptions,
+        equivalent,
+    )
     from coordinaxs.api.representations import cconvert
 
 del install_import_hook

--- a/src/coordinax/vectors/_src/__init__.py
+++ b/src/coordinax/vectors/_src/__init__.py
@@ -7,6 +7,7 @@ from .constants import *
 from .custom_types import *
 from .mixins import *
 from .point import *
+from .register_compare import *
 from .register_cx import *
 from .register_dataclassish import *
 from .register_quax import *

--- a/src/coordinax/vectors/_src/register_compare.py
+++ b/src/coordinax/vectors/_src/register_compare.py
@@ -5,13 +5,17 @@ when they share the same chart, frame, and component data. :func:`equivalent`
 is the chart- and unit-*invariant* counterpart -- it asks whether two vectors
 denote the *same geometric point*, regardless of the chart used to express it.
 
-This mirrors `unxt.equivalent`, which relaxes ``==`` on quantities from
-unit-blind to unit-aware.  The dispatch is registered on the *global* plum
-``dispatch`` (not imported from `unxt`), so when `unxt` ships its own
-``equivalent`` the two coexist on one multiply-dispatched function.
+It is the vector analogue of the unit-aware "same physical amount" relation on
+quantities: where that relaxes a unit-blind ``==`` to compare across units,
+``equivalent`` additionally compares across charts.  The dispatch is registered
+on the *global* plum ``dispatch`` (the same function `unxt` uses for its own
+quantity-level ``equivalent``), *without* importing it from `unxt` -- so a
+coordinax vector overload and a unxt quantity overload coexist on one
+multiply-dispatched ``equivalent`` when both packages are present, and the
+vector overload works standalone otherwise.
 """
 
-__all__ = ("equivalent",)
+__all__: tuple[str, ...] = ("equivalent",)
 
 from typing import Any
 
@@ -20,6 +24,15 @@ from plum import dispatch
 import quaxed.numpy as jnp
 
 from .base import AbstractVector
+
+
+def _strip(leaf: Any, unit: Any) -> Any:
+    """Return *leaf* as a plain array, converting to *unit* if it is a quantity.
+
+    Vector components may be `unxt.Quantity` leaves (unitful vectors) or plain
+    JAX arrays (unitless vectors); this normalises both to comparable arrays.
+    """
+    return leaf.ustrip(unit) if hasattr(leaf, "ustrip") else jnp.asarray(leaf)
 
 
 @dispatch
@@ -39,7 +52,8 @@ def equivalent(
     It remains *frame-strict*, since coordinates in different frames describe
     different physical points.  Because chart transitions are trigonometric and
     square-root heavy, the comparison is tolerance-based (`rtol`, `atol`);
-    ``atol`` is measured in the Cartesian component units of the first operand.
+    ``atol`` is measured in the Cartesian component units of the first operand
+    (or in raw component units for unitless vectors).
 
     Examples
     --------
@@ -87,10 +101,14 @@ def equivalent(
     if ac.chart != bc.chart:
         return jnp.zeros((), dtype=bool)
 
-    # Element-wise, per component, expressed in the first operand's units.
+    # Element-wise, per component, expressed in the first operand's units
+    # (component leaves may be quantities or plain arrays; ``_strip`` handles both).
     checks = [
         jnp.isclose(
-            av.ustrip(av.unit), bc.data[k].ustrip(av.unit), rtol=rtol, atol=atol
+            _strip(av, getattr(av, "unit", None)),
+            _strip(bc.data[k], getattr(av, "unit", None)),
+            rtol=rtol,
+            atol=atol,
         )
         for k, av in ac.data.items()
     ]

--- a/src/coordinax/vectors/_src/register_compare.py
+++ b/src/coordinax/vectors/_src/register_compare.py
@@ -22,6 +22,7 @@ from typing import Any
 from plum import dispatch
 
 import quaxed.numpy as jnp
+import unxt as u
 
 from .base import AbstractVector
 
@@ -101,25 +102,24 @@ def equivalent(
     if ac.chart != bc.chart:
         return jnp.zeros((), dtype=bool)
 
-    # One operand unitful (``unxt.Quantity`` leaves) and the other unitless
-    # (plain-array leaves) live in different spaces, so they are never
-    # equivalent.  Guard here -- a plain Python bool, like the chart/frame
-    # guards -- so the comparison never raises (a unit-vs-unitless ``ustrip``
-    # would otherwise error).
-    a_unitful = hasattr(next(iter(ac.data.values())), "unit")
-    b_unitful = hasattr(next(iter(bc.data.values())), "unit")
-    if a_unitful != b_unitful:
-        return jnp.zeros((), dtype=bool)
-
-    # Element-wise, per component, expressed in the first operand's units
-    # (component leaves may be quantities or plain arrays; ``_strip`` handles both).
-    checks = [
-        jnp.isclose(
-            _strip(av, getattr(av, "unit", None)),
-            _strip(bc.data[k], getattr(av, "unit", None)),
-            rtol=rtol,
-            atol=atol,
+    # Compare per component, in the first operand's units.  A component that is
+    # unitful on one side and unitless on the other -- or that carries an
+    # incompatible dimension -- describes a different space, so the vectors are
+    # not equivalent.  Leaves may be *mixed* within a vector, so this is checked
+    # per component (not just the first), which also keeps the comparison from
+    # ever calling ``ustrip`` on a mismatched leaf (which would raise).  This
+    # mirrors unxt's ``equivalent``: incompatible => not equivalent, never
+    # raising.
+    checks = []
+    for k, av in ac.data.items():
+        bv = bc.data[k]
+        a_unit = getattr(av, "unit", None)
+        b_unit = getattr(bv, "unit", None)
+        if (a_unit is None) != (b_unit is None) or (
+            a_unit is not None and not u.is_unit_convertible(b_unit, a_unit)
+        ):
+            return jnp.zeros((), dtype=bool)
+        checks.append(
+            jnp.isclose(_strip(av, a_unit), _strip(bv, a_unit), rtol=rtol, atol=atol)
         )
-        for k, av in ac.data.items()
-    ]
     return jnp.all(jnp.stack(jnp.broadcast_arrays(*checks)), axis=0)

--- a/src/coordinax/vectors/_src/register_compare.py
+++ b/src/coordinax/vectors/_src/register_compare.py
@@ -101,6 +101,16 @@ def equivalent(
     if ac.chart != bc.chart:
         return jnp.zeros((), dtype=bool)
 
+    # One operand unitful (``unxt.Quantity`` leaves) and the other unitless
+    # (plain-array leaves) live in different spaces, so they are never
+    # equivalent.  Guard here -- a plain Python bool, like the chart/frame
+    # guards -- so the comparison never raises (a unit-vs-unitless ``ustrip``
+    # would otherwise error).
+    a_unitful = hasattr(next(iter(ac.data.values())), "unit")
+    b_unitful = hasattr(next(iter(bc.data.values())), "unit")
+    if a_unitful != b_unitful:
+        return jnp.zeros((), dtype=bool)
+
     # Element-wise, per component, expressed in the first operand's units
     # (component leaves may be quantities or plain arrays; ``_strip`` handles both).
     checks = [

--- a/src/coordinax/vectors/_src/register_compare.py
+++ b/src/coordinax/vectors/_src/register_compare.py
@@ -1,0 +1,97 @@
+"""Equivalence comparison for vectors.
+
+``==`` (see `AbstractVector.__eq__`) is *strict*: two vectors are equal only
+when they share the same chart, frame, and component data. :func:`equivalent`
+is the chart- and unit-*invariant* counterpart -- it asks whether two vectors
+denote the *same geometric point*, regardless of the chart used to express it.
+
+This mirrors `unxt.equivalent`, which relaxes ``==`` on quantities from
+unit-blind to unit-aware.  The dispatch is registered on the *global* plum
+``dispatch`` (not imported from `unxt`), so when `unxt` ships its own
+``equivalent`` the two coexist on one multiply-dispatched function.
+"""
+
+__all__ = ("equivalent",)
+
+from typing import Any
+
+from plum import dispatch
+
+import quaxed.numpy as jnp
+
+from .base import AbstractVector
+
+
+@dispatch
+def equivalent(
+    a: AbstractVector,
+    b: AbstractVector,
+    /,
+    *,
+    rtol: float = 1e-5,
+    atol: float = 1e-8,
+) -> Any:
+    """Whether two vectors denote the same geometric point.
+
+    Unlike ``==`` -- which is *strict* (equal only for matching chart, frame,
+    and data) -- ``equivalent`` is invariant to the chart and to the component
+    units: it compares the two vectors as points in a common Cartesian chart.
+    It remains *frame-strict*, since coordinates in different frames describe
+    different physical points.  Because chart transitions are trigonometric and
+    square-root heavy, the comparison is tolerance-based (`rtol`, `atol`);
+    ``atol`` is measured in the Cartesian component units of the first operand.
+
+    Examples
+    --------
+    >>> import coordinax as cx
+    >>> import coordinax.charts as cxc
+
+    The same point in Cartesian and spherical charts is *not* ``==`` (the charts
+    differ) but *is* ``equivalent``:
+
+    >>> p = cx.Point.from_([1.0, 2.0, 3.0], "m")
+    >>> sph = p.cconvert(cxc.sph3d)
+    >>> bool(p == sph)
+    False
+    >>> bool(cx.equivalent(p, sph))
+    True
+
+    Equivalence is also invariant to the component units:
+
+    >>> q = cx.Point.from_([1.0, 2.0, 3.0], "km")
+    >>> mm = cx.Point.from_([1e6, 2e6, 3e6], "mm")
+    >>> bool(cx.equivalent(q, mm))
+    True
+
+    Distinct points are not equivalent:
+
+    >>> bool(cx.equivalent(p, cx.Point.from_([1.0, 2.0, 4.0], "m")))
+    False
+
+    """
+    # Coordinates in different frames describe different physical points.  Chart
+    # and frame are static metadata, so this is a plain Python bool -- safe under
+    # ``jit`` and mirroring the guard in ``AbstractVector.__eq__``.
+    if a.frame != b.frame:
+        return jnp.zeros((), dtype=bool)
+
+    # Compare as points in a common Cartesian chart.  This avoids the angle
+    # wrapping and coordinate singularities that would make a component-wise
+    # comparison in a curvilinear chart unreliable, and keeps the tolerance
+    # isotropic in space.
+    ac = a.to_cartesian()
+    bc = b.to_cartesian()
+
+    # Different Cartesian charts (e.g. a different manifold dimension) can never
+    # denote the same point.
+    if ac.chart != bc.chart:
+        return jnp.zeros((), dtype=bool)
+
+    # Element-wise, per component, expressed in the first operand's units.
+    checks = [
+        jnp.isclose(
+            av.ustrip(av.unit), bc.data[k].ustrip(av.unit), rtol=rtol, atol=atol
+        )
+        for k, av in ac.data.items()
+    ]
+    return jnp.all(jnp.stack(jnp.broadcast_arrays(*checks)), axis=0)

--- a/src/coordinax/vectors/_src/register_compare.py
+++ b/src/coordinax/vectors/_src/register_compare.py
@@ -108,21 +108,19 @@ def equivalent(
     if ac.chart != bc.chart:
         return jnp.zeros((), dtype=bool)
 
-    # Compare component-wise, in the first operand's units.  A component that is
-    # unitful on one side and unitless on the other -- or that carries an
-    # incompatible dimension -- describes a different space, so the vectors are
-    # not equivalent.  ``jnp.isclose`` is unit-aware when ``atol`` carries the
-    # component's unit (it converts ``b`` into ``a``'s unit itself), and never
-    # raises here because the guard rejects the incompatible cases that would.
+    # Compare component-wise, in the first operand's units.  Promote a unitless
+    # (plain-array) leaf to a *dimensionless* quantity so that a unitful-vs-
+    # unitless mismatch and an incompatible dimension collapse into one
+    # convertibility check (``is_unit_convertible("", "m")`` is ``False``): such
+    # components describe different spaces, so the vectors are not equivalent.
+    # ``jnp.isclose`` is then unit-aware -- ``atol`` carries the component's unit,
+    # so it converts ``b`` into ``a``'s unit itself and never raises here.
     def leaf_close(av: Any, bv: Any) -> Any:
-        a_unit = getattr(av, "unit", None)
-        b_unit = getattr(bv, "unit", None)
-        if (a_unit is None) != (b_unit is None) or (
-            a_unit is not None and not u.is_unit_convertible(b_unit, a_unit)
-        ):
+        av = av if is_any_quantity(av) else u.Q(av, "")
+        bv = bv if is_any_quantity(bv) else u.Q(bv, "")
+        if not u.is_unit_convertible(bv.unit, av.unit):
             return jnp.zeros((), dtype=bool)
-        atol_k = atol if a_unit is None else u.Q(atol, a_unit)
-        return jnp.isclose(av, bv, rtol=rtol, atol=atol_k)
+        return jnp.isclose(av, bv, rtol=rtol, atol=u.Q(atol, av.unit))
 
     # ``is_leaf`` stops the tree walk at the `unxt.Quantity` leaves (which are
     # themselves pytrees); ``tree_reduce``'s initializer makes an empty chart (a

--- a/src/coordinax/vectors/_src/register_compare.py
+++ b/src/coordinax/vectors/_src/register_compare.py
@@ -19,6 +19,7 @@ __all__: tuple[str, ...] = ("equivalent",)
 
 from typing import Any
 
+import jax.tree as jtu
 from plum import dispatch
 
 import quaxed.numpy as jnp
@@ -106,20 +107,13 @@ def equivalent(
     if ac.chart != bc.chart:
         return jnp.zeros((), dtype=bool)
 
-    # Compare per component.  A component that is unitful on one side and
-    # unitless on the other -- or that carries an incompatible dimension --
-    # describes a different space, so the vectors are not equivalent.  Leaves may
-    # be *mixed* within a vector, so this is checked per component (not just the
-    # first).  ``jnp.isclose`` is unit-aware when ``atol`` carries the component's
-    # unit, so it converts ``b`` into ``a``'s unit itself -- no manual stripping,
-    # and it never raises here because the guard rejects the incompatible cases
-    # that would.  Seed with a vacuous ``True`` and AND in each component: this
-    # broadcasts up to the batch shape, and an empty loop (a 0-dimensional
-    # Cartesian chart, e.g. ``Cart0D``) stays ``True`` -- every point of a 0D
-    # space is the same point.
-    result = jnp.ones((), dtype=bool)
-    for k, av in ac.data.items():
-        bv = bc.data[k]
+    # Compare component-wise, in the first operand's units.  A component that is
+    # unitful on one side and unitless on the other -- or that carries an
+    # incompatible dimension -- describes a different space, so the vectors are
+    # not equivalent.  ``jnp.isclose`` is unit-aware when ``atol`` carries the
+    # component's unit (it converts ``b`` into ``a``'s unit itself), and never
+    # raises here because the guard rejects the incompatible cases that would.
+    def leaf_close(av: Any, bv: Any) -> Any:
         a_unit = getattr(av, "unit", None)
         b_unit = getattr(bv, "unit", None)
         if (a_unit is None) != (b_unit is None) or (
@@ -127,8 +121,14 @@ def equivalent(
         ):
             return jnp.zeros((), dtype=bool)
         atol_k = atol if a_unit is None else u.Q(atol, a_unit)
-        result = result & jnp.isclose(av, bv, rtol=rtol, atol=atol_k)
-    # ``isclose`` over unitful leaves yields a dimensionless ``Quantity`` of
-    # bools; strip it back to a plain array so the return type matches the
-    # scalar-``False`` guards above.
+        return jnp.isclose(av, bv, rtol=rtol, atol=atol_k)
+
+    # ``is_leaf`` stops the tree walk at the `unxt.Quantity` leaves (which are
+    # themselves pytrees); ``tree_reduce``'s initializer makes an empty chart (a
+    # 0-dimensional Cartesian chart, e.g. ``Cart0D``) vacuously ``True`` -- every
+    # point of a 0D space is the same point.  ``isclose`` over unitful leaves
+    # yields a dimensionless ``Quantity`` of bools; strip it back to a plain array
+    # so the return type matches the scalar-``False`` guards above.
+    checks = jtu.map(leaf_close, ac.data, bc.data, is_leaf=lambda x: hasattr(x, "unit"))
+    result = jtu.reduce(jnp.logical_and, checks, jnp.ones((), dtype=bool))
     return u.ustrip("", result) if hasattr(result, "unit") else result

--- a/src/coordinax/vectors/_src/register_compare.py
+++ b/src/coordinax/vectors/_src/register_compare.py
@@ -28,15 +28,6 @@ import coordinax.representations as cxr
 from .base import AbstractVector
 
 
-def _strip(leaf: Any, unit: Any) -> Any:
-    """Return *leaf* as a plain array, converting to *unit* if it is a quantity.
-
-    Vector components may be `unxt.Quantity` leaves (unitful vectors) or plain
-    JAX arrays (unitless vectors); this normalises both to comparable arrays.
-    """
-    return leaf.ustrip(unit) if hasattr(leaf, "ustrip") else jnp.asarray(leaf)
-
-
 @dispatch
 def equivalent(
     a: AbstractVector,
@@ -115,17 +106,17 @@ def equivalent(
     if ac.chart != bc.chart:
         return jnp.zeros((), dtype=bool)
 
-    # Compare per component, in the first operand's units.  A component that is
-    # unitful on one side and unitless on the other -- or that carries an
-    # incompatible dimension -- describes a different space, so the vectors are
-    # not equivalent.  Leaves may be *mixed* within a vector, so this is checked
-    # per component (not just the first), which also keeps the comparison from
-    # ever calling ``ustrip`` on a mismatched leaf (which would raise).  This
-    # mirrors unxt's ``equivalent``: incompatible => not equivalent, never
-    # raising.
-    # Seed with a vacuous ``True`` and AND in each component: this broadcasts up
-    # to the batch shape, and an empty loop (a 0-dimensional Cartesian chart, e.g.
-    # ``Cart0D``) stays ``True`` -- every point of a 0D space is the same point.
+    # Compare per component.  A component that is unitful on one side and
+    # unitless on the other -- or that carries an incompatible dimension --
+    # describes a different space, so the vectors are not equivalent.  Leaves may
+    # be *mixed* within a vector, so this is checked per component (not just the
+    # first).  ``jnp.isclose`` is unit-aware when ``atol`` carries the component's
+    # unit, so it converts ``b`` into ``a``'s unit itself -- no manual stripping,
+    # and it never raises here because the guard rejects the incompatible cases
+    # that would.  Seed with a vacuous ``True`` and AND in each component: this
+    # broadcasts up to the batch shape, and an empty loop (a 0-dimensional
+    # Cartesian chart, e.g. ``Cart0D``) stays ``True`` -- every point of a 0D
+    # space is the same point.
     result = jnp.ones((), dtype=bool)
     for k, av in ac.data.items():
         bv = bc.data[k]
@@ -135,7 +126,9 @@ def equivalent(
             a_unit is not None and not u.is_unit_convertible(b_unit, a_unit)
         ):
             return jnp.zeros((), dtype=bool)
-        result = result & jnp.isclose(
-            _strip(av, a_unit), _strip(bv, a_unit), rtol=rtol, atol=atol
-        )
-    return result
+        atol_k = atol if a_unit is None else u.Q(atol, a_unit)
+        result = result & jnp.isclose(av, bv, rtol=rtol, atol=atol_k)
+    # ``isclose`` over unitful leaves yields a dimensionless ``Quantity`` of
+    # bools; strip it back to a plain array so the return type matches the
+    # scalar-``False`` guards above.
+    return u.ustrip("", result) if hasattr(result, "unit") else result

--- a/src/coordinax/vectors/_src/register_compare.py
+++ b/src/coordinax/vectors/_src/register_compare.py
@@ -24,6 +24,7 @@ from plum import dispatch
 
 import quaxed.numpy as jnp
 import unxt as u
+from unxt.quantity import is_any_quantity
 
 import coordinax.representations as cxr
 from .base import AbstractVector
@@ -129,6 +130,6 @@ def equivalent(
     # point of a 0D space is the same point.  ``isclose`` over unitful leaves
     # yields a dimensionless ``Quantity`` of bools; strip it back to a plain array
     # so the return type matches the scalar-``False`` guards above.
-    checks = jtu.map(leaf_close, ac.data, bc.data, is_leaf=lambda x: hasattr(x, "unit"))
+    checks = jtu.map(leaf_close, ac.data, bc.data, is_leaf=is_any_quantity)
     result = jtu.reduce(jnp.logical_and, checks, jnp.ones((), dtype=bool))
     return u.ustrip("", result) if hasattr(result, "unit") else result

--- a/src/coordinax/vectors/_src/register_compare.py
+++ b/src/coordinax/vectors/_src/register_compare.py
@@ -110,7 +110,10 @@ def equivalent(
     # ever calling ``ustrip`` on a mismatched leaf (which would raise).  This
     # mirrors unxt's ``equivalent``: incompatible => not equivalent, never
     # raising.
-    checks = []
+    # Seed with a vacuous ``True`` and AND in each component: this broadcasts up
+    # to the batch shape, and an empty loop (a 0-dimensional Cartesian chart, e.g.
+    # ``Cart0D``) stays ``True`` -- every point of a 0D space is the same point.
+    result = jnp.ones((), dtype=bool)
     for k, av in ac.data.items():
         bv = bc.data[k]
         a_unit = getattr(av, "unit", None)
@@ -119,12 +122,7 @@ def equivalent(
             a_unit is not None and not u.is_unit_convertible(b_unit, a_unit)
         ):
             return jnp.zeros((), dtype=bool)
-        checks.append(
-            jnp.isclose(_strip(av, a_unit), _strip(bv, a_unit), rtol=rtol, atol=atol)
+        result = result & jnp.isclose(
+            _strip(av, a_unit), _strip(bv, a_unit), rtol=rtol, atol=atol
         )
-    # A 0-dimensional Cartesian chart has no components: every point is the same
-    # (the single point of the space), so equivalence is vacuously ``True``,
-    # broadcast over the batch shape.
-    if not checks:
-        return jnp.ones(ac.shape, dtype=bool)
-    return jnp.all(jnp.stack(jnp.broadcast_arrays(*checks)), axis=0)
+    return result

--- a/src/coordinax/vectors/_src/register_compare.py
+++ b/src/coordinax/vectors/_src/register_compare.py
@@ -24,6 +24,7 @@ from plum import dispatch
 import quaxed.numpy as jnp
 import unxt as u
 
+import coordinax.representations as cxr
 from .base import AbstractVector
 
 
@@ -84,6 +85,18 @@ def equivalent(
     False
 
     """
+    # ``equivalent`` is a same-*point* relation, so it is meaningful only for
+    # point-geometry vectors (a `Point`, a `Coordinate`).  A `Tangent` denotes a
+    # displacement, not a point -- and cannot even be re-expressed in Cartesian
+    # without a base point (``to_cartesian`` would raise) -- so any non-point or
+    # cross-geometry pair is never "the same point": scalar ``False``, and this
+    # guard also keeps the promise that ``equivalent`` never raises.
+    if not (
+        isinstance(a.rep.geom_kind, cxr.PointGeometry)
+        and isinstance(b.rep.geom_kind, cxr.PointGeometry)
+    ):
+        return jnp.zeros((), dtype=bool)
+
     # Coordinates in different frames describe different physical points.  Chart
     # and frame are static metadata, so this is a plain Python bool -- safe under
     # ``jit`` and mirroring the guard in ``AbstractVector.__eq__``.

--- a/src/coordinax/vectors/_src/register_compare.py
+++ b/src/coordinax/vectors/_src/register_compare.py
@@ -20,7 +20,7 @@ __all__: tuple[str, ...] = ("equivalent",)
 from typing import Any
 
 import jax.tree as jtu
-from plum import dispatch
+import plum
 
 import quaxed.numpy as jnp
 import unxt as u
@@ -30,7 +30,7 @@ import coordinax.representations as cxr
 from .base import AbstractVector
 
 
-@dispatch
+@plum.dispatch
 def equivalent(
     a: AbstractVector,
     b: AbstractVector,

--- a/src/coordinax/vectors/_src/register_compare.py
+++ b/src/coordinax/vectors/_src/register_compare.py
@@ -122,4 +122,9 @@ def equivalent(
         checks.append(
             jnp.isclose(_strip(av, a_unit), _strip(bv, a_unit), rtol=rtol, atol=atol)
         )
+    # A 0-dimensional Cartesian chart has no components: every point is the same
+    # (the single point of the space), so equivalence is vacuously ``True``,
+    # broadcast over the batch shape.
+    if not checks:
+        return jnp.ones(ac.shape, dtype=bool)
     return jnp.all(jnp.stack(jnp.broadcast_arrays(*checks)), axis=0)

--- a/tests/unit/vectors/test_point.py
+++ b/tests/unit/vectors/test_point.py
@@ -95,3 +95,47 @@ class TestPointEquality:
         p1 = cx.Point.from_([1, 2, 3], "km", cxf.alice)
         p2 = cx.Point.from_([1, 2, 3], "km", cxf.alice)
         assert bool(qnp.all(p1 == p2))
+
+
+class TestPointEquivalence:
+    """`equivalent` is chart- and unit-invariant, but frame-strict."""
+
+    def test_equivalent_across_charts(self):
+        """The same point in different charts is equivalent (though ``!=``)."""
+        p1 = cx.Point.from_([1, 2, 3], "m")
+        p2 = p1.cconvert(cxc.sph3d)
+        assert not bool(qnp.all(p1 == p2))  # strict equality distinguishes charts
+        assert bool(qnp.all(cx.equivalent(p1, p2)))
+
+    def test_equivalent_across_units(self):
+        """The same point in different units is equivalent."""
+        p1 = cx.Point.from_([1000.0, 2000.0, 3000.0], "m")
+        p2 = cx.Point.from_([1.0, 2.0, 3.0], "km")
+        assert bool(qnp.all(cx.equivalent(p1, p2)))
+
+    def test_not_equivalent_different_point(self):
+        """Distinct points are not equivalent."""
+        p1 = cx.Point.from_([1, 2, 3], "m")
+        p2 = cx.Point.from_([1, 2, 4], "m")
+        assert not bool(qnp.all(cx.equivalent(p1, p2)))
+
+    def test_equivalent_is_frame_strict(self):
+        """Identical coordinates in different frames are not equivalent."""
+        p1 = cx.Point.from_([1, 2, 3], "km", cxf.alice)
+        p2 = cx.Point.from_([1, 2, 3], "km", cxf.noframe)
+        assert not bool(qnp.all(cx.equivalent(p1, p2)))
+
+    def test_equivalent_elementwise_over_batch(self):
+        """Equivalence is evaluated element-wise over the batch."""
+        p1 = cx.Point.from_([[1.0, 1, 1], [2, 2, 2]], "m")
+        p2 = cx.Point.from_([[1.0, 1, 1], [9, 9, 9]], "m").cconvert(cxc.sph3d)
+        result = cx.equivalent(p1, p2)
+        assert bool(result[0])
+        assert not bool(result[1])
+
+    def test_equivalent_respects_tolerance(self):
+        """`atol`/`rtol` control how close counts as equivalent."""
+        p1 = cx.Point.from_([1.0, 0.0, 0.0], "m")
+        p2 = cx.Point.from_([1.001, 0.0, 0.0], "m")
+        assert not bool(qnp.all(cx.equivalent(p1, p2)))
+        assert bool(qnp.all(cx.equivalent(p1, p2, atol=1e-2)))

--- a/tests/unit/vectors/test_point.py
+++ b/tests/unit/vectors/test_point.py
@@ -154,3 +154,21 @@ class TestPointEquivalence:
         unitless = cx.Point.from_({"x": 1.0, "y": 2.0, "z": 3.0}, cxc.cart3d)
         assert not bool(qnp.all(cx.equivalent(unitful, unitless)))
         assert not bool(qnp.all(cx.equivalent(unitless, unitful)))
+
+    def test_equivalent_per_component_unit_mismatch_is_false(self):
+        """A per-component unitful/unitless mismatch is False, and never raises."""
+        # Leaves may be mixed within a vector: 'y' is unitful on one side only.
+        a = cx.Point.from_({"x": 0.0, "y": 2.0, "z": 0.0}, cxc.cart3d)
+        b = cx.Point.from_({"x": 0.0, "y": u.Q(2.0, "m"), "z": 0.0}, cxc.cart3d)
+        assert not bool(qnp.all(cx.equivalent(a, b)))
+        assert not bool(qnp.all(cx.equivalent(b, a)))
+
+    def test_equivalent_incompatible_dimensions_is_false(self):
+        """Components with incompatible dimensions are not equivalent (no raise)."""
+        a = cx.Point.from_(
+            {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m"), "z": u.Q(0.0, "m")}, cxc.cart3d
+        )
+        b = cx.Point.from_(
+            {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "s"), "z": u.Q(0.0, "m")}, cxc.cart3d
+        )
+        assert not bool(qnp.all(cx.equivalent(a, b)))

--- a/tests/unit/vectors/test_point.py
+++ b/tests/unit/vectors/test_point.py
@@ -147,3 +147,10 @@ class TestPointEquivalence:
         assert bool(qnp.all(cx.equivalent(p1, p2)))
         p3 = cx.Point.from_({"x": 1.0, "y": 2.0, "z": 9.0}, cxc.cart3d)
         assert not bool(qnp.all(cx.equivalent(p1, p3)))
+
+    def test_equivalent_unitful_vs_unitless_is_false(self):
+        """A unitful and a unitless vector are not equivalent, and never raise."""
+        unitful = cx.Point.from_([1.0, 2.0, 3.0], "m")
+        unitless = cx.Point.from_({"x": 1.0, "y": 2.0, "z": 3.0}, cxc.cart3d)
+        assert not bool(qnp.all(cx.equivalent(unitful, unitless)))
+        assert not bool(qnp.all(cx.equivalent(unitless, unitful)))

--- a/tests/unit/vectors/test_point.py
+++ b/tests/unit/vectors/test_point.py
@@ -139,3 +139,11 @@ class TestPointEquivalence:
         p2 = cx.Point.from_([1.001, 0.0, 0.0], "m")
         assert not bool(qnp.all(cx.equivalent(p1, p2)))
         assert bool(qnp.all(cx.equivalent(p1, p2, atol=1e-2)))
+
+    def test_equivalent_unitless_components(self):
+        """Equivalence works for vectors with plain (unitless) array leaves."""
+        p1 = cx.Point.from_({"x": 1.0, "y": 2.0, "z": 3.0}, cxc.cart3d)
+        p2 = cx.Point.from_({"x": 1.0, "y": 2.0, "z": 3.0}, cxc.cart3d)
+        assert bool(qnp.all(cx.equivalent(p1, p2)))
+        p3 = cx.Point.from_({"x": 1.0, "y": 2.0, "z": 9.0}, cxc.cart3d)
+        assert not bool(qnp.all(cx.equivalent(p1, p3)))

--- a/tests/unit/vectors/test_point.py
+++ b/tests/unit/vectors/test_point.py
@@ -9,6 +9,7 @@ import unxt as u
 import coordinax as cx
 import coordinax.charts as cxc
 import coordinax.frames as cxf
+import coordinax.representations as cxr
 import coordinax.transforms as cxfm
 
 
@@ -177,3 +178,26 @@ class TestPointEquivalence:
         """A 0D Cartesian chart has no components: equivalence is vacuously True."""
         p = cx.Point.from_({}, cxc.cart0d, cx.point)
         assert bool(qnp.all(cx.equivalent(p, p)))
+
+    def test_equivalent_cross_geometry_is_false(self):
+        """A Point and a Tangent are never equivalent, even with matching data."""
+        p = cx.Point.from_([1.0, 2.0, 3.0], "m")
+        # A displacement Tangent with *matching* Cartesian components and units.
+        t = cx.Tangent.from_(
+            {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m"), "z": u.Q(3.0, "m")},
+            cxc.cart3d,
+            cxr.coord_disp,
+        )
+        assert not bool(qnp.all(cx.equivalent(p, t)))
+        assert not bool(qnp.all(cx.equivalent(t, p)))
+
+    def test_equivalent_tangent_never_raises(self):
+        """`equivalent` on non-point (Tangent) vectors returns False, never raises."""
+        t = cx.Tangent.from_(
+            {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")},
+            cxc.cart3d,
+            cxr.coord_vel,
+        )
+        # A Tangent cannot re-chart to Cartesian without a base point, so a naive
+        # implementation would raise; the geometry guard short-circuits to False.
+        assert not bool(qnp.all(cx.equivalent(t, t)))

--- a/tests/unit/vectors/test_point.py
+++ b/tests/unit/vectors/test_point.py
@@ -172,3 +172,8 @@ class TestPointEquivalence:
             {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "s"), "z": u.Q(0.0, "m")}, cxc.cart3d
         )
         assert not bool(qnp.all(cx.equivalent(a, b)))
+
+    def test_equivalent_zero_component_chart_is_true(self):
+        """A 0D Cartesian chart has no components: equivalence is vacuously True."""
+        p = cx.Point.from_({}, cxc.cart0d, cx.point)
+        assert bool(qnp.all(cx.equivalent(p, p)))


### PR DESCRIPTION
Followup to #563.

## Summary

#563 made vector `==` **strict** — equal only when chart, frame, and data all
match. This PR adds `equivalent`, the relaxed, coordinate-free counterpart:

> Do two vectors denote the **same geometric point**?

`equivalent` is invariant to the **chart** and to the component **units**, but
remains **frame-strict** (coordinates in different frames are different physical
points). It is the vector analog of `unxt.equivalent`, which relaxes unit-blind
`==` on quantities to a unit-aware "same physical amount" check.

```python
>>> p   = cx.Point.from_([1., 2., 3.], "m")
>>> sph = p.cconvert(cx.sph3d)
>>> bool(p == sph)            # strict: different chart
False
>>> bool(cx.equivalent(p, sph))
True
>>> bool(cx.equivalent(cx.Point.from_([1., 2., 3.], "km"),
...                     cx.Point.from_([1e6, 2e6, 3e6], "mm")))  # unit-invariant
True
```

## Design

- **Compared in a common Cartesian chart** (`to_cartesian`), which sidesteps
  angle-wrapping and coordinate-singularity issues that make component-wise
  comparison in curvilinear charts unreliable, and keeps the tolerance isotropic.
- **Tolerance-based** (`rtol`, `atol`) — chart transitions are trigonometric and
  √-heavy, so exact equality is fragile. `atol` is measured in the first
  operand's Cartesian component units. Evaluated **element-wise** over the batch,
  mirroring `==`.
- **Frame-strict / chart-guarded**: mismatched frame, or a Cartesian chart of a
  different manifold dimension, returns scalar `False` (mirrors the `__eq__`
  guard from #563), and never raises.
- **No import of `unxt.equivalent`**: registered on the global plum `dispatch`,
  so coordinax's vector overload and unxt's quantity overload coexist on a
  single multiply-dispatched `equivalent` when both packages are present. Works
  standalone against released unxt (which has no `equivalent`) and forward-merges
  when unxt ships one.

## Tests

- `TestPointEquivalence`: chart-invariance, unit-invariance, distinct points,
  frame-strictness, element-wise batching, and tolerance control.
- Doctested examples in the new module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)