### PR TITLE
🐛 fix(charts): convert between non-canonical two-sphere charts via canonical

### DIFF
--- a/src/coordinax/_src/spherical/register_ptmap.py
+++ b/src/coordinax/_src/spherical/register_ptmap.py
@@ -13,6 +13,7 @@ from unxt.quantity import is_any_quantity
 
 import coordinaxs.api.charts as cxcapi
 from .chart import (
+    AbstractSphericalTwoSphere,
     LonCosLatSphericalTwoSphere,
     LonLatSphericalTwoSphere,
     MathSphericalTwoSphere,
@@ -76,24 +77,23 @@ def pt_map(
 def pt_map(
     p: CDict,
     from_M: Sn,
-    from_chart: LonLatSphericalTwoSphere
-    | LonCosLatSphericalTwoSphere
-    | MathSphericalTwoSphere,
+    from_chart: AbstractSphericalTwoSphere,
     to_M: Sn,
-    to_chart: LonLatSphericalTwoSphere
-    | LonCosLatSphericalTwoSphere
-    | MathSphericalTwoSphere,
+    to_chart: AbstractSphericalTwoSphere,
     /,
     *,
     usys: OptUSys = None,
 ) -> CDict:
-    """Route between non-canonical two-sphere charts via `SphericalTwoSphere`.
+    """Route between two-sphere charts via `SphericalTwoSphere`.
 
-    Only ``sph2 <-> {lonlat, loncoslat, math}`` pairs are registered directly,
-    and the two-sphere has no Cartesian chart, so the generic router cannot
-    bridge two non-canonical charts (it raises ``NoGlobalCartesianChartError``).
-    Go ``A -> SphericalTwoSphere -> B`` instead (matching-type pairs are handled
-    by the identity rule above).
+    Each chart registers only its direct ``sph2 <-> chart`` conversion, and the
+    two-sphere has no Cartesian chart, so the generic router cannot bridge two
+    non-canonical charts (it raises ``NoGlobalCartesianChartError``). Go
+    ``A -> SphericalTwoSphere -> B`` instead. Canonical pairs (either side is
+    `SphericalTwoSphere`) and matching-type pairs are handled by the more
+    specific direct/identity rules above, so this fallback fires only for
+    distinct non-canonical charts -- and covers any future
+    `AbstractSphericalTwoSphere` subclass automatically.
 
     >>> import coordinax.charts as cxc
     >>> import coordinax.manifolds as cxm

--- a/src/coordinax/_src/spherical/register_ptmap.py
+++ b/src/coordinax/_src/spherical/register_ptmap.py
@@ -3,7 +3,7 @@
 __all__: tuple[str, ...] = ()
 
 
-from typing import Any, Final
+from typing import Any, Final, cast
 
 import plum
 
@@ -11,6 +11,7 @@ import quaxed.numpy as jnp
 import unxt as u
 from unxt.quantity import is_any_quantity
 
+import coordinaxs.api.charts as cxcapi
 from .chart import (
     LonCosLatSphericalTwoSphere,
     LonLatSphericalTwoSphere,
@@ -69,6 +70,45 @@ def pt_map(
     assert to_M == to_chart.M  # noqa: S101
 
     return p
+
+
+@plum.dispatch
+def pt_map(
+    p: CDict,
+    from_M: Sn,
+    from_chart: LonLatSphericalTwoSphere
+    | LonCosLatSphericalTwoSphere
+    | MathSphericalTwoSphere,
+    to_M: Sn,
+    to_chart: LonLatSphericalTwoSphere
+    | LonCosLatSphericalTwoSphere
+    | MathSphericalTwoSphere,
+    /,
+    *,
+    usys: OptUSys = None,
+) -> CDict:
+    """Route between non-canonical two-sphere charts via `SphericalTwoSphere`.
+
+    Only ``sph2 <-> {lonlat, loncoslat, math}`` pairs are registered directly,
+    and the two-sphere has no Cartesian chart, so the generic router cannot
+    bridge two non-canonical charts (it raises ``NoGlobalCartesianChartError``).
+    Go ``A -> SphericalTwoSphere -> B`` instead (matching-type pairs are handled
+    by the identity rule above).
+
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+    >>> import unxt as u
+
+    >>> p = {"lon": u.Q(45, "deg"), "lat": u.Q(30, "deg")}
+    >>> out = cxc.pt_map(p, cxm.S2, cxc.lonlat_sph2, cxm.S2, cxc.math_sph2)
+    >>> sorted(out)
+    ['phi', 'theta']
+
+    """
+    canon = SphericalTwoSphere(M=from_chart.M)
+    p_canon = cxcapi.pt_map(p, from_M, from_chart, to_M, canon, usys=usys)
+    out = cxcapi.pt_map(p_canon, from_M, canon, to_M, to_chart, usys=usys)
+    return cast("CDict", out)
 
 
 # ===================================================================

--- a/src/coordinax/_src/spherical/register_ptmap.py
+++ b/src/coordinax/_src/spherical/register_ptmap.py
@@ -105,9 +105,12 @@ def pt_map(
     ['phi', 'theta']
 
     """
-    canon = SphericalTwoSphere(M=from_chart.M)
+    assert from_M == from_chart.M  # noqa: S101
+    assert to_M == to_chart.M  # noqa: S101
+
+    canon = SphericalTwoSphere(M=to_M)
     p_canon = cxcapi.pt_map(p, from_M, from_chart, to_M, canon, usys=usys)
-    out = cxcapi.pt_map(p_canon, from_M, canon, to_M, to_chart, usys=usys)
+    out = cxcapi.pt_map(p_canon, to_M, canon, to_M, to_chart, usys=usys)
     return cast("CDict", out)
 
 

--- a/tests/unit/charts/test_register_realize.py
+++ b/tests/unit/charts/test_register_realize.py
@@ -136,3 +136,31 @@ class TestPointTransformCartND:
         assert u.ustrip("m", out["x"]) == pytest.approx([1.0, 4.0])
         assert u.ustrip("m", out["y"]) == pytest.approx([2.0, 5.0])
         assert u.ustrip("m", out["z"]) == pytest.approx([3.0, 6.0])
+
+
+_TWO_SPHERE_PTS = {
+    "lonlat": (cxc.lonlat_sph2, {"lon": u.Q(45, "deg"), "lat": u.Q(30, "deg")}),
+    "math": (cxc.math_sph2, {"theta": u.Q(50, "deg"), "phi": u.Q(35, "deg")}),
+    "loncoslat": (
+        cxc.loncoslat_sph2,
+        {"lon_coslat": u.Q(0.4, "rad"), "lat": u.Q(0.5, "rad")},
+    ),
+}
+
+
+class TestPointTransformTwoSphereCrossChart:
+    """Non-canonical two-sphere charts convert to each other via SphericalTwoSphere."""
+
+    @pytest.mark.parametrize("src", ["lonlat", "math", "loncoslat"])
+    @pytest.mark.parametrize("dst", ["lonlat", "math", "loncoslat"])
+    def test_cross_chart_matches_route_via_canonical(self, src, dst):
+        if src == dst:
+            return
+        a, p = _TWO_SPHERE_PTS[src]
+        b, _ = _TWO_SPHERE_PTS[dst]
+        out = cxc.pt_map(p, a, b)
+        ref = cxc.pt_map(cxc.pt_map(p, a, cxc.sph2), cxc.sph2, b)
+        for k in out:
+            assert u.ustrip(u.unit_of(out[k]), out[k]) == pytest.approx(
+                u.ustrip(u.unit_of(ref[k]), ref[k])
+            )

--- a/tests/unit/charts/test_register_realize.py
+++ b/tests/unit/charts/test_register_realize.py
@@ -160,7 +160,8 @@ class TestPointTransformTwoSphereCrossChart:
         b, _ = _TWO_SPHERE_PTS[dst]
         out = cxc.pt_map(p, a, b)
         ref = cxc.pt_map(cxc.pt_map(p, a, cxc.sph2), cxc.sph2, b)
+        assert set(out) == set(ref)
+        # Compare in a shared canonical unit (rad) so mismatched unit metadata
+        # can't slip through equal magnitudes with different units.
         for k in out:
-            assert u.ustrip(u.unit_of(out[k]), out[k]) == pytest.approx(
-                u.ustrip(u.unit_of(ref[k]), ref[k])
-            )
+            assert u.ustrip("rad", out[k]) == pytest.approx(u.ustrip("rad", ref[k]))

--- a/tests/unit/charts/test_register_realize.py
+++ b/tests/unit/charts/test_register_realize.py
@@ -3,10 +3,11 @@
 cartesian_chart, pt_map.
 """
 
+import hypothesis.strategies as st
 import jax.numpy as jnp
 import plum
 import pytest
-from hypothesis import given
+from hypothesis import assume, given
 
 import unxt as u
 
@@ -138,30 +139,32 @@ class TestPointTransformCartND:
         assert u.ustrip("m", out["z"]) == pytest.approx([3.0, 6.0])
 
 
-_TWO_SPHERE_PTS = {
-    "lonlat": (cxc.lonlat_sph2, {"lon": u.Q(45, "deg"), "lat": u.Q(30, "deg")}),
-    "math": (cxc.math_sph2, {"theta": u.Q(50, "deg"), "phi": u.Q(35, "deg")}),
-    "loncoslat": (
-        cxc.loncoslat_sph2,
-        {"lon_coslat": u.Q(0.4, "rad"), "lat": u.Q(0.5, "rad")},
-    ),
-}
+# Concrete non-canonical two-sphere charts, drawn by type + realization so the
+# test covers any future ``AbstractSphericalTwoSphere`` subclass automatically.
+_two_sphere_charts = cxst.charts(
+    filter=cxc.AbstractSphericalTwoSphere, exclude=(cxc.SphericalTwoSphere,)
+)
 
 
 class TestPointTransformTwoSphereCrossChart:
     """Non-canonical two-sphere charts convert to each other via SphericalTwoSphere."""
 
-    @pytest.mark.parametrize("src", ["lonlat", "math", "loncoslat"])
-    @pytest.mark.parametrize("dst", ["lonlat", "math", "loncoslat"])
-    def test_cross_chart_matches_route_via_canonical(self, src, dst):
-        if src == dst:
-            return
-        a, p = _TWO_SPHERE_PTS[src]
-        b, _ = _TWO_SPHERE_PTS[dst]
+    @given(data=st.data())
+    def test_cross_chart_matches_route_via_canonical(self, data):
+        a = data.draw(_two_sphere_charts)
+        b = data.draw(_two_sphere_charts)
+        assume(type(a) is not type(b))  # matching types are the identity route
+        p = data.draw(cxst.cdicts(a))
+
         out = cxc.pt_map(p, a, b)
         ref = cxc.pt_map(cxc.pt_map(p, a, cxc.sph2), cxc.sph2, b)
+
         assert set(out) == set(ref)
-        # Compare in a shared canonical unit (rad) so mismatched unit metadata
-        # can't slip through equal magnitudes with different units.
+        # Compare in a shared canonical unit (rad); equal_nan lets pole
+        # singularities (cos(lat) -> 0) match on both routes.
         for k in out:
-            assert u.ustrip("rad", out[k]) == pytest.approx(u.ustrip("rad", ref[k]))
+            assert bool(
+                jnp.allclose(
+                    u.ustrip("rad", out[k]), u.ustrip("rad", ref[k]), equal_nan=True
+                )
+            )


### PR DESCRIPTION
## Summary

Only `sph2 ↔ {lonlat, loncoslat, math}` `pt_map` pairs were registered on the two-sphere. Since the two-sphere has no Cartesian chart, the generic `A → A.cartesian → B` router cannot bridge two non-canonical charts, so the cross pairs raised `NoGlobalCartesianChartError`:

```python
cxc.pt_map(p, cxc.lonlat_sph2, cxc.math_sph2)   # NoGlobalCartesianChartError
```

This is inconsistent with the 3D charts (`lonlat_sph3d → math_sph3d` works by routing through `Cart3D`). Found in a fresh v0.24 audit pass. (Loud error, not wrong data — hence low severity.)

## Fix

Register a routing dispatch for non-canonical two-sphere pairs that goes `A → SphericalTwoSphere → B`. Matching-type pairs stay on the existing identity rule; canonical-involving pairs stay on their existing direct dispatches.

## Verification
New parametrized test: all six non-canonical cross pairs match the explicit route through the canonical chart. `tests/unit/charts` passes (249); `register_ptmap.py` doctests pass; `ruff`/`ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)