### PR TITLE
🐛 fix(product): make GalileanCT work with its own manifold (metric, has_chart)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1601,9 +1601,9 @@ The `coordinax.charts` module provides the chart-facing API for representing poi
 
     - `time_chart`: always `time1d`.
     - `factors`: `(time1d, spatial_chart)`.
-    - `factor_names`: `("time", "space")`.
-    - `split_components(p)` partitions a `CDict` into `{"ct": ...}` for the time factor and the spatial keys for the space factor.
-    - `merge_components((time_part, space_part))` merges both factor dicts back into a flat `CDict`.
+    - `factor_names`: `("ct", "space")` (matching `galilean_spacetime`, so `galilean_spacetime.has_chart(galileanct)` holds).
+    - `split_components(p)` partitions a `CDict` into `{"t": ...}` for the time factor (`time1d`'s native key, holding the length-valued `ct`) and the spatial keys for the space factor.
+    - `merge_components((time_part, space_part))` re-keys the time factor's `"t"` back to `"ct"` and merges both factor dicts into a flat `CDict`.
 
     Manifold:
 

--- a/src/coordinax/_src/product/galilean_ct.py
+++ b/src/coordinax/_src/product/galilean_ct.py
@@ -44,9 +44,15 @@ class GalileanCT(AbstractFlatCartesianProductChart[Ks, Ds]):
     This is a Cartesian product chart: GalileanCT(spatial_chart) ≡ time1d x
     spatial_chart
 
-    The time component is always the canonical 1D time chart `time1d` with
-    component "t". The time coordinate is automatically converted to ct using
-    the speed of light.
+    The time axis coordinate is ``x^0 = ct`` — a *length* — stored directly on
+    the chart (component ``"ct"``, dimension ``"length"``). The underlying time
+    factor is the canonical 1D chart ``time1d`` (native component ``"t"``); this
+    chart carries the length-valued ``ct`` on its axis rather than a physical
+    time, consistent with the Euclidean ``R1`` time factor and the
+    ``diag(1, 1, 1, 1)`` product metric. Because ``ct`` *is* the coordinate,
+    ``split_components``/``merge_components`` simply re-key ``"ct" <-> "t"``
+    without a runtime ``c`` multiply. ``c`` is retained to form ``ct`` from a
+    physical time at construction/conversion boundaries.
 
     Mathematical definition:
     $$
@@ -125,10 +131,12 @@ class GalileanCT(AbstractFlatCartesianProductChart[Ks, Ds]):
 
     @override
     def split_components(self, p: CDict) -> tuple[CDict, CDict]:
-        """Split CDict by factors, keeping 'ct' for time factor.
+        """Split CDict by factors, re-keying the ``"ct"`` axis to ``time1d``'s ``"t"``.
 
-        GalileanCT uses 'ct' for the time component. The split returns
-        factor dicts with their native keys ('ct' for time, spatial keys for space).
+        The returned factor dicts use each factor's native keys: ``"t"`` for the
+        time factor (holding the length-valued ``x^0 = ct``) and the spatial
+        keys for the space factor. This is a pure re-key — ``ct`` is already the
+        coordinate, so no ``c`` conversion is applied (see the class docstring).
         """
         # The time factor is `time1d`, whose native component is "t"; map the
         # chart's "ct" value onto it so factor operations (metric, pt_map)
@@ -141,7 +149,9 @@ class GalileanCT(AbstractFlatCartesianProductChart[Ks, Ds]):
     def merge_components(self, parts: tuple[CDict, CDict], /) -> CDict:  # ty: ignore[invalid-method-override]
         """Merge factor CDicts back into GalileanCT components.
 
-        The time factor dict uses `time1d`'s native "t" key; re-key it to "ct".
+        The time factor dict uses `time1d`'s native "t" key (holding the
+        length-valued ``x^0 = ct``); re-key it back to "ct". Pure re-key — no
+        ``c`` conversion (see the class docstring).
         """
         return {"ct": parts[0]["t"], **parts[1]}
 

--- a/src/coordinax/_src/product/galilean_ct.py
+++ b/src/coordinax/_src/product/galilean_ct.py
@@ -39,7 +39,7 @@ C_DEFAULT = u.StaticQuantity(np.array(299_792.458), "km/s")
 @final
 @chart_dataclass_decorator
 class GalileanCT(AbstractFlatCartesianProductChart[Ks, Ds]):
-    r"""4D spacetime rep with components ``(ct, x, y, z)`` and Minkowski metric.
+    r"""4D chart with components ``(ct, x, y, z)`` on Galilean spacetime.
 
     This is a Cartesian product chart: GalileanCT(spatial_chart) ≡ time1d x
     spatial_chart
@@ -51,9 +51,12 @@ class GalileanCT(AbstractFlatCartesianProductChart[Ks, Ds]):
     Mathematical definition:
     $$
        x^0 = ct,\quad x^i = \text{spatial components}
-       \\
-       g = \mathrm{diag}(-1, 1, 1, 1) \quad \text{(signature } - + + +)
     $$
+
+    The underlying manifold is ``galilean_spacetime = R1 x R3`` (both Euclidean),
+    so the induced product metric is ``diag(1, 1, 1, 1)`` — Galilean spacetime
+    carries no invariant Lorentzian spacetime metric. (This is *not* Minkowski
+    ``diag(-1, 1, 1, 1)``; a Lorentzian variant would need a different manifold.)
 
     Parameters
     ----------
@@ -117,8 +120,8 @@ class GalileanCT(AbstractFlatCartesianProductChart[Ks, Ds]):
     @override
     @property
     def factor_names(self) -> tuple[str, ...]:
-        """Factor names are ('time', 'space')."""
-        return ("time", "space")
+        """Factor names are ('ct', 'space'), matching ``galilean_spacetime``."""
+        return ("ct", "space")
 
     @override
     def split_components(self, p: CDict) -> tuple[CDict, CDict]:
@@ -127,7 +130,10 @@ class GalileanCT(AbstractFlatCartesianProductChart[Ks, Ds]):
         GalileanCT uses 'ct' for the time component. The split returns
         factor dicts with their native keys ('ct' for time, spatial keys for space).
         """
