### PR TITLE
🐛 fix(manifolds): embedded metric_matrix respects the passed chart (+ batch-safe)

### DIFF
--- a/src/coordinax/_src/embedded/register_metric.py
+++ b/src/coordinax/_src/embedded/register_metric.py
@@ -5,9 +5,10 @@ intrinsic :class:`~coordinax._src.base.AbstractChart`.
 
 The *induced* (pullback) metric on an embedded submanifold is computed as
 $g = J^T J$ where $J$ is the Jacobian of the composition
-``intrinsic → Cartesian ambient``.  Routing through the Cartesian ambient
-ensures every entry of $J$ carries the *same* unit (``cart_unit / intrinsic_unit``),
-which makes $J^T J$ unit-compatible across all summation terms.
+``chart → intrinsic → Cartesian ambient``.  Routing through the Cartesian
+ambient makes every ambient output share the single unit ``cart_unit`` (column
+*i* of $J$ then has unit ``cart_unit / chart_unit_i``), which makes each
+$J^T J$ summation term unit-compatible.
 
 All results are wrapped in a :class:`~coordinax._src.metric.matrix.DenseMetric`
 because the induced metric is not guaranteed to be diagonal.
@@ -79,9 +80,11 @@ def metric_matrix(
     Computes $g_{ij} = \sum_k J^k_i J^k_j$ where $J$ is the Jacobian of the
     composition ``chart → intrinsic → Cartesian ambient`` (the ``chart →
     intrinsic`` leg is the identity when ``chart`` is the intrinsic chart).
-    Routing through Cartesian ambient coordinates ensures all entries of $J$
-    share the same unit (``cart_unit / chart_unit``), so the matrix product
-    $J^T J$ is unit-compatible and the result carries physically correct units.
+    Routing through Cartesian ambient coordinates makes every ambient output
+    share the single unit ``cart_unit`` (so column *i* of $J$ has unit
+    ``cart_unit / chart_unit_i``); each ``g_{ij}`` term $J^k_i J^k_j$ then has a
+    consistent unit ``cart_unit^2 / (chart_unit_i * chart_unit_j)`` and the
+    result carries physically correct units.
 
     Parameters
     ----------
@@ -146,8 +149,8 @@ def metric_matrix(
     # intrinsic chart (where the embedding is defined) when they differ.
     chart_keys = chart.components
 
-    # Use Cartesian ambient so every J entry has the same unit
-    # (cart_unit / chart_unit).
+    # Use Cartesian ambient so all outputs share cart_unit; column i of J then
+    # has unit cart_unit / chart_unit_i, making each g_ij term unit-consistent.
     cart_chart = ambient_chart.cartesian
     cart_keys = cart_chart.components
 
@@ -176,8 +179,8 @@ def metric_matrix(
         ]
         return qnp.stack(vals)
 
-    J_arr = jax.jacfwd(_embed_cart)(xat)  # (n_cart, n_intrinsic)
-    result_vals = J_arr.T @ J_arr  # (n_intrinsic, n_intrinsic)
+    J_arr = jax.jacfwd(_embed_cart)(xat)  # (n_cart, n_chart)
+    result_vals = J_arr.T @ J_arr  # (n_chart, n_chart)
 
     # g_{ij} unit = uto_[0]² / (ufrom_[i] × ufrom_[j])
     # Valid because all Cartesian coordinates share the same unit.

--- a/src/coordinax/_src/embedded/register_metric.py
+++ b/src/coordinax/_src/embedded/register_metric.py
@@ -30,7 +30,6 @@ import unxt as u
 import coordinaxs.api.charts as cxcapi
 from .manifold import EmbeddedManifold
 from coordinax._src.base import AbstractChart  # type: ignore[type-arg]
-from coordinax._src.custom_types import CDict
 from coordinax._src.metric.matrix import DenseMetric
 from coordinax.internal import pack_nonuniform_unit
 from coordinaxs.api.manifolds import metric_matrix
@@ -154,10 +153,10 @@ def metric_matrix(
     cart_chart = ambient_chart.cartesian
     cart_keys = cart_chart.components
 
-    def _to_intrinsic(q: CDict) -> CDict:
-        if chart == intrinsic_chart:
-            return q
-        return cast("CDict", cxcapi.pt_map(q, chart, intrinsic_chart))
+    # chart → intrinsic; the identity map when chart is already the intrinsic
+    # chart (same-chart pt_map is an exact-identity round-trip).
+    def _to_intrinsic(q: dict) -> dict:
+        return cast("dict", cxcapi.pt_map(q, chart, intrinsic_chart))
 
     xat, ufrom = pack_nonuniform_unit(point, chart_keys)
     ufrom_ = tuple(uf if uf is not None else DMLS for uf in ufrom)

--- a/src/coordinax/_src/embedded/register_metric.py
+++ b/src/coordinax/_src/embedded/register_metric.py
@@ -178,8 +178,21 @@ def metric_matrix(
         ]
         return qnp.stack(vals)
 
-    J_arr = jax.jacfwd(_embed_cart)(xat)  # (n_cart, n_chart)
-    result_vals = J_arr.T @ J_arr  # (n_chart, n_chart)
+    def _single_metric(x_vec: jnp.ndarray) -> jnp.ndarray:
+        j = jax.jacfwd(_embed_cart)(x_vec)  # (n_cart, n_chart)
+        return j.T @ j  # (n_chart, n_chart)
+
+    if xat.ndim == 1:
+        result_vals = _single_metric(xat)
+    else:
+        # `xat` is (*batch, n_chart) — components last, batch leading. vmap the
+        # per-point Jacobian over the flattened batch; a plain jacfwd of the
+        # batched input would give a wrong (cross-batch) Jacobian.
+        n_chart = xat.shape[-1]
+        batch_shape = xat.shape[:-1]
+        flat = xat.reshape(-1, n_chart)  # (prod(batch), n_chart)
+        result_vals = jax.vmap(_single_metric)(flat)  # (prod, n, n)
+        result_vals = result_vals.reshape(*batch_shape, n_chart, n_chart)
 
     # g_{ij} unit = uto_[0]² / (ufrom_[i] × ufrom_[j])
     # Valid because all Cartesian coordinates share the same unit.

--- a/src/coordinax/_src/embedded/register_metric.py
+++ b/src/coordinax/_src/embedded/register_metric.py
@@ -16,6 +16,8 @@ because the induced metric is not guaranteed to be diagonal.
 
 __all__: tuple[str, ...] = ()
 
+from typing import cast
+
 import jax
 import jax.numpy as jnp
 import plum
@@ -27,6 +29,7 @@ import unxt as u
 import coordinaxs.api.charts as cxcapi
 from .manifold import EmbeddedManifold
 from coordinax._src.base import AbstractChart  # type: ignore[type-arg]
+from coordinax._src.custom_types import CDict
 from coordinax._src.metric.matrix import DenseMetric
 from coordinax.internal import pack_nonuniform_unit
 from coordinaxs.api.manifolds import metric_matrix
@@ -133,27 +136,34 @@ def metric_matrix(
     Unit("m2 / rad2")
 
     """
-    del chart
     embed_map = M.embed_map
     ambient_chart = embed_map.ambient
-    intrinsic_keys = embed_map.intrinsic.components
+    intrinsic_chart = embed_map.intrinsic
+    # The metric is returned in the *passed* chart's coordinates; map into the
+    # intrinsic chart (where the embedding is defined) when they differ.
+    chart_keys = chart.components
 
     # Use Cartesian ambient so every J entry has the same unit
-    # (cart_unit / intrinsic_unit).
+    # (cart_unit / chart_unit).
     cart_chart = ambient_chart.cartesian
     cart_keys = cart_chart.components
 
-    xat, ufrom = pack_nonuniform_unit(point, intrinsic_keys)
+    def _to_intrinsic(q: CDict) -> CDict:
+        if chart == intrinsic_chart:
+            return q
+        return cast("CDict", cxcapi.pt_map(q, chart, intrinsic_chart))
+
+    xat, ufrom = pack_nonuniform_unit(point, chart_keys)
     ufrom_ = tuple(uf if uf is not None else DMLS for uf in ufrom)
 
-    at_ambient = embed_map.embed(point, usys=None)
+    at_ambient = embed_map.embed(_to_intrinsic(point), usys=None)
     at_cart = cxcapi.pt_map(at_ambient, ambient_chart, cart_chart)
     uto_ = ul.cdict_units(at_cart, cart_keys)
     uto_ = tuple(ut if ut is not None else DMLS for ut in uto_)
 
     def _embed_cart(x_arr: jnp.ndarray) -> jnp.ndarray:
-        q = {k: u.Q(x_arr[i], ufrom_[i]) for i, k in enumerate(intrinsic_keys)}
-        q_ambient = embed_map.embed(q, usys=None)
+        q = {k: u.Q(x_arr[i], ufrom_[i]) for i, k in enumerate(chart_keys)}
+        q_ambient = embed_map.embed(_to_intrinsic(q), usys=None)
         q_cart = cxcapi.pt_map(q_ambient, ambient_chart, cart_chart)
         vals = [
             u.ustrip(uto_[j], q_cart[k])  # ty: ignore[not-subscriptable]
@@ -168,7 +178,7 @@ def metric_matrix(
 
     # g_{ij} unit = uto_[0]² / (ufrom_[i] × ufrom_[j])
     # Valid because all Cartesian coordinates share the same unit.
-    n = len(intrinsic_keys)
+    n = len(chart_keys)
     result_unit = ul.UnitsMatrix(
         tuple(
             tuple(uto_[0] ** 2 / (ufrom_[i] * ufrom_[j]) for j in range(n))  # ty: ignore[unsupported-operator]

--- a/src/coordinax/_src/embedded/register_metric.py
+++ b/src/coordinax/_src/embedded/register_metric.py
@@ -77,10 +77,11 @@ def metric_matrix(
     r"""Induced metric on an embedded submanifold via Jacobian pullback.
 
     Computes $g_{ij} = \sum_k J^k_i J^k_j$ where $J$ is the Jacobian of the
-    composition ``intrinsic → Cartesian ambient``.  Routing through Cartesian
-    ambient coordinates ensures all entries of $J$ share the same unit
-    (``cart_unit / intrinsic_unit``), so the matrix product $J^T J$ is
-    unit-compatible and the result carries physically correct units.
+    composition ``chart → intrinsic → Cartesian ambient`` (the ``chart →
+    intrinsic`` leg is the identity when ``chart`` is the intrinsic chart).
+    Routing through Cartesian ambient coordinates ensures all entries of $J$
+    share the same unit (``cart_unit / chart_unit``), so the matrix product
+    $J^T J$ is unit-compatible and the result carries physically correct units.
 
     Parameters
     ----------
@@ -88,16 +89,18 @@ def metric_matrix(
         An embedded submanifold; carries ``intrinsic``, ``ambient``, and
         ``embed_map`` fields.
     point : dict
-        A coordinate dictionary in the *intrinsic* chart coordinates.
+        A coordinate dictionary in the passed ``chart``'s coordinates.
     chart : AbstractChart
-        The intrinsic chart (passed through for API consistency).
+        The chart in which ``point`` is expressed and in which the metric is
+        returned; mapped into the embedding's intrinsic chart when the two
+        differ.
 
     Returns
     -------
     DenseMetric
         Induced metric matrix at ``point``, backed by a
         :class:`~unxts.linalg.QuantityMatrix` with units
-        ``cart_unit^2 / (intrinsic_unit_i * intrinsic_unit_j)``.
+        ``cart_unit^2 / (chart_unit_i * chart_unit_j)``.
 
     Examples
     --------

--- a/tests/unit/manifolds/test_embedded_twosphere.py
+++ b/tests/unit/manifolds/test_embedded_twosphere.py
@@ -67,3 +67,43 @@ class TestEmbeddedTwosphereAmbient:
         out = cxm.pt_embed(_P, m)
         assert set(out) == {"r", "theta", "phi"}
         np.testing.assert_allclose(u.ustrip("km", out["r"]), 2.0, atol=1e-6)
+
+
+class TestEmbeddedMetricRespectsChart:
+    """metric_matrix returns the induced metric in the *passed* chart's coords."""
+
+    @staticmethod
+    def _embedding_metric(chart, coords):
+        """J^T J of the unit-sphere R^3 embedding, expressed in ``chart`` coords."""
+        import jax
+
+        keys = chart.components
+
+        def embed(x):
+            p = {k: u.Q(x[i], "rad") for i, k in enumerate(keys)}
+            s = cxc.pt_map(p, chart, cxc.sph2)
+            th, ph = u.ustrip("rad", s["theta"]), u.ustrip("rad", s["phi"])
+            return jnp.array(
+                [jnp.sin(th) * jnp.cos(ph), jnp.sin(th) * jnp.sin(ph), jnp.cos(th)]
+            )
+
+        x0 = jnp.array([coords[k] for k in keys])
+        j = jax.jacfwd(embed)(x0)
+        return np.asarray(j.T @ j)
+
+    def test_metric_in_each_two_sphere_chart(self) -> None:
+        emb = cxm.EmbeddedManifold(
+            intrinsic=cxm.S2, ambient=cxm.R3, embed_map=cxm.TwoSphereIn3D(radius=1)
+        )
+        cases = [
+            (cxc.sph2, {"theta": 0.9, "phi": 0.6}),
+            (cxc.lonlat_sph2, {"lon": 0.6, "lat": 0.7}),
+            (cxc.loncoslat_sph2, {"lon_coslat": 0.3, "lat": 0.5}),
+            (cxc.math_sph2, {"theta": 0.6, "phi": 0.9}),
+        ]
+        for chart, coords in cases:
+            pt = {k: u.Q(v, "rad") for k, v in coords.items()}
+            g = cxm.metric_matrix(emb, pt, chart)
+            got = np.asarray(g.matrix.value)
+            ref = self._embedding_metric(chart, coords)
+            assert np.allclose(got, ref, atol=1e-9), f"{chart}: {got} != {ref}"

--- a/tests/unit/manifolds/test_embedded_twosphere.py
+++ b/tests/unit/manifolds/test_embedded_twosphere.py
@@ -107,3 +107,9 @@ class TestEmbeddedMetricRespectsChart:
             got = np.asarray(g.matrix.value)
             ref = self._embedding_metric(chart, coords)
             assert np.allclose(got, ref, atol=1e-9), f"{chart}: {got} != {ref}"
+            # Units: dimensionless ambient (radius=1) over angular coords, so
+            # every g_ij is cart_unit^2 / (rad * rad) = 1 / rad^2.
+            unit = g.matrix.unit
+            assert all(
+                str(unit[i, j]) == "1 / rad2" for i in range(2) for j in range(2)
+            ), f"{chart}: unexpected units {unit}"

--- a/tests/unit/manifolds/test_embedded_twosphere.py
+++ b/tests/unit/manifolds/test_embedded_twosphere.py
@@ -124,3 +124,20 @@ class TestEmbeddedMetricRespectsChart:
             assert all(
                 str(unit[i, j]) == "1 / rad2" for i in range(2) for j in range(2)
             ), f"{chart}: unexpected units {unit}"
+
+    def test_metric_is_batch_safe(self) -> None:
+        """A batched (B,) point gives (B, n, n) matching the per-point metric."""
+        emb = cxm.EmbeddedManifold(
+            intrinsic=cxm.S2, ambient=cxm.R3, embed_map=cxm.TwoSphereIn3D(radius=1)
+        )
+        pt = {
+            "theta": u.Q(jnp.array([0.9, 0.5, 1.3]), "rad"),
+            "phi": u.Q(jnp.array([0.6, 0.2, 0.9]), "rad"),
+        }
+        g = cxm.metric_matrix(emb, pt, cxc.sph2)
+        m = jnp.asarray(g.matrix.value)
+        assert m.shape == (3, 2, 2)
+        for i in range(3):
+            single = {k: u.Q(v.value[i], u.unit_of(v)) for k, v in pt.items()}
+            ref = jnp.asarray(cxm.metric_matrix(emb, single, cxc.sph2).matrix.value)
+            assert jnp.allclose(m[i], ref)

--- a/tests/unit/manifolds/test_embedded_twosphere.py
+++ b/tests/unit/manifolds/test_embedded_twosphere.py
@@ -95,17 +95,28 @@ class TestEmbeddedMetricRespectsChart:
         emb = cxm.EmbeddedManifold(
             intrinsic=cxm.S2, ambient=cxm.R3, embed_map=cxm.TwoSphereIn3D(radius=1)
         )
+        # (chart, coords, analytic closed-form g or None). The closed forms are
+        # independent of the J^T J machinery under test; where the closed form is
+        # unwieldy (loncoslat, math) fall back to the R^3-embedding J^T J.
         cases = [
-            (cxc.sph2, {"theta": 0.9, "phi": 0.6}),
-            (cxc.lonlat_sph2, {"lon": 0.6, "lat": 0.7}),
-            (cxc.loncoslat_sph2, {"lon_coslat": 0.3, "lat": 0.5}),
-            (cxc.math_sph2, {"theta": 0.6, "phi": 0.9}),
+            (cxc.sph2, {"theta": 0.9, "phi": 0.6}, np.diag([1.0, np.sin(0.9) ** 2])),
+            (
+                cxc.lonlat_sph2,
+                {"lon": 0.6, "lat": 0.7},
+                np.diag([np.cos(0.7) ** 2, 1.0]),
+            ),
+            (cxc.loncoslat_sph2, {"lon_coslat": 0.3, "lat": 0.5}, None),
+            (cxc.math_sph2, {"theta": 0.6, "phi": 0.9}, None),
         ]
-        for chart, coords in cases:
+        for chart, coords, analytic in cases:
             pt = {k: u.Q(v, "rad") for k, v in coords.items()}
             g = cxm.metric_matrix(emb, pt, chart)
             got = np.asarray(g.matrix.value)
-            ref = self._embedding_metric(chart, coords)
+            ref = (
+                analytic
+                if analytic is not None
+                else self._embedding_metric(chart, coords)
+            )
             assert np.allclose(got, ref, atol=1e-9), f"{chart}: {got} != {ref}"
             # Units: dimensionless ambient (radius=1) over angular coords, so
             # every g_ij is cart_unit^2 / (rad * rad) = 1 / rad^2.


### PR DESCRIPTION
## Summary

Two fixes to the embedded-manifold `metric_matrix`:

### 1. Respect the passed chart (crash fix)
It did `del chart` and hardcoded `embed_map.intrinsic.components` (e.g. `theta`/`phi`), so a point in any **other** valid intrinsic chart crashed:
```python
metric_matrix(S2_embedded, {"lon_coslat":…, "lat":…}, cxc.loncoslat_sph2)  # KeyError: 'theta'
```
Now maps the point from `chart` into the embedding's intrinsic chart and pulls the Jacobian back through `chart`'s components, returning the induced metric in the **passed** chart's coordinates (like every other `metric_matrix` dispatch).

### 2. Batch-safety
`jax.jacfwd(_embed_cart)(xat)` on a batched point (`xat` shape `(*batch, n_chart)`) produced a cross-batch Jacobian, so `Jᵀ J` had mismatched shapes and crashed. Now vmaps the per-point Jacobian over the flattened leading batch and reshapes to `(*batch, n, n)`.

## Verification
- Induced metric matches the R³ embedding `JᵀJ` in `sph2` / `lonlat` / `loncoslat` / `math` two-sphere charts (values and units).
- A batched point gives `(B, n, n)` matching the per-point metric; unbatched unchanged.
- `tests/unit/manifolds` passes (378); doctests pass; `ruff`/`ty` clean.

Companion to #613 (the `DiagonalMetric.to_dense` + product-metric batch fix). Both are the batch-safety follow-up unblocked by #591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)