### PR TITLE
♻️ refactor: dedupe the optional entry-point export loaders

### DIFF
--- a/src/coordinax/_src/optional_exports.py
+++ b/src/coordinax/_src/optional_exports.py
@@ -1,0 +1,46 @@
+"""Shared loader for optional entry-point export groups (frames, transforms)."""
+
+__all__: tuple[str, ...] = ()
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def load_exports(
+    entrypoints: list[Any], /, *, group: str, noun: str
+) -> dict[str, object]:
+    """Load and validate optional exports from entry points.
+
+    Each entry point must load a callable that returns a string-keyed mapping;
+    conflicting exports (same name, different value) are rejected. ``group``
+    names the entry-point group in the validation messages and ``noun`` (e.g.
+    ``"frame export"``) is used in the conflict message. Returns the merged
+    export mapping; the caller injects it into its own namespace.
+    """
+    exported: dict[str, object] = {}
+    export_owners: dict[str, str] = {}
+    for ep in entrypoints:
+        provider = ep.load()
+        if not callable(provider):
+            msg = f"Entry point {ep.name!r} in group '{group}' is not callable."
+            raise TypeError(msg)
+        exports = provider()
+        if not isinstance(exports, Mapping):
+            msg = f"Entry point {ep.name!r} in group '{group}' must return a mapping."
+            raise TypeError(msg)
+        for name, value in exports.items():
+            if not isinstance(name, str):
+                msg = (
+                    f"Entry point {ep.name!r} in group '{group}' produced a "
+                    "non-string export name."
+                )
+                raise TypeError(msg)
+            if name in exported and exported[name] is not value:
+                msg = (
+                    f"Conflicting {noun} {name!r} from entry points "
+                    f"{export_owners[name]!r} and {ep.name!r}."
+                )
+                raise RuntimeError(msg)
+            exported[name] = value
+            export_owners[name] = ep.name
+    return exported

--- a/src/coordinax/frames/__init__.py
+++ b/src/coordinax/frames/__init__.py
@@ -52,9 +52,9 @@ Array(True, dtype=bool)
 import warnings
 from importlib.metadata import entry_points
 
-from collections.abc import Mapping
 from typing import Any, Final
 
+from coordinax._src.optional_exports import load_exports
 from coordinax._src.setup_package import install_import_hook
 
 # Defined here b/c it's mutated by optional imports
@@ -141,47 +141,12 @@ def _load_optional_frame_exports() -> None:
         return
 
     _OPTIONAL_FRAME_EXPORTS_STATE["loading"] = True
-    exported: dict[str, object] = {}
-    export_owners: dict[str, str] = {}
-
     try:
-        entrypoints = _frame_export_entrypoints()
-        for ep in entrypoints:
-            provider = ep.load()
-            if not callable(provider):
-                msg = (
-                    f"Entry point {ep.name!r} in group "
-                    f"'{_FRAME_EXPORTS_ENTRYPOINT_GROUP}' "
-                    "is not callable."
-                )
-                raise TypeError(msg)
-            exports = provider()
-            if not isinstance(exports, Mapping):
-                msg = (
-                    f"Entry point {ep.name!r} in group "
-                    f"'{_FRAME_EXPORTS_ENTRYPOINT_GROUP}' "
-                    "must return a mapping."
-                )
-                raise TypeError(msg)
-            for name, value in exports.items():
-                if not isinstance(name, str):
-                    msg = (
-                        f"Entry point {ep.name!r} in group "
-                        f"'{_FRAME_EXPORTS_ENTRYPOINT_GROUP}' produced "
-                        "a non-string export name."
-                    )
-                    raise TypeError(msg)
-
-                if name in exported and exported[name] is not value:
-                    msg = (
-                        f"Conflicting frame export {name!r} from entry points "
-                        f"{export_owners[name]!r} and {ep.name!r}."
-                    )
-                    raise RuntimeError(msg)
-
-                exported[name] = value
-                export_owners[name] = ep.name
-
+        exported = load_exports(
+            _frame_export_entrypoints(),
+            group=_FRAME_EXPORTS_ENTRYPOINT_GROUP,
+            noun="frame export",
+        )
         globals().update(exported)
     finally:
         _OPTIONAL_FRAME_EXPORTS_STATE["loading"] = False

