### PR TITLE
➖ build(deps): drop unused optional-dependencies dep from coordinaxs.astro

### DIFF
--- a/packages/coordinaxs.astro/pyproject.toml
+++ b/packages/coordinaxs.astro/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-dependencies = ["coordinax>=0.24", "optional-dependencies>=0.4.0"]
+dependencies = ["coordinax>=0.24"]
 description = "Astronomy-specific reference frames for coordinax"
 dynamic = ["version"]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -751,7 +751,6 @@ name = "coordinaxs-astro"
 source = { editable = "packages/coordinaxs.astro" }
 dependencies = [
     { name = "coordinax" },
-    { name = "optional-dependencies" },
 ]
 
 [package.optional-dependencies]
@@ -770,7 +769,6 @@ requires-dist = [
     { name = "coordinax", editable = "." },
     { name = "coordinaxs-hypothesis", marker = "extra == 'hypothesis'", editable = "packages/coordinaxs.hypothesis" },
     { name = "hypothesis", marker = "extra == 'hypothesis'", specifier = ">=6.148.7" },
-    { name = "optional-dependencies", specifier = ">=0.4.0" },
     { name = "unxt-hypothesis", marker = "extra == 'hypothesis'", specifier = ">=2.0" },
 ]
 provides-extras = ["astropy", "hypothesis"]


### PR DESCRIPTION
**Stacked refactor sequence — Part 2/7.** Stacked on #596; merge after it. Base `main`, so the diff currently also shows Part 1 — this part's own change is the top commit (`157801a5`).

`coordinaxs.astro` declared `optional-dependencies>=0.4.0` as a runtime dependency but never imports it (the root package uses it for build metadata; astro's extras are static). Dropping it removes one forced install for astro consumers, no code change. `uv.lock` updated (drops only the astro→optional-dependencies edge; the package stays for the root).

**Tests:** astro imports + suite pass. Pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)