### PR TITLE
✨ feat(vectors): add `separation` (manifold-norm distance between points)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2918,6 +2918,64 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
     - This API is for tangent-space geometry. Point-role coordinates should first be converted into a tangent/displacement representation if that is the intended meaning.
     - The angle is defined intrinsically by the metric at the supplied base point and is therefore chart-invariant under valid coordinate changes.
 
+(software-spec-separation)=
+
+!!! info `separation`
+
+    The straight-line distance between two points, as a manifold measurement.
+
+    `separation` is a dispatched function that returns the manifold
+    `~coordinax.manifolds.norm` of the two points' coordinate difference:
+
+    $$
+    \mathrm{separation}(a, b) = \| b - a \|_a,
+    $$
+
+    the Euclidean distance for a flat manifold. It sits alongside `norm` and
+    `angle_between` as the third manifold measurement. `cx.separation` and
+    `cx.manifolds.separation` are the same function object.
+
+    **Signatures:**
+
+    ```
+    # manifold-level (raw data)
+    cxm.separation(chart, a, b, /, *, usys=None)          # component dicts; uses chart.M.metric
+    cxm.separation(metric, chart, a, b, /, *, usys=None)  # explicit metric: norm(b - a) at a
+    cxm.separation(chart, a, b, /, *, usys=None)          # packed unxt.Quantity operands
+    cxm.separation(chart, a, b, /, *, usys=None)          # packed (unitless) Array operands
+
+    # vector-level
+    cx.separation(a, b, /)                                # two coordinax.vectors.Point objects
+    ```
+
+    **Arguments:**
+
+    - `chart`: the coordinate chart in whose components `a` and `b` are expressed.
+    - `metric`: an explicit `AbstractMetricField`; when omitted, `chart.M.metric` is used.
+    - `a`, `b`: the two points, as `CDict` component dicts, packed `unxt.Quantity` / `Array` vectors (trailing axis in `chart.components` order), or — at the vector level — `coordinax.vectors.Point` objects.
+    - `usys` (keyword, optional): unit system forwarded to metric evaluation when needed.
+
+    **Return:**
+
+    - A length result is returned as a `coordinax.distances.Distance`; a dimensionless one as a bare array (or dimensionless `Quantity`).
+    - Dimensionality follows the points' manifold: 2-D points give a 2-D distance, 3-D points a 3-D distance. There is no `separation_3d` — map the points into the target space first, then call `separation`.
+
+    **Dispatch behavior:**
+
+    - The manifold-level overloads measure the norm of the coordinate difference in the given chart (exact for flat manifolds).
+    - The `Point` overload is *frame-strict* (cross-frame raises) and brings both points into a common Cartesian chart before delegating to the manifold-level `separation`, so the result is invariant to the chart and component units each operand happens to use.
+
+    **Examples**
+
+    ```pycon
+    >>> import coordinax as cx
+
+    >>> p = cx.Point.from_([3.0, 0.0, 0.0], "m")
+    >>> q = cx.Point.from_([0.0, 4.0, 0.0], "m")
+    >>> cx.separation(p, q).round(2)
+    Distance(5., 'm')
+    ```
+
 (software-spec-abstractatlas)=
 
 !!! info `AbstractAtlas`

--- a/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
+++ b/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
@@ -10,6 +10,7 @@ __all__ = (
     "pt_project",
     "pt_map",
     "norm",
+    "separation",
 )
 
 from typing import TYPE_CHECKING, Any
@@ -63,6 +64,20 @@ def scale_factors(chart: Any, /, *args: Any, **kwargs: Any) -> Any:
     """Return the diagonal entries of the metric matrix.
 
     Dispatches on the first argument (metric or manifold) and the chart.
+    """
+    raise NotImplementedError  # pragma: no cover
+
+
+@plum.dispatch.abstract
+def separation(*args: Any, **kwargs: Any) -> Any:
+    """Distance between two points on a manifold.
+
+    The straight-line distance is the manifold `norm` of the two points'
+    coordinate difference, evaluated in the chart they are given in (exact for a
+    flat manifold).  Dispatches on the inputs: two `~coordinax.vectors.Point`
+    objects (chart/frame extracted automatically), or a ``chart`` / ``metric``
+    together with the two points as component dictionaries, packed quantities,
+    or bare arrays.
     """
     raise NotImplementedError  # pragma: no cover
 

--- a/packages/coordinaxs.hypothesis/docs/plum-dispatch-hypothesis-guide.md
+++ b/packages/coordinaxs.hypothesis/docs/plum-dispatch-hypothesis-guide.md
@@ -6,7 +6,7 @@ The patterns here are taken from integration coverage in `packages/coordinaxs.hy
 
 ## Why Combine Them?
 
-- `@dispatch` selects behavior from argument types.
+- `@plum.dispatch` selects behavior from argument types.
 - `@st.composite` lets a strategy perform dependent draws.
 
 Together, you can build one strategy name with multiple typed overloads while still getting the flexibility of composite draws.
@@ -16,17 +16,17 @@ Together, you can build one strategy name with multiple typed overloads while st
 Use this order:
 
 ```python
+import plum
 from hypothesis import strategies as st
-from plum import dispatch
 
 
-@dispatch
+@plum.dispatch
 @st.composite
 def bounded_value(draw, x: int):
     return draw(st.integers(min_value=x, max_value=x + 10))
 
 
-@dispatch
+@plum.dispatch
 @st.composite
 def bounded_value(draw, x: float):
     return draw(st.floats(min_value=x, max_value=x + 1.0, allow_nan=False))
@@ -45,7 +45,7 @@ Annotating `draw` (for example `draw: Any`) does not change dispatch behavior. `
 from typing import Any
 
 
-@dispatch
+@plum.dispatch
 @st.composite
 def annotated_draw(draw: Any, x: int):
     return draw(st.integers(min_value=x, max_value=x + 10))
@@ -70,13 +70,13 @@ Use normal runtime type objects in annotations instead.
 You can dispatch on multiple typed positional arguments:
 
 ```python
-@dispatch
+@plum.dispatch
 @st.composite
 def interval_value(draw, lo: int, hi: int):
     return draw(st.integers(min_value=lo, max_value=hi))
 
 
-@dispatch
+@plum.dispatch
 @st.composite
 def interval_value(draw, lo: float, hi: float):
     return draw(st.floats(min_value=lo, max_value=hi, allow_nan=False))
@@ -92,25 +92,21 @@ Plum picks the most specific matching overload in a type hierarchy.
 from numbers import Number, Real
 
 
-@dispatch
+@plum.dispatch
 @st.composite
 def typed_number(draw, x: Number):
     return draw(st.floats(min_value=0.0, max_value=1.0, allow_nan=False))
 
 
-@dispatch
+@plum.dispatch
 @st.composite
 def typed_number(draw, x: Real):
     return draw(
-        st.floats(
-            min_value=float(x) - 1.0,
-            max_value=float(x) + 1.0,
-            allow_nan=False,
-        )
+        st.floats(min_value=float(x) - 1.0, max_value=float(x) + 1.0, allow_nan=False)
     )
 
 
