### PR TITLE
🐛 fix(manifolds): make analytic curvilinear metric_matrix batch-safe

### DIFF
--- a/src/coordinax/_src/euclidean/register_metric.py
+++ b/src/coordinax/_src/euclidean/register_metric.py
@@ -273,7 +273,7 @@ def metric_matrix(
     del M, chart
     r_val, r_unit = _val_unit(point["r"])
     theta_unit = _angle_unit(point["theta"])
-    diag = jnp.stack([jnp.ones_like(r_val), r_val**2], axis=-1)
+    diag = jnp.stack([jnp.ones_like(r_val, dtype=float), r_val**2], axis=-1)
     units = ul.UnitsMatrix((u.unit(""), r_unit**2 / theta_unit**2))
     return DiagonalMetric(ul.QuantityMatrix(diag, unit=units))
 
@@ -305,7 +305,12 @@ def metric_matrix(
     phi_unit = _angle_unit(point["phi"])
     dmls = u.unit("")
     diag = jnp.stack(
-        [jnp.ones_like(rho_val), rho_val**2, jnp.ones_like(rho_val)], axis=-1
+        [
+            jnp.ones_like(rho_val, dtype=float),
+            rho_val**2,
+            jnp.ones_like(rho_val, dtype=float),
+        ],
+        axis=-1,
     )
     units = ul.UnitsMatrix((dmls, rho_unit**2 / phi_unit**2, dmls))
     return DiagonalMetric(ul.QuantityMatrix(diag, unit=units))
@@ -348,7 +353,9 @@ def metric_matrix(
     phi_unit = _angle_unit(point["phi"])
     r2 = r_val**2
     r2_unit = r_unit**2
-    diag = jnp.stack([jnp.ones_like(r2), r2, r2 * jnp.sin(theta_val) ** 2], axis=-1)
+    diag = jnp.stack(
+        [jnp.ones_like(r2, dtype=float), r2, r2 * jnp.sin(theta_val) ** 2], axis=-1
+    )
     units = ul.UnitsMatrix((u.unit(""), r2_unit / theta_unit**2, r2_unit / phi_unit**2))
     return DiagonalMetric(ul.QuantityMatrix(diag, unit=units))
 
@@ -390,7 +397,9 @@ def metric_matrix(
     phi_unit = _angle_unit(point["phi"])
     r2 = r_val**2
     r2_unit = r_unit**2
-    diag = jnp.stack([jnp.ones_like(r2), r2 * jnp.sin(phi_val) ** 2, r2], axis=-1)
+    diag = jnp.stack(
+        [jnp.ones_like(r2, dtype=float), r2 * jnp.sin(phi_val) ** 2, r2], axis=-1
+    )
     units = ul.UnitsMatrix((u.unit(""), r2_unit / theta_unit**2, r2_unit / phi_unit**2))
     return DiagonalMetric(ul.QuantityMatrix(diag, unit=units))
 
@@ -431,7 +440,9 @@ def metric_matrix(
     lat_unit = _angle_unit(point["lat"])
     d2 = d_val**2
     d2_unit = d_unit**2
-    diag = jnp.stack([d2 * jnp.cos(lat_val) ** 2, d2, jnp.ones_like(d2)], axis=-1)
+    diag = jnp.stack(
+        [d2 * jnp.cos(lat_val) ** 2, d2, jnp.ones_like(d2, dtype=float)], axis=-1
+    )
     units = ul.UnitsMatrix((d2_unit / lon_unit**2, d2_unit / lat_unit**2, u.unit("")))
     return DiagonalMetric(ul.QuantityMatrix(diag, unit=units))
 

--- a/src/coordinax/_src/euclidean/register_metric.py
+++ b/src/coordinax/_src/euclidean/register_metric.py
@@ -273,7 +273,7 @@ def metric_matrix(
     del M, chart
     r_val, r_unit = _val_unit(point["r"])
     theta_unit = _angle_unit(point["theta"])
-    diag = jnp.stack([jnp.asarray(1.0), r_val**2])
+    diag = jnp.stack([jnp.ones_like(r_val), r_val**2], axis=-1)
     units = ul.UnitsMatrix((u.unit(""), r_unit**2 / theta_unit**2))
     return DiagonalMetric(ul.QuantityMatrix(diag, unit=units))
 
@@ -304,7 +304,9 @@ def metric_matrix(
     rho_val, rho_unit = _val_unit(point["rho"])
     phi_unit = _angle_unit(point["phi"])
     dmls = u.unit("")
-    diag = jnp.stack([jnp.asarray(1.0), rho_val**2, jnp.asarray(1.0)])
+    diag = jnp.stack(
+        [jnp.ones_like(rho_val), rho_val**2, jnp.ones_like(rho_val)], axis=-1
+    )
     units = ul.UnitsMatrix((dmls, rho_unit**2 / phi_unit**2, dmls))
     return DiagonalMetric(ul.QuantityMatrix(diag, unit=units))
 
@@ -346,7 +348,7 @@ def metric_matrix(
     phi_unit = _angle_unit(point["phi"])
     r2 = r_val**2
     r2_unit = r_unit**2
-    diag = jnp.stack([jnp.asarray(1.0), r2, r2 * jnp.sin(theta_val) ** 2])
+    diag = jnp.stack([jnp.ones_like(r2), r2, r2 * jnp.sin(theta_val) ** 2], axis=-1)
     units = ul.UnitsMatrix((u.unit(""), r2_unit / theta_unit**2, r2_unit / phi_unit**2))
     return DiagonalMetric(ul.QuantityMatrix(diag, unit=units))
 
@@ -388,7 +390,7 @@ def metric_matrix(
     phi_unit = _angle_unit(point["phi"])
     r2 = r_val**2
     r2_unit = r_unit**2
-    diag = jnp.stack([jnp.asarray(1.0), r2 * jnp.sin(phi_val) ** 2, r2])
+    diag = jnp.stack([jnp.ones_like(r2), r2 * jnp.sin(phi_val) ** 2, r2], axis=-1)
     units = ul.UnitsMatrix((u.unit(""), r2_unit / theta_unit**2, r2_unit / phi_unit**2))
     return DiagonalMetric(ul.QuantityMatrix(diag, unit=units))
 
@@ -429,7 +431,7 @@ def metric_matrix(
     lat_unit = _angle_unit(point["lat"])
     d2 = d_val**2
     d2_unit = d_unit**2
-    diag = jnp.stack([d2 * jnp.cos(lat_val) ** 2, d2, jnp.asarray(1.0)])
+    diag = jnp.stack([d2 * jnp.cos(lat_val) ** 2, d2, jnp.ones_like(d2)], axis=-1)
     units = ul.UnitsMatrix((d2_unit / lon_unit**2, d2_unit / lat_unit**2, u.unit("")))
     return DiagonalMetric(ul.QuantityMatrix(diag, unit=units))
 

--- a/src/coordinax/representations/_src/basis_change.py
+++ b/src/coordinax/representations/_src/basis_change.py
@@ -132,7 +132,8 @@ def change_basis(
     mm = cxmapi.metric_matrix(M, at, chart)
     if isinstance(mm, DiagonalMetric):
         h = jnp.sqrt(mm.diagonal)
-        return {k: h[i] * v[k] for i, k in enumerate(keys)}
+        # Components are on the last axis (leading axes are batch).
+        return {k: h[..., i] * v[k] for i, k in enumerate(keys)}
     # General case: Cholesky vielbein E = L^T, hat_v = E @ v
     assert isinstance(mm, DenseMetric)  # noqa: S101
     mat = mm.matrix
@@ -211,7 +212,8 @@ def change_basis(
     mm = cxmapi.metric_matrix(M, at, chart)
     if isinstance(mm, DiagonalMetric):
         h = jnp.sqrt(mm.diagonal)
-        return {k: v[k] / h[i] for i, k in enumerate(keys)}
+        # Components are on the last axis (leading axes are batch).
+        return {k: v[k] / h[..., i] for i, k in enumerate(keys)}
     # General case: Cholesky vielbein E = L^T, v = E^{-1} hat_v (triangular solve)
     assert isinstance(mm, DenseMetric)  # noqa: S101
     mat = mm.matrix

--- a/tests/unit/manifolds/test_metric_matrix_dispatch.py
+++ b/tests/unit/manifolds/test_metric_matrix_dispatch.py
@@ -378,3 +378,13 @@ def test_curvilinear_metric_is_batch_safe(manifold, chart, point1):
     # wrong axis ordering that still yields the right shape is caught.
     assert jnp.allclose(jnp.asarray(gb.value)[0], jnp.asarray(g1.value))
     assert jnp.allclose(jnp.asarray(gb.value)[1], jnp.asarray(g2.value))
+    # Unit metadata must be preserved (and not reordered) under batching.
+    assert g1.unit == gb.unit
+    assert g2.unit == gb.unit
+
+
+def test_curvilinear_metric_diagonal_is_float_for_integer_coords():
+    """Integer-valued coordinates still yield a floating-dtype metric diagonal."""
+    pt = {"r": u.Q(2, "m"), "theta": u.Q(1, "rad")}  # integer magnitudes
+    g = cxmapi.metric_matrix(cxm.R2, pt, cxc.polar2d).diagonal
+    assert jnp.issubdtype(jnp.asarray(g.value).dtype, jnp.inexact)

--- a/tests/unit/manifolds/test_metric_matrix_dispatch.py
+++ b/tests/unit/manifolds/test_metric_matrix_dispatch.py
@@ -363,13 +363,18 @@ class TestMetricRepresentation:
 def test_curvilinear_metric_is_batch_safe(manifold, chart, point1):
     """Batched points give a (batch, n) diagonal whose rows match the unbatched."""
     n = len(chart.components)
+    point2 = {k: u.Q(q.value * 1.3, q.unit) for k, q in point1.items()}
     batch = {
         k: u.Q(jnp.array([q.value, q.value * 1.3]), q.unit) for k, q in point1.items()
     }
 
     g1 = cxmapi.metric_matrix(manifold, point1, chart).diagonal
+    g2 = cxmapi.metric_matrix(manifold, point2, chart).diagonal
     gb = cxmapi.metric_matrix(manifold, batch, chart).diagonal
 
     assert g1.shape == (n,)
     assert gb.shape == (2, n)
+    # Both batched rows must match their corresponding unbatched results, so a
+    # wrong axis ordering that still yields the right shape is caught.
     assert jnp.allclose(jnp.asarray(gb.value)[0], jnp.asarray(g1.value))
+    assert jnp.allclose(jnp.asarray(gb.value)[1], jnp.asarray(g2.value))

--- a/tests/unit/manifolds/test_metric_matrix_dispatch.py
+++ b/tests/unit/manifolds/test_metric_matrix_dispatch.py
@@ -327,3 +327,49 @@ class TestMetricRepresentation:
     )
     def test_metric_representation_type(self, manifold, chart, expected_cls):
         assert cxmapi.metric_representation(manifold, chart) is expected_cls
+
+
+# =============================================================================
+# Batch safety of the analytic curvilinear diagonal metrics
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("manifold", "chart", "point1"),
+    [
+        (cxm.R2, cxc.polar2d, {"r": u.Q(2.0, "m"), "theta": u.Q(0.6, "rad")}),
+        (
+            cxm.R3,
+            cxc.cyl3d,
+            {"rho": u.Q(2.0, "m"), "phi": u.Q(0.6, "rad"), "z": u.Q(1.0, "m")},
+        ),
+        (
+            cxm.R3,
+            cxc.sph3d,
+            {"r": u.Q(2.0, "m"), "theta": u.Q(0.6, "rad"), "phi": u.Q(0.3, "rad")},
+        ),
+        (
+            cxm.R3,
+            cxc.math_sph3d,
+            {"r": u.Q(2.0, "m"), "theta": u.Q(0.6, "rad"), "phi": u.Q(0.3, "rad")},
+        ),
+        (
+            cxm.R3,
+            cxc.lonlat_sph3d,
+            {"lon": u.Q(0.6, "rad"), "lat": u.Q(0.3, "rad"), "distance": u.Q(2.0, "m")},
+        ),
+    ],
+)
+def test_curvilinear_metric_is_batch_safe(manifold, chart, point1):
+    """Batched points give a (batch, n) diagonal whose rows match the unbatched."""
+    n = len(chart.components)
+    batch = {
+        k: u.Q(jnp.array([q.value, q.value * 1.3]), q.unit) for k, q in point1.items()
+    }
+
+    g1 = cxmapi.metric_matrix(manifold, point1, chart).diagonal
+    gb = cxmapi.metric_matrix(manifold, batch, chart).diagonal
+
+    assert g1.shape == (n,)
+    assert gb.shape == (2, n)
+    assert jnp.allclose(jnp.asarray(gb.value)[0], jnp.asarray(g1.value))

--- a/tests/unit/representations/test_change_basis.py
+++ b/tests/unit/representations/test_change_basis.py
@@ -145,6 +145,40 @@ class TestChangeBasisDispatch:
             u.ustrip("rad/s", v_back["phi"]), u.ustrip("rad/s", v["phi"])
         )
 
+    def test_diagonal_metric_batched_at_matches_unbatched(self):
+        """Batched `at` scales per-component on the last axis (h[..., i]).
+
+        Guards the DiagonalMetric fast path against reading the batch axis
+        instead of the component axis (the original bug).
+        """
+        M = cxm.R3
+        v = {
+            "r": u.Q(4.0, "m/s"),
+            "theta": u.Q(0.5, "rad/s"),
+            "phi": u.Q(0.25, "rad/s"),
+        }
+        at0 = {"r": u.Q(3.0, "m"), "theta": u.Q(0.5, "rad"), "phi": u.Q(0.0, "rad")}
+        at1 = {"r": u.Q(5.0, "m"), "theta": u.Q(1.0, "rad"), "phi": u.Q(0.0, "rad")}
+        at_b = {
+            "r": u.Q(jnp.array([3.0, 5.0]), "m"),
+            "theta": u.Q(jnp.array([0.5, 1.0]), "rad"),
+            "phi": u.Q(jnp.array([0.0, 0.0]), "rad"),
+        }
+
+        def cb(at):
+            return cxr.change_basis(
+                v, cxc.sph3d, M, cxr.coord_basis, cxr.phys_basis, at=at
+            )
+
+        o0, o1, ob = cb(at0), cb(at1), cb(at_b)
+        # Physical (orthonormal) components are all m/s; each batched row must
+        # match its unbatched counterpart (theta/phi are the discriminating,
+        # r-dependent ones — a wrong axis would give the wrong per-row scaling).
+        for k in ("r", "theta", "phi"):
+            got = u.ustrip("m/s", ob[k])
+            want = np.array([u.ustrip("m/s", o0[k]), u.ustrip("m/s", o1[k])])
+            np.testing.assert_allclose(np.broadcast_to(got, (2,)), want)
+
     def test_round_trip_general_metric(self):
         M = cxm.EmbeddedManifold(
             intrinsic=cxm.S2,

--- a/tests/unit/representations/test_change_basis.py
+++ b/tests/unit/representations/test_change_basis.py
@@ -171,13 +171,19 @@ class TestChangeBasisDispatch:
             )
 
         o0, o1, ob = cb(at0), cb(at1), cb(at_b)
-        # Physical (orthonormal) components are all m/s; each batched row must
-        # match its unbatched counterpart (theta/phi are the discriminating,
-        # r-dependent ones — a wrong axis would give the wrong per-row scaling).
-        for k in ("r", "theta", "phi"):
-            got = u.ustrip("m/s", ob[k])
+        # theta/phi scale by h = r and h = r·sin(theta), so they must genuinely
+        # come back batched (shape (2,)) and match the per-row unbatched results;
+        # a wrong axis would give the wrong per-row scaling.
+        for k in ("theta", "phi"):
+            got = np.asarray(u.ustrip("m/s", ob[k]))
+            assert got.shape == (2,)
             want = np.array([u.ustrip("m/s", o0[k]), u.ustrip("m/s", o1[k])])
-            np.testing.assert_allclose(np.broadcast_to(got, (2,)), want)
+            np.testing.assert_allclose(got, want)
+        # r scales by the constant h = 1, so it is r-independent (may stay scalar).
+        np.testing.assert_allclose(
+            np.broadcast_to(np.asarray(u.ustrip("m/s", ob["r"])), (2,)),
+            np.array([u.ustrip("m/s", o0["r"]), u.ustrip("m/s", o1["r"])]),
+        )
 
     def test_round_trip_general_metric(self):
         M = cxm.EmbeddedManifold(


### PR DESCRIPTION
## Summary

The analytic diagonal metrics for the orthogonal curvilinear Euclidean charts built the diagonal with `jnp.stack([jnp.asarray(1.0), <coord-dependent>...])` on the default `axis=0`. On a **batched** point this crashes — mixing a scalar `()` with `(batch,)` entries — and even if it broadcast, `axis=0` would place components on the leading axis, violating the library's batch-leading / component-trailing convention (the same one the CartND fix in #590 restored).

```python
def B(x, un): return u.Q(jnp.array([x, x*1.2]), un)
metric_matrix(cxm.R3, {"r": B(2.,"m"), "theta": B(1.,"rad"), "phi": B(.3,"rad")}, cxc.sph3d)
# ValueError: All input arrays must have the same shape.   (unbatched: fine)
```

Affects `Polar2D`, `Cylindrical3D`, `Spherical3D`, `MathSpherical3D`, `LonLatSpherical3D`. All reachable via the public `coordinax.manifolds.metric_matrix`, and this propagates into `norm` / `scale_factors` / `separation` on these charts. (`LonCosLat` uses the dense Jacobian path and is unaffected.)

## Fix

Replace each constant `jnp.asarray(1.0)` with `jnp.ones_like(<a batched sibling>)` and stack on `axis=-1`. Verified against the `jax.vmap` reference; unbatched output is unchanged (a scalar stack is `(n,)` either way).

Also fixes the now-reachable sibling in `representations/_src/basis_change.py`: the `DiagonalMetric` fast path indexed `h[i]` (batch axis) — now `h[..., i]` (component axis), for both the forward and inverse basis change.

## Verification
New parametrized batched regression test (batched metrics give `(batch, n)` rows matching the unbatched result); `tests/unit/manifolds` + `test_change_basis` pass; `register_metric.py` doctests pass; `ruff`/`ty` clean.

Related to #590 (same batch-axis family, different mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)