### PR TITLE
✨ feat(transforms): compose time-dependent rotations with @

### DIFF
--- a/src/coordinax/transforms/_src/actions/rotate.py
+++ b/src/coordinax/transforms/_src/actions/rotate.py
@@ -25,7 +25,7 @@ from .custom_types import CDict, OptUSys
 from .identity import identity
 from .linear import AbstractLinearTransform
 from .prolong import _attach_leaf, _strip_leaf, _tau_value_unit, prolong_slot
-from .utils import Neg
+from .utils import ComposedR, Neg
 from coordinax.internal import pack_uniform_unit
 from coordinax.transforms._src import groups
 
@@ -272,12 +272,27 @@ class Rotate(AbstractLinearTransform):
         >>> jnp.allclose(op3.R, op2.R @ op1.R)
         Q(True, '')
 
+        Time-dependent (callable) rotations compose too, pointwise in ``tau``:
+
+        >>> from jaxtyping import Array, Real
+        >>> def Rz(t) -> Real[Array, "3 3"]:
+        ...     th = t.ustrip("s")
+        ...     c, s = jnp.cos(th), jnp.sin(th)
+        ...     return jnp.asarray([[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]])
+        >>> spin = cxfm.Rotate.from_(Rz)
+        >>> combined = spin @ spin
+        >>> tau = u.Q(0.3, "s")
+        >>> M = cxfm.materialize_transform(combined, tau).R
+        >>> bool(jnp.allclose(M, Rz(tau) @ Rz(tau)))
+        True
+
         """
         if not isinstance(other, Rotate):
             return NotImplemented
         if callable(self.R) or callable(other.R):
-            msg = "@ is not yet implemented for Rotate with callable R."
-            raise NotImplementedError(msg)
+            # Compose pointwise in tau: (self then other)(tau) =
+            # other.R(tau) @ self.R(tau), matching the constant product below.
+            return replace(self, R=ComposedR(self.R, other.R))
         return replace(self, R=other.R @ self.R)
 
 

--- a/src/coordinax/transforms/_src/actions/utils.py
+++ b/src/coordinax/transforms/_src/actions/utils.py
@@ -3,7 +3,12 @@
 This module defines helpers for operator implementations.
 """
 
-__all__: tuple[str, ...] = ("Neg", "is_componentwise_offset", "is_flat_chart")
+__all__: tuple[str, ...] = (
+    "ComposedR",
+    "Neg",
+    "is_componentwise_offset",
+    "is_flat_chart",
+)
 
 import dataclasses
 
@@ -50,6 +55,31 @@ class Neg:
     def __neg__(self) -> Any:
         """Return the original parameter."""
         return self.param
