### PR TITLE
♻️ refactor(atlas)!: remove unused AbstractAtlas.default_chart_for

### DIFF
--- a/src/coordinax/_src/base/atlas.py
+++ b/src/coordinax/_src/base/atlas.py
@@ -3,7 +3,6 @@
 __all__ = ("AbstractAtlas",)
 
 import abc
-import dataclasses
 
 from typing import TYPE_CHECKING, Any
 
@@ -115,34 +114,6 @@ class AbstractAtlas(metaclass=abc.ABCMeta):
 
         """
         raise NotImplementedError  # pragma: no cover
-
-    def default_chart_for(
-        self, M: "coordinax.manifolds.AbstractManifold", /
-    ) -> "coordinax.charts.AbstractChart[Any, Any, Any]":
-        """Return a default chart from the atlas for the given manifold.
-
-        This is a thin convenience wrapper over ``self.default_chart()`` that
-        checks that the manifold's atlas matches this atlas.
-
-        >>> import coordinax.manifolds as cxm
-        >>> M = cxm.R2
-        >>> M.atlas.default_chart_for(M)
-        Cart2D(M=Rn(2))
-
-        >>> try: M.atlas.default_chart_for(cxm.R3)
-        ... except ValueError as e: print(e)
-        Atlas EuclideanAtlas(ndim=2) does not match manifold atlas
-        EuclideanAtlas(ndim=3).
-
-        """
-        # Get the default chart
-        chart = self.default_chart()
-        # Validate that the manifold is compatible with this atlas
-        if M.atlas != self:
-            msg = f"Atlas {self!r} does not match manifold atlas {M.atlas!r}."
-            raise ValueError(msg)
-
-        return dataclasses.replace(chart, M=M)
 
     @abc.abstractmethod
     def has_chart(


### PR DESCRIPTION
**Stacked refactor sequence — Part 6/6 (final).** Stacked on #600; merge after it.

`AbstractAtlas.default_chart_for` had no callers anywhere in the workspace (only its own doctests referenced it) and duplicated logic trivially derivable from the retained `default_chart()`. Remove it.

⚠️ **BREAKING CHANGE:** `AbstractAtlas.default_chart_for` is removed. Callers should use `default_chart()` and set the manifold themselves if needed.

> **Note on the second API finding.** The audit also flagged `coordinax.internal.pack_with_usys` as removable, but it is **not** unused — it is demonstrated in `docs/guides/perf.md` (sybil-executed examples) and documented in `docs/spec.md`. Removing it would break the perf guide and drop a documented helper, so it is intentionally **kept**.

> **Note:** the original 7th PR (drop redundant tangent-ladder overrides) was reverted after a performance review — those overrides are a deliberate optimization (`derivative()` 49ns → 198ns without them), not dead code.

**Tests:** full suite green (8439 passed, 0 failed). ty + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