--- a/src/coordinax/transforms/__init__.py
+++ b/src/coordinax/transforms/__init__.py
@@ -14,9 +14,9 @@ Rotate(f64[3,3](jax))
 import warnings
 from importlib.metadata import entry_points
 
-from collections.abc import Mapping
 from typing import Final
 
+from coordinax._src.optional_exports import load_exports
 from coordinax._src.setup_package import install_import_hook
 
 __all__: tuple[str, ...] = (
@@ -105,9 +105,6 @@ def _load_optional_transform_exports() -> None:
         return
 
     _OPTIONAL_TRANSFORM_EXPORTS_STATE["loading"] = True
-    exported: dict[str, object] = {}
-    export_owners: dict[str, str] = {}
-
     try:
         current = list(entry_points(group=_TRANSFORM_EXPORTS_ENTRYPOINT_GROUP))
         seen = {ep.name for ep in current}
@@ -128,40 +125,11 @@ def _load_optional_transform_exports() -> None:
                 stacklevel=3,
             )
         eps = sorted(current + legacy, key=lambda ep: ep.name)
-        for ep in eps:
-            provider = ep.load()
-            if not callable(provider):
-                msg = (
-                    f"Entry point {ep.name!r} in group "
-                    f"'{_TRANSFORM_EXPORTS_ENTRYPOINT_GROUP}' "
-                    "is not callable."
-                )
-                raise TypeError(msg)
-            exports = provider()
-            if not isinstance(exports, Mapping):
-                msg = (
-                    f"Entry point {ep.name!r} in group "
-                    f"'{_TRANSFORM_EXPORTS_ENTRYPOINT_GROUP}' "
-                    "must return a mapping."
-                )
-                raise TypeError(msg)
-            for name, value in exports.items():
-                if not isinstance(name, str):
-                    msg = (
-                        f"Entry point {ep.name!r} in group "
-                        f"'{_TRANSFORM_EXPORTS_ENTRYPOINT_GROUP}' produced "
-                        "a non-string export name."
-                    )
-                    raise TypeError(msg)
-                if name in exported and exported[name] is not value:
-                    msg = (
-                        f"Conflicting transform export {name!r} from entry points "
-                        f"{export_owners[name]!r} and {ep.name!r}."
-                    )
-                    raise RuntimeError(msg)
-                exported[name] = value
-                export_owners[name] = ep.name
-
+        exported = load_exports(
+            eps,
+            group=_TRANSFORM_EXPORTS_ENTRYPOINT_GROUP,
+            noun="transform export",
+        )
         globals().update(exported)
     finally:
         _OPTIONAL_TRANSFORM_EXPORTS_STATE["loading"] = False


### PR DESCRIPTION
Audit follow-up. The `frames` and `transforms` optional-export loaders had a byte-identical inner loop (load entry point → validate callable + str-keyed mapping → reject conflicts → accumulate).

Extract it into `coordinax._src.optional_exports.load_exports(entrypoints, *, group, noun)`. Each loader now discovers its entry points (frames via the tested `_frame_export_entrypoints`, transforms inline with its legacy-group warning) and calls the helper, then `globals().update(...)`.

**Contract-preserving:** the tested internal names (`_frame_export_entrypoints`, `_load_optional_*`), the group constants, the legacy-group `DeprecationWarning`, and the exact validation/conflict message substrings are all unchanged. Verified with `test_entrypoint_backcompat` + `test_interop_loader` + frames/transforms suites — **317 passed**. ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)