-        time_dict = {"ct": p["ct"]}
+        # The time factor is `time1d`, whose native component is "t"; map the
+        # chart's "ct" value onto it so factor operations (metric, pt_map)
+        # validate against the real factor chart.
+        time_dict = {"t": p["ct"]}
         spatial_dict = {k: p[k] for k in self.spatial_chart.components}
         return (time_dict, spatial_dict)
 
@@ -135,9 +141,9 @@ class GalileanCT(AbstractFlatCartesianProductChart[Ks, Ds]):
     def merge_components(self, parts: tuple[CDict, CDict], /) -> CDict:  # ty: ignore[invalid-method-override]
         """Merge factor CDicts back into GalileanCT components.
 
-        Expects time factor dict with 'ct' key, spatial factor dict with spatial keys.
+        The time factor dict uses `time1d`'s native "t" key; re-key it to "ct".
         """
-        return {**parts[0], **parts[1]}
+        return {"ct": parts[0]["t"], **parts[1]}
 
     # ===============================================================
     # Chart API

--- a/tests/unit/charts/test_galilean_charts.py
+++ b/tests/unit/charts/test_galilean_charts.py
@@ -147,12 +147,12 @@ class TestGalileanCTProductStructure:
         assert chart.factors[1] == cxc.sph3d
 
     def test_factor_names(self) -> None:
-        """factor_names is ('time', 'space')."""
+        """factor_names is ('ct', 'space'), matching galilean_spacetime."""
         chart = cxc.GalileanCT()
-        assert chart.factor_names == ("time", "space")
+        assert chart.factor_names == ("ct", "space")
 
-    def test_split_components_ct_key(self) -> None:
-        """split_components returns time dict with 'ct' key."""
+    def test_split_components_time_key(self) -> None:
+        """split_components returns the time dict with time1d's native 't' key."""
         chart = cxc.GalileanCT()
         p = {
             "ct": u.Q(1, "km"),
@@ -161,7 +161,8 @@ class TestGalileanCTProductStructure:
             "z": u.Q(4, "km"),
         }
         time_part, spatial_part = chart.split_components(p)
-        assert "ct" in time_part
+        assert set(time_part) == {"t"}
+        assert time_part["t"] == p["ct"]
         assert set(spatial_part.keys()) == {"x", "y", "z"}
 
     def test_merge_components_roundtrip(self) -> None:
@@ -334,3 +335,26 @@ class TestGalileanSpacetimeManifold:
     def test_accessible_from_manifolds_module(self) -> None:
         """galilean_spacetime is exported from coordinax.manifolds."""
         assert hasattr(cxm, "galilean_spacetime")
