### PR TITLE
♻️ refactor(manifolds): dedupe _as_quantity_matrix into a shared helper

### DIFF
--- a/src/coordinax/_src/manifolds/_utils.py
+++ b/src/coordinax/_src/manifolds/_utils.py
@@ -1,0 +1,19 @@
+"""Shared internal helpers for the manifolds subpackage."""
+
+__all__: tuple[str, ...] = ()
+
+from jaxtyping import Array
+
+import unxts.linalg as ul
+
+import unxt as u
+
+DMLS = u.unit("")
+
+
+def as_quantity_matrix(x: ul.QM | Array, /) -> ul.QM:
+    """Return *x* as a `QM`, wrapping a plain array as a dimensionless matrix."""
+    if isinstance(x, ul.QM):
+        return x
+    n_rows, n_cols = x.shape[-2:]
+    return ul.QM(value=x, unit=ul.UnitsMatrix.full((n_rows, n_cols), DMLS))

--- a/src/coordinax/_src/manifolds/_utils.py
+++ b/src/coordinax/_src/manifolds/_utils.py
@@ -12,7 +12,26 @@ DMLS = u.unit("")
 
 
 def as_quantity_matrix(x: ul.QM | Array, /) -> ul.QM:
-    """Return *x* as a `QM`, wrapping a plain array as a dimensionless matrix."""
+    """Return *x* as a `QM`, wrapping a plain array as a dimensionless matrix.
+
+    `ul.QM` is an alias of `ul.QuantityMatrix`, so a unitful matrix of either
+    spelling passes through untouched and keeps its units.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxts.linalg as ul
+    >>> from coordinax._src.manifolds._utils import as_quantity_matrix
+
+    >>> as_quantity_matrix(jnp.eye(2))
+    QM([[1., 0.],
+        [0., 1.]], '((, ), (, ))')
+
+    >>> g = ul.QuantityMatrix(jnp.eye(2), unit=ul.UnitsMatrix.full((2, 2), "m"))
+    >>> as_quantity_matrix(g) is g
+    True
+
+    """
     if isinstance(x, ul.QM):
         return x
     n_rows, n_cols = x.shape[-2:]

--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -2,18 +2,16 @@
 
 __all__: tuple[str, ...] = ()
 
-from jaxtyping import Array
 
 import jax
-import numpy as np
 import plum
-import unxts.linalg as ul
 
 import quaxed.numpy as qnp
 import unxt as u
 
 import coordinax.angles as cxa
 import coordinaxs.api.manifolds as cxmapi
+from ._utils import as_quantity_matrix
 from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.custom_types import CDict, OptUSys
 from coordinax._src.metric.matrix import DenseMetric
@@ -95,7 +93,7 @@ def angle_between(
     chart.check_data(vvec, keys=True, values=False)
 
     mm = cxmapi.metric_matrix(chart.M, at, chart)
-    g = _as_quantity_matrix(
+    g = as_quantity_matrix(
         mm.matrix if isinstance(mm, DenseMetric) else mm.to_dense().matrix  # ty: ignore[unresolved-attribute]
     )
     u_qm = pack_to_qmatrix(uvec, keys=chart.components)
@@ -110,16 +108,6 @@ def angle_between(
     cosine = inner / qnp.sqrt(uu * vv)
     cosine_value = qnp.clip(u.ustrip("", cosine), -1.0, 1.0)
     return cxa.Angle(qnp.arccos(cosine_value), "rad")
-
-
-def _as_quantity_matrix(x: ul.QuantityMatrix | Array) -> ul.QuantityMatrix:
-    """Convert a numeric matrix into a dimensionless QuantityMatrix."""
-    if isinstance(x, ul.QuantityMatrix):
-        return x
-
-    n_rows, n_cols = x.shape[-2:]
-    units = ul.UnitsMatrix(np.full((n_rows, n_cols), u.unit("")))
-    return ul.QuantityMatrix(value=x, unit=units)
 
 
 def _check_nonzero_norm(*norms: u.AbstractQuantity) -> None:

--- a/src/coordinax/_src/manifolds/scale_factors.py
+++ b/src/coordinax/_src/manifolds/scale_factors.py
@@ -2,7 +2,6 @@
 
 __all__: tuple[str, ...] = ()
 
-from jaxtyping import Array
 
 import jax
 import jax.numpy as jnp
@@ -14,6 +13,7 @@ import unxt as u
 
 import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
+from ._utils import as_quantity_matrix
 from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.custom_types import CDict, OptUSys
 from coordinax._src.embedded.metric import PullbackMetric
@@ -76,17 +76,7 @@ def scale_factors(
             return diag
         units = ul.UnitsMatrix.full(diag.shape[-1], DMLS)
         return ul.QM(diag, unit=units)
-    return _as_quantity_matrix(mm.matrix).diag()  # ty: ignore[unresolved-attribute]
-
-
-def _as_quantity_matrix(x: ul.QM | Array) -> ul.QM:
-    """Convert a numeric matrix into a dimensionless QuantityMatrix."""
-    if isinstance(x, ul.QM):
-        return x
-
-    n_rows, n_cols = x.shape[-2:]
-    units = ul.UnitsMatrix.full((n_rows, n_cols), DMLS)
-    return ul.QM(value=x, unit=units)
+    return as_quantity_matrix(mm.matrix).diag()  # ty: ignore[unresolved-attribute]
 
 
 @plum.dispatch


### PR DESCRIPTION
Audit follow-up. `manifolds/scale_factors.py` and `manifolds/angle_between.py` each defined an identical `_as_quantity_matrix` (coerce an array-or-`QM` into a dimensionless `QM`) — and they had drifted (`ul.QM` + `UnitsMatrix.full` vs the older `ul.QuantityMatrix` + `np.full`).

Hoist the single improved form into `manifolds/_utils.as_quantity_matrix` and import it in both.

**552 passed** (manifolds suites), ruff + ty clean.

> A future `unxts.linalg` `QM.dimensionless(array)` classmethod could reduce this to an inline one-liner and drop the helper entirely — noted for upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)