### PR TITLE
🧪 test(frames): skip interop order test when parent namespace is absent

### DIFF
--- a/tests/integration/frames/test_interop_import_order.py
+++ b/tests/integration/frames/test_interop_import_order.py
@@ -32,7 +32,14 @@ import coordinax as cx
 _REQUIRE_INTEROP = os.environ.get("COORDINAX_REQUIRE_INTEROP_TESTS") == "1"
 
 for _pkg in ("coordinaxs.astro", "coordinaxs.interop.astropy"):
-    if importlib.util.find_spec(_pkg) is None:
+    # `find_spec` *raises* ModuleNotFoundError (rather than returning None) when
+    # a parent namespace is absent — e.g. `coordinaxs.interop` when only the
+    # astro extra is installed — so treat that as "not installed" too.
+    try:
+        _spec = importlib.util.find_spec(_pkg)
+    except ModuleNotFoundError:
+        _spec = None
+    if _spec is None:
         if _REQUIRE_INTEROP:
             msg = (
                 f"{_pkg} is not installed, but COORDINAX_REQUIRE_INTEROP_TESTS=1 "

--- a/tests/integration/frames/test_interop_import_order.py
+++ b/tests/integration/frames/test_interop_import_order.py
@@ -34,10 +34,13 @@ _REQUIRE_INTEROP = os.environ.get("COORDINAX_REQUIRE_INTEROP_TESTS") == "1"
 for _pkg in ("coordinaxs.astro", "coordinaxs.interop.astropy"):
     # `find_spec` *raises* ModuleNotFoundError (rather than returning None) when
     # a parent namespace is absent — e.g. `coordinaxs.interop` when only the
-    # astro extra is installed — so treat that as "not installed" too.
+    # astro extra is installed — so treat that as "not installed" too. Any other
+    # missing module is a genuine packaging/runtime failure: let it propagate.
     try:
         _spec = importlib.util.find_spec(_pkg)
-    except ModuleNotFoundError:
+    except ModuleNotFoundError as exc:
+        if not f"{_pkg}.".startswith(f"{exc.name}."):
+            raise
         _spec = None
     if _spec is None:
         if _REQUIRE_INTEROP:


### PR DESCRIPTION
## Summary

`tests/integration/frames/test_interop_import_order.py` intends to skip gracefully on a minimal install, but its guard used `importlib.util.find_spec(pkg) is None`. `find_spec` **raises** `ModuleNotFoundError` (rather than returning `None`) when a *parent* namespace is absent — e.g. `find_spec("coordinaxs.interop.astropy")` when only the `astro` extra is installed, because the `coordinaxs.interop` namespace doesn't exist. That defeats the skip and **errors collection** instead:

```
ERROR tests/integration/frames/test_interop_import_order.py
ModuleNotFoundError: No module named 'coordinaxs.interop'
```

which also halts `pytest -x` runs immediately. (CI installs the full `workspace` extra, so it doesn't hit this — only partial local installs do.)

## Fix

Catch the `ModuleNotFoundError` from `find_spec` and treat it as not-installed. The `COORDINAX_REQUIRE_INTEROP_TESTS=1` hard-error path (nox `test` session) is unchanged.

## Verification
- `--extra astro` only: test now **skips** (was erroring).
- `COORDINAX_REQUIRE_INTEROP_TESTS=1`: still raises the intended hard error.

Found while reviewing the frames subsystem for the v0.24 audit (the subsystem itself is clean — all ICRS/Galactic/Galactocentric transforms match astropy to machine precision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)