### PR TITLE
📝 docs(manifolds): fix pt_embed sphere-verification doctest

### DIFF
--- a/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
+++ b/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
@@ -243,8 +243,8 @@ def pt_embed(
 
     >>> p_ambient_cart = cxm.pt_map(p_ambient, chart.ambient, cxc.cart3d)
     >>> r = jnp.linalg.norm(jnp.array(list(p_ambient_cart.values())))
-    >>> jnp.allclose(r, u.Q(5.0, "km"), atol=u.Q(1e-10, "km"))
-    Array(True, dtype=bool)
+    >>> jnp.allclose(r, chart.embed_map.radius, atol=u.Q(1e-10, "km"))
+    Q(True, '')
 
     Embedding a point at the north pole:
 

--- a/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
+++ b/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
@@ -242,9 +242,9 @@ def pt_embed(
     Verify the point lies on the sphere:
 
     >>> p_ambient_cart = cxm.pt_map(p_ambient, chart.ambient, cxc.cart3d)
-    >>> r2 = jnp.linalg.norm(jnp.array(list(p_ambient_cart.values())))
-    >>> jnp.allclose(r2, u.Q(25.0, "km"), atol=u.Q(1e-10, "km"))
-    Q(False, '')
+    >>> r = jnp.linalg.norm(jnp.array(list(p_ambient_cart.values())))
+    >>> jnp.allclose(r, u.Q(5.0, "km"), atol=u.Q(1e-10, "km"))
+    Array(True, dtype=bool)
 
     Embedding a point at the north pole:
 


### PR DESCRIPTION
## Summary

The `pt_embed` docstring in `packages/coordinax.api/src/coordinax/api/manifolds.py` had an example headed "Verify the point lies on the sphere" that actually asserted `False`:

- The point sits on a radius-5 km sphere, so its Cartesian norm is 5 km.
- The example compared that norm against `u.Q(25.0, "km")`, so `jnp.allclose(...)` returned `False` — contradicting the "verify the point lies on the sphere" prose.

This fixes the example to compare the norm against the actual radius (`u.Q(5.0, "km")`), so it returns `True` and genuinely verifies the point is on the sphere. This is a pre-existing bug on `main`, not introduced by the unxt-linalg transition (#571).

## Test plan

- `uv run --no-project pytest packages/coordinax.api/src/coordinax/api/manifolds.py` → 74 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)