### PR TITLE
✨ feat(interop-astropy): coordinax Point → astropy frame-with-data / SkyCoord

### DIFF
--- a/packages/coordinaxs.interop.astropy/src/coordinaxs/interop/astropy/_src/vec_constructors.py
+++ b/packages/coordinaxs.interop.astropy/src/coordinaxs/interop/astropy/_src/vec_constructors.py
@@ -178,29 +178,66 @@ def convert_astropy_frame_with_data_to_cx_point(
     return cxv.Point.from_(obj)  # ty: ignore[invalid-return-type]
 
 
-# TODO: coordinax -> astropy
-# @plum.conversion_method(type_from=cxv.Point, type_to=apyc.BaseCoordinateFrame)
-# def convert_cx_point_to_astropy_frame_with_data(
-#     obj: cxv.Point, /
-# ) -> apyc.BaseCoordinateFrame:
-#     """Convert a Coordinax Point to an Astropy frame with data.
+@plum.conversion_method(type_from=cxv.Point, type_to=apyc.BaseCoordinateFrame)
+def convert_cx_point_to_astropy_frame_with_data(
+    obj: cxv.Point, /
+) -> apyc.BaseCoordinateFrame:
+    """Convert a Coordinax `Point` (with a frame) to an Astropy frame with data.
 
-#     Examples
-#     --------
-#     >>> import astropy.units as apyu
-#     >>> import astropy.coordinates as apyc
-#     >>> import plum
-#     >>> import coordinax.vectors as cxv
+    The inverse of :func:`convert_astropy_frame_with_data_to_cx_point`: the
+    point's chart data becomes the Astropy representation and the point's frame
+    becomes the enclosing Astropy frame. The point must carry a real reference
+    frame (not ``noframe``).
 
-#     """
-#     # Convert the frame
-#     apy_frame = plum.convert(obj.frame, apyc.BaseCoordinateFrame)
+    >>> import astropy.units as apyu
+    >>> import astropy.coordinates as apyc
+    >>> import plum
+    >>> import coordinax.vectors as cxv
 
-#     # Convert and attach the data
-#     data = plum.convert(obj.data)
-#     apy_frame = apy_frame.realize_frame()
+    >>> vec = apyc.ICRS(ra=90 * apyu.deg, dec=45 * apyu.deg, distance=1 * apyu.kpc)
+    >>> point = cxv.Point.from_(vec)
+    >>> apy = plum.convert(point, apyc.BaseCoordinateFrame)
+    >>> bool(isinstance(apy, apyc.ICRS) and apy.has_data)
+    True
 
-#     return apy_frame
+    Round-trips back to the original frame with data:
+
+    >>> bool(apy.separation_3d(vec) < 1e-9 * apyu.kpc)
+    True
+
+    """
+    if obj.frame is cxf.noframe:
+        msg = (
+            "Point has no reference frame (noframe); cannot convert to an Astropy "
+            "coordinate frame. Convert to an Astropy representation instead: "
+            "plum.convert(point, astropy.coordinates.BaseRepresentation)."
+        )
+        raise ValueError(msg)
+
+    apy_frame = plum.convert(obj.frame, apyc.BaseCoordinateFrame)
+    representation = plum.convert(obj, apyc.BaseRepresentation)
+    return apy_frame.realize_frame(representation)
+
+
+@plum.conversion_method(type_from=cxv.Point, type_to=apyc.SkyCoord)
+def convert_cx_point_to_astropy_skycoord(obj: cxv.Point, /) -> apyc.SkyCoord:
+    """Convert a Coordinax `Point` (with a frame) to an Astropy `SkyCoord`.
+
+    >>> import astropy.units as apyu
+    >>> import astropy.coordinates as apyc
+    >>> import plum
+    >>> import coordinax.vectors as cxv
+
+    >>> vec = apyc.SkyCoord(ra=90 * apyu.deg, dec=45 * apyu.deg, distance=1 * apyu.kpc)
+    >>> point = cxv.Point.from_(vec)
+    >>> sc = plum.convert(point, apyc.SkyCoord)
+    >>> isinstance(sc, apyc.SkyCoord)
+    True
+    >>> bool(sc.separation_3d(vec) < 1e-9 * apyu.kpc)
+    True
+
+    """
+    return apyc.SkyCoord(plum.convert(obj, apyc.BaseCoordinateFrame))
 
 
 ##############################################################################

--- a/packages/coordinaxs.interop.astropy/tests/test_vectors.py
+++ b/packages/coordinaxs.interop.astropy/tests/test_vectors.py
@@ -188,3 +188,53 @@ def test_spherical_to_lonlatspherical_astropy():
     assert np.allclose(plum.convert(vec["distance"], apyu.Quantity), apyvec.distance)
     assert np.allclose(plum.convert(vec["lon"], apyu.Quantity), apyvec.lon)
     assert np.allclose(plum.convert(vec["lat"], apyu.Quantity), apyvec.lat)
+
+
+# ============================================================================
+# coordinax Point (with frame) -> astropy frame-with-data / SkyCoord
+
+
+@pytest.mark.parametrize(
+    ("frame", "kw"),
+    [
+        (
+            apyc.ICRS,
+            {"ra": 90 * apyu.deg, "dec": 45 * apyu.deg, "distance": 1 * apyu.kpc},
+        ),
+        (
+            apyc.Galactic,
+            {"l": 30 * apyu.deg, "b": 20 * apyu.deg, "distance": 2 * apyu.kpc},
+        ),
+        (
+            apyc.Galactocentric,
+            {"x": 1 * apyu.kpc, "y": 2 * apyu.kpc, "z": 3 * apyu.kpc},
+        ),
+    ],
+)
+def test_point_to_astropy_frame_roundtrip(frame, kw):
+    """Astropy frame-with-data -> Point -> astropy frame-with-data is identity."""
+    orig = frame(**kw)
+    point = cx.Point.from_(orig)
+    back = plum.convert(point, apyc.BaseCoordinateFrame)
+
+    assert isinstance(back, frame)
+    assert back.has_data
+    d = (back.cartesian.xyz - orig.cartesian.xyz).to(apyu.pc).value
+    assert np.allclose(d, 0.0, atol=1e-6)
+
+
+def test_point_to_astropy_skycoord_roundtrip():
+    """Astropy SkyCoord -> Point -> SkyCoord preserves the sky position."""
+    orig = apyc.SkyCoord(ra=10 * apyu.deg, dec=-5 * apyu.deg, distance=5 * apyu.kpc)
+    point = cx.Point.from_(orig)
+    back = plum.convert(point, apyc.SkyCoord)
+
+    assert isinstance(back, apyc.SkyCoord)
+    assert back.separation_3d(orig).to(apyu.pc).value < 1e-6
+
+
+def test_point_without_frame_to_astropy_frame_raises():
+    """A Point with no reference frame cannot become an astropy frame."""
+    point = cx.Point.from_([1, 2, 3], "kpc")  # noframe
+    with pytest.raises(ValueError, match="no reference frame"):
+        plum.convert(point, apyc.BaseCoordinateFrame)


### PR DESCRIPTION
## Summary

The `astropy → coordinax` direction (frame-with-data / `SkyCoord` → `Point`) was complete, but the reverse was a `# TODO: coordinax -> astropy` stub — so a `Point` carrying a reference frame could not be handed back to astropy. Surfaced by the v0.24 pre-release audit.

Adds two `plum` conversion methods, composing the two building blocks that already existed (the `Point → astropy representation` converter in `vec_converters.py` and the `coordinax-frame → astropy-frame` converter in `frames.py`) via `astropy_frame.realize_frame(representation)`:

- `Point → astropy.coordinates.BaseCoordinateFrame` (with data)
- `Point → astropy.coordinates.SkyCoord`

A `Point` with `noframe` raises a clear `ValueError` pointing at the representation-level conversion (`plum.convert(point, BaseRepresentation)`) instead.

## Verification
- `astropy frame-with-data / SkyCoord → Point → back` is an **exact** round-trip (under x64) for **ICRS, Galactic, and Galactocentric**.
- New unit tests (`test_vectors.py`) + doctests.

Built on current `main` (post-#571, unxt v2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)