### PR TITLE
♻️ refactor: dedupe repeated helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "quaxed>=0.10.5",
   "typing-extensions>=4.13.2",
   "unxt>=2.0",
-  "unxts.linalg>=2.0.1",
+  "unxts.linalg>=2.0.3",
   "wadler-lindig>=0.1.6",
   "xmmutablemap>=0.1",
 ]

--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -65,17 +65,6 @@ chart_dataclass_decorator = dataclasses.dataclass(
 MISSING = object()
 
 
-class MissingDefault:
-    """Sentinel for missing default values in dataclass fields."""
-
-    @property
-    def default(self) -> object:
-        return MISSING
-
-
-MISSINGDEFAULT = MissingDefault()
-
-
 ##############################################################################
 # AbstractChart
 
@@ -243,7 +232,7 @@ class AbstractChart(Generic[MT, Ks, Ds], metaclass=abc.ABCMeta):
             for k, v in field_items
             if k == "M"
             or not kw["hide_defaults"]
-            or v is not defaults.get(k, MISSINGDEFAULT).default
+            or v is not (defaults[k].default if k in defaults else MISSING)
         ]
         return wl.bracketed(
             begin=cls_name, docs=docs, sep=wl.comma, end=wl.TextDoc(")"), indent=4

--- a/src/coordinax/_src/charts/scale_factors.py
+++ b/src/coordinax/_src/charts/scale_factors.py
@@ -7,7 +7,6 @@ import plum
 import unxts.linalg as ul
 
 import quaxed.numpy as jnp
-import unxt as u
 
 from .d0 import Cart0D
 from .d1 import Cart1D
@@ -51,6 +50,4 @@ def scale_factors(
         if isinstance(chart, AbstractDimensionalFlag)
         else len(chart.components)
     )
-    return ul.QuantityMatrix(
-        jnp.ones((n,)), unit=ul.UnitsMatrix(tuple(u.unit("") for _ in range(n)))
-    )
+    return ul.QM(jnp.ones((n,)), unit=ul.UnitsMatrix.full(n, ""))

--- a/src/coordinax/_src/euclidean/scale_factors.py
+++ b/src/coordinax/_src/euclidean/scale_factors.py
@@ -27,7 +27,7 @@ def scale_factors(
     *,
     at: CDict,
     usys: OptUSys = None,
-) -> ul.QuantityMatrix:
+) -> ul.QM:
     """Compute only the Euclidean metric diagonal instead of forming ``J.T @ J``.
 
     >>> import jax.numpy as jnp
@@ -50,40 +50,33 @@ def scale_factors(
 
     if chart == cart_chart:
         n = len(chart.components)
-        return ul.QuantityMatrix(
-            jnp.ones((n,)), unit=ul.UnitsMatrix(tuple(u.unit("") for _ in range(n)))
-        )
+        return ul.QM(jnp.ones((n,)), unit=ul.UnitsMatrix.full(n, ""))
 
     J = cxcapi.jac_pt_map(at, chart, cart_chart, usys=usys)
     return _column_squared_norms(J)
 
 
-def _column_squared_norms(J: ul.QuantityMatrix | Array, /) -> ul.QuantityMatrix:
+def _column_squared_norms(J: ul.QM | Array, /) -> ul.QM:
     """Return ``diag(J.T @ J)`` without forming the full Gram matrix."""
-    if isinstance(J, ul.QuantityMatrix):
+    if isinstance(J, ul.QM):
         return _quantity_column_squared_norms(J)
     return _array_column_squared_norms(J)
 
 
-def _array_column_squared_norms(J: Array, /) -> ul.QuantityMatrix:
+def _array_column_squared_norms(J: Array, /) -> ul.QM:
     """Return squared column norms for a dimensionless Jacobian array."""
     value = jnp.einsum("...ji,...ji->...i", J, J)
     n = value.shape[-1]
-    unit = ul.UnitsMatrix(tuple(DMLS for _ in range(n)))
-    return ul.QuantityMatrix(value, unit)
+    unit = ul.UnitsMatrix.full(n, DMLS)
+    return ul.QM(value, unit)
 
 
-def _quantity_column_squared_norms(J: ul.QuantityMatrix) -> ul.QuantityMatrix:
+def _quantity_column_squared_norms(J: ul.QM) -> ul.QM:
     """Return squared column norms for a heterogeneous-unit Jacobian."""
-    xs = tuple(_colnorm2(J[:, i]) for i in range(J.shape[-1]))
+    xs = tuple(jnp.dot(J[:, i], J[:, i]) for i in range(J.shape[-1]))
     units = tuple(u.unit_of(x) if is_any_quantity(x) else DMLS for x in xs)
     value = jnp.stack(
         [u.ustrip(AllowValue, unit, x) for x, unit in zip(xs, units, strict=True)],
         axis=-1,
     )
-    return ul.QuantityMatrix(value, unit=ul.UnitsMatrix(units))
-
-
-def _colnorm2(column: ul.QuantityMatrix) -> u.AbstractQuantity | Array:
-    """Return the squared norm of a single Jacobian column."""
-    return jnp.dot(column, column)
+    return ul.QM(value, unit=ul.UnitsMatrix(units))

--- a/src/coordinax/_src/internal/dtype_utils.py
+++ b/src/coordinax/_src/internal/dtype_utils.py
@@ -22,10 +22,7 @@ InexactLeaf = Float[Array, "..."] | Complex[Array, "..."]
 
 def _cast_int_bool_leaf_to_float(x: NumericLeaf, /) -> InexactLeaf:
     """Cast integer/bool leaves to the configured default floating dtype."""
-    dtype = x.dtype
-    if jnp.issubdtype(dtype, jnp.integer) or jnp.issubdtype(dtype, jnp.bool_):
-        return x.astype(DEFAULT_FLOAT_DTYPE)
-    return x
+    return x if jnp.issubdtype(x.dtype, jnp.inexact) else x.astype(DEFAULT_FLOAT_DTYPE)
 
 
 def tree_cast_int_bool_to_float(tree: PyTree[NumericLeaf], /) -> PyTree[InexactLeaf]:

--- a/src/coordinax/_src/manifolds/scale_factors.py
+++ b/src/coordinax/_src/manifolds/scale_factors.py
@@ -6,7 +6,6 @@ from jaxtyping import Array
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 import plum
 import unxts.linalg as ul
 
@@ -18,7 +17,7 @@ import coordinaxs.api.manifolds as cxmapi
 from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.custom_types import CDict, OptUSys
 from coordinax._src.embedded.metric import PullbackMetric
-from coordinax._src.euclidean.scale_factors import _column_squared_norms as _csn
+from coordinax._src.euclidean.scale_factors import _column_squared_norms
 from coordinax._src.metric.matrix import DiagonalMetric
 from coordinax.internal import pack_nonuniform_unit
 
@@ -26,9 +25,7 @@ DMLS = u.unit("")
 
 
 @plum.dispatch
-def scale_factors(
-    chart: AbstractChart, /, *, at: CDict, usys: OptUSys = None
-) -> ul.QuantityMatrix:
+def scale_factors(chart: AbstractChart, /, *, at: CDict, usys: OptUSys = None) -> ul.QM:
     """Manifold-level dispatch: delegate to the attached metric.
 
     >>> import jax.numpy as jnp