+
+
+@final
+@dataclasses.dataclass(slots=True)
+class ComposedR:
+    """Matrix product of two rotation parameters, ``second @ first``.
+
+    Each of ``first`` / ``second`` is either a constant matrix or a callable of
+    ``tau``. Evaluating at ``tau`` returns ``eval(second, tau) @ eval(first,
+    tau)``, i.e. the matrix that applies ``first`` and then ``second`` — the
+    time-dependent generalization of ``Rotate.__matmul__`` for composed
+    rotations.
+    """
+
+    first: Any
+    """The rotation applied first (an array, or a callable of ``tau``)."""
+
+    second: Any
+    """The rotation applied second (an array, or a callable of ``tau``)."""
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Evaluate the composed matrix at ``tau``: ``second(tau) @ first(tau)``."""
+        a = self.first(*args, **kwargs) if callable(self.first) else self.first
+        b = self.second(*args, **kwargs) if callable(self.second) else self.second
+        return b @ a
 
 
 def is_componentwise_offset(op: Any, chart: Any, /) -> bool:

--- a/tests/unit/transforms/test_simplify.py
+++ b/tests/unit/transforms/test_simplify.py
@@ -123,3 +123,56 @@ def test_approx_false_works_under_jit() -> None:
 def test_default_simplify_is_not_jit_safe() -> None:
     with pytest.raises(jax.errors.TracerBoolConversionError):
         jax.jit(lambda op: cxfm.simplify(op))(cxfm.Rotate(jnp.eye(3)))
+
+
+# ===================================================================
+# Rotate.__matmul__ with time-dependent (callable) rotations
+
+
+def _Rz(t) -> Real[Array, "3 3"]:
+    th = t.ustrip("s")
+    c, s = jnp.cos(th), jnp.sin(th)
+    return jnp.asarray([[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]])
+
+
+def _Rx(t) -> Real[Array, "3 3"]:
+    th = t.ustrip("s")
+    c, s = jnp.cos(th), jnp.sin(th)
+    return jnp.asarray([[1.0, 0.0, 0.0], [0.0, c, -s], [0.0, s, c]])
+
+
+def test_matmul_callable_rotations_composes_pointwise() -> None:
+    """`op1 @ op2` composes time-dependent rotations pointwise in tau."""
+    op1 = cxfm.Rotate.from_(_Rz)
+    op2 = cxfm.Rotate.from_(_Rx)
+    combined = op1 @ op2
+    assert cxfm.is_time_dependent(combined)
+    tau = u.Q(0.3, "s")
+    m = cxfm.materialize_transform(combined, tau).R
+    # constant-case convention: (op1 @ op2).R == op2.R @ op1.R
+    np.testing.assert_allclose(
+        np.asarray(m), np.asarray(_Rx(tau) @ _Rz(tau)), atol=1e-7
+    )
+
+
+def test_matmul_callable_action_equals_sequential() -> None:
+    """Acting with `op1 @ op2` equals applying op1 then op2."""
+    op1 = cxfm.Rotate.from_(_Rz)
+    op2 = cxfm.Rotate.from_(_Rx)
+    combined = op1 @ op2
+    tau = u.Q(0.4, "s")
+    p = _point()
+    got = cxfm.act(combined, tau, p, cxc.cart3d, cxr.point)
+    seq = cxfm.act(
+        op2, tau, cxfm.act(op1, tau, p, cxc.cart3d, cxr.point), cxc.cart3d, cxr.point
+    )
+    np.testing.assert_allclose(_xyz(got), _xyz(seq), atol=1e-7)
+
+
+def test_matmul_mixed_callable_and_constant() -> None:
+    """`@` works when only one operand is time-dependent."""
+    spin = cxfm.Rotate.from_(_Rz)
+    const = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+    tau = u.Q(0.25, "s")
+    m = cxfm.materialize_transform(spin @ const, tau).R
+    np.testing.assert_allclose(np.asarray(m), np.asarray(const.R @ _Rz(tau)), atol=1e-7)

--- a/tests/unit/transforms/test_simplify.py
+++ b/tests/unit/transforms/test_simplify.py
@@ -176,3 +176,13 @@ def test_matmul_mixed_callable_and_constant() -> None:
     tau = u.Q(0.25, "s")
     m = cxfm.materialize_transform(spin @ const, tau).R
     np.testing.assert_allclose(np.asarray(m), np.asarray(const.R @ _Rz(tau)), atol=1e-7)
+
+
+def test_matmul_callable_materialize_under_jit() -> None:
+    """`materialize_transform` on a composed callable rotation is jit-safe."""
+    combined = cxfm.Rotate.from_(_Rz) @ cxfm.Rotate.from_(_Rx)
+    materialize = jax.jit(lambda tau: cxfm.materialize_transform(combined, tau).R)
+    tau = u.Q(0.3, "s")
+    np.testing.assert_allclose(
+        np.asarray(materialize(tau)), np.asarray(_Rx(tau) @ _Rz(tau)), atol=1e-7
+    )


### PR DESCRIPTION
## Summary

`Rotate.__matmul__` raised `NotImplementedError` whenever either operand had a callable (time-dependent) rotation matrix:

```python
spin = cxfm.Rotate.from_(R_of_t)
spin @ spin   # NotImplementedError: @ is not yet implemented for Rotate with callable R.
```

so rotating frames could only be combined via `|`/`Composed`, not `@`. Surfaced by the v0.24 pre-release audit.

## Fix

Compose **pointwise in `tau`**: `op1 @ op2` yields a `Rotate` whose matrix is `op2.R(τ) @ op1.R(τ)`, matching the existing constant-matrix convention `(op1 @ op2).R == op2.R @ op1.R`. A small `ComposedR` wrapper (alongside the existing `Neg`) evaluates the two operands — each a constant matrix **or** a callable of `τ` — and returns their product, so the result materializes/JITs correctly and is reported as time-dependent. Mixed callable/constant operands work too.

## Verification
- Composition matches the pointwise product `op2.R(τ) @ op1.R(τ)`.
- Acting with `op1 @ op2` equals applying `op1` then `op2`.
- `is_time_dependent(op1 @ op2)` is `True`; constant `@` unchanged.
- New unit tests (`test_simplify.py`) + a doctest; `tests/unit/transforms` passes (264).

Built on current `main` (post-#571, unxt v2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)