### PR TITLE
🐛 fix(charts): read CartND components on the last axis, not the batch axis

### DIFF
--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -1432,9 +1432,10 @@ def pt_map(
     # Get dimensionality from the target chart
     target_ndim = to_chart.ndim
 
-    # Check that the CartND data has the right dimensionality
+    # Check that the CartND data has the right dimensionality. Components are on
+    # the last axis (leading axes are batch), matching the `q[..., i]` unpack below.
     q = p["q"]
-    data_ndim = q.shape[0]
+    data_ndim = q.shape[-1]
     if data_ndim != target_ndim:
         msg = (
             f"CartND data has {data_ndim} dimensions but target chart "

--- a/src/coordinax/_src/euclidean/register_metric.py
+++ b/src/coordinax/_src/euclidean/register_metric.py
@@ -195,7 +195,9 @@ def metric_matrix(
 
     """
     del M, chart
-    n = jnp.asarray(point["q"]).shape[0]
+    # Components are stored on the last axis (leading axes are batch), matching
+    # the `q[..., i]` unpacking used elsewhere for CartND.
+    n = jnp.asarray(point["q"]).shape[-1]
     return DiagonalMetric(jnp.ones(n))
 
 

--- a/src/coordinax/_src/euclidean/register_metric.py
+++ b/src/coordinax/_src/euclidean/register_metric.py
@@ -197,7 +197,7 @@ def metric_matrix(
     del M, chart
     # Components are stored on the last axis (leading axes are batch), matching
     # the `q[..., i]` unpacking used elsewhere for CartND.
-    n = jnp.asarray(point["q"]).shape[-1]
+    n = jnp.shape(point["q"])[-1]
     return DiagonalMetric(jnp.ones(n))
 
 

--- a/tests/unit/charts/test_register_realize.py
+++ b/tests/unit/charts/test_register_realize.py
@@ -134,4 +134,5 @@ class TestPointTransformCartND:
         out = cxc.pt_map(p, cxc.cartnd, cxc.cart3d)
         assert set(out) == {"x", "y", "z"}
         assert u.ustrip("m", out["x"]) == pytest.approx([1.0, 4.0])
+        assert u.ustrip("m", out["y"]) == pytest.approx([2.0, 5.0])
         assert u.ustrip("m", out["z"]) == pytest.approx([3.0, 6.0])

--- a/tests/unit/charts/test_register_realize.py
+++ b/tests/unit/charts/test_register_realize.py
@@ -122,3 +122,16 @@ class TestPointTransformProlate:
         p = {"r": u.Q(3.0, "m"), "theta": u.Q(0.6, "rad"), "phi": u.Q(0.4, "rad")}
         out = cxc.pt_map(p, cxc.sph3d, prolate)
         assert set(out) == {"mu", "nu", "phi"}
+
+
+class TestPointTransformCartND:
+    """``pt_map`` from CartND reads components on the last axis (batch-safe)."""
+
+    def test_cartnd_to_cart3d_batched(self) -> None:
+        # A batch of 2 points in 3D: the dimensionality guard must read the
+        # component axis (last), not the batch axis (leading), and not raise.
+        p = {"q": u.Q(jnp.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]), "m")}
+        out = cxc.pt_map(p, cxc.cartnd, cxc.cart3d)
+        assert set(out) == {"x", "y", "z"}
+        assert u.ustrip("m", out["x"]) == pytest.approx([1.0, 4.0])
+        assert u.ustrip("m", out["z"]) == pytest.approx([3.0, 6.0])

--- a/tests/unit/manifolds/test_metric_matrix_dispatch.py
+++ b/tests/unit/manifolds/test_metric_matrix_dispatch.py
@@ -164,6 +164,13 @@ class TestMetricMatrixNumericalValues:
         assert g.diagonal.shape == (3,)
         assert jnp.allclose(g.diagonal, jnp.ones(3))
 
+    def test_euclidean_cartnd_batched_reads_component_axis(self):
+        """CartND: component count is the last axis, not the batch axis."""
+        # A batch of 2 points in 3D -> I_3, not I_2.
+        pt = {"q": jnp.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])}  # (2, 3)
+        g = cxmapi.metric_matrix(cxm.R3, pt, cxc.cartnd)
+        assert g.diagonal.shape == (3,)
+
     def test_minkowski_diagonal_signature(self):
         """Minkowski metric in (ct, x, y, z) coords: diag = [-1, 1, 1, 1]."""
         M = cxm.MinkowskiManifold()

--- a/tests/unit/manifolds/test_metric_matrix_dispatch.py
+++ b/tests/unit/manifolds/test_metric_matrix_dispatch.py
@@ -170,6 +170,7 @@ class TestMetricMatrixNumericalValues:
         pt = {"q": jnp.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])}  # (2, 3)
         g = cxmapi.metric_matrix(cxm.R3, pt, cxc.cartnd)
         assert g.diagonal.shape == (3,)
+        assert jnp.allclose(g.diagonal, jnp.ones(3))
 
     def test_minkowski_diagonal_signature(self):
         """Minkowski metric in (ct, x, y, z) coords: diag = [-1, 1, 1, 1]."""


### PR DESCRIPTION
## Summary

Two CartND dispatches read `q.shape[0]` for the component count, but CartND stores components on the **last** axis (leading axes are batch) — as the sibling `q[..., i]` unpacking shows. For a batched point of shape `(batch, N)` they read the batch size instead of `N`. Found in a fresh v0.24 audit pass; both are untested batched paths.

### 1. `metric_matrix(R3, point, cartnd)` — silent wrong dimension
```python
at = {"q": jnp.array([[1., 2., 3.], [4., 5., 6.]])}   # (2, 3)
metric_matrix(cxm.R3, at, cxc.cartnd).diagonal        # [1., 1.]  ← I_2, should be I_3
```
Silently returns a metric of the wrong dimension, which propagates into `manifolds.norm`, `scale_factors`, and `separation` on CartND charts (whose Euclidean CDict fast-path excludes CartND, so they route through this dispatch).

### 2. CartND → fixed-dim `pt_map` — spurious crash
```python
p = {"q": u.Q(jnp.array([[1., 2., 3.], [4., 5., 6.]]), "m")}   # (2, 3)
cxc.pt_map(p, cxm.RN, cxc.cartnd, cxm.R3, cxc.cart3d)
# ValueError: CartND data has 2 dimensions but target chart Cart3D requires 3
```
The guard reads `q.shape[0]` while the unpack two lines later correctly uses `q[..., i]`.

## Fix
`q.shape[0]` → `q.shape[-1]` in both. Unbatched input was unaffected (batch == N, so both axes matched). Regression tests added for batched CartND metric and `pt_map`.

## Verification
`tests/unit/manifolds/test_metric_matrix_dispatch.py` + `tests/unit/charts/test_register_realize.py` pass (65); `ruff`/`ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)