### PR TITLE
♻️ refactor(hypothesis): dedupe representation-kind class samplers

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/_common.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/_common.py
@@ -1,0 +1,33 @@
+"""Shared strategy helpers for representation-kind class samplers."""
+
+__all__: tuple[str, ...] = ()
+
+from typing import TypeVar
+
+import hypothesis.strategies as st
+
+T = TypeVar("T")
+
+
+def draw_subclass(
+    draw: st.DrawFn,
+    all_classes: tuple[type[T], ...],
+    /,
+    *,
+    include: tuple[type[T], ...] | None,
+    exclude: tuple[type[T], ...],
+    kind: str,
+) -> type[T]:
+    """Draw a concrete subclass, honouring ``include`` / ``exclude``.
+
+    Shared body for the ``*_classes`` strategies (bases, geometries, semantic
+    kinds): candidates default to ``all_classes`` unless ``include`` is given,
+    then ``exclude`` is removed and one is sampled. Raises `ValueError` (naming
+    ``kind``) if nothing remains.
+    """
+    candidates = all_classes if include is None else include
+    candidates = tuple(c for c in candidates if c not in exclude)
+    if not candidates:
+        msg = f"No {kind} classes left after exclusions"
+        raise ValueError(msg)
+    return draw(st.sampled_from(candidates))

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/_common.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/_common.py
@@ -26,7 +26,8 @@ def draw_subclass(
     ``kind``) if nothing remains.
     """
     candidates = all_classes if include is None else include
-    candidates = tuple(c for c in candidates if c not in exclude)
+    exclude_set = set(exclude)
+    candidates = tuple(c for c in candidates if c not in exclude_set)
     if not candidates:
         msg = f"No {kind} classes left after exclusions"
         raise ValueError(msg)

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/bases.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/bases.py
@@ -8,6 +8,7 @@ import hypothesis.strategies as st
 
 import coordinax.representations as cxr
 
+from ._common import draw_subclass
 from coordinaxs.hypothesis.utils import get_all_subclasses
 
 BASES: Final = get_all_subclasses(cxr.AbstractBasis, exclude_abstract=True)
@@ -52,17 +53,7 @@ def basis_classes(
     ...     assert issubclass(basis_cls, cxr.NoBasis)
 
     """
-    # Determine candidate basis classes
-    candidates = BASES if include is None else include
-
-    # Filter out excluded basis classes
-    candidates = tuple(r for r in candidates if r not in exclude)
-
-    if not candidates:
-        msg = "No basis classes left after exclusions"
-        raise ValueError(msg)
-
-    return draw(st.sampled_from(candidates))  # ty: ignore[invalid-return-type]
+    return draw_subclass(draw, BASES, include=include, exclude=exclude, kind="basis")  # ty: ignore[invalid-return-type]
 
 
 @st.composite

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/geoms.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/geoms.py
@@ -8,6 +8,7 @@ import hypothesis.strategies as st
 
 import coordinax.representations as cxr
 
+from ._common import draw_subclass
 from coordinaxs.hypothesis.utils import get_all_subclasses
 
 GEOMETRIES: Final = get_all_subclasses(cxr.AbstractGeometry, exclude_abstract=True)
@@ -52,17 +53,9 @@ def geometry_classes(
     ...     assert issubclass(geom_cls, cxr.PointGeometry)
 
     """
-    # Determine candidate geometry classes
-    candidates = GEOMETRIES if include is None else include
-
-    # Filter out excluded geometry classes
-    candidates = tuple(r for r in candidates if r not in exclude)
-
-    if not candidates:
-        msg = "No role classes left after exclusions"
-        raise ValueError(msg)
-
-    return draw(st.sampled_from(candidates))  # ty: ignore[invalid-return-type]
+    return draw_subclass(
+        draw, GEOMETRIES, include=include, exclude=exclude, kind="geometry"
+    )  # ty: ignore[invalid-return-type]
 
 
 @st.composite

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/semantics.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/semantics.py
@@ -8,6 +8,7 @@ import hypothesis.strategies as st
 
 import coordinax.representations as cxr
 
+from ._common import draw_subclass
 from coordinaxs.hypothesis.utils import get_all_subclasses
 
 SEMANTICS: Final = get_all_subclasses(cxr.AbstractSemanticKind, exclude_abstract=True)
@@ -52,17 +53,9 @@ def semantic_classes(
     ...     assert issubclass(sem_cls, cxr.Location)
 
     """
-    # Determine candidate semantic classes
-    candidates = SEMANTICS if include is None else include
-
-    # Filter out excluded semantic classes
-    candidates = tuple(r for r in candidates if r not in exclude)
-
-    if not candidates:
-        msg = "No semantic classes left after exclusions"
-        raise ValueError(msg)
-
-    return draw(st.sampled_from(candidates))  # ty: ignore[invalid-return-type]
+    return draw_subclass(
+        draw, SEMANTICS, include=include, exclude=exclude, kind="semantic"
+    )  # ty: ignore[invalid-return-type]
 
 
 @st.composite

--- a/packages/coordinaxs.hypothesis/tests/unit/representations/test_geometry_classes.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/representations/test_geometry_classes.py
@@ -50,7 +50,7 @@ class TestGeometryClasses:
     def test_empty_candidates_raises_value_error(self, data: st.DataObject) -> None:
         """Excluding all candidates raises ValueError."""
         all_geometries = get_all_subclasses(cxr.AbstractGeometry, exclude_abstract=True)
-        with pytest.raises(ValueError, match="No role classes left after exclusions"):
+        with pytest.raises(ValueError, match="No geometry classes"):
             data.draw(cxrst.geometry_classes(exclude=tuple(all_geometries)))
 
     def test_also_accessible_via_main(self) -> None:


### PR DESCRIPTION
Audit follow-up. `basis_classes` / `geometry_classes` / `semantic_classes` carried a byte-identical candidate-filter + `sampled_from` body (only the class tuple and error noun differed).

- Extract the shared body into `draw_subclass` (`representations/_src/_common.py`); each public strategy keeps its signature + docstring and becomes a one-liner.
- Fix the geometry sampler's stale error message (`"No role classes"` → `"No geometry classes"`) and its test.

Doc-preserving (all 6 public strategies unchanged). **114 passed**, ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)