-@dispatch
+@plum.dispatch
 @st.composite
 def typed_number(draw, x: int):
     return draw(st.integers(min_value=x, max_value=x + 5))
@@ -123,13 +119,13 @@ Calling `typed_number(10)` selects the `int` overload, not the broader `Real`/`N
 Homogeneous varargs dispatch is supported:
 
 ```python
-@dispatch
+@plum.dispatch
 @st.composite
 def multi_bounded(draw, *xs: int):
     return [draw(st.integers(min_value=x, max_value=x + 10)) for x in xs]
 
 
-@dispatch
+@plum.dispatch
 @st.composite
 def multi_bounded(draw, *xs: float):
     return [
@@ -144,12 +140,12 @@ This works only when all positional varargs match one element type. Mixed types 
 For mixed inputs, dispatch per element inside a single composite strategy:
 
 ```python
-@dispatch
+@plum.dispatch
 def _element_strategy(x: int):
     return st.integers(min_value=x, max_value=x + 10)
 
 
-@dispatch
+@plum.dispatch
 def _element_strategy(x: float):
     return st.floats(min_value=x, max_value=x + 1.0, allow_nan=False)
 

--- a/src/coordinax/__init__.py
+++ b/src/coordinax/__init__.py
@@ -87,6 +87,7 @@ __all__ = (  # distances
     "Tangent",
     "ToUnitsOptions",
     "equivalent",
+    "separation",
 )
 
 import warnings
@@ -181,6 +182,7 @@ from coordinax.vectors import (
     Tangent,
     ToUnitsOptions,
     equivalent,
+    separation,
 )
 
 # ============================================================================

--- a/src/coordinax/__init__.py
+++ b/src/coordinax/__init__.py
@@ -35,6 +35,7 @@ __all__ = (  # distances
     "EmbeddedManifold",
     "CustomAtlas",
     "CustomManifold",
+    "separation",
     # frames -- frames
     "noframe",
     # frame -- transforms
@@ -130,6 +131,7 @@ from coordinax.manifolds import (
     FlatMetric,
     Rn,
     embedded_twosphere,
+    separation,
 )
 from coordinax.representations import (
     AbstractLinearBasis,

--- a/src/coordinax/_src/manifolds/__init__.py
+++ b/src/coordinax/_src/manifolds/__init__.py
@@ -6,3 +6,4 @@ from .angle_between import *
 from .guess import *
 from .norm import *
 from .scale_factors import *
+from .separation import *

--- a/src/coordinax/_src/manifolds/separation.py
+++ b/src/coordinax/_src/manifolds/separation.py
@@ -1,0 +1,139 @@
+"""Dispatch implementations for `coordinaxs.api.manifolds.separation`.
+
+The straight-line distance between two points is the manifold
+`~coordinax.manifolds.norm` of their coordinate difference, evaluated in the
+chart they are given in.  This is exact for a flat manifold (e.g. the Euclidean
+distance in a Cartesian chart); in a curvilinear chart it is the norm of the
+coordinate difference at the first point, not the geodesic distance, so bring
+the points into a Cartesian chart first (as the `~coordinax.vectors.Point`
+overload does) for a chart-invariant result.
+"""
+
+__all__: tuple[str, ...] = ()
+
+from jaxtyping import Array
+from typing import Any
+
+import plum
+
+import unxt as u
+
+import coordinax.distances as cxd
+import coordinaxs.api.charts as cxcapi
+import coordinaxs.api.manifolds as cxmapi
+from coordinax._src.base import AbstractChart, AbstractMetricField
+from coordinax._src.custom_types import CDict, OptUSys
+
+_LENGTH = u.dimension("length")
+
+
+def _as_distance(dist: Any) -> Any:
+    """Wrap a length magnitude as a `Distance`; pass anything else through."""
+    if hasattr(dist, "unit") and u.dimension_of(dist) == _LENGTH:
+        return cxd.Distance.from_(dist)
+    return dist
+
+
+@plum.dispatch
+def separation(
+    chart: AbstractChart, a: CDict, b: CDict, /, *, usys: OptUSys = None
+) -> Any:
+    """Distance between two points, using the chart manifold's metric.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> a = {"x": u.Q(3.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> b = {"x": u.Q(0.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+    >>> cxm.separation(cxc.cart3d, a, b).round(2)
+    Distance(5., 'm')
+
+    """
+    return cxmapi.separation(chart.M.metric, chart, a, b, usys=usys)
+
+
+@plum.dispatch
+def separation(
+    metric: AbstractMetricField,
+    chart: AbstractChart,
+    a: CDict,
+    b: CDict,
+    /,
+    *,
+    usys: OptUSys = None,
+) -> Any:
+    """Distance between two points with respect to an explicit metric.
+
+    The distance is the `~coordinax.manifolds.norm` of ``b - a`` (evaluated at
+    ``a``); a length result is returned as a `Distance`, a dimensionless one as a
+    bare array.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> metric = cxm.FlatMetric(3)
+    >>> a = {"x": u.Q(3.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> b = {"x": u.Q(0.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+    >>> cxm.separation(metric, cxc.cart3d, a, b).round(2)
+    Distance(5., 'm')
+
+    """
+    chart.check_data(a, keys=True, values=False)
+    chart.check_data(b, keys=True, values=False)
+    diff = {k: b[k] - a[k] for k in chart.components}
+    return _as_distance(cxmapi.norm(diff, metric, chart, at=a, usys=usys))
+
+
+@plum.dispatch
+def separation(
+    chart: AbstractChart,
+    a: u.AbstractQuantity,
+    b: u.AbstractQuantity,
+    /,
+    *,
+    usys: OptUSys = None,
+) -> Any:
+    """Distance between two points given as packed `unxt.Quantity` vectors.
+
+    Each quantity's trailing axis holds the components in ``chart.components``
+    order; it is unpacked into a component dictionary and delegated to the
+    ``CDict`` overload.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> a = u.Q([3.0, 0.0, 0.0], "m")
+    >>> b = u.Q([0.0, 4.0, 0.0], "m")
+    >>> cxm.separation(cxc.cart3d, a, b).round(2)
+    Distance(5., 'm')
+
+    """
+    return cxmapi.separation(
+        chart, cxcapi.cdict(a, chart), cxcapi.cdict(b, chart), usys=usys
+    )
+
+
+@plum.dispatch
+def separation(
+    chart: AbstractChart, a: Array, b: Array, /, *, usys: OptUSys = None
+) -> Any:
+    """Distance between two points given as packed (unitless) arrays.
+
+    The trailing axis holds the components in ``chart.components`` order.
+
+    >>> import jax.numpy as jnp
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> a = jnp.array([3.0, 0.0, 0.0])
+    >>> b = jnp.array([0.0, 4.0, 0.0])
+    >>> float(cxm.separation(cxc.cart3d, a, b))
+    5.0
+
+    """
+    return cxmapi.separation(
+        chart, cxcapi.cdict(a, chart), cxcapi.cdict(b, chart), usys=usys
+    )

--- a/src/coordinax/manifolds.py
+++ b/src/coordinax/manifolds.py
@@ -11,6 +11,7 @@ __all__ = (
     "metric_matrix",
     "metric_representation",
     "norm",
+    "separation",
     # Abstract Manifold/Atlas/Metric
     "AbstractAtlas",
     "AbstractMetricField",
@@ -140,6 +141,7 @@ with install_import_hook("coordinax.manifolds"):
         pt_embed,
         pt_project,
         scale_factors,
+        separation,
     )
 
 

--- a/src/coordinax/vectors/__init__.py
+++ b/src/coordinax/vectors/__init__.py
@@ -3,6 +3,7 @@
 __all__ = (
     "cconvert",
     "equivalent",
+    "separation",
     "AbstractVector",
     "Point",
     "Coordinate",
@@ -20,6 +21,7 @@ with install_import_hook("coordinax.vectors"):
         Tangent,
         ToUnitsOptions,
         equivalent,
+        separation,
     )
     from coordinaxs.api.representations import cconvert
 

--- a/src/coordinax/vectors/_src/__init__.py
+++ b/src/coordinax/vectors/_src/__init__.py
@@ -11,6 +11,7 @@ from .register_compare import *
 from .register_cx import *
 from .register_dataclassish import *
 from .register_quax import *
+from .register_separation import *
 from .register_unxt import *
 from .tangent import *
 from .utils import *

--- a/src/coordinax/vectors/_src/register_separation.py
+++ b/src/coordinax/vectors/_src/register_separation.py
@@ -1,0 +1,123 @@
+"""Separation (distance) between vectors.
+
+Two metrics, modelled on `astropy.coordinates.SkyCoord.separation` /
+``separation_3d``:
+
+- :func:`separation_3d` -- the straight-line (Euclidean, embedded-Cartesian)
+  distance between two points, returned as a `Distance`.
+- :func:`separation` -- the angular separation between the two directions as
+  seen from the origin, returned as an `Angle`.
+
+Both are chart- and unit-invariant: the operands are brought into a common
+Cartesian chart before measuring.  They are *frame-strict* -- coordinates in
+different frames describe different physical points, so a cross-frame separation
+is undefined and raises; align the operands with `to_frame` first.
+"""
+
+__all__ = ("separation", "separation_3d")
+
+from jaxtyping import Array
+from typing import Any
+
+from plum import dispatch
+
+import quaxed.numpy as jnp
+
+from .base import AbstractVector
+from coordinax.angles import Angle
+from coordinax.distances import Distance
+
+
+def _cartesian_components(
+    a: AbstractVector, b: AbstractVector
+) -> tuple[Array, Array, Any]:
+    """Return ``a`` and ``b`` as stacked Cartesian arrays in a shared unit.
+
+    Guards that the two vectors share a frame and a Cartesian chart, then strips
+    every component to the first operand's unit so the results are plain arrays
+    ready for elementwise arithmetic.
+    """
+    if a.frame != b.frame:
+        msg = "cannot measure separation between vectors in different frames"
+        raise ValueError(msg)
+
+    ac = a.to_cartesian()
+    bc = b.to_cartesian()
+    if ac.chart != bc.chart:
+        msg = "cannot measure separation between vectors on different manifolds"
+        raise ValueError(msg)
+
+    unit = next(iter(ac.data.values())).unit
+    ca = jnp.stack([ac.data[k].ustrip(unit) for k in ac.data])
+    cb = jnp.stack([bc.data[k].ustrip(unit) for k in ac.data])
+    return ca, cb, unit
+
+
+@dispatch
+def separation_3d(a: AbstractVector, b: AbstractVector, /) -> Distance:
+    """Straight-line distance between two points.
+
+    The Euclidean distance between the points in their common Cartesian chart,
+    invariant to the chart and component units of either operand.
+
+    Examples
+    --------
+    >>> import coordinax as cx
+    >>> import coordinax.charts as cxc
+
+    A 3-4-5 right triangle:
+
+    >>> p = cx.Point.from_([3.0, 0.0, 0.0], "m")
+    >>> q = cx.Point.from_([0.0, 4.0, 0.0], "m")
+    >>> cx.separation_3d(p, q).round(2)
+    Distance(5., 'm')
+
+    Chart- and unit-invariant -- the same points expressed differently give the
+    same distance:
+
+    >>> cx.separation_3d(p, q.cconvert(cxc.sph3d)).round(2)
+    Distance(5., 'm')
+    >>> q_km = cx.Point.from_([0.0, 0.004, 0.0], "km")
+    >>> cx.separation_3d(p, q_km).uconvert("m").round(2)
+    Distance(5., 'm')
+
+    """
+    ca, cb, unit = _cartesian_components(a, b)
+    d = ca - cb
+    return Distance(jnp.sqrt(jnp.sum(d**2, axis=0)), unit)
+
+
+@dispatch
+def separation(a: AbstractVector, b: AbstractVector, /) -> Angle:
+    """Angular separation between two directions.
+
+    The angle subtended at the origin by the two points, computed in their
+    common Cartesian chart with a numerically stable, dimension-agnostic
+    formula (no cross product), and invariant to chart and component units.
+
+    Examples
+    --------
+    >>> import coordinax as cx
+    >>> import coordinax.charts as cxc
+
+    Two orthogonal directions are 90 degrees apart:
+
+    >>> p = cx.Point.from_([3.0, 0.0, 0.0], "m")
+    >>> q = cx.Point.from_([0.0, 4.0, 0.0], "m")
+    >>> cx.separation(p, q).uconvert("deg").round(2)
+    Angle(90., 'deg')
+
+    Chart-invariant:
+
+    >>> cx.separation(p, q.cconvert(cxc.sph3d)).uconvert("deg").round(2)
+    Angle(90., 'deg')
+
+    """
+    ca, cb, _ = _cartesian_components(a, b)
+    ua = ca / jnp.sqrt(jnp.sum(ca**2, axis=0))
+    ub = cb / jnp.sqrt(jnp.sum(cb**2, axis=0))
+    # theta = 2 * atan2(|uhat - vhat|, |uhat + vhat|): stable for all angles and
+    # any dimension, unlike arccos(dot) which loses precision near 0 and pi.
+    sub = jnp.sqrt(jnp.sum((ua - ub) ** 2, axis=0))
+    add = jnp.sqrt(jnp.sum((ua + ub) ** 2, axis=0))
+    return Angle(2.0 * jnp.arctan2(sub, add), "rad")

--- a/src/coordinax/vectors/_src/register_separation.py
+++ b/src/coordinax/vectors/_src/register_separation.py
@@ -1,34 +1,30 @@
-"""Separation (distance) between vectors.
+"""`separation` dispatch for vector-like objects.
 
-:func:`separation` measures the straight-line distance between two points using
-the manifold's `~coordinax.manifolds.norm`.  The *geometry* is the manifold's:
-the distance is computed in the points' own (Cartesian) chart, so it is the
-Euclidean distance for a flat manifold, and its dimensionality follows the
-points' manifold (2-D points give a 2-D distance, 3-D points a 3-D distance).
-To measure across a different-dimensional or projected space, map the points
-into that space first, then call :func:`separation`.
+This registers the `~coordinax.vectors.Point` (``AbstractVector``) overload of
+`coordinaxs.api.manifolds.separation`.  The distance itself is a manifold
+measurement -- see `coordinax._src.manifolds.separation` for the ``chart`` /
+``metric`` + component-dict / quantity / array overloads.  Here the two points
+are brought into a common Cartesian chart (so the result is invariant to the
+chart and component units each operand happens to use) and the measurement is
+delegated to the manifold-level `separation`.
 
 It is *frame-strict*: coordinates in different frames describe different physical
 points, so a cross-frame separation is undefined and raises; align the operands
 with `to_frame` first.
 """
 
-__all__: tuple[str, ...] = ("separation",)
+__all__: tuple[str, ...] = ()
 
 from typing import Any
 
 from plum import dispatch
 
-import unxt as u
-
+import coordinaxs.api.manifolds as cxmapi
 from .base import AbstractVector
-from coordinax.distances import Distance
-
-_LENGTH = u.dimension("length")
 
 
 @dispatch
-def separation(a: AbstractVector, b: AbstractVector, /) -> Distance | Any:
+def separation(a: AbstractVector, b: AbstractVector, /) -> Any:
     """Distance between two points, via the manifold norm.
 
     The two points are brought into a common Cartesian chart (so the result is
@@ -82,12 +78,4 @@ def separation(a: AbstractVector, b: AbstractVector, /) -> Distance | Any:
         msg = "cannot measure separation between vectors on different manifolds"
         raise ValueError(msg)
 
-    # Difference built per component so it works for both ``unxt.Quantity`` and
-    # plain-array (unitless) leaves, then measured with the manifold's norm.
-    diff = {k: bc.data[k] - ac.data[k] for k in ac.data}
-    dist = ac.M.norm(diff, ac.chart, at=ac.data)
-
-    # A length is a ``Distance``; a dimensionless magnitude is returned as-is.
-    if hasattr(dist, "unit") and u.dimension_of(dist) == _LENGTH:
-        return Distance.from_(dist)  # ty: ignore[invalid-return-type]
-    return dist
+    return cxmapi.separation(ac.chart, ac.data, bc.data)

--- a/src/coordinax/vectors/_src/register_separation.py
+++ b/src/coordinax/vectors/_src/register_separation.py
@@ -105,6 +105,10 @@ def separation(a: AbstractVector, b: AbstractVector, /) -> Angle:
     common Cartesian chart with a numerically stable, dimension-agnostic
     formula (no cross product), and invariant to chart and component units.
 
+    A vector *at* the origin has no direction, so its angular separation is
+    undefined; the result is ``nan`` (rather than raising, so the function
+    stays ``jit``/``vmap`` friendly).
+
     Examples
     --------
     >>> import coordinax as cx

--- a/src/coordinax/vectors/_src/register_separation.py
+++ b/src/coordinax/vectors/_src/register_separation.py
@@ -1,6 +1,6 @@
 """`separation` dispatch for vector-like objects.
 
-This registers the `~coordinax.vectors.Point` (``AbstractVector``) overload of
+This registers the `~coordinax.vectors.Point` overload of
 `coordinaxs.api.manifolds.separation`.  The distance itself is a manifold
 measurement -- see `coordinax._src.manifolds.separation` for the ``chart`` /
 ``metric`` + component-dict / quantity / array overloads.  Here the two points
@@ -13,18 +13,18 @@ points, so a cross-frame separation is undefined and raises; align the operands
 with `to_frame` first.
 """
 
-__all__: tuple[str, ...] = ()
+__all__: tuple[str, ...] = ("separation",)
 
 from typing import Any
 
 from plum import dispatch
 
 import coordinaxs.api.manifolds as cxmapi
-from .base import AbstractVector
+from .point import Point
 
 
 @dispatch
-def separation(a: AbstractVector, b: AbstractVector, /) -> Any:
+def separation(a: Point, b: Point, /) -> Any:
     """Distance between two points, via the manifold norm.
 
     The two points are brought into a common Cartesian chart (so the result is

--- a/src/coordinax/vectors/_src/register_separation.py
+++ b/src/coordinax/vectors/_src/register_separation.py
@@ -16,28 +16,28 @@ is undefined and raises; align the operands with `to_frame` first.
 
 __all__ = ("separation", "separation_3d")
 
-from jaxtyping import Array
-from typing import Any
-
-from plum import dispatch
+from plum import convert, dispatch
 
 import quaxed.numpy as jnp
+import unxt as u
 
 from .base import AbstractVector
 from coordinax.angles import Angle
 from coordinax.distances import Distance
 
+_LENGTH = u.dimension("length")
+
 
 def _cartesian_components(
     a: AbstractVector, b: AbstractVector
-) -> tuple[Array, Array, Any]:
-    """Return ``a`` and ``b`` as stacked Cartesian arrays in a shared unit.
+) -> tuple[u.AbstractQuantity, u.AbstractQuantity]:
+    """Return ``a`` and ``b`` as Cartesian `unxt.Quantity` vectors.
 
-    Guards that the two vectors share a frame and a Cartesian chart, then strips
-    every component to the first operand's unit so the results are plain arrays
-    ready for elementwise arithmetic.  Component leaves may be `unxt.Quantity`
-    objects (unitful vectors) or plain JAX arrays (unitless vectors); the shared
-    unit is ``None`` in the latter case.
+    Guards that the two vectors share a frame and a Cartesian chart, then
+    converts each to a single `unxt.Quantity` (components stacked on the last
+    axis) via the registered ``plum`` conversion.  Unit-aware `unxt.Quantity`
+    arithmetic then makes the downstream measures chart- and unit-invariant with
+    no manual per-component unit handling.
     """
     if a.frame != b.frame:
         msg = "cannot measure separation between vectors in different frames"
@@ -49,23 +49,19 @@ def _cartesian_components(
         msg = "cannot measure separation between vectors on different manifolds"
         raise ValueError(msg)
 
-    unit = getattr(next(iter(ac.data.values())), "unit", None)
-
-    def _strip(leaf: Any) -> Array:
-        return leaf.ustrip(unit) if hasattr(leaf, "ustrip") else jnp.asarray(leaf)
-
-    ca = jnp.stack([_strip(ac.data[k]) for k in ac.data])
-    cb = jnp.stack([_strip(bc.data[k]) for k in ac.data])
-    return ca, cb, unit
+    return convert(ac, u.Quantity), convert(bc, u.Quantity)
 
 
 @dispatch
-def separation_3d(a: AbstractVector, b: AbstractVector, /) -> Distance | Array:
+def separation_3d(
+    a: AbstractVector, b: AbstractVector, /
+) -> Distance | u.AbstractQuantity:
     """Straight-line distance between two points.
 
     The Euclidean distance between the points in their common Cartesian chart,
     invariant to the chart and component units of either operand.  Returns a
-    `Distance` for unitful vectors, or a bare JAX array for unitless ones.
+    `Distance` for unitful vectors, or a dimensionless `unxt.Quantity` for
+    unitless ones (a dimensionless magnitude is not a `Distance`).
 
     Examples
     --------
@@ -89,12 +85,11 @@ def separation_3d(a: AbstractVector, b: AbstractVector, /) -> Distance | Array:
     Distance(5., 'm')
 
     """
-    ca, cb, unit = _cartesian_components(a, b)
-    d = ca - cb
-    dist = jnp.sqrt(jnp.sum(d**2, axis=0))
-    # Unitless vectors have no length dimension for a ``Distance``; return the
-    # bare magnitude instead.
-    return dist if unit is None else Distance(dist, unit)
+    d = _cartesian_components(a, b)
+    dist = jnp.sqrt(jnp.sum((d[0] - d[1]) ** 2, axis=-1))
+    if u.dimension_of(dist) == _LENGTH:
+        return Distance.from_(dist)  # ty: ignore[invalid-return-type]
+    return dist  # ty: ignore[invalid-return-type]
 
 
 @dispatch
@@ -127,11 +122,11 @@ def separation(a: AbstractVector, b: AbstractVector, /) -> Angle:
     Angle(90., 'deg')
 
     """
-    ca, cb, _ = _cartesian_components(a, b)
-    ua = ca / jnp.sqrt(jnp.sum(ca**2, axis=0))
-    ub = cb / jnp.sqrt(jnp.sum(cb**2, axis=0))
+    qa, qb = _cartesian_components(a, b)
+    ua = qa / jnp.sqrt(jnp.sum(qa**2, axis=-1, keepdims=True))
+    ub = qb / jnp.sqrt(jnp.sum(qb**2, axis=-1, keepdims=True))
     # theta = 2 * atan2(|uhat - vhat|, |uhat + vhat|): stable for all angles and
     # any dimension, unlike arccos(dot) which loses precision near 0 and pi.
-    sub = jnp.sqrt(jnp.sum((ua - ub) ** 2, axis=0))
-    add = jnp.sqrt(jnp.sum((ua + ub) ** 2, axis=0))
-    return Angle(2.0 * jnp.arctan2(sub, add), "rad")
+    sub = jnp.sqrt(jnp.sum((ua - ub) ** 2, axis=-1))
+    add = jnp.sqrt(jnp.sum((ua + ub) ** 2, axis=-1))
+    return Angle.from_(2.0 * jnp.arctan2(sub, add))  # ty: ignore[invalid-return-type]

--- a/src/coordinax/vectors/_src/register_separation.py
+++ b/src/coordinax/vectors/_src/register_separation.py
@@ -17,13 +17,13 @@ __all__: tuple[str, ...] = ("separation",)
 
 from typing import Any
 
-from plum import dispatch
+import plum
 
 import coordinaxs.api.manifolds as cxmapi
 from .point import Point
 
 
-@dispatch
+@plum.dispatch
 def separation(a: Point, b: Point, /) -> Any:
     """Distance between two points, via the manifold norm.
 

--- a/src/coordinax/vectors/_src/register_separation.py
+++ b/src/coordinax/vectors/_src/register_separation.py
@@ -1,43 +1,76 @@
 """Separation (distance) between vectors.
 
-Two metrics, modelled on `astropy.coordinates.SkyCoord.separation` /
-``separation_3d``:
+:func:`separation` measures the straight-line distance between two points using
+the manifold's `~coordinax.manifolds.norm`.  The *geometry* is the manifold's:
+the distance is computed in the points' own (Cartesian) chart, so it is the
+Euclidean distance for a flat manifold, and its dimensionality follows the
+points' manifold (2-D points give a 2-D distance, 3-D points a 3-D distance).
+To measure across a different-dimensional or projected space, map the points
+into that space first, then call :func:`separation`.
 
-- :func:`separation_3d` -- the straight-line (Euclidean, embedded-Cartesian)
-  distance between two points, returned as a `Distance`.
-- :func:`separation` -- the angular separation between the two directions as
-  seen from the origin, returned as an `Angle`.
-
-Both are chart- and unit-invariant: the operands are brought into a common
-Cartesian chart before measuring.  They are *frame-strict* -- coordinates in
-different frames describe different physical points, so a cross-frame separation
-is undefined and raises; align the operands with `to_frame` first.
+It is *frame-strict*: coordinates in different frames describe different physical
+points, so a cross-frame separation is undefined and raises; align the operands
+with `to_frame` first.
 """
 
-__all__ = ("separation", "separation_3d")
+__all__: tuple[str, ...] = ("separation",)
 
-from plum import convert, dispatch
+from typing import Any
 
-import quaxed.numpy as jnp
+from plum import dispatch
+
 import unxt as u
 
 from .base import AbstractVector
-from coordinax.angles import Angle
 from coordinax.distances import Distance
 
 _LENGTH = u.dimension("length")
 
 
-def _cartesian_components(
-    a: AbstractVector, b: AbstractVector
-) -> tuple[u.AbstractQuantity, u.AbstractQuantity]:
-    """Return ``a`` and ``b`` as Cartesian `unxt.Quantity` vectors.
+@dispatch
+def separation(a: AbstractVector, b: AbstractVector, /) -> Distance | Any:
+    """Distance between two points, via the manifold norm.
 
-    Guards that the two vectors share a frame and a Cartesian chart, then
-    converts each to a single `unxt.Quantity` (components stacked on the last
-    axis) via the registered ``plum`` conversion.  Unit-aware `unxt.Quantity`
-    arithmetic then makes the downstream measures chart- and unit-invariant with
-    no manual per-component unit handling.
+    The two points are brought into a common Cartesian chart (so the result is
+    invariant to the chart and component units each operand happens to use), and
+    the distance is the manifold `~coordinax.manifolds.norm` of their coordinate
+    difference -- the Euclidean distance for a flat manifold.  A length result is
+    returned as a `Distance`; a unitless (dimensionless) result is returned as a
+    bare array.
+
+    Dimensionality follows the points' manifold: 2-D points give a 2-D distance,
+    3-D points a 3-D distance.  There is no ``separation_3d`` -- to measure in a
+    particular N-D space, map the points into it first, then call `separation`.
+
+    Examples
+    --------
+    >>> import coordinax as cx
+    >>> import coordinax.charts as cxc
+
+    A 3-4-5 right triangle:
+
+    >>> p = cx.Point.from_([3.0, 0.0, 0.0], "m")
+    >>> q = cx.Point.from_([0.0, 4.0, 0.0], "m")
+    >>> cx.separation(p, q).round(2)
+    Distance(5., 'm')
+
+    Chart- and unit-invariant -- the same points expressed differently give the
+    same distance:
+
+    >>> cx.separation(p, q.cconvert(cxc.sph3d)).round(2)
+    Distance(5., 'm')
+    >>> q_km = cx.Point.from_([0.0, 0.004, 0.0], "km")
+    >>> cx.separation(p, q_km).uconvert("m").round(2)
+    Distance(5., 'm')
+
+    The distance lives on the points' manifold, so 2-D points give a 2-D
+    distance:
+
+    >>> p2 = cx.Point.from_([3.0, 0.0], "m")
+    >>> q2 = cx.Point.from_([0.0, 4.0], "m")
+    >>> cx.separation(p2, q2).round(2)
+    Distance(5., 'm')
+
     """
     if a.frame != b.frame:
         msg = "cannot measure separation between vectors in different frames"
@@ -49,84 +82,12 @@ def _cartesian_components(
         msg = "cannot measure separation between vectors on different manifolds"
         raise ValueError(msg)
 
-    return convert(ac, u.Quantity), convert(bc, u.Quantity)
+    # Difference built per component so it works for both ``unxt.Quantity`` and
+    # plain-array (unitless) leaves, then measured with the manifold's norm.
+    diff = {k: bc.data[k] - ac.data[k] for k in ac.data}
+    dist = ac.M.norm(diff, ac.chart, at=ac.data)
 
-
-@dispatch
-def separation_3d(
-    a: AbstractVector, b: AbstractVector, /
-) -> Distance | u.AbstractQuantity:
-    """Straight-line distance between two points.
-
-    The Euclidean distance between the points in their common Cartesian chart,
-    invariant to the chart and component units of either operand.  Returns a
-    `Distance` for unitful vectors, or a dimensionless `unxt.Quantity` for
-    unitless ones (a dimensionless magnitude is not a `Distance`).
-
-    Examples
-    --------
-    >>> import coordinax as cx
-    >>> import coordinax.charts as cxc
-
-    A 3-4-5 right triangle:
-
-    >>> p = cx.Point.from_([3.0, 0.0, 0.0], "m")
-    >>> q = cx.Point.from_([0.0, 4.0, 0.0], "m")
-    >>> cx.separation_3d(p, q).round(2)
-    Distance(5., 'm')
-
-    Chart- and unit-invariant -- the same points expressed differently give the
-    same distance:
-
-    >>> cx.separation_3d(p, q.cconvert(cxc.sph3d)).round(2)
-    Distance(5., 'm')
-    >>> q_km = cx.Point.from_([0.0, 0.004, 0.0], "km")
-    >>> cx.separation_3d(p, q_km).uconvert("m").round(2)
-    Distance(5., 'm')
-
-    """
-    d = _cartesian_components(a, b)
-    dist = jnp.sqrt(jnp.sum((d[0] - d[1]) ** 2, axis=-1))
-    if u.dimension_of(dist) == _LENGTH:
+    # A length is a ``Distance``; a dimensionless magnitude is returned as-is.
+    if hasattr(dist, "unit") and u.dimension_of(dist) == _LENGTH:
         return Distance.from_(dist)  # ty: ignore[invalid-return-type]
-    return dist  # ty: ignore[invalid-return-type]
-
-
-@dispatch
-def separation(a: AbstractVector, b: AbstractVector, /) -> Angle:
-    """Angular separation between two directions.
-
-    The angle subtended at the origin by the two points, computed in their
-    common Cartesian chart with a numerically stable, dimension-agnostic
-    formula (no cross product), and invariant to chart and component units.
-
-    A vector *at* the origin has no direction, so its angular separation is
-    undefined; the result is ``nan`` (rather than raising, so the function
-    stays ``jit``/``vmap`` friendly).
-
-    Examples
-    --------
-    >>> import coordinax as cx
-    >>> import coordinax.charts as cxc
-
-    Two orthogonal directions are 90 degrees apart:
-
-    >>> p = cx.Point.from_([3.0, 0.0, 0.0], "m")
-    >>> q = cx.Point.from_([0.0, 4.0, 0.0], "m")
-    >>> cx.separation(p, q).uconvert("deg").round(2)
-    Angle(90., 'deg')
-
-    Chart-invariant:
-
-    >>> cx.separation(p, q.cconvert(cxc.sph3d)).uconvert("deg").round(2)
-    Angle(90., 'deg')
-
-    """
-    qa, qb = _cartesian_components(a, b)
-    ua = qa / jnp.sqrt(jnp.sum(qa**2, axis=-1, keepdims=True))
-    ub = qb / jnp.sqrt(jnp.sum(qb**2, axis=-1, keepdims=True))
-    # theta = 2 * atan2(|uhat - vhat|, |uhat + vhat|): stable for all angles and
-    # any dimension, unlike arccos(dot) which loses precision near 0 and pi.
-    sub = jnp.sqrt(jnp.sum((ua - ub) ** 2, axis=-1))
-    add = jnp.sqrt(jnp.sum((ua + ub) ** 2, axis=-1))
-    return Angle.from_(2.0 * jnp.arctan2(sub, add))  # ty: ignore[invalid-return-type]
+    return dist

--- a/src/coordinax/vectors/_src/register_separation.py
+++ b/src/coordinax/vectors/_src/register_separation.py
@@ -35,7 +35,9 @@ def _cartesian_components(
 
     Guards that the two vectors share a frame and a Cartesian chart, then strips
     every component to the first operand's unit so the results are plain arrays
-    ready for elementwise arithmetic.
+    ready for elementwise arithmetic.  Component leaves may be `unxt.Quantity`
+    objects (unitful vectors) or plain JAX arrays (unitless vectors); the shared
+    unit is ``None`` in the latter case.
     """
     if a.frame != b.frame:
         msg = "cannot measure separation between vectors in different frames"
@@ -47,18 +49,23 @@ def _cartesian_components(
         msg = "cannot measure separation between vectors on different manifolds"
         raise ValueError(msg)
 
-    unit = next(iter(ac.data.values())).unit
-    ca = jnp.stack([ac.data[k].ustrip(unit) for k in ac.data])
-    cb = jnp.stack([bc.data[k].ustrip(unit) for k in ac.data])
+    unit = getattr(next(iter(ac.data.values())), "unit", None)
+
+    def _strip(leaf: Any) -> Array:
+        return leaf.ustrip(unit) if hasattr(leaf, "ustrip") else jnp.asarray(leaf)
+
+    ca = jnp.stack([_strip(ac.data[k]) for k in ac.data])
+    cb = jnp.stack([_strip(bc.data[k]) for k in ac.data])
     return ca, cb, unit
 
 
 @dispatch
-def separation_3d(a: AbstractVector, b: AbstractVector, /) -> Distance:
+def separation_3d(a: AbstractVector, b: AbstractVector, /) -> Distance | Array:
     """Straight-line distance between two points.
 
     The Euclidean distance between the points in their common Cartesian chart,
-    invariant to the chart and component units of either operand.
+    invariant to the chart and component units of either operand.  Returns a
+    `Distance` for unitful vectors, or a bare JAX array for unitless ones.
 
     Examples
     --------
@@ -84,7 +91,10 @@ def separation_3d(a: AbstractVector, b: AbstractVector, /) -> Distance:
     """
     ca, cb, unit = _cartesian_components(a, b)
     d = ca - cb
-    return Distance(jnp.sqrt(jnp.sum(d**2, axis=0)), unit)
+    dist = jnp.sqrt(jnp.sum(d**2, axis=0))
+    # Unitless vectors have no length dimension for a ``Distance``; return the
+    # bare magnitude instead.
+    return dist if unit is None else Distance(dist, unit)
 
 
 @dispatch

--- a/tests/unit/manifolds/test_separation_dispatch.py
+++ b/tests/unit/manifolds/test_separation_dispatch.py
@@ -1,0 +1,60 @@
+"""Tests for the separation() manifold API dispatches."""
+
+import jax.numpy as jnp
+
+import quaxed.numpy as qnp
+import unxt as u
+
+import coordinax as cx
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+
+
+class TestSeparationDispatches:
+    """The manifold-level `separation` accepts several input forms."""
+
+    def test_chart_and_cdicts(self):
+        a = {"x": u.Q(3.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+        b = {"x": u.Q(0.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+        d = cxm.separation(cxc.cart3d, a, b)
+        assert isinstance(d, cx.Distance)
+        assert bool(qnp.isclose(d.ustrip("m"), 5.0))
+
+    def test_metric_chart_and_cdicts(self):
+        metric = cxm.FlatMetric(3)
+        a = {"x": u.Q(3.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+        b = {"x": u.Q(0.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+        assert bool(
+            qnp.isclose(cxm.separation(metric, cxc.cart3d, a, b).ustrip("m"), 5.0)
+        )
+
+    def test_chart_and_packed_quantities(self):
+        a = u.Q([3.0, 0.0, 0.0], "m")
+        b = u.Q([0.0, 4.0, 0.0], "m")
+        assert bool(qnp.isclose(cxm.separation(cxc.cart3d, a, b).ustrip("m"), 5.0))
+
+    def test_chart_and_bare_arrays(self):
+        a = jnp.array([3.0, 0.0, 0.0])
+        b = jnp.array([0.0, 4.0, 0.0])
+        assert bool(qnp.isclose(cxm.separation(cxc.cart3d, a, b), 5.0))
+
+    def test_all_forms_agree_with_the_point_overload(self):
+        p = cx.Point.from_([3.0, 0.0, 0.0], "m")
+        q = cx.Point.from_([0.0, 4.0, 0.0], "m")
+        ref = cx.separation(p, q).ustrip("m")
+        packed = cxm.separation(
+            cxc.cart3d, u.Q([3.0, 0.0, 0.0], "m"), u.Q([0.0, 4.0, 0.0], "m")
+        )
+        assert bool(qnp.isclose(packed.ustrip("m"), ref))
+
+    def test_packed_quantity_is_unit_invariant(self):
+        a = u.Q([3.0, 0.0, 0.0], "m")
+        b = u.Q([0.0, 0.004, 0.0], "km")
+        assert bool(qnp.isclose(cxm.separation(cxc.cart3d, a, b).ustrip("m"), 5.0))
+
+    def test_batched_packed_quantities(self):
+        a = u.Q([[3.0, 0.0, 0.0], [1.0, 0.0, 0.0]], "m")
+        b = u.Q([[0.0, 4.0, 0.0], [0.0, 1.0, 0.0]], "m")
+        d = cxm.separation(cxc.cart3d, a, b).ustrip("m")
+        assert bool(qnp.isclose(d[0], 5.0))
+        assert bool(qnp.isclose(d[1], qnp.sqrt(2.0)))

--- a/tests/unit/manifolds/test_separation_dispatch.py
+++ b/tests/unit/manifolds/test_separation_dispatch.py
@@ -41,7 +41,7 @@ class TestSeparationDispatches:
     def test_all_forms_agree_with_the_point_overload(self):
         p = cx.Point.from_([3.0, 0.0, 0.0], "m")
         q = cx.Point.from_([0.0, 4.0, 0.0], "m")
-        ref = cx.separation(p, q).ustrip("m")
+        ref = cxm.separation(p, q).ustrip("m")
         packed = cxm.separation(
             cxc.cart3d, u.Q([3.0, 0.0, 0.0], "m"), u.Q([0.0, 4.0, 0.0], "m")
         )

--- a/tests/unit/vectors/test_point.py
+++ b/tests/unit/vectors/test_point.py
@@ -206,33 +206,51 @@ class TestPointEquivalence:
 
 
 class TestPointSeparation:
-    """`separation_3d` and `separation` measure between two points."""
+    """`separation` measures the manifold-norm distance between two points."""
 
-    def test_separation_angular(self):
-        """Angular separation is the angle subtended at the origin."""
+    def test_separation_euclidean(self):
+        """Separation is the straight-line (Cartesian) distance."""
         p = cx.Point.from_([3.0, 0.0, 0.0], "m")
         q = cx.Point.from_([0.0, 4.0, 0.0], "m")
-        sep = cx.separation(p, q)
-        assert isinstance(sep, cx.Angle)
-        assert bool(qnp.isclose(sep.ustrip("deg"), 90.0))
+        d = cx.separation(p, q)
+        assert isinstance(d, cx.Distance)
+        assert bool(qnp.isclose(d.ustrip("m"), 5.0))
 
-    def test_separation_angular_is_unit_invariant(self):
-        """Angular separation does not depend on the component units."""
+    def test_separation_is_chart_invariant(self):
+        """Separation does not depend on the chart of either operand."""
+        p = cx.Point.from_([3.0, 0.0, 0.0], "m")
+        q = cx.Point.from_([0.0, 4.0, 0.0], "m").cconvert(cxc.sph3d)
+        assert bool(qnp.isclose(cx.separation(p, q).ustrip("m"), 5.0))
+
+    def test_separation_is_unit_invariant(self):
+        """Separation does not depend on the component units."""
         p = cx.Point.from_([3.0, 0.0, 0.0], "m")
         q = cx.Point.from_([0.0, 0.004, 0.0], "km")
-        assert bool(qnp.isclose(cx.separation(p, q).ustrip("deg"), 90.0))
+        assert bool(qnp.isclose(cx.separation(p, q).ustrip("m"), 5.0))
 
-    def test_separation_angular_elementwise_over_batch(self):
-        """Angular separation is evaluated element-wise over the batch."""
-        p = cx.Point.from_([[3.0, 0, 0], [0, 2, 0]], "m")
-        q = cx.Point.from_([[0.0, 4, 0], [0, 0, 5]], "m")
-        sep = cx.separation(p, q).ustrip("deg")
-        assert bool(qnp.isclose(sep[0], 90.0))
-        assert bool(qnp.isclose(sep[1], 90.0))
+    def test_separation_elementwise_over_batch(self):
+        """Separation is evaluated element-wise over the batch."""
+        p = cx.Point.from_([[3.0, 0, 0], [1, 0, 0]], "m")
+        q = cx.Point.from_([[0.0, 4, 0], [0, 1, 0]], "m")
+        d = cx.separation(p, q)
+        assert bool(qnp.isclose(d.ustrip("m")[0], 5.0))
+        assert bool(qnp.isclose(d.ustrip("m")[1], qnp.sqrt(2.0)))
 
-    def test_separation_angular_different_frames_raises(self):
-        """Angular separation across frames is undefined without alignment."""
+    def test_separation_dimensionality_follows_manifold(self):
+        """2-D points give a 2-D distance -- no separate ``separation_3d``."""
+        p = cx.Point.from_([3.0, 0.0], "m")
+        q = cx.Point.from_([0.0, 4.0], "m")
+        assert bool(qnp.isclose(cx.separation(p, q).ustrip("m"), 5.0))
+
+    def test_separation_different_frames_raises(self):
+        """Separation across frames is undefined without alignment."""
         p = cx.Point.from_([1.0, 0.0, 0.0], "m", cxf.alice)
         q = cx.Point.from_([0.0, 1.0, 0.0], "m", cxf.noframe)
         with pytest.raises(ValueError, match="frame"):
             cx.separation(p, q)
+
+    def test_separation_unitless_components(self):
+        """Separation works for vectors with plain (unitless) array leaves."""
+        p = cx.Point.from_({"x": 3.0, "y": 0.0, "z": 0.0}, cxc.cart3d)
+        q = cx.Point.from_({"x": 0.0, "y": 4.0, "z": 0.0}, cxc.cart3d)
+        assert bool(qnp.isclose(cx.separation(p, q), 5.0))

--- a/tests/unit/vectors/test_point.py
+++ b/tests/unit/vectors/test_point.py
@@ -201,3 +201,15 @@ class TestPointEquivalence:
         # A Tangent cannot re-chart to Cartesian without a base point, so a naive
         # implementation would raise; the geometry guard short-circuits to False.
         assert not bool(qnp.all(cx.equivalent(t, t)))
+
+
+class TestPointSeparation:
+    """`separation_3d` and `separation` measure between two points."""
+
+    def test_separation_angular(self):
+        """Angular separation is the angle subtended at the origin."""
+        p = cx.Point.from_([3.0, 0.0, 0.0], "m")
+        q = cx.Point.from_([0.0, 4.0, 0.0], "m")
+        sep = cx.separation(p, q)
+        assert isinstance(sep, cx.Angle)
+        assert bool(qnp.isclose(sep.ustrip("deg"), 90.0))

--- a/tests/unit/vectors/test_point.py
+++ b/tests/unit/vectors/test_point.py
@@ -3,6 +3,8 @@
 __all__: tuple[str, ...] = ()
 
 
+import pytest
+
 import quaxed.numpy as qnp
 import unxt as u
 
@@ -213,3 +215,24 @@ class TestPointSeparation:
         sep = cx.separation(p, q)
         assert isinstance(sep, cx.Angle)
         assert bool(qnp.isclose(sep.ustrip("deg"), 90.0))
+
+    def test_separation_angular_is_unit_invariant(self):
+        """Angular separation does not depend on the component units."""
+        p = cx.Point.from_([3.0, 0.0, 0.0], "m")
+        q = cx.Point.from_([0.0, 0.004, 0.0], "km")
+        assert bool(qnp.isclose(cx.separation(p, q).ustrip("deg"), 90.0))
+
+    def test_separation_angular_elementwise_over_batch(self):
+        """Angular separation is evaluated element-wise over the batch."""
+        p = cx.Point.from_([[3.0, 0, 0], [0, 2, 0]], "m")
+        q = cx.Point.from_([[0.0, 4, 0], [0, 0, 5]], "m")
+        sep = cx.separation(p, q).ustrip("deg")
+        assert bool(qnp.isclose(sep[0], 90.0))
+        assert bool(qnp.isclose(sep[1], 90.0))
+
+    def test_separation_angular_different_frames_raises(self):
+        """Angular separation across frames is undefined without alignment."""
+        p = cx.Point.from_([1.0, 0.0, 0.0], "m", cxf.alice)
+        q = cx.Point.from_([0.0, 1.0, 0.0], "m", cxf.noframe)
+        with pytest.raises(ValueError, match="frame"):
+            cx.separation(p, q)


### PR DESCRIPTION
Followup to #563.

## Summary

Adds `coordinax.separation` — the straight-line distance between two points, as a **manifold measurement** (it is the manifold `norm` of the points' coordinate difference), sitting alongside `norm` and `angle_between`.

```python
>>> p = cx.Point.from_([3., 0., 0.], "m")
>>> q = cx.Point.from_([0., 4., 0.], "m")
>>> cx.separation(p, q).round(2)
Distance(5., 'm')
```

## Dispatches & placement

`separation` is one multiply-dispatched function (`cx.separation is cx.manifolds.separation`) with overloads placed by layer, mirroring `norm`/`angle_between`:

- **api abstract** in `coordinaxs.api.manifolds`.
- **manifold-level** (`coordinax/_src/manifolds/separation.py`) — the raw-data forms:
  - `separation(chart, a, b)` — component dicts; delegates to the chart's metric.
  - `separation(metric, chart, a, b)` — explicit metric; computes `norm(b − a)` at `a`.
  - `separation(chart, a, b)` for packed `unxt.Quantity` and for bare `Array` operands (unpacked to a component dict via `cdict`).
- **vector-level** (`coordinax/vectors/_src/register_separation.py`) — the `Point` (`AbstractVector`) overload stays in `vectors` (which depends on `manifolds`); it brings both points into a common Cartesian chart (chart- and unit-invariant) and delegates to the manifold-level `separation`.

A length result is a `Distance`, a dimensionless one a bare array. Dimensionality follows the points' manifold — 2-D points give a 2-D distance — so there is no `separation_3d`; map into the target space first. `Point` inputs are **frame-strict** (cross-frame raises).

> The manifold-level overloads measure the norm of the coordinate difference in the given chart (exact for flat manifolds); the `Point` overload converts to Cartesian first for chart-invariance.

## Tests

- `tests/unit/manifolds/test_separation_dispatch.py`: the cdict / metric+cdict / packed-quantity / bare-array forms, unit-invariance, batching, and agreement with the `Point` overload.
- `TestPointSeparation` (vectors): Euclidean distance, chart/unit-invariance, batching, dimensionality-follows-manifold, unitless, cross-frame error.
- Doctests on every new dispatch.

> Note: the repo-wide `-W` docs build lands in #572; this addition is warnings-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)