### PR TITLE
♻️ refactor(packages): dedupe small helpers, drop dead aliases

### DIFF
--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/parallax.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/parallax.py
@@ -11,7 +11,6 @@ import equinox as eqx
 
 import quaxed.numpy as jnp
 import unxt as u
-from unxt.quantity import Quantity
 
 import coordinax.distances as cxd
 from .constants import ANGLE, LENGTH, MAGNITUDE
@@ -157,7 +156,7 @@ def from_(cls: type[Parallax], q: u.AbstractQuantity, /, **kw: Any) -> Parallax:
         return cls(jnp.asarray(p.value, **kw), p.unit)  # ty: ignore[unresolved-attribute]
 
     if dim == MAGNITUDE:  # distance modulus
-        d = Quantity(10 ** (1 + q.ustrip("mag") / 5), "pc")
+        d = u.Q(10 ** (1 + q.ustrip("mag") / 5), "pc")
         p = jnp.atan2(parallax_base_length, d)
         unit = u.unit_of(p)
         return cls(jnp.asarray(p.ustrip(unit), **kw), unit)  # ty: ignore[unresolved-attribute]

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/custom_types.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/custom_types.py
@@ -1,16 +1,12 @@
 """Internal custom types."""
 
-__all__ = (
-    "CKey",
-    "CDict",
-)
+__all__ = ("CDict",)
 
 from typing import TYPE_CHECKING, Any, TypeAlias
 
-CKey: TypeAlias = str
 if TYPE_CHECKING:
     # Typed for static checkers only.
-    CDict: TypeAlias = dict[CKey, Any]
+    CDict: TypeAlias = dict[str, Any]
 else:
     # A parametric `dict[...]` annotation makes every plum signature
     # using CDict "unfaithful", disabling plum's method cache (a full

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/subclasses.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/subclasses.py
@@ -32,14 +32,7 @@ def _public_coordinax_module_candidates(module: str, /) -> tuple[str, ...]:
     )
     candidates.extend(loaded_public)
 
-    seen: set[str] = set()
-    unique_candidates: list[str] = []
-    for name in candidates:
-        if name in seen:
-            continue
-        seen.add(name)
-        unique_candidates.append(name)
-    return tuple(unique_candidates)
+    return tuple(dict.fromkeys(candidates))
 
 
 @ft.cache

--- a/packages/coordinaxs.interop.astropy/src/coordinaxs/interop/astropy/_src/custom_types.py
+++ b/packages/coordinaxs.interop.astropy/src/coordinaxs/interop/astropy/_src/custom_types.py
@@ -1,16 +1,12 @@
 """Internal custom types."""
 
-__all__ = (
-    "CKey",
-    "CDict",
-)
+__all__ = ("CDict",)
 
 from typing import TYPE_CHECKING, Any, TypeAlias
 
-CKey: TypeAlias = str
 if TYPE_CHECKING:
     # Typed for static checkers only.
-    CDict: TypeAlias = dict[CKey, Any]
+    CDict: TypeAlias = dict[str, Any]
 else:
     # A parametric `dict[...]` annotation makes every plum signature
     # using CDict "unfaithful", disabling plum's method cache (a full


### PR DESCRIPTION
**Stacked refactor sequence — Part 5/7.** Stacked on #599; merge after it. Own change is the top commit (`bcf5be20`).

Small, API-neutral cleanups across the companion packages:

- hypothesis/utils: order-preserving dedup via `tuple(dict.fromkeys(...))` instead of a hand-rolled seen-set loop
- coordinaxs.astro/parallax: use the already-imported `u.Q` and drop `from unxt.quantity import Quantity`
- coordinaxs.curveframes / coordinaxs.interop.astropy: drop the unused private `CKey` alias (never imported) and inline `dict[str, Any]` in the typed `CDict`

**Tests:** astro/curveframes/interop + hypothesis-utils suites pass (1337 passed). Pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)