### PR TITLE
🐛 fix(charts): route Cart3D → ProlateSpheroidal3D via Cylindrical3D (stop recursion)

### DIFF
--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -1272,6 +1272,42 @@ def pt_map(
 def pt_map(
     p: CDict,
     from_M: Rn,
+    from_chart: Cart3D,
+    to_M: Rn,
+    to_chart: ProlateSpheroidal3D,
+    /,
+    *,
+    usys: OptUSys = None,
+) -> CDict:
+    """Cart3D -> Cylindrical3D -> ProlateSpheroidal3D.
+
+    ``ProlateSpheroidal3D`` is only registered as a target from ``Cylindrical3D``;
+    without this route the generic ``A -> A.cartesian -> B`` fallback would send
+    ``Cart3D -> Cart3D -> ProlateSpheroidal3D`` and recurse forever. Route through
+    ``Cylindrical3D`` instead (mirrors the ``Cart3D -> AbstractSpherical3D`` rule).
+
+    >>> import coordinax.manifolds as cxm
+    >>> import coordinax.charts as cxc
+    >>> import unxt as u
+
+    >>> prolate = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m"))
+    >>> p = {"x": u.Q(0.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(3.0, "m")}
+    >>> cxc.pt_map(p, cxm.R3, cxc.cart3d, cxm.R3, prolate)
+    {'mu': Q(9., 'm2'), 'nu': Q(4., 'm2'), 'phi': Q(0., 'rad')}
+
+    """
+    assert from_M == from_chart.M  # noqa: S101
+    assert to_M == to_chart.M  # noqa: S101
+    cyl = Cylindrical3D(M=from_chart.M)
+    p_cyl = cxcapi.pt_map(p, from_M, from_chart, to_M, cyl, usys=usys)
+    out = cxcapi.pt_map(p_cyl, from_M, cyl, to_M, to_chart, usys=usys)
+    return cast("CDict", out)
+
+
+@plum.dispatch
+def pt_map(
+    p: CDict,
+    from_M: Rn,
     from_chart: ProlateSpheroidal3D,
     to_M: Rn,
     to_chart: ProlateSpheroidal3D,

--- a/tests/unit/charts/test_register_realize.py
+++ b/tests/unit/charts/test_register_realize.py
@@ -102,3 +102,23 @@ class TestPointTransformProductCharts:
         assert u.ustrip("rad", result["q.phi"]) == pytest.approx(0)
         assert u.ustrip("m", result["p.r"]) == pytest.approx(1)
         assert u.ustrip("rad", result["p.phi"]) == pytest.approx(jnp.pi / 2)
+
+
+class TestPointTransformProlate:
+    """``pt_map`` into ProlateSpheroidal3D routes via Cylindrical3D (no recursion)."""
+
+    def test_cart3d_to_prolate_roundtrips(self) -> None:
+        prolate = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m"))
+        p = {"x": u.Q(0.5, "m"), "y": u.Q(1.5, "m"), "z": u.Q(3.0, "m")}
+        out = cxc.pt_map(p, cxc.cart3d, prolate)
+        assert set(out) == {"mu", "nu", "phi"}
+        back = cxc.pt_map(out, prolate, cxc.cart3d)
+        for k in ("x", "y", "z"):
+            assert u.ustrip("m", back[k]) == pytest.approx(u.ustrip("m", p[k]))
+
+    def test_spherical_to_prolate(self) -> None:
+        # Routes via the generic fallback: Spherical3D -> Cart3D -> Cyl -> Prolate.
+        prolate = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m"))
+        p = {"r": u.Q(3.0, "m"), "theta": u.Q(0.6, "rad"), "phi": u.Q(0.4, "rad")}
+        out = cxc.pt_map(p, cxc.sph3d, prolate)
+        assert set(out) == {"mu", "nu", "phi"}


### PR DESCRIPTION
## Summary

`ProlateSpheroidal3D` is only registered as a `pt_map` target from `Cylindrical3D`. For any other source chart the generic `A → A.cartesian → B` fallback applies — and since prolate's `.cartesian` is `Cart3D`, `Cart3D → Prolate` re-emits `Cart3D → Prolate` and recurses forever:

```python
cxc.pt_map(p, cxc.cart3d, cxc.ProlateSpheroidal3D(Delta=...))   # RecursionError
cxc.pt_map(p, cxc.sph3d,  cxc.ProlateSpheroidal3D(Delta=...))   # RecursionError
# only cylindrical -> prolate worked
```

Found in a fresh v0.24 audit pass.

## Fix

Register an explicit `Cart3D → ProlateSpheroidal3D` that routes through `Cylindrical3D` (mirrors the existing `Cart3D | Cylindrical3D → AbstractSpherical3D` rule). This also fixes `Spherical3D → Prolate` (and other sources), which the generic fallback now routes `→ Cart3D → Cyl → Prolate`.

## Verification
New tests: `Cart3D ↔ Prolate` round-trip (exact) and `Spherical3D → Prolate`; `tests/unit/charts` passes (447) and `register_ptmap.py` doctests pass; `ruff`/`ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)