### PR TITLE
📝 docs: simplify doctest output formatting

### DIFF
--- a/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
+++ b/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
@@ -223,7 +223,6 @@ def pt_embed(
     >>> import coordinax.charts as cxc
     >>> import coordinax.manifolds as cxm
     >>> import unxt as u
-    >>> import wadler_lindig as wl
 
     Create an embedded manifold for a sphere of radius 5 km:
 
@@ -236,8 +235,8 @@ def pt_embed(
     ...     "phi": u.Angle(0.0, "rad"),           # along x-axis
     ... }
     >>> p_ambient = cxm.pt_embed(p_intrinsic, chart)
-    >>> wl.pprint(p_ambient, short_arrays='compact', named_unit=False)
-    {'r': Quantity(5, 'km'), 'theta': Angle(1.57079633, 'rad'), 'phi': Angle(0., 'rad')}
+    >>> p_ambient
+    {'r': Q(5, 'km'), 'theta': Angle(1.57079633, 'rad'), 'phi': Angle(0., 'rad')}
 
     Verify the point lies on the sphere:
 
@@ -253,8 +252,8 @@ def pt_embed(
     ...     "phi": u.Angle(0.0, "rad"),    # phi is arbitrary at poles
     ... }
     >>> p_ambient_pole = cxm.pt_embed(p_pole, chart)
-    >>> wl.pprint(p_ambient_pole, short_arrays='compact', named_unit=False)
-    {'r': Quantity(5, 'km'), 'theta': Angle(0., 'rad'), 'phi': Angle(0., 'rad')}
+    >>> p_ambient_pole
+    {'r': Q(5, 'km'), 'theta': Angle(0., 'rad'), 'phi': Angle(0., 'rad')}
 
     """
     raise NotImplementedError  # pragma: no cover
@@ -379,14 +378,13 @@ def pt_project(*args: object, usys: u.AbstractUnitSystem | None = None) -> CDict
 
     >>> p_cart = {"x": u.Q(0.5, "km"), "y": u.Q(0.5, "km"), "z": u.Q(0.707, "km")}
     >>> p_sphere = cxm.pt_project(p_cart, cxc.cart3d, sphere)
-    >>> wl.pprint(p_sphere, short_arrays='compact', named_unit=False)
-    {'theta': Quantity(0.78547367, 'rad'), 'phi': Quantity(0.78539816, 'rad')}
+    >>> p_sphere
+    {'theta': Q(0.78547367, 'rad'), 'phi': Q(0.78539816, 'rad')}
 
     The projection normalizes the point to lie exactly on the sphere.  Verify
     round-trip accuracy (project after embed returns original point):
 
-    >>> q_sphere = {"theta": u.Q(jnp.pi / 3, "rad"),
-    ...             "phi": u.Q(jnp.pi / 4, "rad")}
+    >>> q_sphere = {"theta": u.Q(jnp.pi / 3, "rad"), "phi": u.Q(jnp.pi / 4, "rad")}
     >>> q_cart = cxm.pt_embed(q_sphere, sphere)
     >>> q_recovered = cxm.pt_project(q_cart, sphere)
     >>> all(jax.tree.map(jnp.isclose, q_sphere, q_recovered))
@@ -398,8 +396,8 @@ def pt_project(*args: object, usys: u.AbstractUnitSystem | None = None) -> CDict
     >>> p_far = {"x": u.Q(2.0,"km"), "y": u.Q(2.0,"km"), "z": u.Q(2.0,"km")}
     >>> p_normalized = cxm.pt_project(p_far, cxc.cart3d, sphere)
     >>> # Direction is preserved: all coordinates equal → theta ≈ 54.7°, phi = 45°
-    >>> wl.pprint(p_normalized, short_arrays='compact', named_unit=False)
-    {'theta': Quantity(0.95531662, 'rad'), 'phi': Quantity(0.78539816, 'rad')}
+    >>> p_normalized
+    {'theta': Q(0.95531662, 'rad'), 'phi': Q(0.78539816, 'rad')}
 
     Handle coordinate singularities at the poles.
     At the north pole ($\theta = 0$), $\phi$ is conventionally set to 0:

--- a/src/coordinax/_src/product/manifold.py
+++ b/src/coordinax/_src/product/manifold.py
@@ -82,10 +82,8 @@ class CartesianProductManifold(AbstractManifold):
     >>> M = cxm.CartesianProductManifold(
     ...     factors=(cxm.S2, cxm.R1), factor_names=("S2", "R1")
     ... )
-    >>> wl.pprint(M, width=60)
-    CartesianProductManifold(
-        factors=(Sn(2), Rn(1)), factor_names=('S2', 'R1')
-    )
+    >>> wl.pprint(M, width=76)
+    CartesianProductManifold(factors=(Sn(2), Rn(1)), factor_names=('S2', 'R1'))
 
     **Dimension**
 

--- a/src/coordinax/transforms/_src/actions/rotate.py
+++ b/src/coordinax/transforms/_src/actions/rotate.py
@@ -69,7 +69,6 @@ class Rotate(AbstractLinearTransform):
     >>> import unxt as u
     >>> import coordinax as cx
     >>> import coordinax.transforms as cxfm
-    >>> import wadler_lindig as wl
 
     We can then create a rotation operator:
 
@@ -101,8 +100,8 @@ class Rotate(AbstractLinearTransform):
 
     >>> q = {"x": u.Q(1, "m"), "y": u.Q(0, "m"), "z": u.Q(0, "m")}
     >>> nq = op(t, q)  # inferred chart & rep -> cxr.Point
-    >>> wl.pprint(nq, short_arrays="compact", use_short_name=True)
-    {'x': Q(0, unit='m'), 'y': Q(1, unit='m'), 'z': Q(0, unit='m')}
+    >>> nq
+    {'x': Q(0, 'm'), 'y': Q(1, 'm'), 'z': Q(0, 'm')}
 
     In addition to the standard low-level objects, Rotation operators can be
     applied to {class}`~unxt.Quantity` and Array-like objects, taken to


### PR DESCRIPTION
Replace `wl.pprint(...)` calls with plain reprs in doctests where the default repr is already compact enough, and widen the one remaining `wl.pprint` in `CartesianProductManifold` to keep its output on a single line.