### PR TITLE
♻️ refactor(charts): drop redundant is-chart-subclass guard from flag overrides

### DIFF
--- a/src/coordinax/_src/charts/d0.py
+++ b/src/coordinax/_src/charts/d0.py
@@ -14,7 +14,6 @@ from coordinax._src.base import (
     AbstractFixedComponentsChart,
     AbstractManifold,
     chart_dataclass_decorator,
-    is_not_abstract_chart_subclass,
 )
 from coordinax._src.euclidean.atlas import (
     EUCLIDEAN_ATLAS_DEFAULT_CHARTS,
@@ -33,11 +32,6 @@ class Abstract0D(AbstractDimensionalFlag, n=0):
 
     @override
     def __init_subclass__(cls, n: int | L["N"] | None = None, **kw: Any) -> None:
-        # Enforce that this is a subclass of AbstractChart
-        if is_not_abstract_chart_subclass(cls):
-            msg = f"{cls.__name__} must be a subclass of AbstractChart"
-            raise TypeError(msg)
-
         if n is not None:
             msg = f"{cls.__name__} does not support variable n"
             raise NotImplementedError(msg)

--- a/src/coordinax/_src/charts/d1.py
+++ b/src/coordinax/_src/charts/d1.py
@@ -28,7 +28,6 @@ from coordinax._src.base import (
     AbstractFixedComponentsChart,
     AbstractManifold,
     chart_dataclass_decorator,
-    is_not_abstract_chart_subclass,
 )
 from coordinax._src.custom_types import Len
 from coordinax._src.euclidean.atlas import (
@@ -49,11 +48,6 @@ class Abstract1D(AbstractDimensionalFlag, n=1):
 
     @override
     def __init_subclass__(cls, n: int | L["N"] | None = None, **kw: Any) -> None:
-        # Enforce that this is a subclass of AbstractChart
-        if is_not_abstract_chart_subclass(cls):
-            msg = f"{cls.__name__} must be a subclass of AbstractChart"
-            raise TypeError(msg)
-
         if n is not None:
             msg = f"{cls.__name__} does not support variable n"
             raise NotImplementedError(msg)

--- a/src/coordinax/_src/charts/d2.py
+++ b/src/coordinax/_src/charts/d2.py
@@ -15,7 +15,6 @@ from coordinax._src.base import (
     AbstractFixedComponentsChart,
     AbstractManifold,
     chart_dataclass_decorator,
-    is_not_abstract_chart_subclass,
 )
 from coordinax._src.custom_types import Ang, Len
 from coordinax._src.euclidean.atlas import (
@@ -37,11 +36,6 @@ class Abstract2D(AbstractDimensionalFlag, n=2):
 
     @override
     def __init_subclass__(cls, n: int | L["N"] | None = None, **kw: Any) -> None:
-        # Enforce that this is a subclass of AbstractChart
-        if is_not_abstract_chart_subclass(cls):
-            msg = f"{cls.__name__} must be a subclass of AbstractChart"
-            raise TypeError(msg)
-
         if n is not None:
             msg = f"{cls.__name__} does not support variable n"
             raise NotImplementedError(msg)

--- a/src/coordinax/_src/charts/d3.py
+++ b/src/coordinax/_src/charts/d3.py
@@ -34,7 +34,6 @@ from coordinax._src.base import (
     AbstractDimensionalFlag,
     AbstractFixedComponentsChart,
     chart_dataclass_decorator,
-    is_not_abstract_chart_subclass,
 )
 from coordinax._src.charts import checks
 from coordinax._src.constants import Deg0, Deg90, Deg180
@@ -56,11 +55,6 @@ class Abstract3D(AbstractDimensionalFlag, n=3):
 
     @override
     def __init_subclass__(cls, n: int | L["N"] | None = None, **kw: Any) -> None:
-        # Enforce that this is a subclass of AbstractChart
-        if is_not_abstract_chart_subclass(cls):
-            msg = f"{cls.__name__} must be a subclass of AbstractChart"
-            raise TypeError(msg)
-
         if n is not None:
             msg = f"{cls.__name__} does not support variable n"
             raise NotImplementedError(msg)

--- a/src/coordinax/_src/charts/d4.py
+++ b/src/coordinax/_src/charts/d4.py
@@ -6,7 +6,6 @@ from typing import Any, Literal as L, override  # noqa: N817
 
 from coordinax._src.base import (
     AbstractDimensionalFlag,
-    is_not_abstract_chart_subclass,
 )
 
 
@@ -19,11 +18,6 @@ class Abstract4D(AbstractDimensionalFlag, n=4):
 
     @override
     def __init_subclass__(cls, n: int | L["N"] | None = None, **kw: Any) -> None:
-        # Enforce that this is a subclass of AbstractChart
-        if is_not_abstract_chart_subclass(cls):
-            msg = f"{cls.__name__} must be a subclass of AbstractChart"
-            raise TypeError(msg)
-
         if n is not None:
             msg = f"{cls.__name__} does not support variable n"
             raise NotImplementedError(msg)

--- a/src/coordinax/_src/charts/d6.py
+++ b/src/coordinax/_src/charts/d6.py
@@ -14,7 +14,6 @@ from coordinax._src.base import (
     AbstractFixedComponentsChart,
     AbstractManifold,
     chart_dataclass_decorator,
-    is_not_abstract_chart_subclass,
 )
 from coordinax._src.custom_types import Len, Spd
 from coordinax._src.exceptions import NoGlobalCartesianChartError
@@ -30,10 +29,6 @@ class Abstract6D(AbstractDimensionalFlag, n=6):
 
     @override
     def __init_subclass__(cls, n: int | L["N"] | None = None, **kw: Any) -> None:
-        # Enforce that this is a subclass of AbstractChart
-        if is_not_abstract_chart_subclass(cls):
-            msg = f"{cls.__name__} must be a subclass of AbstractChart"
-            raise TypeError(msg)
         # n is already fixed to 6
         if n is not None:
             msg = f"{cls.__name__} does not support variable n"

--- a/src/coordinax/_src/charts/dn.py
+++ b/src/coordinax/_src/charts/dn.py
@@ -15,7 +15,6 @@ from coordinax._src.base import (
     AbstractFixedComponentsChart,
     AbstractManifold,
     chart_dataclass_decorator,
-    is_not_abstract_chart_subclass,
 )
 from coordinax._src.custom_types import Len
 from coordinax._src.euclidean.atlas import EuclideanAtlas
@@ -36,10 +35,6 @@ class AbstractND(AbstractDimensionalFlag, n="N"):
     M: AbstractManifold = no_manifold
 
     def __init_subclass__(cls, n: int | L["N"] | None = None, **kw: Any) -> None:
-        # Enforce that this is a subclass of AbstractChart
-        if is_not_abstract_chart_subclass(cls):
-            msg = f"{cls.__name__} must be a subclass of AbstractChart"
-            raise TypeError(msg)
         # n is already fixed to "N"
         if n is not None:
             msg = f"{cls.__name__} does not support fixed n"


### PR DESCRIPTION
Continuing the over-engineering audit (follow-up to #596–#602).

Each `Abstract{0,1,2,3,4,6,N}D.__init_subclass__` re-ran the exact `is_not_abstract_chart_subclass(cls)` check — with the same `TypeError` message — that `AbstractDimensionalFlag.__init_subclass__` already performs when the override calls `super().__init_subclass__(...)`. So every flag subclass definition ran that check twice.

This drops the duplicated block (and its now-unused import) from all seven flag overrides; each keeps only its unique `n is not None` guard. **−40 lines.**

Behaviour-preserving: defining a non-chart flag subclass still raises the same `TypeError` (now via the base). Verified with the charts unit + doctest suites and the hypothesis chart-strategy tests (which define charts dynamically): **1067 passed, 0 failed**. ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)