+
+
+class TestGalileanCTMetricAndAtlas:
+    """Regression tests: the GalileanCT chart works with its own manifold."""
+
+    def test_metric_matrix_is_euclidean_4d(self) -> None:
+        """metric_matrix assembles a 4x4 Euclidean product metric (no key crash)."""
+        import numpy as np
+
+        pt = {
+            "ct": u.Q(0.0, "m"),
+            "x": u.Q(1.0, "m"),
+            "y": u.Q(0.0, "m"),
+            "z": u.Q(0.0, "m"),
+        }
+        g = cxm.metric_matrix(cxm.galilean_spacetime, pt, cxc.galileanct)
+        assert np.allclose(np.diag(np.asarray(g.matrix.value)), [1.0, 1.0, 1.0, 1.0])
+
+    def test_manifold_recognizes_its_chart(self) -> None:
+        """galilean_spacetime.has_chart(galileanct) — factor_names must agree."""
+        assert cxc.galileanct.M is cxm.galilean_spacetime
+        assert cxm.galilean_spacetime.has_chart(cxc.galileanct)
+        assert cxc.galileanct.factor_names == cxm.galilean_spacetime.factor_names

--- a/tests/unit/charts/test_galilean_charts.py
+++ b/tests/unit/charts/test_galilean_charts.py
@@ -1,6 +1,7 @@
 """Tests specific to GalileanCT, galileanct, and galilean_spacetime."""
 
 import jax
+import numpy as np
 
 import unxt as u
 
@@ -342,8 +343,6 @@ class TestGalileanCTMetricAndAtlas:
 
     def test_metric_matrix_is_euclidean_4d(self) -> None:
         """metric_matrix assembles a 4x4 Euclidean product metric (no key crash)."""
-        import numpy as np
-
         pt = {
             "ct": u.Q(0.0, "m"),
             "x": u.Q(1.0, "m"),

--- a/tests/unit/charts/test_galilean_charts.py
+++ b/tests/unit/charts/test_galilean_charts.py
@@ -351,7 +351,11 @@ class TestGalileanCTMetricAndAtlas:
             "z": u.Q(0.0, "m"),
         }
         g = cxm.metric_matrix(cxm.galilean_spacetime, pt, cxc.galileanct)
-        assert np.allclose(np.diag(np.asarray(g.matrix.value)), [1.0, 1.0, 1.0, 1.0])
+        # Euclidean product metric: the full 4x4 must be the identity, so this
+        # also catches any spurious off-diagonal terms.
+        mat = np.asarray(g.matrix.value)
+        assert mat.shape == (4, 4)
+        assert np.allclose(mat, np.eye(4))
 
     def test_manifold_recognizes_its_chart(self) -> None:
         """galilean_spacetime.has_chart(galileanct) — factor_names must agree."""


### PR DESCRIPTION
## Summary

Three interrelated defects on the Galilean spacetime chart, found reviewing the product manifolds for the v0.24 audit.

### 1. `metric_matrix` crashes
`split_components` emitted the time factor keyed `"ct"`, but the time factor chart is `time1d` whose component is `"t"`, so recursing into the factor metric hit:
```
metric_matrix(galilean_spacetime, {"ct":…, "x":…, "y":…, "z":…}, cxc.galileanct)
# ValueError: Data keys do not match chart components: {'ct'} != {'t'}
```
Fixed by splitting to the factor's native `"t"` key and re-keying `"t"→"ct"` on merge. (`pt_map` tolerated it only because identical-chart transitions skip `check_data`.)

### 2. Manifold doesn't recognize its own chart
`galilean_spacetime.has_chart(galileanct)` returned `False` even though `galileanct.M is galilean_spacetime`, because the chart's `factor_names` were `("time","space")` while the manifold's are `("ct","space")`. Aligned.

### 3. Docstring contradicts the actual metric
The docstring claimed Minkowski `diag(-1,1,1,1)` (signature −+++), but the manifold is `R1 × R3` (both Euclidean) so the metric is `diag(1,1,1,1)`. Corrected the docstring. **Note for maintainer:** if a *Lorentzian* GalileanCT was intended, that's a design change (a different manifold/metric), not just a doc fix — flagging rather than guessing.

## Verification
New tests: 4×4 Euclidean metric assembles without the key crash; `has_chart` holds; `factor_names` agree. Updated two existing tests that encoded the old (buggy) `("time","space")` / `"ct"`-split values. `tests/unit/charts/test_galilean_charts.py` + `tests/unit/manifolds` pass; `ruff`/`ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)