### PR TITLE
✨ feat(transforms): kinematic acts for Scale/Reflect/Shear without a base point

### DIFF
--- a/src/coordinax/transforms/_src/actions/linear.py
+++ b/src/coordinax/transforms/_src/actions/linear.py
@@ -374,8 +374,7 @@ def pushforward(
 
     >>> ps = cxc.CartesianProductChart((cxc.cart3d, cxc.cart3d), ("q", "p"))
     >>> op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
-    >>> v = {"q.x": u.Q(1.0, "m/s"), "q.y": u.Q(1.0, "m/s"), "q.z": u.Q(1.0, "m/s"),
-    ...      "p.x": u.Q(1.0, "m/s2"), "p.y": u.Q(1.0, "m/s2"), "p.z": u.Q(1.0, "m/s2")}
+    >>> v = {f"{f}.{c}": u.Q(1.0, "m/s") for f in ("q", "p") for c in "xyz"}
     >>> out = cxfm.act(op, None, v, ps, cxr.tangent_geom, cxr.coord_vel)
     >>> [out[k].value.round(3) for k in ("q.x", "q.y", "q.z", "p.x", "p.y", "p.z")]
     [Array(2., dtype=float64), Array(3., dtype=float64), Array(4., dtype=float64),

--- a/src/coordinax/transforms/_src/actions/linear.py
+++ b/src/coordinax/transforms/_src/actions/linear.py
@@ -294,7 +294,7 @@ def pushforward(
     else:
         if at is None:
             msg = (
-                f"pushforward({type(op).__name__}, ..., TangentGeometry) on a "
+                f"pushforward({type(op).__name__}, ..., {rep!r}) on a "
                 f"non-Cartesian chart ({chart!r}) requires 'at' (base point in "
                 "chart coords) so the Jacobian pushforward can be evaluated."
             )
@@ -349,6 +349,13 @@ def pushforward(
      Array(2., dtype=float64), Array(3., dtype=float64), Array(4., dtype=float64)]
 
     """
+    # Validate the full product-chart keys up front (a clear error instead of a
+    # raw KeyError from split_components), mirroring the non-product overload.
+    ref = f"do not match the chart's {sorted(chart.components)}"
+    for name, d in (("tangent", v), *(() if at is None else (("base point", at),))):
+        pre = f"pushforward({type(op).__name__}, ...): the {name} components "
+        require_matching_keys(d, chart.components, pre + ref)
+
     n = op._validate_square(materialize_transform(op, tau)._raw_matrix).shape[-1]
     n_factors = len(chart.factors)
     parts = chart.split_components(v)

--- a/src/coordinax/transforms/_src/actions/linear.py
+++ b/src/coordinax/transforms/_src/actions/linear.py
@@ -292,7 +292,7 @@ def _linear_pushforward_cdict(
     cart = chart.cartesian
     matrix = op._matrix(cart, tau)
 
-    if chart is cart:
+    if chart == cart:
         p_cart = x
     else:
         if at is None:
@@ -310,7 +310,7 @@ def _linear_pushforward_cdict(
     v_out = jnp.einsum("ij,...j->...i", matrix, v)
     p_cart_out = cxc.cdict(v_out, unit, comps_cart)
 
-    if chart is cart:
+    if chart == cart:
         return cast("CDict", p_cart_out)
 
     # Map the base point forward (M @ at) to anchor the inverse Jacobian.

--- a/src/coordinax/transforms/_src/actions/linear.py
+++ b/src/coordinax/transforms/_src/actions/linear.py
@@ -240,10 +240,11 @@ def act(
 # pushforward — tangent geometry (shared by every linear transform)
 
 
-def _linear_pushforward_cdict(
+@plum.dispatch
+def pushforward(
     op: AbstractLinearTransform,
     tau: Any,
-    x: CDict,
+    v: CDict,
     chart: cxc.AbstractChart,
     rep: cxr.Representation,
     /,
@@ -254,10 +255,12 @@ def _linear_pushforward_cdict(
     r"""Frozen-$\tau$ pushforward of tangent data under a linear map: $v \mapsto M v$.
 
     A linear map has a *constant* Jacobian equal to its matrix ``M``, so in the
-    canonical Cartesian chart the pushforward is simply ``M v`` and needs no
-    base point ``at``. For a non-Cartesian chart the tangent is pushed through
-    the chart Jacobian (which does require ``at``), ``M`` is applied in
-    Cartesian, then the result is pulled back to the original chart.
+    canonical Cartesian chart the pushforward is simply ``M v`` and needs no base
+    point ``at`` (matching `Rotate`). For a non-Cartesian chart the tangent is
+    pushed through the chart Jacobian (which does require ``at``), ``M`` is applied
+    in Cartesian, then pulled back. Time-dependent linear maps instead route
+    through the generic prolongation, which supplies the ``dot(M)`` term and
+    requires the jet anchors.
 
     Examples
     --------
@@ -279,7 +282,7 @@ def _linear_pushforward_cdict(
     # The tangent must carry exactly the chart's components (a clear error
     # instead of a raw KeyError when packing); an anchor, if given, must match.
     ref = f"do not match the chart's {sorted(chart.components)}"
-    for name, d in (("tangent", x), *(() if at is None else (("base point", at),))):
+    for name, d in (("tangent", v), *(() if at is None else (("base point", at),))):
         pre = f"pushforward({type(op).__name__}, ...): the {name} components "
         require_matching_keys(d, chart.components, pre + ref)
 
@@ -287,7 +290,7 @@ def _linear_pushforward_cdict(
     matrix = op._matrix(cart, tau)
 
     if chart == cart:
-        p_cart = x
+        p_cart = v
     else:
         if at is None:
             msg = (
@@ -297,7 +300,7 @@ def _linear_pushforward_cdict(
             )
             raise TypeError(msg)
         at_cart = cxc.pt_map(at, chart, cart, usys=usys)
-        p_cart = cxr.tangent_map(x, chart, rep, cart, at=at, usys=usys)  # ty: ignore[missing-argument]
+        p_cart = cxr.tangent_map(v, chart, rep, cart, at=at, usys=usys)  # ty: ignore[missing-argument]
 
     comps_cart = cart.components
     p_cart_out = _matmul_cdict(matrix, p_cart, comps_cart)
@@ -311,31 +314,6 @@ def _linear_pushforward_cdict(
         "CDict",
         cxr.tangent_map(p_cart_out, cart, rep, chart, at=at_out, usys=usys),  # ty: ignore[missing-argument]
     )
-
-
-@plum.dispatch
-def pushforward(
-    op: AbstractLinearTransform,
-    tau: Any,
-    v: CDict,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    *,
-    at: CDict | None = None,
-    usys: OptUSys = None,
-) -> CDict:
-    r"""Frozen-$\tau$ pushforward of tangent data under a linear map.
-
-    A linear map's Jacobian is its (constant) matrix, so a Cartesian velocity
-    or acceleration transforms as ``v -> M v`` with no base point required —
-    matching the behavior already provided for `Rotate`. This is used by the
-    generic tangent ``act`` for displacement data and for every time-independent
-    linear transform (`Scale`, `Reflect`, `Shear`). Time-dependent linear maps
-    still route through the generic prolongation, which supplies the ``dot(M)``
-    term and requires the jet anchors.
-    """
-    return _linear_pushforward_cdict(op, tau, v, chart, rep, at=at, usys=usys)
 
 
 @plum.dispatch
@@ -387,7 +365,7 @@ def pushforward(
             return part
         return cast(
             "CDict",
-            _linear_pushforward_cdict(
+            cxfmapi.pushforward(
                 op, tau, part, factor_chart, rep, at=at_part, usys=usys
             ),
         )

--- a/src/coordinax/transforms/_src/actions/linear.py
+++ b/src/coordinax/transforms/_src/actions/linear.py
@@ -25,7 +25,7 @@ import coordinax.representations as cxr
 import coordinaxs.api.transforms as cxfmapi
 from .base import AbstractTransform, materialize_transform
 from .custom_types import CDict, HasShape, OptUSys
-from .utils import require_matching_keys
+from .utils import is_flat_chart, require_matching_keys
 from coordinax.internal import pack_uniform_unit
 
 
@@ -258,9 +258,13 @@ def pushforward(
     canonical Cartesian chart the pushforward is simply ``M v`` and needs no base
     point ``at`` (matching `Rotate`). For a non-Cartesian chart the tangent is
     pushed through the chart Jacobian (which does require ``at``), ``M`` is applied
-    in Cartesian, then pulled back. Time-dependent linear maps instead route
-    through the generic prolongation, which supplies the ``dot(M)`` term and
-    requires the jet anchors.
+    in Cartesian, then pulled back.
+
+    This overload is the frozen-$\tau$ rule. For an order $\ge 1$ act on a
+    *time-dependent* linear map, the ``act``-level router (see ``prolong``, which
+    branches on ``is_time_dependent``) dispatches to the generic prolongation
+    instead — that path adds the ``dot(M)`` term and requires the jet anchors —
+    so time-dependent maps do not reach this frozen-$\tau$ overload via ``act``.
 
     Examples
     --------
@@ -289,7 +293,7 @@ def pushforward(
     cart = chart.cartesian
     matrix = op._matrix(cart, tau)
 
-    if chart == cart:
+    if is_flat_chart(chart):
         p_cart = v
     else:
         if at is None:
@@ -305,7 +309,7 @@ def pushforward(
     comps_cart = cart.components
     p_cart_out = _matmul_cdict(matrix, p_cart, comps_cart)
 
-    if chart == cart:
+    if is_flat_chart(chart):
         return p_cart_out
 
     # Map the base point forward (M @ at) to anchor the inverse Jacobian.

--- a/src/coordinax/transforms/_src/actions/linear.py
+++ b/src/coordinax/transforms/_src/actions/linear.py
@@ -231,3 +231,118 @@ def act(
         for i, (f, p) in enumerate(zip(chart.factors, parts, strict=True))
     )
     return chart.merge_components(mapped_parts)
+
+
+# ============================================================================
+# pushforward — tangent geometry (shared by every linear transform)
+
+
+def _linear_pushforward_cdict(
+    op: AbstractLinearTransform,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+    *,
+    at: CDict | None = None,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Frozen-$\tau$ pushforward of tangent data under a linear map: $v \mapsto M v$.
+
+    A linear map has a *constant* Jacobian equal to its matrix ``M``, so in the
+    canonical Cartesian chart the pushforward is simply ``M v`` and needs no
+    base point ``at``. For a non-Cartesian chart the tangent is pushed through
+    the chart Jacobian (which does require ``at``), ``M`` is applied in
+    Cartesian, then the result is pulled back to the original chart.
+
+    Examples
+    --------
+    Scale a Cartesian velocity vector (no base point needed):
+
+    >>> import quaxed.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import coordinax.transforms as cxfm
+
+    >>> op = cxfm.Scale.from_factors([2.0, 3.0, 1.0])
+    >>> v = {"x": u.Q(1.0, "m/s"), "y": u.Q(1.0, "m/s"), "z": u.Q(1.0, "m/s")}
+    >>> out = cxfm.act(op, None, v, cxc.cart3d, cxr.tangent_geom, cxr.coord_vel)
+    >>> jnp.stack([out[c].to_value("m/s") for c in ("x", "y", "z")]).round(3)
+    Array([2., 3., 1.], dtype=float64)
+
+    """
+    # The tangent must carry exactly the chart's components (a clear error
+    # instead of a raw KeyError when packing); an anchor, if given, must match.
+    expected = set(chart.components)
+    for name, d in (("tangent", x), *(() if at is None else (("base point", at),))):
+        if set(d) != expected:
+            missing = sorted(expected - set(d))
+            extra = sorted(set(d) - expected)
+            msg = (
+                f"pushforward({type(op).__name__}, ...): the {name} components "
+                f"do not match the chart's {sorted(expected)}"
+                + (f"; missing {missing}" if missing else "")
+                + (f"; unexpected {extra}" if extra else "")
+                + "."
+            )
+            raise TypeError(msg)
+
+    cart = chart.cartesian
+    matrix = op._matrix(cart, tau)
+
+    if chart is cart:
+        p_cart = x
+    else:
+        if at is None:
+            msg = (
+                f"pushforward({type(op).__name__}, ..., TangentGeometry) on a "
+                f"non-Cartesian chart ({chart!r}) requires 'at' (base point in "
+                "chart coords) so the Jacobian pushforward can be evaluated."
+            )
+            raise TypeError(msg)
+        at_cart = cxc.pt_map(at, chart, cart, usys=usys)
+        p_cart = cxr.tangent_map(x, chart, rep, cart, at=at, usys=usys)  # ty: ignore[missing-argument]
+
+    comps_cart = cart.components
+    v, unit = pack_uniform_unit(p_cart, keys=comps_cart)  # ty: ignore[no-matching-overload]
+    v_out = jnp.einsum("ij,...j->...i", matrix, v)
+    p_cart_out = cxc.cdict(v_out, unit, comps_cart)
+
+    if chart is cart:
+        return cast("CDict", p_cart_out)
+
+    # Map the base point forward (M @ at) to anchor the inverse Jacobian.
+    at_arr, at_unit = pack_uniform_unit(at_cart, keys=comps_cart)  # ty: ignore[no-matching-overload]
+    at_out_arr = jnp.einsum("ij,...j->...i", matrix, at_arr)
+    at_out = cxc.cdict(at_out_arr, at_unit, comps_cart)
+    return cast(
+        "CDict",
+        cxr.tangent_map(p_cart_out, cart, rep, chart, at=at_out, usys=usys),  # ty: ignore[missing-argument]
+    )
+
+
+@plum.dispatch
+def pushforward(
+    op: AbstractLinearTransform,
+    tau: Any,
+    v: CDict,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+    *,
+    at: CDict | None = None,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Frozen-$\tau$ pushforward of tangent data under a linear map.
+
+    A linear map's Jacobian is its (constant) matrix, so a Cartesian velocity
+    or acceleration transforms as ``v -> M v`` with no base point required —
+    matching the behavior already provided for `Rotate`. This is used by the
+    generic tangent ``act`` for displacement data and for every time-independent
+    linear transform (`Scale`, `Reflect`, `Shear`). Time-dependent linear maps
+    still route through the generic prolongation, which supplies the ``dot(M)``
+    term and requires the jet anchors.
+    """
+    return _linear_pushforward_cdict(op, tau, v, chart, rep, at=at, usys=usys)

--- a/src/coordinax/transforms/_src/actions/linear.py
+++ b/src/coordinax/transforms/_src/actions/linear.py
@@ -346,3 +346,64 @@ def pushforward(
     term and requires the jet anchors.
     """
     return _linear_pushforward_cdict(op, tau, v, chart, rep, at=at, usys=usys)
+
+
+@plum.dispatch
+def pushforward(
+    op: AbstractLinearTransform,
+    tau: Any,
+    v: CDict,
+    chart: cxc.AbstractCartesianProductChart,
+    rep: cxr.Representation,
+    /,
+    *,
+    at: CDict | None = None,
+    usys: OptUSys = None,
+) -> CDict:
+    """Pushforward tangent data factorwise on a Cartesian-product chart.
+
+    Mirrors the point action: the operator matrix is applied only to factors
+    whose Cartesian dimension matches the matrix size (e.g. a 3x3 `Scale` acts on
+    each `Cart3D` factor of a 6D phase-space chart); other factors pass through.
+
+    >>> import quaxed.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+    >>> import coordinax.transforms as cxfm
+
+    >>> ps = cxc.CartesianProductChart((cxc.cart3d, cxc.cart3d), ("q", "p"))
+    >>> op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
+    >>> v = {"q.x": u.Q(1.0, "m/s"), "q.y": u.Q(1.0, "m/s"), "q.z": u.Q(1.0, "m/s"),
+    ...      "p.x": u.Q(1.0, "m/s2"), "p.y": u.Q(1.0, "m/s2"), "p.z": u.Q(1.0, "m/s2")}
+    >>> out = cxfm.act(op, None, v, ps, cxr.tangent_geom, cxr.coord_vel)
+    >>> [out[k].value.round(3) for k in ("q.x", "q.y", "q.z", "p.x", "p.y", "p.z")]
+    [Array(2., dtype=float64), Array(3., dtype=float64), Array(4., dtype=float64),
+     Array(2., dtype=float64), Array(3., dtype=float64), Array(4., dtype=float64)]
+
+    """
+    n = op._validate_square(materialize_transform(op, tau)._raw_matrix).shape[-1]
+    n_factors = len(chart.factors)
+    parts = chart.split_components(v)
+    at_parts = chart.split_components(at) if at is not None else [None] * n_factors
+
+    def _maybe(
+        factor_chart: cxc.AbstractChart[Any, Any, Any],
+        part: CDict,
+        at_part: CDict | None,
+        /,
+    ) -> CDict:
+        cart = factor_chart.cartesian
+        if cart.ndim != n or len(cart.components) != n:
+            return part
+        return cast(
+            "CDict",
+            _linear_pushforward_cdict(
+                op, tau, part, factor_chart, rep, at=at_part, usys=usys
+            ),
+        )
+
+    mapped = tuple(
+        _maybe(f, p, a) for f, p, a in zip(chart.factors, parts, at_parts, strict=True)
+    )
+    return chart.merge_components(mapped)

--- a/src/coordinax/transforms/_src/actions/linear.py
+++ b/src/coordinax/transforms/_src/actions/linear.py
@@ -292,27 +292,24 @@ def pushforward(
 
     cart = chart.cartesian
     matrix = op._matrix(cart, tau)
-
-    if is_flat_chart(chart):
-        p_cart = v
-    else:
-        if at is None:
-            msg = (
-                f"pushforward({type(op).__name__}, ..., {rep!r}) on a "
-                f"non-Cartesian chart ({chart!r}) requires 'at' (base point in "
-                "chart coords) so the Jacobian pushforward can be evaluated."
-            )
-            raise TypeError(msg)
-        at_cart = cxc.pt_map(at, chart, cart, usys=usys)
-        p_cart = cxr.tangent_map(v, chart, rep, cart, at=at, usys=usys)  # ty: ignore[missing-argument]
-
     comps_cart = cart.components
-    p_cart_out = _matmul_cdict(matrix, p_cart, comps_cart)
 
+    # Flat chart: the Jacobian is the identity, so M acts directly, no base point.
     if is_flat_chart(chart):
-        return p_cart_out
+        return _matmul_cdict(matrix, v, comps_cart)
 
-    # Map the base point forward (M @ at) to anchor the inverse Jacobian.
+    # Non-flat: push the tangent through the chart Jacobian at `at`, apply M in
+    # Cartesian, then pull back (anchoring the inverse Jacobian at M @ at).
+    if at is None:
+        msg = (
+            f"pushforward({type(op).__name__}, ..., {rep!r}) on a "
+            f"non-Cartesian chart ({chart!r}) requires 'at' (base point in "
+            "chart coords) so the Jacobian pushforward can be evaluated."
+        )
+        raise TypeError(msg)
+    at_cart = cxc.pt_map(at, chart, cart, usys=usys)
+    p_cart = cxr.tangent_map(v, chart, rep, cart, at=at, usys=usys)  # ty: ignore[missing-argument]
+    p_cart_out = _matmul_cdict(matrix, p_cart, comps_cart)
     at_out = _matmul_cdict(matrix, at_cart, comps_cart)
     return cast(
         "CDict",
@@ -361,9 +358,10 @@ def pushforward(
         require_matching_keys(d, chart.components, pre + ref)
 
     n = op._validate_square(materialize_transform(op, tau)._raw_matrix).shape[-1]
-    n_factors = len(chart.factors)
     parts = chart.split_components(v)
-    at_parts = chart.split_components(at) if at is not None else [None] * n_factors
+    at_parts = (
+        chart.split_components(at) if at is not None else [None] * len(chart.factors)
+    )
 
     def _maybe(
         factor_chart: cxc.AbstractChart[Any, Any, Any],

--- a/src/coordinax/transforms/_src/actions/linear.py
+++ b/src/coordinax/transforms/_src/actions/linear.py
@@ -25,7 +25,14 @@ import coordinax.representations as cxr
 import coordinaxs.api.transforms as cxfmapi
 from .base import AbstractTransform, materialize_transform
 from .custom_types import CDict, HasShape, OptUSys
+from .utils import require_matching_keys
 from coordinax.internal import pack_uniform_unit
+
+
+def _matmul_cdict(matrix: Array, d: CDict, comps: tuple[str, ...], /) -> CDict:
+    """Apply ``matrix`` to a Cartesian cdict ``d``, packed into a shared unit."""
+    v, unit = pack_uniform_unit(d, keys=comps)
+    return cast("CDict", cxc.cdict(jnp.einsum("ij,...j->...i", matrix, v), unit, comps))
 
 
 class AbstractLinearTransform(AbstractTransform):
@@ -180,11 +187,7 @@ def act(
     matrix = op._matrix(cart, tau)
 
     p_cart = cxc.pt_map(x, chart, cart, usys=usys)
-
-    v, unit = pack_uniform_unit(p_cart, keys=comps_cart)  # ty: ignore[no-matching-overload]
-    v_out = jnp.einsum("ij,...j->...i", matrix, v)
-    p_cart_out = cxc.cdict(v_out, unit, comps_cart)
-
+    p_cart_out = _matmul_cdict(matrix, p_cart, comps_cart)
     out = cxc.pt_map(p_cart_out, cart, chart, usys=usys)
     return cast("CDict", out)
 
@@ -275,19 +278,10 @@ def _linear_pushforward_cdict(
     """
     # The tangent must carry exactly the chart's components (a clear error
     # instead of a raw KeyError when packing); an anchor, if given, must match.
-    expected = set(chart.components)
+    ref = f"do not match the chart's {sorted(chart.components)}"
     for name, d in (("tangent", x), *(() if at is None else (("base point", at),))):
-        if set(d) != expected:
-            missing = sorted(expected - set(d))
-            extra = sorted(set(d) - expected)
-            msg = (
-                f"pushforward({type(op).__name__}, ...): the {name} components "
-                f"do not match the chart's {sorted(expected)}"
-                + (f"; missing {missing}" if missing else "")
-                + (f"; unexpected {extra}" if extra else "")
-                + "."
-            )
-            raise TypeError(msg)
+        pre = f"pushforward({type(op).__name__}, ...): the {name} components "
+        require_matching_keys(d, chart.components, pre + ref)
 
     cart = chart.cartesian
     matrix = op._matrix(cart, tau)
@@ -306,17 +300,13 @@ def _linear_pushforward_cdict(
         p_cart = cxr.tangent_map(x, chart, rep, cart, at=at, usys=usys)  # ty: ignore[missing-argument]
 
     comps_cart = cart.components
-    v, unit = pack_uniform_unit(p_cart, keys=comps_cart)  # ty: ignore[no-matching-overload]
-    v_out = jnp.einsum("ij,...j->...i", matrix, v)
-    p_cart_out = cxc.cdict(v_out, unit, comps_cart)
+    p_cart_out = _matmul_cdict(matrix, p_cart, comps_cart)
 
     if chart == cart:
-        return cast("CDict", p_cart_out)
+        return p_cart_out
 
     # Map the base point forward (M @ at) to anchor the inverse Jacobian.
-    at_arr, at_unit = pack_uniform_unit(at_cart, keys=comps_cart)  # ty: ignore[no-matching-overload]
-    at_out_arr = jnp.einsum("ij,...j->...i", matrix, at_arr)
-    at_out = cxc.cdict(at_out_arr, at_unit, comps_cart)
+    at_out = _matmul_cdict(matrix, at_cart, comps_cart)
     return cast(
         "CDict",
         cxr.tangent_map(p_cart_out, cart, rep, chart, at=at_out, usys=usys),  # ty: ignore[missing-argument]

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -59,6 +59,7 @@ import coordinax.representations as cxr
 import coordinaxs.api.transforms as cxfmapi
 from .base import AbstractTransform, is_time_dependent
 from .custom_types import CDict, OptUSys
+from .utils import require_matching_keys
 from coordinax.internal import tree_cast_int_bool_to_float
 
 JetDict: TypeAlias = dict[int, CDict]
@@ -269,17 +270,12 @@ def pushforward_generic(
     if at is None:
         msg = _MSG_AT_REQUIRED.format(verb="pushforward", op=type(op).__name__, m=order)
         raise TypeError(msg)
-    if set(v) != set(at):
-        missing = sorted(set(at) - set(v))
-        extra = sorted(set(v) - set(at))
-        msg = (
-            f"pushforward({type(op).__name__}, ...): the tangent components "
-            f"do not match the base point's {sorted(at)}"
-            + (f"; missing {missing}" if missing else "")
-            + (f"; unexpected {extra}" if extra else "")
-            + "."
-        )
-        raise TypeError(msg)
+    require_matching_keys(
+        v,
+        at,
+        f"pushforward({type(op).__name__}, ...): the tangent components "
+        f"do not match the base point's {sorted(at)}",
+    )
 
     in_units = _cdict_units(at)
     out_units = _point_act_units(op, tau, at, chart, usys=usys)
@@ -436,17 +432,12 @@ def prolong_jet(
         if m not in jet:
             msg = _MSG_JET_SLOT_MISSING.format(op=type(op).__name__, m=max_order, k=m)
             raise TypeError(msg)
-        if set(jet[m]) != set(q0):
-            missing = sorted(set(q0) - set(jet[m]))
-            extra = sorted(set(jet[m]) - set(q0))
-            msg = (
-                f"act_jet({type(op).__name__}, ...): jet slot {m} components "
-                f"do not match slot 0's {sorted(q0)}"
-                + (f"; missing {missing}" if missing else "")
-                + (f"; unexpected {extra}" if extra else "")
-                + "."
-            )
-            raise TypeError(msg)
+        require_matching_keys(
+            jet[m],
+            q0,
+            f"act_jet({type(op).__name__}, ...): jet slot {m} components "
+            f"do not match slot 0's {sorted(q0)}",
+        )
 
     if is_time_dependent(op) and tau is None and max_order >= 1:
         msg = _MSG_TAU_REQUIRED.format(op=type(op).__name__)

--- a/src/coordinax/transforms/_src/actions/utils.py
+++ b/src/coordinax/transforms/_src/actions/utils.py
@@ -3,10 +3,16 @@
 This module defines helpers for operator implementations.
 """
 
-__all__: tuple[str, ...] = ("Neg", "is_componentwise_offset", "is_flat_chart")
+__all__: tuple[str, ...] = (
+    "Neg",
+    "is_componentwise_offset",
+    "is_flat_chart",
+    "require_matching_keys",
+)
 
 import dataclasses
 
+from collections.abc import Iterable
 from typing import Any, final
 
 import jax.numpy as jnp
@@ -67,3 +73,22 @@ def is_componentwise_offset(op: Any, chart: Any, /) -> bool:
     """
     k = getattr(op, "semantic_kind", cxr.dpl).order
     return k != 0 or (chart == op.chart and is_flat_chart(chart))
+
+
+def require_matching_keys(
+    actual: Iterable[str], expected: Iterable[str], message: str, /
+) -> None:
+    """Raise ``TypeError(message + missing/unexpected keys)`` if keys differ.
+
+    Shared by `act`, `pushforward`, and `prolong` so component-mismatch errors
+    report the missing and unexpected keys in one consistent format.
+    """
+    got, exp = set(actual), set(expected)
+    if got != exp:
+        miss, extra = sorted(exp - got), sorted(got - exp)
+        raise TypeError(
+            message
+            + (f"; missing {miss}" if miss else "")
+            + (f"; unexpected {extra}" if extra else "")
+            + "."
+        )

--- a/tests/unit/transforms/test_prolongation.py
+++ b/tests/unit/transforms/test_prolongation.py
@@ -491,11 +491,24 @@ class TestErrors:
         out = cxfm.act_jet(moving, u.Q(1.0, "s"), jet, cxc.cart3d)
         assert jnp.allclose(u.ustrip("km/s2", out[2]["x"]), 2.0)
 
-    def test_static_scale_vel_requires_at(self):
+    def test_static_scale_vel_no_at_needed(self):
+        # A static (time-independent) linear map has a constant Jacobian equal
+        # to its matrix, so a Cartesian velocity transforms as v -> M v with no
+        # base point required (matching Rotate).
         op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
         v = q3(1.0, 1.0, 1.0, "m/s")
-        with pytest.raises(TypeError, match="base point"):
-            cxfm.act(op, None, v, cxc.cart3d, cxr.coord_vel)
+        out = cxfm.act(op, None, v, cxc.cart3d, cxr.coord_vel)
+        assert jnp.allclose(u.ustrip("m/s", out["x"]), 2.0)
+        assert jnp.allclose(u.ustrip("m/s", out["y"]), 3.0)
+        assert jnp.allclose(u.ustrip("m/s", out["z"]), 4.0)
+
+    def test_static_scale_vel_noncartesian_still_requires_at(self):
+        # On a non-Cartesian chart the Jacobian varies with position, so the
+        # base point is still required.
+        op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
+        v = {"r": u.Q(1.0, "m/s"), "theta": u.Q(0.0, "rad/s"), "phi": u.Q(0.0, "rad/s")}
+        with pytest.raises(TypeError, match="'at'"):
+            cxfm.act(op, None, v, cxc.sph3d, cxr.coord_vel)
 
 
 # ============================================================================

--- a/tests/unit/transforms/test_spatial_linear_transforms.py
+++ b/tests/unit/transforms/test_spatial_linear_transforms.py
@@ -157,8 +157,8 @@ def test_linear_velocity_on_product_chart_is_factorwise() -> None:
     op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
     v = {f"{f}.{c}": u.Q(1.0, "m/s") for f in ("q", "p") for c in "xyz"}
     out = cxfm.act(op, None, v, ps, cxr.tangent_geom, cxr.coord_vel)
-    got = [float(out[k].value) for k in ("q.x", "q.y", "q.z", "p.x", "p.y", "p.z")]
-    assert got == [2.0, 3.0, 4.0, 2.0, 3.0, 4.0]
+    got = [_to_np(out[k], "m/s") for k in ("q.x", "q.y", "q.z", "p.x", "p.y", "p.z")]
+    np.testing.assert_allclose(got, [2.0, 3.0, 4.0, 2.0, 3.0, 4.0])
 
 
 def test_linear_acceleration_on_product_chart_is_factorwise() -> None:
@@ -167,8 +167,8 @@ def test_linear_acceleration_on_product_chart_is_factorwise() -> None:
     op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
     a = {f"{f}.{c}": u.Q(1.0, "m/s2") for f in ("q", "p") for c in "xyz"}
     out = cxfm.act(op, None, a, ps, cxr.tangent_geom, cxr.coord_acc)
-    got = [float(out[k].value) for k in ("q.x", "q.y", "q.z", "p.x", "p.y", "p.z")]
-    assert got == [2.0, 3.0, 4.0, 2.0, 3.0, 4.0]
+    got = [_to_np(out[k], "m/s2") for k in ("q.x", "q.y", "q.z", "p.x", "p.y", "p.z")]
+    np.testing.assert_allclose(got, [2.0, 3.0, 4.0, 2.0, 3.0, 4.0])
 
 
 def test_linear_velocity_on_nested_product_charts_recurses() -> None:
@@ -191,7 +191,7 @@ def test_linear_velocity_on_nested_product_charts_recurses() -> None:
 
     v = {k: u.Q(1.0, "m/s") for k in ps.components}
     out = cxfm.act(op, None, v, ps, cxr.tangent_geom, cxr.coord_vel)
-    got = {k: float(out[k].value) for k in ps.components}
+    got = {k: float(_to_np(out[k], "m/s")) for k in ps.components}
 
     # nested product factors pass through; only the plain Cart3D is scaled
     assert got == {
@@ -204,4 +204,4 @@ def test_linear_velocity_on_nested_product_charts_recurses() -> None:
     # pushforward stays consistent with the point action on the same chart
     pt = {k: u.Q(1.0, "m") for k in ps.components}
     pa = cxfm.act(op, None, pt, ps, cxr.point)
-    assert {k: float(pa[k].value) for k in ps.components} == got
+    assert {k: float(_to_np(pa[k], "m")) for k in ps.components} == got

--- a/tests/unit/transforms/test_spatial_linear_transforms.py
+++ b/tests/unit/transforms/test_spatial_linear_transforms.py
@@ -115,15 +115,20 @@ def test_linear_transform_acts_on_acceleration_without_at() -> None:
 
 
 def test_linear_velocity_matches_generic_prolongation_with_at() -> None:
-    """Keystone: the no-`at` fast path equals the generic prolongation given `at`."""
+    """Keystone: the no-`at` fast path equals the generic autodiff prolongation.
+
+    Compare against `cxfm.act_jet` (which differentiates the point action) with
+    `at` as jet slot 0 — not merely against the same pushforward path invoked
+    with `at`, which for a static linear map is the identical code.
+    """
     op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
     v = _vel(1.0, -2.0, 0.5)
     at = {"x": u.Q(2.0, "m"), "y": u.Q(-1.0, "m"), "z": u.Q(3.0, "m")}
     fast = cxfm.act(op, None, v, cxc.cart3d, cxr.coord_vel)
-    withat = cxfm.act(op, None, v, cxc.cart3d, cxr.coord_vel, at=at)
+    generic = cxfm.act_jet(op, None, {0: at, 1: v}, cxc.cart3d)[1]
     for c in ("x", "y", "z"):
         np.testing.assert_allclose(
-            _to_np(fast[c], "m/s"), _to_np(withat[c], "m/s"), atol=1e-12
+            _to_np(fast[c], "m/s"), _to_np(generic[c], "m/s"), atol=1e-12
         )
 
 

--- a/tests/unit/transforms/test_spatial_linear_transforms.py
+++ b/tests/unit/transforms/test_spatial_linear_transforms.py
@@ -10,6 +10,8 @@ import pytest
 import quaxed.numpy as jnp
 import unxt as u
 
+import coordinax.charts as cxc
+import coordinax.representations as cxr
 import coordinax.transforms as cxfm
 
 
@@ -73,3 +75,53 @@ def test_simplify_identity_scale_and_shear_to_identity() -> None:
 
     assert cxfm.simplify(s) is cxfm.identity
     assert cxfm.simplify(h) is cxfm.identity
+
+
+# ============================================================================
+# Kinematic (velocity / acceleration) acts — constant linear maps need no `at`
+
+
+def _vel(x, y, z):
+    return {"x": u.Q(x, "m/s"), "y": u.Q(y, "m/s"), "z": u.Q(z, "m/s")}
+
+
+@pytest.mark.parametrize(
+    ("op", "expected"),
+    [
+        (cxfm.Scale.from_factors([2.0, 3.0, 4.0]), (2.0, 3.0, 4.0)),
+        (cxfm.Reflect.from_normal([1.0, 0.0, 0.0]), (-1.0, 1.0, 1.0)),
+        (
+            cxfm.Shear(
+                jnp.asarray([[1.0, 1.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+            ),
+            (2.0, 1.0, 1.0),
+        ),
+    ],
+)
+def test_linear_transform_acts_on_velocity_without_at(op, expected) -> None:
+    """A constant linear map transforms a Cartesian velocity as v -> M v, no `at`."""
+    out = cxfm.act(op, None, _vel(1.0, 1.0, 1.0), cxc.cart3d, cxr.coord_vel)
+    got = tuple(round(float(u.ustrip("m/s", out[c])), 6) for c in ("x", "y", "z"))
+    assert got == expected
+
+
+def test_linear_transform_acts_on_acceleration_without_at() -> None:
+    """Acceleration also transforms as a -> M a for a constant linear map."""
+    op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
+    acc = {"x": u.Q(1.0, "m/s2"), "y": u.Q(0.0, "m/s2"), "z": u.Q(2.0, "m/s2")}
+    out = cxfm.act(op, None, acc, cxc.cart3d, cxr.coord_acc)
+    got = tuple(round(float(u.ustrip("m/s2", out[c])), 6) for c in ("x", "y", "z"))
+    assert got == (2.0, 0.0, 8.0)
+
+
+def test_linear_velocity_matches_generic_prolongation_with_at() -> None:
+    """Keystone: the no-`at` fast path equals the generic prolongation given `at`."""
+    op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
+    v = _vel(1.0, -2.0, 0.5)
+    at = {"x": u.Q(2.0, "m"), "y": u.Q(-1.0, "m"), "z": u.Q(3.0, "m")}
+    fast = cxfm.act(op, None, v, cxc.cart3d, cxr.coord_vel)
+    withat = cxfm.act(op, None, v, cxc.cart3d, cxr.coord_vel, at=at)
+    for c in ("x", "y", "z"):
+        np.testing.assert_allclose(
+            _to_np(fast[c], "m/s"), _to_np(withat[c], "m/s"), atol=1e-12
+        )

--- a/tests/unit/transforms/test_spatial_linear_transforms.py
+++ b/tests/unit/transforms/test_spatial_linear_transforms.py
@@ -152,17 +152,20 @@ def test_linear_velocity_noncartesian_roundtrips_with_at() -> None:
 
 
 def test_linear_velocity_on_product_chart_is_factorwise() -> None:
-    """A 3x3 Scale acts factorwise on each Cart3D factor of a 6D phase-space chart."""
+    """A 3x3 Scale acts factorwise on each Cart3D factor of a 6D velocity."""
     ps = cxc.CartesianProductChart((cxc.cart3d, cxc.cart3d), ("q", "p"))
     op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
-    v = {
-        "q.x": u.Q(1.0, "m/s"),
-        "q.y": u.Q(1.0, "m/s"),
-        "q.z": u.Q(1.0, "m/s"),
-        "p.x": u.Q(1.0, "m/s2"),
-        "p.y": u.Q(1.0, "m/s2"),
-        "p.z": u.Q(1.0, "m/s2"),
-    }
+    v = {f"{f}.{c}": u.Q(1.0, "m/s") for f in ("q", "p") for c in "xyz"}
     out = cxfm.act(op, None, v, ps, cxr.tangent_geom, cxr.coord_vel)
+    got = [float(out[k].value) for k in ("q.x", "q.y", "q.z", "p.x", "p.y", "p.z")]
+    assert got == [2.0, 3.0, 4.0, 2.0, 3.0, 4.0]
+
+
+def test_linear_acceleration_on_product_chart_is_factorwise() -> None:
+    """A 3x3 Scale acts factorwise on each Cart3D factor of a 6D acceleration."""
+    ps = cxc.CartesianProductChart((cxc.cart3d, cxc.cart3d), ("q", "p"))
+    op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
+    a = {f"{f}.{c}": u.Q(1.0, "m/s2") for f in ("q", "p") for c in "xyz"}
+    out = cxfm.act(op, None, a, ps, cxr.tangent_geom, cxr.coord_acc)
     got = [float(out[k].value) for k in ("q.x", "q.y", "q.z", "p.x", "p.y", "p.z")]
     assert got == [2.0, 3.0, 4.0, 2.0, 3.0, 4.0]

--- a/tests/unit/transforms/test_spatial_linear_transforms.py
+++ b/tests/unit/transforms/test_spatial_linear_transforms.py
@@ -169,3 +169,39 @@ def test_linear_acceleration_on_product_chart_is_factorwise() -> None:
     out = cxfm.act(op, None, a, ps, cxr.tangent_geom, cxr.coord_acc)
     got = [float(out[k].value) for k in ("q.x", "q.y", "q.z", "p.x", "p.y", "p.z")]
     assert got == [2.0, 3.0, 4.0, 2.0, 3.0, 4.0]
+
+
+def test_linear_velocity_on_nested_product_charts_recurses() -> None:
+    """Factorwise pushforward recurses through product-of-product charts.
+
+    A factor that is itself a product chart re-dispatches through the public
+    `pushforward`, so nesting is handled recursively and stays consistent with
+    the point action. A 3x3 `Scale` passes both a 6D ``cart3d x cart3d`` factor
+    and a 3D ``cart1d x cart1d x cart1d`` factor through unchanged, while scaling
+    a sibling `Cart3D`. The 3D nested factor is the keystone: recursion skips
+    each 1D sub-factor rather than flattening the three into one 3-vector (which
+    a non-recursive, direct-helper call would wrongly scale to 2, 3, 4).
+    """
+    op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
+    six = cxc.CartesianProductChart((cxc.cart3d, cxc.cart3d), ("q", "p"))
+    line3 = cxc.CartesianProductChart(
+        (cxc.cart1d, cxc.cart1d, cxc.cart1d), ("a", "b", "c")
+    )
+    ps = cxc.CartesianProductChart((six, line3, cxc.cart3d), ("six", "line3", "z"))
+
+    v = {k: u.Q(1.0, "m/s") for k in ps.components}
+    out = cxfm.act(op, None, v, ps, cxr.tangent_geom, cxr.coord_vel)
+    got = {k: float(out[k].value) for k in ps.components}
+
+    # nested product factors pass through; only the plain Cart3D is scaled
+    assert got == {
+        "six.q.x": 1.0, "six.q.y": 1.0, "six.q.z": 1.0,
+        "six.p.x": 1.0, "six.p.y": 1.0, "six.p.z": 1.0,
+        "line3.a.x": 1.0, "line3.b.x": 1.0, "line3.c.x": 1.0,
+        "z.x": 2.0, "z.y": 3.0, "z.z": 4.0,
+    }  # fmt: skip
+
+    # pushforward stays consistent with the point action on the same chart
+    pt = {k: u.Q(1.0, "m") for k in ps.components}
+    pa = cxfm.act(op, None, pt, ps, cxr.point)
+    assert {k: float(pa[k].value) for k in ps.components} == got

--- a/tests/unit/transforms/test_spatial_linear_transforms.py
+++ b/tests/unit/transforms/test_spatial_linear_transforms.py
@@ -125,3 +125,39 @@ def test_linear_velocity_matches_generic_prolongation_with_at() -> None:
         np.testing.assert_allclose(
             _to_np(fast[c], "m/s"), _to_np(withat[c], "m/s"), atol=1e-12
         )
+
+
+def test_linear_velocity_noncartesian_roundtrips_with_at() -> None:
+    """Non-Cartesian pushforward (needs `at`): Scale then inverse recovers v."""
+    op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
+    at = {"r": u.Q(2.0, "kpc"), "theta": u.Q(1.0, "rad"), "phi": u.Q(0.5, "rad")}
+    v = {
+        "r": u.Q(0.1, "kpc/Myr"),
+        "theta": u.Q(0.2, "rad/Myr"),
+        "phi": u.Q(0.3, "rad/Myr"),
+    }
+    fwd = cxfm.act(op, None, v, cxc.sph3d, cxr.tangent_geom, cxr.coord_vel, at=at)
+    at2 = cxfm.act(op, None, at, cxc.sph3d, cxr.point)
+    back = cxfm.act(
+        op.inverse, None, fwd, cxc.sph3d, cxr.tangent_geom, cxr.coord_vel, at=at2
+    )
+    for k, vk in v.items():
+        unit = u.unit_of(vk).to_string()
+        np.testing.assert_allclose(_to_np(back[k], unit), _to_np(vk, unit), atol=1e-9)
+
+
+def test_linear_velocity_on_product_chart_is_factorwise() -> None:
+    """A 3x3 Scale acts factorwise on each Cart3D factor of a 6D phase-space chart."""
+    ps = cxc.CartesianProductChart((cxc.cart3d, cxc.cart3d), ("q", "p"))
+    op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
+    v = {
+        "q.x": u.Q(1.0, "m/s"),
+        "q.y": u.Q(1.0, "m/s"),
+        "q.z": u.Q(1.0, "m/s"),
+        "p.x": u.Q(1.0, "m/s2"),
+        "p.y": u.Q(1.0, "m/s2"),
+        "p.z": u.Q(1.0, "m/s2"),
+    }
+    out = cxfm.act(op, None, v, ps, cxr.tangent_geom, cxr.coord_vel)
+    got = [float(out[k].value) for k in ("q.x", "q.y", "q.z", "p.x", "p.y", "p.z")]
+    assert got == [2.0, 3.0, 4.0, 2.0, 3.0, 4.0]


### PR DESCRIPTION
## Summary

Only `Boost` and `Rotate` had `TangentGeometry` (velocity/acceleration) act paths. The other linear transforms (`Scale`, `Reflect`, `Shear`) fell through to the generic jet prolongation, which requires a base point `at` — even for a **constant Cartesian** map where none is mathematically needed. So:

```python
cxfm.act(cxfm.Scale.from_factors([2, 3, 4]), None, velocity, cxc.cart3d, cxr.coord_vel)
# TypeError: pushforward(Scale, ...) on order-1 tangent data requires the base point ...
```

while the same call on `Rotate` works. Surfaced by the v0.24 pre-release audit.

## Fix

A linear map's Jacobian **is** its (constant) matrix, so a Cartesian velocity/acceleration transforms as `v → M·v` with no anchor. This registers a shared `pushforward` on `AbstractLinearTransform`:

- **Cartesian chart** → apply `M` directly, no `at` needed (matches `Rotate`).
- **Non-Cartesian chart** → push the tangent through the chart Jacobian (which *does* need `at`), apply `M` in Cartesian, pull back.
- **Time-dependent** linear maps still route through the generic prolongation (the `Ṁ` term genuinely needs the jet anchors).

`Rotate` keeps its own, more-specific dispatch, so there is no plum ambiguity. The new path also reports mismatched tangent/anchor components with a clear `TypeError` instead of a raw `KeyError`.

## Verification
- Keystone property: the no-`at` fast path equals the generic prolongation when `at` is supplied.
- Scale/Reflect/Shear on velocity and acceleration; non-Cartesian still requires `at`.
- New unit tests (`test_spatial_linear_transforms.py`, `test_prolongation.py`) + a doctest; full `tests/unit/transforms` suite passes (265).

One pre-existing test (`test_static_scale_vel_requires_at`) encoded the old "requires at" behavior and is inverted to assert the new, correct behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)