@@ -56,7 +53,7 @@ def scale_factors(
     *,
     at: CDict,
     usys: OptUSys = None,
-) -> ul.QuantityMatrix:
+) -> ul.QM:
     """Return the diagonal entries of the metric at ``at`` in ``chart``.
 
     Uses the ``metric_matrix`` dispatch API to compute the metric, then
@@ -75,21 +72,21 @@ def scale_factors(
     mm = cxmapi.metric_matrix(chart.M, at, chart)
     if isinstance(mm, DiagonalMetric):
         diag = mm.diagonal
-        if isinstance(diag, ul.QuantityMatrix):
+        if isinstance(diag, ul.QM):
             return diag
-        units = ul.UnitsMatrix(tuple(DMLS for _ in range(diag.shape[-1])))
-        return ul.QuantityMatrix(diag, unit=units)
+        units = ul.UnitsMatrix.full(diag.shape[-1], DMLS)
+        return ul.QM(diag, unit=units)
     return _as_quantity_matrix(mm.matrix).diag()  # ty: ignore[unresolved-attribute]
 
 
-def _as_quantity_matrix(x: ul.QuantityMatrix | Array) -> ul.QuantityMatrix:
+def _as_quantity_matrix(x: ul.QM | Array) -> ul.QM:
     """Convert a numeric matrix into a dimensionless QuantityMatrix."""
-    if isinstance(x, ul.QuantityMatrix):
+    if isinstance(x, ul.QM):
         return x
 
     n_rows, n_cols = x.shape[-2:]
-    units = ul.UnitsMatrix(np.full((n_rows, n_cols), DMLS))
-    return ul.QuantityMatrix(value=x, unit=units)
+    units = ul.UnitsMatrix.full((n_rows, n_cols), DMLS)
+    return ul.QM(value=x, unit=units)
 
 
 @plum.dispatch
@@ -100,7 +97,7 @@ def scale_factors(
     *,
     at: CDict,
     usys: OptUSys = None,
-) -> ul.QuantityMatrix:
+) -> ul.QM:
     """Return scale factors for a pullback (induced) metric via Jacobian pullback.
 
     Computes the Jacobian of the composed embedding ``intrinsic →
