### PR TITLE
📝 docs(spec): describe #563's chart/frame guard in `AbstractVector.__eq__`

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2261,7 +2261,7 @@ Separating semantics from geometry provides two advantages:
       - ``(V, *args, **kwargs) -> uconvert(*args, V, **kwargs)`` redispatch
       - ``(V, u.AbstractUnitSystem) -> uconvert(u.AbstractUnitSystem, V)`` redispatch
     - ``__array_namespace__``: the array API namespace -- `quax.numpy`. This delegates to `quax` primitives.
-    - ``__eq__``: strict equality — requires the same type, chart, and frame, then compares component data via the `quax` equality primitive. Chart and frame are static metadata, so a mismatch short-circuits to ``False`` as a plain Python bool (safe under `jit`) and never raises on differing component keys.
+    - ``__eq__``: strict equality — requires the same type, chart, and frame, then compares component data via the `quax` equality primitive. Chart and frame are static metadata, so the chart/frame comparison is a plain Python bool (safe under `jit`); on a mismatch it short-circuits to a scalar boolean array (``jnp.zeros((), dtype=bool)``), matching ``==``'s array-valued result, and never raises on differing component keys.
     - ``copy()``: call `dataclass.replace`.
     - ``flatten()``: flatten the vector.
     - ``ravel()``: return a flattened vector.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2261,7 +2261,9 @@ Separating semantics from geometry provides two advantages:
       - ``(V, *args, **kwargs) -> uconvert(*args, V, **kwargs)`` redispatch
       - ``(V, u.AbstractUnitSystem) -> uconvert(u.AbstractUnitSystem, V)`` redispatch
     - ``__array_namespace__``: the array API namespace -- `quax.numpy`. This delegates to `quax` primitives.
-    - ``__eq__``: strict equality — requires the same type, chart, and frame, then compares component data via the `quax` equality primitive. Chart and frame are static metadata, so they are compared with ordinary Python ``!=`` (safe under `jit`); when they differ, ``__eq__`` short-circuits and returns a 0-d boolean array (``jnp.zeros((), dtype=bool)``) instead of comparing the component dicts, which also avoids raising on their differing keys.
+    - ``__eq__``: strict equality — requires the same type, chart, and frame, then compares component data via the `quax` equality primitive.
+      - Chart and frame are static metadata, so they are compared with ordinary Python ``!=`` (safe under `jit`).
+      - When they differ, ``__eq__`` short-circuits and returns a 0-d boolean array (``jnp.zeros((), dtype=bool)``) instead of comparing the component dicts, which also avoids raising on their differing keys.
     - ``copy()``: call `dataclass.replace`.
     - ``flatten()``: flatten the vector.
     - ``ravel()``: return a flattened vector.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2261,7 +2261,7 @@ Separating semantics from geometry provides two advantages:
       - ``(V, *args, **kwargs) -> uconvert(*args, V, **kwargs)`` redispatch
       - ``(V, u.AbstractUnitSystem) -> uconvert(u.AbstractUnitSystem, V)`` redispatch
     - ``__array_namespace__``: the array API namespace -- `quax.numpy`. This delegates to `quax` primitives.
-    - ``__eq__``: strict equality — requires the same type, chart, and frame, then compares component data via the `quax` equality primitive. Chart and frame are static metadata, so the chart/frame comparison is a plain Python bool (safe under `jit`); on a mismatch it short-circuits to a scalar boolean array (``jnp.zeros((), dtype=bool)``), matching ``==``'s array-valued result, and never raises on differing component keys.
+    - ``__eq__``: strict equality — requires the same type, chart, and frame, then compares component data via the `quax` equality primitive. Chart and frame are static metadata, so they are compared with ordinary Python ``!=`` (safe under `jit`); when they differ, ``__eq__`` short-circuits and returns a 0-d boolean array (``jnp.zeros((), dtype=bool)``) instead of comparing the component dicts, which also avoids raising on their differing keys.
     - ``copy()``: call `dataclass.replace`.
     - ``flatten()``: flatten the vector.
     - ``ravel()``: return a flattened vector.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2261,7 +2261,7 @@ Separating semantics from geometry provides two advantages:
       - ``(V, *args, **kwargs) -> uconvert(*args, V, **kwargs)`` redispatch
       - ``(V, u.AbstractUnitSystem) -> uconvert(u.AbstractUnitSystem, V)`` redispatch
     - ``__array_namespace__``: the array API namespace -- `quax.numpy`. This delegates to `quax` primitives.
-    - ``__eq__``: equality check, based on type equality and `quax` equality primitive.
+    - ``__eq__``: strict equality — requires the same type, chart, and frame, then compares component data via the `quax` equality primitive. Chart and frame are static metadata, so a mismatch short-circuits to ``False`` as a plain Python bool (safe under `jit`) and never raises on differing component keys.
     - ``copy()``: call `dataclass.replace`.
     - ``flatten()``: flatten the vector.
     - ``ravel()``: return a flattened vector.


### PR DESCRIPTION
Followup to #563.

#563 made `AbstractVector.__eq__` **strict**: when the chart or frame differs it short-circuits and returns a 0-d boolean array (`jnp.zeros((), dtype=bool)`) instead of comparing the component dicts — which also avoids the key mismatch that comparing different-chart dicts would raise. (Chart and frame are static metadata, so *comparing* them is an ordinary Python `!=`, safe under `jit`; only the returned value is array-valued.)

The `docs/spec.md` `AbstractVector` entry still described the **pre-#563** behaviour:

> `__eq__`: equality check, based on type equality and `quax` equality primitive.

which omits the chart/frame requirement. This updates that one line to match the shipped behaviour.

Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)