### PR TITLE
🐛 fix(manifolds): correct the round metric on non-canonical two-sphere charts

### DIFF
--- a/src/coordinax/_src/spherical/chart.py
+++ b/src/coordinax/_src/spherical/chart.py
@@ -17,6 +17,7 @@ __all__ = (
     "loncoslat_sph2",
     "MathSphericalTwoSphere",
     "math_sph2",
+    "NonCanonicalTwoSphere",
 )
 
 
@@ -392,3 +393,14 @@ class MathSphericalTwoSphere(
 
 math_sph2: Final = MathSphericalTwoSphere(M=S2)
 """Standard spherical coordinates on the two-sphere with mathematics convention."""
+
+
+NonCanonicalTwoSphere = (
+    LonLatSphericalTwoSphere | LonCosLatSphericalTwoSphere | MathSphericalTwoSphere
+)
+"""Two-sphere charts whose components are not nested polar angles.
+
+These relabel or swap the polar and azimuthal angles (``LonLat``, ``Math``) or
+are outright non-orthogonal (``LonCosLat``), so the nested sine-product used by
+`SphericalTwoSphere` does not describe their round metric.
+"""

--- a/src/coordinax/_src/spherical/register_metric.py
+++ b/src/coordinax/_src/spherical/register_metric.py
@@ -62,6 +62,10 @@ def _round_metric_pullback(
     """
     keys = chart.components
     x0 = jnp.stack([jnp.asarray(_rad_value(point[k])) for k in keys])
+    # jax.jacfwd needs an inexact input; promote integer angles (e.g. u.Q(0,
+    # "rad")) to float while leaving float32/float64 inputs untouched.
+    if not jnp.issubdtype(x0.dtype, jnp.inexact):
+        x0 = x0.astype(float)
 
     def to_canon(x: jnp.ndarray) -> jnp.ndarray:
         p = {k: u.Q(x[i], "rad") for i, k in enumerate(keys)}

--- a/src/coordinax/_src/spherical/register_metric.py
+++ b/src/coordinax/_src/spherical/register_metric.py
@@ -17,11 +17,12 @@ from typing import cast
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import plum
 import unxts.linalg as ul
 
 import unxt as u
-from unxt.quantity import AllowValue
+from unxt.quantity import AllowValue, is_any_quantity
 
 import coordinaxs.api.charts as cxcapi
 from .chart import (
@@ -42,11 +43,12 @@ from coordinax.internal import CDict
 RAD = u.unit("rad")
 
 
+_CANON_SPH2 = SphericalTwoSphere()
+
+
 def _rad_value(q: object, /) -> object:
     """Numeric value of an angular coordinate in radians (bare arrays pass through)."""
-    if isinstance(q, u.AbstractQuantity):
-        return u.ustrip("rad", q)
-    return jnp.asarray(q)
+    return u.ustrip("rad", q) if is_any_quantity(q) else jnp.asarray(q)
 
 
 def _round_metric_pullback(
@@ -59,12 +61,11 @@ def _round_metric_pullback(
     (diagonal) and non-orthogonal (dense, e.g. ``LonCosLat``) charts.
     """
     keys = chart.components
-    x0 = jnp.stack([jnp.asarray(_rad_value(point[k]), dtype=float) for k in keys])
-    canon = SphericalTwoSphere()
+    x0 = jnp.stack([jnp.asarray(_rad_value(point[k])) for k in keys])
 
     def to_canon(x: jnp.ndarray) -> jnp.ndarray:
         p = {k: u.Q(x[i], "rad") for i, k in enumerate(keys)}
-        s = cast("CDict", cxcapi.pt_map(p, chart, canon))
+        s = cast("CDict", cxcapi.pt_map(p, chart, _CANON_SPH2))
         return jnp.stack([u.ustrip("rad", s["theta"]), u.ustrip("rad", s["phi"])])
 
     jc = jax.jacfwd(to_canon)(x0)  # (2, n)
@@ -72,7 +73,7 @@ def _round_metric_pullback(
     g_can = jnp.diag(jnp.stack([jnp.ones_like(theta), jnp.sin(theta) ** 2]))
     g = jc.T @ g_can @ jc  # (n, n), dimensionless (angles map angles -> angles)
     n = len(keys)
-    units = ul.UnitsMatrix(tuple(tuple(u.unit("") for _ in range(n)) for _ in range(n)))
+    units = ul.UnitsMatrix(np.full((n, n), u.unit(""), dtype=object))
     return DenseMetric(ul.QuantityMatrix(g, unit=units))
 
 

--- a/src/coordinax/_src/spherical/register_metric.py
+++ b/src/coordinax/_src/spherical/register_metric.py
@@ -17,19 +17,16 @@ from typing import cast
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 import plum
 import unxts.linalg as ul
 
 import unxt as u
-from unxt.quantity import AllowValue, is_any_quantity
+from unxt.quantity import AllowValue
 
 import coordinaxs.api.charts as cxcapi
 from .chart import (
     AbstractSphericalHyperSphere,
-    LonCosLatSphericalTwoSphere,
-    LonLatSphericalTwoSphere,
-    MathSphericalTwoSphere,
+    NonCanonicalTwoSphere,
     SphericalTwoSphere,
 )
 from .manifold import HyperSphericalManifold
@@ -38,47 +35,9 @@ from coordinax._src.metric.matrix import (
     DiagonalMetric,
     _sine_product_diagonal,
 )
-from coordinax.internal import CDict
+from coordinax.internal import CDict, tree_cast_int_bool_to_float
 
 RAD = u.unit("rad")
-
-
-_CANON_SPH2 = SphericalTwoSphere()
-
-
-def _rad_value(q: object, /) -> object:
-    """Numeric value of an angular coordinate in radians (bare arrays pass through)."""
-    return u.ustrip("rad", q) if is_any_quantity(q) else jnp.asarray(q)
-
-
-def _round_metric_pullback(
-    point: CDict, chart: AbstractSphericalHyperSphere
-) -> DenseMetric:
-    r"""Round metric on the two-sphere via pullback of the canonical metric.
-
-    ``g = Jc^T diag(1, sin^2 theta) Jc`` where ``Jc`` is the Jacobian of the
-    coordinate map ``chart -> SphericalTwoSphere``. Correct for both orthogonal
-    (diagonal) and non-orthogonal (dense, e.g. ``LonCosLat``) charts.
-    """
-    keys = chart.components
-    x0 = jnp.stack([jnp.asarray(_rad_value(point[k])) for k in keys])
-    # jax.jacfwd needs an inexact input; promote integer angles (e.g. u.Q(0,
-    # "rad")) to float while leaving float32/float64 inputs untouched.
-    if not jnp.issubdtype(x0.dtype, jnp.inexact):
-        x0 = x0.astype(float)
-
-    def to_canon(x: jnp.ndarray) -> jnp.ndarray:
-        p = {k: u.Q(x[i], "rad") for i, k in enumerate(keys)}
-        s = cast("CDict", cxcapi.pt_map(p, chart, _CANON_SPH2))
-        return jnp.stack([u.ustrip("rad", s["theta"]), u.ustrip("rad", s["phi"])])
-
-    jc = jax.jacfwd(to_canon)(x0)  # (2, n)
-    theta = to_canon(x0)[0]
-    g_can = jnp.diag(jnp.stack([jnp.ones_like(theta), jnp.sin(theta) ** 2]))
-    g = jc.T @ g_can @ jc  # (n, n), dimensionless (angles map angles -> angles)
-    n = len(keys)
-    units = ul.UnitsMatrix(np.full((n, n), u.unit(""), dtype=object))
-    return DenseMetric(ul.QuantityMatrix(g, unit=units))
 
 
 @plum.dispatch
@@ -150,11 +109,7 @@ def metric_matrix(
 
 @plum.dispatch
 def metric_representation(
-    M: HyperSphericalManifold,
-    chart: LonLatSphericalTwoSphere
-    | LonCosLatSphericalTwoSphere
-    | MathSphericalTwoSphere,
-    /,
+    M: HyperSphericalManifold, chart: NonCanonicalTwoSphere, /
 ) -> type[DenseMetric]:
     """Non-canonical two-sphere charts return a `DenseMetric`.
 
@@ -174,19 +129,16 @@ def metric_representation(
 
 @plum.dispatch
 def metric_matrix(
-    M: HyperSphericalManifold,
-    point: CDict,
-    chart: LonLatSphericalTwoSphere
-    | LonCosLatSphericalTwoSphere
-    | MathSphericalTwoSphere,
-    /,
+    M: HyperSphericalManifold, point: CDict, chart: NonCanonicalTwoSphere, /
 ) -> DenseMetric:
     r"""Round metric on a non-canonical two-sphere chart (pullback).
 
     The nested sine-product used by the canonical dispatch assumes the
     components are polar angles in nested order; that is false for these charts
     (LonLat, Math swap/relabel the polar and azimuthal angles; LonCosLat is
-    non-orthogonal). The metric is instead pulled back from the canonical chart.
+    non-orthogonal). The metric is instead pulled back from the canonical chart:
+    ``g = Jc^T diag(1, sin^2 theta) Jc``, where ``Jc`` is the Jacobian of the
+    coordinate map ``chart -> SphericalTwoSphere``.
 
     >>> import math
     >>> import unxt as u
@@ -202,4 +154,19 @@ def metric_matrix(
 
     """
     del M
-    return _round_metric_pullback(point, chart)
+    keys = chart.components
+    x0 = tree_cast_int_bool_to_float(
+        jnp.stack([jnp.asarray(u.ustrip(AllowValue, RAD, point[k])) for k in keys])
+    )
+
+    def to_canon(x: jnp.ndarray) -> jnp.ndarray:
+        p = {k: u.Q(x[i], RAD) for i, k in enumerate(keys)}
+        s = cast("CDict", cxcapi.pt_map(p, chart, SphericalTwoSphere()))
+        return jnp.stack([u.ustrip(RAD, s["theta"]), u.ustrip(RAD, s["phi"])])
+
+    jc = jax.jacfwd(to_canon)(x0)  # (2, n)
+    theta = to_canon(x0)[0]
+    g_can = jnp.diag(jnp.stack([jnp.ones_like(theta), jnp.sin(theta) ** 2]))
+    n = len(keys)
+    dmls = ul.UnitsMatrix.full((n, n), "")  # angles -> angles, so g is dimensionless
+    return DenseMetric(ul.QM(jc.T @ g_can @ jc, unit=dmls))

--- a/src/coordinax/_src/spherical/register_metric.py
+++ b/src/coordinax/_src/spherical/register_metric.py
@@ -13,18 +13,67 @@ helper, avoiding a full-matrix allocation.
 
 __all__: tuple[str, ...] = ()
 
+from typing import cast
+
+import jax
 import jax.numpy as jnp
 import plum
+import unxts.linalg as ul
 
 import unxt as u
 from unxt.quantity import AllowValue
 
-from .chart import AbstractSphericalHyperSphere
+import coordinaxs.api.charts as cxcapi
+from .chart import (
+    AbstractSphericalHyperSphere,
+    LonCosLatSphericalTwoSphere,
+    LonLatSphericalTwoSphere,
+    MathSphericalTwoSphere,
+    SphericalTwoSphere,
+)
 from .manifold import HyperSphericalManifold
-from coordinax._src.metric.matrix import DiagonalMetric, _sine_product_diagonal
+from coordinax._src.metric.matrix import (
+    DenseMetric,
+    DiagonalMetric,
+    _sine_product_diagonal,
+)
 from coordinax.internal import CDict
 
 RAD = u.unit("rad")
+
+
+def _rad_value(q: object, /) -> object:
+    """Numeric value of an angular coordinate in radians (bare arrays pass through)."""
+    if isinstance(q, u.AbstractQuantity):
+        return u.ustrip("rad", q)
+    return jnp.asarray(q)
+
+
+def _round_metric_pullback(
+    point: CDict, chart: AbstractSphericalHyperSphere
+) -> DenseMetric:
+    r"""Round metric on the two-sphere via pullback of the canonical metric.
+
+    ``g = Jc^T diag(1, sin^2 theta) Jc`` where ``Jc`` is the Jacobian of the
+    coordinate map ``chart -> SphericalTwoSphere``. Correct for both orthogonal
+    (diagonal) and non-orthogonal (dense, e.g. ``LonCosLat``) charts.
+    """
+    keys = chart.components
+    x0 = jnp.stack([jnp.asarray(_rad_value(point[k]), dtype=float) for k in keys])
+    canon = SphericalTwoSphere()
+
+    def to_canon(x: jnp.ndarray) -> jnp.ndarray:
+        p = {k: u.Q(x[i], "rad") for i, k in enumerate(keys)}
+        s = cast("CDict", cxcapi.pt_map(p, chart, canon))
+        return jnp.stack([u.ustrip("rad", s["theta"]), u.ustrip("rad", s["phi"])])
+
+    jc = jax.jacfwd(to_canon)(x0)  # (2, n)
+    theta = to_canon(x0)[0]
+    g_can = jnp.diag(jnp.stack([jnp.ones_like(theta), jnp.sin(theta) ** 2]))
+    g = jc.T @ g_can @ jc  # (n, n), dimensionless (angles map angles -> angles)
+    n = len(keys)
+    units = ul.UnitsMatrix(tuple(tuple(u.unit("") for _ in range(n)) for _ in range(n)))
+    return DenseMetric(ul.QuantityMatrix(g, unit=units))
 
 
 @plum.dispatch
@@ -92,3 +141,60 @@ def metric_matrix(
         thetas = jnp.array([])
     diag = _sine_product_diagonal(thetas, 1.0)
     return DiagonalMetric(diag)
+
+
+@plum.dispatch
+def metric_representation(
+    M: HyperSphericalManifold,
+    chart: LonLatSphericalTwoSphere
+    | LonCosLatSphericalTwoSphere
+    | MathSphericalTwoSphere,
+    /,
+) -> type[DenseMetric]:
+    """Non-canonical two-sphere charts return a `DenseMetric`.
+
+    Their round metric is obtained by pullback (see `metric_matrix`); it is
+    diagonal for LonLat/Math but genuinely dense for LonCosLat, so all three use
+    `DenseMetric`.
+
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+    >>> cxm.metric_representation(cxm.S2, cxc.loncoslat_sph2)
+    <class 'coordinax._src.metric.matrix.DenseMetric'>
+
+    """
+    del M, chart
+    return DenseMetric
+
+
+@plum.dispatch
+def metric_matrix(
+    M: HyperSphericalManifold,
+    point: CDict,
+    chart: LonLatSphericalTwoSphere
+    | LonCosLatSphericalTwoSphere
+    | MathSphericalTwoSphere,
+    /,
+) -> DenseMetric:
+    r"""Round metric on a non-canonical two-sphere chart (pullback).
+
+    The nested sine-product used by the canonical dispatch assumes the
+    components are polar angles in nested order; that is false for these charts
+    (LonLat, Math swap/relabel the polar and azimuthal angles; LonCosLat is
+    non-orthogonal). The metric is instead pulled back from the canonical chart.
+
+    >>> import math
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    LonLat at lat=40 deg: ``g = diag(cos^2(lat), 1)``:
+
+    >>> at = {"lon": u.Q(0.6, "rad"), "lat": u.Q(math.radians(40), "rad")}
+    >>> g = cxm.metric_matrix(cxm.S2, at, cxc.lonlat_sph2)
+    >>> [round(float(g.matrix.value[i, i]), 4) for i in (0, 1)]
+    [0.5868, 1.0]
+
+    """
+    del M
+    return _round_metric_pullback(point, chart)

--- a/src/coordinax/_src/spherical/scale_factors.py
+++ b/src/coordinax/_src/spherical/scale_factors.py
@@ -9,9 +9,41 @@ import quaxed.numpy as jnp
 import unxt as u
 from unxt.quantity import AllowValue
 
+from .chart import (
+    LonCosLatSphericalTwoSphere,
+    LonLatSphericalTwoSphere,
+    MathSphericalTwoSphere,
+)
 from .metric import RoundMetric
 from coordinax._src.base import AbstractChart
 from coordinax._src.custom_types import CDict, OptUSys
+
+
+@plum.dispatch
+def scale_factors(
+    metric: RoundMetric,
+    chart: LonLatSphericalTwoSphere
+    | LonCosLatSphericalTwoSphere
+    | MathSphericalTwoSphere,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> ul.QuantityMatrix:
+    """Non-canonical two-sphere charts have no nested-sine scale factors.
+
+    The cumulative sine-product below assumes ``components[:-1]`` are polar
+    angles in nested order, which is false for these charts (they relabel/swap
+    the polar and azimuthal angles, and ``LonCosLat`` is non-orthogonal so its
+    metric is not even diagonal). Use ``metric_matrix`` for their round metric.
+    """
+    del metric, at, usys
+    msg = (
+        "scale_factors is only defined for the canonical nested-angle spherical "
+        f"chart; {type(chart).__name__} relabels the angles (and LonCosLat is "
+        "non-orthogonal). Use coordinax.manifolds.metric_matrix instead."
+    )
+    raise NotImplementedError(msg)
 
 
 @plum.dispatch

--- a/src/coordinax/_src/spherical/scale_factors.py
+++ b/src/coordinax/_src/spherical/scale_factors.py
@@ -9,11 +9,7 @@ import quaxed.numpy as jnp
 import unxt as u
 from unxt.quantity import AllowValue
 
-from .chart import (
-    LonCosLatSphericalTwoSphere,
-    LonLatSphericalTwoSphere,
-    MathSphericalTwoSphere,
-)
+from .chart import NonCanonicalTwoSphere
 from .metric import RoundMetric
 from coordinax._src.base import AbstractChart
 from coordinax._src.custom_types import CDict, OptUSys
@@ -22,21 +18,13 @@ from coordinax._src.custom_types import CDict, OptUSys
 @plum.dispatch
 def scale_factors(
     metric: RoundMetric,
-    chart: LonLatSphericalTwoSphere
-    | LonCosLatSphericalTwoSphere
-    | MathSphericalTwoSphere,
+    chart: NonCanonicalTwoSphere,
     /,
     *,
     at: CDict,
     usys: OptUSys = None,
 ) -> ul.QuantityMatrix:
-    """Non-canonical two-sphere charts have no nested-sine scale factors.
-
-    The cumulative sine-product below assumes ``components[:-1]`` are polar
-    angles in nested order, which is false for these charts (they relabel/swap
-    the polar and azimuthal angles, and ``LonCosLat`` is non-orthogonal so its
-    metric is not even diagonal). Use ``metric_matrix`` for their round metric.
-    """
+    """Non-canonical two-sphere charts have no nested-sine scale factors."""
     del metric, at, usys
     msg = (
         "scale_factors is only defined for the canonical nested-angle spherical "

--- a/src/coordinax/_src/spherical/scale_factors.py
+++ b/src/coordinax/_src/spherical/scale_factors.py
@@ -40,8 +40,8 @@ def scale_factors(
     del metric, at, usys
     msg = (
         "scale_factors is only defined for the canonical nested-angle spherical "
-        f"chart; {type(chart).__name__} relabels the angles (and LonCosLat is "
-        "non-orthogonal). Use coordinax.manifolds.metric_matrix instead."
+        f"chart; {type(chart).__name__} has no nested-sine scale factors. "
+        "Use coordinax.manifolds.metric_matrix instead."
     )
     raise NotImplementedError(msg)
 

--- a/tests/unit/manifolds/test_metric_pullback_consistency.py
+++ b/tests/unit/manifolds/test_metric_pullback_consistency.py
@@ -228,12 +228,6 @@ class TestNonCanonicalTwoSphereMetric:
         ref = _embedding_metric(chart, coords)
         assert jnp.allclose(got, ref, atol=1e-9), f"{got}\n!=\n{ref}"
 
-    def test_loncoslat_metric_is_dense(self):
-        """LonCosLat is non-orthogonal: the metric has a nonzero off-diagonal."""
-        pt = {"lon_coslat": u.Q(0.4, "rad"), "lat": u.Q(0.7, "rad")}
-        g = cxmapi.metric_matrix(cxm.S2, pt, cxc.loncoslat_sph2)
-        assert abs(float(jnp.asarray(g.matrix.value)[0, 1])) > 1e-3
-
     def test_integer_angles_do_not_break_jacfwd(self):
         """Integer-valued angles are promoted to float so the pullback jacfwd works."""
         pt = {"lon": u.Q(0, "rad"), "lat": u.Q(0, "rad")}  # integer magnitudes

--- a/tests/unit/manifolds/test_metric_pullback_consistency.py
+++ b/tests/unit/manifolds/test_metric_pullback_consistency.py
@@ -234,7 +234,9 @@ class TestNonCanonicalTwoSphereMetric:
         g = cxmapi.metric_matrix(cxm.S2, pt, cxc.loncoslat_sph2)
         assert abs(float(jnp.asarray(g.matrix.value)[0, 1])) > 1e-3
 
-    @pytest.mark.parametrize("chart", [cxc.lonlat_sph2, cxc.loncoslat_sph2])
+    @pytest.mark.parametrize(
+        "chart", [cxc.lonlat_sph2, cxc.loncoslat_sph2, cxc.math_sph2]
+    )
     def test_scale_factors_not_defined(self, chart):
         """scale_factors is undefined for non-canonical charts (use metric_matrix)."""
         keys = chart.components

--- a/tests/unit/manifolds/test_metric_pullback_consistency.py
+++ b/tests/unit/manifolds/test_metric_pullback_consistency.py
@@ -234,6 +234,13 @@ class TestNonCanonicalTwoSphereMetric:
         g = cxmapi.metric_matrix(cxm.S2, pt, cxc.loncoslat_sph2)
         assert abs(float(jnp.asarray(g.matrix.value)[0, 1])) > 1e-3
 
+    def test_integer_angles_do_not_break_jacfwd(self):
+        """Integer-valued angles are promoted to float so the pullback jacfwd works."""
+        pt = {"lon": u.Q(0, "rad"), "lat": u.Q(0, "rad")}  # integer magnitudes
+        g = cxmapi.metric_matrix(cxm.S2, pt, cxc.lonlat_sph2)
+        assert isinstance(g, DenseMetric)
+        assert bool(jnp.all(jnp.isfinite(g.matrix.value)))
+
     @pytest.mark.parametrize(
         "chart", [cxc.lonlat_sph2, cxc.loncoslat_sph2, cxc.math_sph2]
     )

--- a/tests/unit/manifolds/test_metric_pullback_consistency.py
+++ b/tests/unit/manifolds/test_metric_pullback_consistency.py
@@ -185,3 +185,59 @@ class TestPullbackMetricUnits:
         # Metric = R² × I at equator → values should be [[4, 0], [0, 4]]
         assert jnp.allclose(g.matrix.value, 4 * jnp.eye(2), atol=1e-6)
         assert str(g.matrix.unit[0, 0]) == "m2 / rad2"
+
+
+# ---------------------------------------------------------------------------
+# Non-canonical two-sphere charts: metric must match the R³ embedding J^T J
+# ---------------------------------------------------------------------------
+
+
+def _embedding_metric(chart, coords_rad):
+    """Induced metric of ``chart`` from the unit-sphere R³ embedding, via J^T J."""
+    keys = chart.components
+
+    def embed(x):
+        p = {k: u.Q(x[i], "rad") for i, k in enumerate(keys)}
+        s = cxc.pt_map(p, chart, cxc.sph2)
+        th, ph = u.ustrip("rad", s["theta"]), u.ustrip("rad", s["phi"])
+        return jnp.array(
+            [jnp.sin(th) * jnp.cos(ph), jnp.sin(th) * jnp.sin(ph), jnp.cos(th)]
+        )
+
+    x0 = jnp.array([coords_rad[k] for k in keys])
+    jmat = jax.jacfwd(embed)(x0)  # (3, n)
+    return jmat.T @ jmat
+
+
+class TestNonCanonicalTwoSphereMetric:
+    """metric_matrix for LonLat/Math/LonCosLat charts must be the true metric."""
+
+    @pytest.mark.parametrize(
+        ("chart", "coords"),
+        [
+            (cxc.math_sph2, {"theta": 0.6, "phi": 0.9}),
+            (cxc.lonlat_sph2, {"lon": 0.6, "lat": 0.7}),
+            (cxc.loncoslat_sph2, {"lon_coslat": 0.4, "lat": 0.7}),
+        ],
+    )
+    def test_metric_matches_embedding(self, chart, coords):
+        pt = {k: u.Q(v, "rad") for k, v in coords.items()}
+        g = cxmapi.metric_matrix(cxm.S2, pt, chart)
+        assert isinstance(g, DenseMetric)
+        got = jnp.asarray(g.matrix.value)
+        ref = _embedding_metric(chart, coords)
+        assert jnp.allclose(got, ref, atol=1e-9), f"{got}\n!=\n{ref}"
+
+    def test_loncoslat_metric_is_dense(self):
+        """LonCosLat is non-orthogonal: the metric has a nonzero off-diagonal."""
+        pt = {"lon_coslat": u.Q(0.4, "rad"), "lat": u.Q(0.7, "rad")}
+        g = cxmapi.metric_matrix(cxm.S2, pt, cxc.loncoslat_sph2)
+        assert abs(float(jnp.asarray(g.matrix.value)[0, 1])) > 1e-3
+
+    @pytest.mark.parametrize("chart", [cxc.lonlat_sph2, cxc.loncoslat_sph2])
+    def test_scale_factors_not_defined(self, chart):
+        """scale_factors is undefined for non-canonical charts (use metric_matrix)."""
+        keys = chart.components
+        at = {k: u.Q(0.4, "rad") for k in keys}
+        with pytest.raises(NotImplementedError, match="canonical"):
+            cxm.scale_factors(chart, at=at)


### PR DESCRIPTION
## Summary

`metric_matrix` and `scale_factors` for a unit two-sphere used the nested sine-product `g_kk = ∏_{j<k} sin²(θ_j)`, which assumes the components are polar angles in **nested (polar-then-azimuth) order**. That only holds for the canonical `SphericalTwoSphere`. For the other 2-sphere charts the component roles differ, so the metric was **silently wrong**:

| chart | `metric_matrix` (before) | true (induced) |
|---|---|---|
| `sph2` | `[1, 0.587]` | `[1, 0.587]` ✓ |
| `math_sph2` | `[1, 0.329]` | `[0.587, 1]` ✗ |
| `lonlat_sph2` | `[1, 0.329]` | `[0.587, 1]` ✗ |
| `loncoslat_sph2` | `diag[1, 0.087]` | **dense** `[[1, .34],[.34, 1.11]]` ✗ |

(`loncoslat_sph2` is genuinely non-orthogonal, so returning a `DiagonalMetric` at all was wrong.) This corrupts any downstream geometry — norms, geodesics, volume elements — on these charts. Found in a fresh v0.24 audit pass.

## Fix

Keep the sine-product for the canonical `SphericalTwoSphere`. For the three non-canonical charts, pull the canonical round metric back through the coordinate map:

```
g = Jc^T · diag(1, sin²θ) · Jc,   Jc = ∂(θ,φ)/∂(chart coords)
```

returning a `DenseMetric` (correct for the diagonal LonLat/Math and the dense LonCosLat); `metric_representation` returns `DenseMetric` for them. `scale_factors` (a diagonal orthonormal-frame concept) is undefined for these relabeled / non-orthogonal charts, so it now raises a clear `NotImplementedError` pointing at `metric_matrix` instead of returning a wrong diagonal.

## Verification
New regression tests assert `metric_matrix` matches the **R³-embedding `JᵀJ`** for all three charts (incl. the LonCosLat off-diagonal); `change_basis` (which consumes `metric_matrix`) keeps working via its Cholesky dense path. `tests/unit/manifolds` + `tests/unit/representations` + spherical doctests pass (871); `ruff`/`ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)