@@ -159,10 +156,5 @@ def scale_factors(
         return qnp.stack(vals)
 
     J_arr = jax.jacfwd(_embed_cart)(xat)  # (n_cart, n_intrinsic)
-    J_cart = ul.QuantityMatrix(J_arr, unit=unit_matrix)
+    J_cart = ul.QM(J_arr, unit=unit_matrix)
     return _column_squared_norms(J_cart)
-
-
-def _column_squared_norms(J: ul.QuantityMatrix | Array) -> ul.QuantityMatrix:
-    """Return the squared column norms of a Jacobian matrix as a QuantityMatrix."""
-    return _csn(J)

--- a/src/coordinax/_src/minkowski/scale_factors.py
+++ b/src/coordinax/_src/minkowski/scale_factors.py
@@ -6,8 +6,6 @@ import jax.numpy as jnp
 import plum
 import unxts.linalg as ul
 
-import unxt as u
-
 from .charts import MinkowskiCT
 from .metric import MinkowskiMetric
 from coordinax._src.custom_types import CDict, OptUSys
@@ -37,5 +35,5 @@ def scale_factors(
     del chart, at, usys
     n = metric.ndim
     value = jnp.array(list(metric.signature), dtype=float)
-    units = ul.UnitsMatrix(tuple(u.unit("") for _ in range(n)))
-    return ul.QuantityMatrix(value, unit=units)
+    units = ul.UnitsMatrix.full(n, "")
+    return ul.QM(value, unit=units)

--- a/src/coordinax/_src/spherical/scale_factors.py
+++ b/src/coordinax/_src/spherical/scale_factors.py
@@ -54,5 +54,5 @@ def scale_factors(
     sin2 = jnp.sin(angles) ** 2
     value = jnp.concatenate([jnp.ones(1, dtype=sin2.dtype), jnp.cumprod(sin2)])
     n = len(components)
-    units = ul.UnitsMatrix(tuple(u.unit("") for _ in range(n)))
-    return ul.QuantityMatrix(value, unit=units)
+    units = ul.UnitsMatrix.full(n, "")
+    return ul.QM(value, unit=units)

--- a/src/coordinax/distances/_src/base.py
+++ b/src/coordinax/distances/_src/base.py
@@ -44,10 +44,4 @@ class AbstractDistance(u.AbstractQuantity):
 # are not those of a distance.
 add_promotion_rule(AbstractDistance, u.Q, u.Q)
 add_promotion_rule(AbstractDistance, u.quantity.Quantity, u.quantity.Quantity)
-
-
-# Add a rule that when a AbstractDistance interacts with a Quantity, the
-# distance degrades to a Quantity. This is necessary for many operations, e.g.
-# division of a distance by non-dimensionless quantity where the resulting units
-# are not those of a distance.
 add_promotion_rule(AbstractDistance, u.quantity.AbstractAngle, u.Q)

--- a/src/coordinax/representations/_src/_canonical.py
+++ b/src/coordinax/representations/_src/_canonical.py
@@ -1,0 +1,91 @@
+"""Shared canonical-name Wadler-Lindig repr for static dispatch kinds."""
+
+__all__: tuple[str, ...] = ()
+
+import dataclasses
+
+from typing import Any, ClassVar
+
+import wadler_lindig as wl
+
+from dataclassish import field_items
+
+
+class CanonicalStaticReprMixin:
+    """Mixin providing the canonical/verbose repr shared by static kinds.
+
+    `AbstractGeometry`, `AbstractBasis`, and `AbstractSemanticKind` are all
+    static dispatch objects that carry no runtime data. Each renders as a short
+    canonical name (e.g. ``point_geom``) when ``canonical_name`` is set, or as
+    the verbose dataclass form otherwise. This mixin holds that single shared
+    implementation.
+    """
+
+    canonical_name: ClassVar[str | None] = None
+    """Canonical name for the kind, or ``None`` to always render verbosely."""
+
+    # ===============================================================
+    # Wadler-Lindig API
+
+    def __pdoc__(self, *, canonical: bool = True, **kw: Any) -> wl.AbstractDoc:
+        """Generate a Wadler-Lindig docstring for this kind.
+
+        Parameters
+        ----------
+        canonical
+            Whether to use the canonical form of the kind in the docstring.
+            E.g. `PointGeometry()` -> `point_geom`.
+        **kw
+            Additional keyword arguments to pass to the Wadler-Lindig docstring
+            formatter.
+
+        Examples
+        --------
+        >>> import wadler_lindig as wl
+        >>> import coordinax.representations as cxr
+
+        >>> geom = cxr.PointGeometry()
+        >>> wl.pprint(geom, canonical=False)
+        PointGeometry()
+
+        >>> wl.pprint(geom, canonical=True)
+        point_geom
+
+        """
+        if canonical and self.canonical_name is not None:
+            return wl.TextDoc(self.canonical_name)
+
+        items = field_items(self) if dataclasses.is_dataclass(self) else ()
+        return wl.bracketed(
+            begin=wl.TextDoc(f"{self.__class__.__name__}("),
+            docs=wl.named_objs(items, **kw),
+            sep=wl.comma,
+            end=wl.TextDoc(")"),
+            indent=kw.get("indent", 4),
+        )
+
+    def __repr__(self) -> str:
+        """Return the canonical string representation.
+
+        >>> import coordinax.representations as cxr
+        >>> repr(cxr.point_geom)
+        'point_geom'
+        >>> repr(cxr.coord_basis)
+        'coord_basis'
+        >>> repr(cxr.vel)
+        'vel'
+
+        """
+        return wl.pformat(self, canonical=True)
+
+    def __str__(self) -> str:
+        """Return the verbose string representation.
+
+        >>> import coordinax.representations as cxr
+        >>> str(cxr.point_geom)
+        'PointGeometry()'
+        >>> str(cxr.coord_basis)
+        'CoordinateBasis()'
+
+        """
+        return wl.pformat(self, canonical=False)

--- a/src/coordinax/representations/_src/basis.py
+++ b/src/coordinax/representations/_src/basis.py
@@ -17,16 +17,15 @@ __all__ = (
 import abc
 import dataclasses
 
-from typing import Any, ClassVar, Final, final
+from typing import ClassVar, Final, final
 
 import jax.tree_util as jtu
-import wadler_lindig as wl
 
-from dataclassish import field_items
+from ._canonical import CanonicalStaticReprMixin
 
 
 @jtu.register_static
-class AbstractBasis(metaclass=abc.ABCMeta):
+class AbstractBasis(CanonicalStaticReprMixin, metaclass=abc.ABCMeta):
     r"""Abstract base class for basis kind.
 
     A basis kind specifies the **component basis** in which data is expressed,
@@ -95,71 +94,6 @@ class AbstractBasis(metaclass=abc.ABCMeta):
     Concrete subclasses should represent immutable basis categories.
 
     """
-
-    canonical_name: ClassVar[str | None] = None
-    """Canonical name for the basis kind."""
-
-    # ===============================================================
-    # Wadler-Lindig API
-
-    def __pdoc__(self, *, canonical: bool = True, **kw: Any) -> wl.AbstractDoc:
-        """Generate a Wadler-Lindig docstring for this Basis.
-
-        Parameters
-        ----------
-        canonical
-            Whether to use the canonical forms of the representation in the
-            docstring. E.g. `PointGeometry()` -> `point_geom`.
-        **kw
-            Additional keyword arguments to pass to the Wadler-Lindig docstring
-            formatter.
-
-        Examples
-        --------
-        >>> import wadler_lindig as wl
-        >>> import coordinax.representations as cxr
-
-        >>> basis = cxr.NoBasis()
-        >>> wl.pprint(basis, canonical=False)
-        NoBasis()
-
-        >>> wl.pprint(basis, canonical=True)
-        no_basis
-
-        """
-        if canonical and self.canonical_name is not None:
-            return wl.TextDoc(self.canonical_name)
-
-        items = field_items(self) if dataclasses.is_dataclass(self) else ()
-        return wl.bracketed(
-            begin=wl.TextDoc(f"{self.__class__.__name__}("),
-            docs=wl.named_objs(items, **kw),
-            sep=wl.comma,
-            end=wl.TextDoc(")"),
-            indent=kw.get("indent", 4),
-        )
-
-    def __repr__(self) -> str:
-        """Return the canonical string representation.
-
-        >>> import coordinax.representations as cxr
-        >>> repr(cxr.coord_basis)
-        'coord_basis'
-        >>> repr(cxr.CoordinateBasis())
-        'coord_basis'
-
-        """
-        return wl.pformat(self, canonical=True)
-
-    def __str__(self) -> str:
-        """Return the verbose string representation.
-
-        >>> import coordinax.representations as cxr
-        >>> str(cxr.coord_basis)
-        'CoordinateBasis()'
-
-        """
-        return wl.pformat(self, canonical=False)
 
 
 @final

--- a/src/coordinax/representations/_src/basis_change.py
+++ b/src/coordinax/representations/_src/basis_change.py
@@ -45,9 +45,7 @@ def _add_rad_unit(q: ArrayLike | u.AbstractQuantity) -> ArrayLike | u.AbstractQu
     return Quantity(q.value, unit=q.unit * _RAD) if is_any_quantity(q) else q
 
 
-def _qm_triangular_solve(
-    E: ul.QuantityMatrix, b: ul.QuantityMatrix
-) -> ul.QuantityMatrix:
+def _qm_triangular_solve(E: ul.QM, b: ul.QM) -> ul.QM:
     """Solve upper-triangular system E @ x = b for x, respecting units.
 
     Uses the fact that E is upper-triangular (vielbein = L^T from Cholesky).
@@ -57,8 +55,7 @@ def _qm_triangular_solve(
     dimensionless (unit diagonal = 1), solves the normalised system, and
     reattaches output units.
     """
-    n = E.unit.shape[0]
-    x_units = ul.UnitsMatrix(tuple(b.unit[i] / E.unit[i, i] for i in range(n)))
+    x_units = b.unit / E.unit.diagonal()
     # Scale b[i] → b_norm[i] = b.value[i] / E.value[i,i]  (dimensionless in
     # the sense that both numerator and denominator carry the same combined unit)
     # Since x[i] = b[i]/E[i,i] dimensionally, the raw solve gives the right
@@ -71,7 +68,20 @@ def _qm_triangular_solve(
     x_vals = jax.scipy.linalg.solve_triangular(
         E_norm, b_norm[..., None], lower=False
     ).squeeze(-1)
-    return ul.QuantityMatrix(x_vals, unit=x_units)
+    return ul.QM(x_vals, unit=x_units)
+
+
+def _cholesky_vielbein(mm: DenseMetric, /) -> ul.QM:
+    """Upper-triangular vielbein E = L^T from a dense metric's Cholesky factor."""
+    mat = mm.matrix
+    if isinstance(mat, ul.QM):
+        L_val = jnp.linalg.cholesky(mat.value)
+        L = ul.QM(L_val, unit=mat.unit.sqrt())
+    else:
+        L_raw = jnp.linalg.cholesky(mat)
+        n = mat.shape[-1]
+        L = ul.QM(L_raw, unit=ul.UnitsMatrix.full((n, n), ""))
+    return jnp.transpose(L, axes=(-2, -1))  # E = L^T, upper-triangular vielbein
 
 
 ##############################################################################
@@ -135,25 +145,8 @@ def change_basis(
         return {k: h[i] * v[k] for i, k in enumerate(keys)}
     # General case: Cholesky vielbein E = L^T, hat_v = E @ v
     assert isinstance(mm, DenseMetric)  # noqa: S101
-    mat = mm.matrix
-    if isinstance(mat, ul.QuantityMatrix):
-        L_val = jnp.linalg.cholesky(mat.value)
-        L_units = ul.UnitsMatrix(
-            tuple(tuple(uu**0.5 for uu in row) for row in mat.unit.to_tuple())
-        )
-        L = ul.QuantityMatrix(L_val, unit=L_units)
-    else:
-        L_raw = jnp.linalg.cholesky(mat)
-        n = mat.shape[-1]
-        _dmls = u.unit("")
-        L = ul.QuantityMatrix(
-            L_raw,
-            unit=ul.UnitsMatrix(
-                tuple(tuple(_dmls for _ in range(n)) for _ in range(n))
-            ),
-        )
-    E = jnp.transpose(L, axes=(-2, -1))  # E = L^T, upper-triangular vielbein
-    v_vec = ul.QuantityMatrix.from_cdict(v, keys)
+    E = _cholesky_vielbein(mm)
+    v_vec = ul.QM.from_cdict(v, keys)
     hat_v_vec = jnp.matmul(E, v_vec)
     return cxc.cdict(hat_v_vec, keys)  # ty: ignore[invalid-return-type]
 
@@ -214,25 +207,8 @@ def change_basis(
         return {k: v[k] / h[i] for i, k in enumerate(keys)}
     # General case: Cholesky vielbein E = L^T, v = E^{-1} hat_v (triangular solve)
     assert isinstance(mm, DenseMetric)  # noqa: S101
-    mat = mm.matrix
-    if isinstance(mat, ul.QuantityMatrix):
-        L_val = jnp.linalg.cholesky(mat.value)
-        L_units = ul.UnitsMatrix(
-            tuple(tuple(uu**0.5 for uu in row) for row in mat.unit.to_tuple())
-        )
-        L = ul.QuantityMatrix(L_val, unit=L_units)
-    else:
-        L_raw = jnp.linalg.cholesky(mat)
-        n = mat.shape[-1]
-        _dmls = u.unit("")
-        L = ul.QuantityMatrix(
-            L_raw,
-            unit=ul.UnitsMatrix(
-                tuple(tuple(_dmls for _ in range(n)) for _ in range(n))
-            ),
-        )
-    E = jnp.transpose(L, axes=(-2, -1))  # E = L^T, upper-triangular vielbein
-    hat_v_vec = ul.QuantityMatrix.from_cdict(v, keys)
+    E = _cholesky_vielbein(mm)
+    hat_v_vec = ul.QM.from_cdict(v, keys)
     v_vec = _qm_triangular_solve(E, hat_v_vec)
     return cxc.cdict(v_vec, keys)  # ty: ignore[invalid-return-type]
 

--- a/src/coordinax/representations/_src/geom.py
+++ b/src/coordinax/representations/_src/geom.py
@@ -14,16 +14,15 @@ __all__ = (
 import abc
 import dataclasses
 
-from typing import Any, ClassVar, final
+from typing import ClassVar, final
 
 import jax.tree_util as jtu
-import wadler_lindig as wl
 
-from dataclassish import field_items
+from ._canonical import CanonicalStaticReprMixin
 
 
 @jtu.register_static
-class AbstractGeometry(metaclass=abc.ABCMeta):
+class AbstractGeometry(CanonicalStaticReprMixin, metaclass=abc.ABCMeta):
     r"""Abstract base class for geometric kind.
 
     A geometric kind specifies the underlying **geometric type** of the data,
@@ -86,73 +85,6 @@ class AbstractGeometry(metaclass=abc.ABCMeta):
     Concrete subclasses should represent immutable geometric categories.
 
     """
-
-    canonical_name: ClassVar[str | None] = None
-    """Canonical name for the geometric kind."""
-
-    # ===============================================================
-    # Wadler-Lindig API
-
-    def __pdoc__(self, *, canonical: bool = True, **kw: Any) -> wl.AbstractDoc:
-        """Generate a Wadler-Lindig docstring for this Basis.
-
-        Parameters
-        ----------
-        canonical
-            Whether to use the canonical forms of the representation in the
-            docstring. E.g. `PointGeometry()` -> `point_geom`.
-        **kw
-            Additional keyword arguments to pass to the Wadler-Lindig docstring
-            formatter.
-
-        Examples
-        --------
-        >>> import wadler_lindig as wl
-        >>> import coordinax.representations as cxr
-
-        >>> geom = cxr.PointGeometry()
-        >>> wl.pprint(geom, canonical=False)
-        PointGeometry()
-
-        >>> wl.pprint(geom, canonical=True)
-        point_geom
-
-        """
-        if canonical and self.canonical_name is not None:
-            return wl.TextDoc(self.canonical_name)
-
-        items = field_items(self) if dataclasses.is_dataclass(self) else ()
-        return wl.bracketed(
-            begin=wl.TextDoc(f"{self.__class__.__name__}("),
-            docs=wl.named_objs(items, **kw),
-            sep=wl.comma,
-            end=wl.TextDoc(")"),
-            indent=kw.get("indent", 4),
-        )
-
-    def __repr__(self) -> str:
-        """Return the canonical string representation.
-
-        >>> import coordinax.representations as cxr
-        >>> repr(cxr.point_geom)
-        'point_geom'
-        >>> repr(cxr.PointGeometry())
-        'point_geom'
-
-        """
-        return wl.pformat(self, canonical=True)
-
-    def __str__(self) -> str:
-        """Return the verbose string representation.
-
-        >>> import coordinax.representations as cxr
-        >>> str(cxr.point_geom)
-        'PointGeometry()'
-        >>> str(cxr.PointGeometry())
-        'PointGeometry()'
-
-        """
-        return wl.pformat(self, canonical=False)
 
 
 @final

--- a/src/coordinax/representations/_src/guess.py
+++ b/src/coordinax/representations/_src/guess.py
@@ -126,6 +126,15 @@ def guess_geometry_kind(obj: u.AbstractQuantity, /) -> AbstractGeometry:
 dim_name = lambda dim: dim._physical_type[0]
 
 
+def _reduce_dims(obj: CDict, what: str, /) -> Any:
+    """Reduce a component dict to a single dimension or sorted tuple for lookup."""
+    dims = {u.dimension_of(v) for v in obj.values()}
+    if len(dims) == 0:
+        msg = f"Cannot infer {what} without dimensions"
+        raise ValueError(msg)
+    return dims.pop() if len(dims) == 1 else tuple(sorted(dims, key=dim_name))
+
+
 @plum.dispatch
 def guess_geometry_kind(obj: CDict, /) -> AbstractGeometry:
     """Infer geometry kind from the physical dimensions of a component dictionary.
@@ -146,16 +155,7 @@ def guess_geometry_kind(obj: CDict, /) -> AbstractGeometry:
     tangent_geom
 
     """
-    # Find the `dim` for determining the geometry kind
-    dims = {u.dimension_of(v) for v in obj.values()}
-    if len(dims) == 0:
-        msg = "Cannot infer geometry kind without dimensions"
-        raise ValueError(msg)
-
-    # Get down to a single dimension or tuple of dimensions for the lookup
-    dim = dims.pop() if len(dims) == 1 else tuple(sorted(dims, key=dim_name))
-
-    # Now we can infer geometry kind from the dimension.
+    dim = _reduce_dims(obj, "geometry kind")
     out = cxrapi.guess_geometry_kind(dim)
     return cast("AbstractGeometry", out)
 
@@ -293,14 +293,7 @@ def guess_basis_kind(obj: CDict, /) -> AbstractBasis:
     no_basis
 
     """
-    dims = {u.dimension_of(v) for v in obj.values()}
-    if len(dims) == 0:
-        msg = "Cannot infer basis kind without dimensions"
-        raise ValueError(msg)
-
-    # Get down to a single dimension or tuple of dimensions for the lookup
-    dim = dims.pop() if len(dims) == 1 else tuple(sorted(dims, key=dim_name))
-
+    dim = _reduce_dims(obj, "basis kind")
     out = cxrapi.guess_basis_kind(dim)
     return cast("AbstractBasis", out)
 
@@ -405,16 +398,7 @@ def guess_semantic_kind(obj: CDict, /) -> AbstractSemanticKind:
     loc
 
     """
-    # Find the `dim` for determining the semantic kind
-    dims = {u.dimension_of(v) for v in obj.values()}
-    if len(dims) == 0:
-        msg = "Cannot infer semantic kind without dimensions"
-        raise ValueError(msg)
-
-    # Get down to a single dimension or tuple of dimensions for the lookup
-    dim = dims.pop() if len(dims) == 1 else tuple(sorted(dims, key=dim_name))
-
-    # Now we can infer semantic kind from the dimension.
+    dim = _reduce_dims(obj, "semantic kind")
     out = cxrapi.guess_semantic_kind(dim)
     return cast("AbstractSemanticKind", out)
 

--- a/src/coordinax/representations/_src/semantics.py
+++ b/src/coordinax/representations/_src/semantics.py
@@ -22,17 +22,16 @@ import functools as ft
 from typing import Any, ClassVar, Final, final, overload
 
 import jax.tree_util as jtu
-import wadler_lindig as wl
 
 import unxt as u
-from dataclassish import field_items
 
 import coordinax.charts as cxc
+from ._canonical import CanonicalStaticReprMixin
 from .constants import TIME
 
 
 @jtu.register_static
-class AbstractSemanticKind(metaclass=abc.ABCMeta):
+class AbstractSemanticKind(CanonicalStaticReprMixin, metaclass=abc.ABCMeta):
     r"""Abstract base class for semantic kind.
 
     A semantic kind specifies the **meaning** attached to a represented
@@ -104,9 +103,6 @@ class AbstractSemanticKind(metaclass=abc.ABCMeta):
 
     """
 
-    canonical_name: ClassVar[str | None] = None
-    """Canonical name for the geometric kind."""
-
     order: ClassVar[int | None] = None
     """Time-derivative ladder order, or ``None`` if not on the ladder.
 
@@ -139,68 +135,6 @@ class AbstractSemanticKind(metaclass=abc.ABCMeta):
 
         """
         raise NotImplementedError  # pragma: no cover
-
-    # ===============================================================
-    # Wadler-Lindig API
-
-    def __pdoc__(self, *, canonical: bool = True, **kw: Any) -> wl.AbstractDoc:
-        """Generate a Wadler-Lindig docstring for this Basis.
-
-        Parameters
-        ----------
-        canonical
-            Whether to use the canonical forms of the representation in the
-            docstring. E.g. `PointGeometry()` -> `point_geom`.
-        **kw
-            Additional keyword arguments to pass to the Wadler-Lindig docstring
-            formatter.
-
-        Examples
-        --------
-        >>> import wadler_lindig as wl
-        >>> import coordinax.representations as cxr
-
-        >>> semantic = cxr.Location()
-        >>> wl.pprint(semantic, canonical=False)
-        Location()
-
-        >>> wl.pprint(semantic, canonical=True)
-        loc
-
-        """
-        if canonical and self.canonical_name is not None:
-            return wl.TextDoc(self.canonical_name)
-
-        items = field_items(self) if dataclasses.is_dataclass(self) else ()
-        return wl.bracketed(
-            begin=wl.TextDoc(f"{self.__class__.__name__}("),
-            docs=wl.named_objs(items, **kw),
-            sep=wl.comma,
-            end=wl.TextDoc(")"),
-            indent=kw.get("indent", 4),
-        )
-
-    def __repr__(self) -> str:
-        """Return the canonical string representation.
-
-        >>> import coordinax.representations as cxr
-        >>> repr(cxr.vel)
-        'vel'
-        >>> repr(cxr.Velocity())
-        'vel'
-
-        """
-        return wl.pformat(self, canonical=True)
-
-    def __str__(self) -> str:
-        """Return the verbose string representation.
-
-        >>> import coordinax.representations as cxr
-        >>> str(cxr.vel)
-        'Velocity()'
-
-        """
-        return wl.pformat(self, canonical=False)
 
 
 # ===================================================================

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -146,17 +146,7 @@ class AbstractAdd(AbstractTransform):
             width=80,
         )
 
-    def __str__(self) -> str:
-        """Return string representation of Add operator."""
-        return wl.pformat(
-            self.__pdoc__(
-                short_arrays="compact",
-                use_short_name=True,
-                include_params=False,
-                named_unit=False,
-            ),
-            width=80,
-        )
+    __str__ = __repr__
 
 
 # ============================================================================

--- a/src/coordinax/vectors/_src/base.py
+++ b/src/coordinax/vectors/_src/base.py
@@ -412,6 +412,12 @@ class AbstractVector(
     # view() addressable_shards, at, committed, globarl_shards,
     # is_fully_addressable, is_fully_replcated, nbytes, sharding
 
+    def _tree_apply(self, method: str, /, *args: Any, **kwargs: Any) -> "Self":
+        """Apply an array method to every leaf that supports it, in-tree."""
+        dynamic, static = eqx.partition(self, lambda x: hasattr(x, method))
+        dynamic = jtu.map(lambda x: getattr(x, method)(*args, **kwargs), dynamic)
+        return eqx.combine(dynamic, static)
+
     def astype(self, dtype: Any, /, **kwargs: Any) -> "AbstractVector":
         """Cast the vector to a new dtype.
 
@@ -456,33 +462,23 @@ class AbstractVector(
 
     def flatten(self) -> "Self":
         """Flatten the vector."""
-        dynamic, static = eqx.partition(self, lambda x: hasattr(x, "flatten"))
-        dynamic = jtu.map(lambda x: x.flatten(), dynamic)
-        return eqx.combine(dynamic, static)
+        return self._tree_apply("flatten")
 
     def ravel(self) -> "Self":
         """Return a flattened vector."""
-        dynamic, static = eqx.partition(self, lambda x: hasattr(x, "ravel"))
-        dynamic = jtu.map(lambda x: x.ravel(), dynamic)
-        return eqx.combine(dynamic, static)
+        return self._tree_apply("ravel")
 
     def reshape(self, *shape: int) -> "Self":
         """Return a reshaped vector."""
-        dynamic, static = eqx.partition(self, lambda x: hasattr(x, "reshape"))
-        dynamic = jtu.map(lambda x: x.reshape(*shape), dynamic)
-        return eqx.combine(dynamic, static)
+        return self._tree_apply("reshape", *shape)
 
     def round(self, decimals: int = 0) -> "Self":
         """Return a rounded vector."""
-        dynamic, static = eqx.partition(self, lambda x: hasattr(x, "round"))
-        dynamic = jtu.map(lambda x: x.round(decimals), dynamic)
-        return eqx.combine(dynamic, static)
+        return self._tree_apply("round", decimals)
 
     def to_device(self, device: None | jax.Device = None) -> "Self":
         """Move the vector to a new device."""
-        dynamic, static = eqx.partition(self, lambda x: hasattr(x, "to_device"))
-        dynamic = jtu.map(lambda x: x.to_device(device), dynamic)
-        return eqx.combine(dynamic, static)
+        return self._tree_apply("to_device", device)
 
     # ===============================================================
     # Python API

--- a/src/coordinax/vectors/_src/bundle.py
+++ b/src/coordinax/vectors/_src/bundle.py
@@ -42,16 +42,6 @@ ChartT = TypeVar(
 # ---------------------------------------------------------------------------
 
 
-def _broadcast_shapes(shapes: list[tuple[int, ...]]) -> tuple[int, ...]:
-    """Return the broadcast shape of a list of shapes."""
-    if not shapes:
-        return ()
-    result = shapes[0]
-    for s in shapes[1:]:
-        result = jnp.broadcast_shapes(result, s)
-    return result
-
-
 def vectorform_pdoc(pv: "Coordinate", **kwargs: Any) -> wl.AbstractDoc:
     """Return the vector-form Wadler-Lindig document for a `Coordinate`."""
     kwargs.setdefault("canonical", True)
@@ -428,7 +418,7 @@ class Coordinate(AbstractVector):
 
         """
         all_shapes = [self.point.shape, *(v.shape for v in self._data.values())]
-        return _broadcast_shapes(all_shapes)
+        return jnp.broadcast_shapes(*all_shapes)
 
     # ===================================================================
     # Quax API

--- a/uv.lock
+++ b/uv.lock
@@ -626,7 +626,7 @@ requires-dist = [
     { name = "quaxed", specifier = ">=0.10.5" },
     { name = "typing-extensions", specifier = ">=4.13.2" },
     { name = "unxt", specifier = ">=2.0" },
-    { name = "unxts-linalg", specifier = ">=2.0.1" },
+    { name = "unxts-linalg", specifier = ">=2.0.3" },
     { name = "wadler-lindig", specifier = ">=0.1.6" },
     { name = "xmmutablemap", specifier = ">=0.1" },
 ]
@@ -3365,7 +3365,7 @@ wheels = [
 
 [[package]]
 name = "unxts-linalg"
-version = "2.0.1"
+version = "2.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "equinox" },
@@ -3374,9 +3374,9 @@ dependencies = [
     { name = "quax" },
     { name = "unxt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/a2/6fdab6f4069684a3f1d31f1832a1798d8cac25da6444bd8315618267d4ec/unxts_linalg-2.0.1.tar.gz", hash = "sha256:ff20b4240968a0db685b0e10d20dbeaf2539093344d8bee91c25de06f121834f", size = 54966, upload-time = "2026-07-24T18:39:34.373Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c4/307dcab757c6ebc933b6f11c78aac1a98dd82f6b9b96839f1364cc12abb5/unxts_linalg-2.0.3.tar.gz", hash = "sha256:8c745be6a4d4ed599159ea21c75ac0a6fcd9492ad687c30a585f7e9f2e59905a", size = 55864, upload-time = "2026-07-28T13:17:05.384Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/d1/2a79a8cffc9a90d3514c203b588042485df4b071a6423e886f626a131a36/unxts_linalg-2.0.1-py3-none-any.whl", hash = "sha256:54d216c4b00de17b79fef29a7cee9b04becfa63d1b4f3a62a8b9f129409daf30", size = 33671, upload-time = "2026-07-24T18:39:33.207Z" },
+    { url = "https://files.pythonhosted.org/packages/11/78/56ee7aa4159f24ed467034ce6514393758a2e5400f5212f0e357f1134f99/unxts_linalg-2.0.3-py3-none-any.whl", hash = "sha256:46181cf364dc8086ab066f178258f2a923ca7ea3460955c0b509e3883b160cfc", size = 34365, upload-time = "2026-07-28T13:17:04.222Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Stacked refactor sequence — Part 4/7.** Stacked on #598; merge after it. Own change is the top commit (`603e0b78`).

Collapse copy-pasted logic behind shared helpers. All behaviour-preserving and API-neutral.

- representations: `CanonicalStaticReprMixin` for the identical `__pdoc__`/`__repr__`/`__str__`/`canonical_name` on `AbstractGeometry`/`AbstractBasis`/`AbstractSemanticKind`
- representations/basis_change: `_cholesky_vielbein` (Cholesky vielbein was duplicated in both change-basis directions)
- representations/guess: `_reduce_dims` for the three `guess_*_kind(CDict)` dispatches
- vectors: fold `flatten`/`ravel`/`reshape`/`round`/`to_device` into `_tree_apply`
- vectors/bundle: `jnp.broadcast_shapes(*shapes)` instead of a hand-rolled reduce
- transforms/add: `__str__ = __repr__`; internal/dtype: `not issubdtype(..., inexact)`; base/charts: inline the `MissingDefault` sentinel; euclidean/manifolds: inline single-caller wrappers; distances: drop a duplicated comment

**Tests:** representations/vectors/transforms/distances/charts/manifolds/euclidean suites pass (3805 passed). ty + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)