### PR TITLE
✨ feat(charts): add `carray`, the packing complement of `cdict`

### DIFF
--- a/docs/guides/perf.md
+++ b/docs/guides/perf.md
@@ -186,10 +186,9 @@ To achieve the same performance as the raw array version, we can shift the pytre
 
 ```{code-cell} ipython3
 from jaxmore import structured
-from coordinax.internal import pack_with_usys
 
 structurer = structured(lambda x: cx.cdict(x, cx.cart3d),
-                        lambda x:pack_with_usys(x, cx.sph3d.components, usys)[0])
+                        lambda x:cx.carray(x, cx.sph3d.components, usys).value)
 c2s_cx_dict = jax.jit(vmap(structurer(_c2s_cx)))
 
 %time jax.block_until_ready(c2s_cx_dict(xarr))
@@ -273,7 +272,7 @@ Just like the basic JAX version, this is around 2-3x slower than the raw array v
 ```{code-cell} ipython3
 # Pre-specialize `c2s_cx`, pushing pytrees into a JIT-optimizable closure.
 structurer = structured(lambda x: cx.cdict(x, usys["length"], cx.cart3d),
-                        lambda x: pack_with_usys(x, cx.sph3d.components, usys)[0])
+                        lambda x: cx.carray(x, cx.sph3d.components, usys).value)
 c2s_cx_qdict = jax.jit(jax.vmap(structurer(_c2s_cx)))
 
 %time jax.block_until_ready(c2s_cx_qdict(xarr))
@@ -320,7 +319,7 @@ With `coordinax`, optimizing is very easy.
 ```{code-cell} ipython3
 # Pre-specialize `c2s_cx`, pushing pytrees into a JIT-optimizable closure.
 structurer = structured(lambda x: cx.Point.from_(u.Q(x, usys["length"]), cx.cart3d),
-                        lambda x: pack_with_usys(x.data, cx.sph3d.components, usys)[0])
+                        lambda x: cx.carray(x.data, cx.sph3d.components, usys).value)
 c2s_cx_vec = jax.jit(vmap(structurer(_c2s_cx)))
 
 %time jax.block_until_ready(c2s_cx_vec(xarr))

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1003,8 +1003,7 @@ Semi-public API:
 
 - `pack_uniform_unit`: stack component data into an array using a shared unit
 - `pack_nonuniform_unit`: stack component data into an array while preserving per-component units
-- `pack_with_usys`: stack component data into an array, resolving per-component units from a unit system
-- `pack_to_qmatrix`: pack a component dictionary into a `QuantityMatrix` (unitless components are treated as dimensionless)
+- `carray`: pack a component dictionary into a `QuantityMatrix` (the complement of `cdict`; unitless components are treated as dimensionless; a unit system or shared unit may be supplied)
 - `tree_cast_int_bool_to_float`: promote integer/boolean PyTree leaves to floating point (e.g. for `jax.jacfwd` inputs)
 - `pos_named_objs`, `jax_scalar_handler`: wadler-lindig rendering helpers used by `__pdoc__` implementations
 - `CDict`, `OptUSys`: the component-dictionary and optional-unit-system type aliases
@@ -1242,7 +1241,7 @@ The `coordinax.charts` module provides the chart-facing API for representing poi
         dispatch handles it.
 
       - **Quantity-valued** (`is_array=False`): packs `at` into a 1-D `QuantityMatrix`
-        via `pack_to_qmatrix(at, keys=from_chart.components)`, casts to `float`, then
+        via `carray(at, from_chart.components)`, casts to `float`, then
         computes `J_qq = jax.jacfwd(pt_map_fn)(at_in)`. The jacfwd result is a
         `QuantityMatrix` whose `.value` is itself a `QuantityMatrix` encoding the input
         units, and whose `.unit` encodes the output units. `_repack_q_from_jac` extracts

--- a/packages/coordinaxs.api/src/coordinaxs/api/charts.py
+++ b/packages/coordinaxs.api/src/coordinaxs/api/charts.py
@@ -360,9 +360,10 @@ def carray(p: Any, /, *args: Any) -> Any:
 
         - ``carray(p, keys)`` / ``carray(p, chart)`` — one unit per component
           (dimensionless where a component carries no unit)
-        - ``carray(p, keys, usys)`` — units resolved from a unit system by each
-          component's dimension
-        - ``carray(p, keys, unit)`` — a single shared unit for every component
+        - ``carray(p, keys, usys)`` / ``carray(p, chart, usys)`` — units resolved
+          from a unit system by each component's dimension
+        - ``carray(p, keys, unit)`` / ``carray(p, chart, unit)`` — a single
+          shared unit for every component
 
     Returns
     -------

--- a/packages/coordinaxs.api/src/coordinaxs/api/charts.py
+++ b/packages/coordinaxs.api/src/coordinaxs/api/charts.py
@@ -6,6 +6,7 @@ __all__ = (
     "jac_pt_map",
     # Data
     "cdict",
+    "carray",
     "guess_chart",
 )
 
@@ -339,6 +340,49 @@ def cdict(_: Any, /) -> CDict:
     >>> cx.cdict(arr, cx.cart3d)
     {'x': Array(1., dtype=float64), 'y': Array(2., dtype=float64),
      'z': Array(3., dtype=float64)}
+
+    """
+    raise NotImplementedError  # pragma: no cover
+
+
+@plum.dispatch.abstract
+def carray(p: Any, /, *args: Any) -> Any:
+    """Pack a component dictionary into a ``QuantityMatrix`` (complement of `cdict`).
+
+    Parameters
+    ----------
+    p
+        A component dictionary (keys are component names, values are
+        scalars/arrays or quantities).
+    *args
+        Either ``keys`` (a tuple of component names) or a chart, optionally
+        followed by a unit or unit system controlling the packed units:
+
+        - ``carray(p, keys)`` / ``carray(p, chart)`` — one unit per component
+          (dimensionless where a component carries no unit)
+        - ``carray(p, keys, usys)`` — units resolved from a unit system by each
+          component's dimension
+        - ``carray(p, keys, unit)`` — a single shared unit for every component
+
+    Returns
+    -------
+    unxts.linalg.QuantityMatrix
+        The packed 1-D quantity matrix, stacked along the trailing axis, with
+        one unit per component.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax as cx
+
+    >>> p = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
+    >>> cx.carray(p, ("x", "y", "z"))
+    QM([1., 2., 3.], '(km, km, km)')
+
+    Unitless components pack as dimensionless:
+
+    >>> cx.carray({"x": 1.0, "y": 2.0}, cx.cart2d)
+    QM([1., 2.], '(, )')
 
     """
     raise NotImplementedError  # pragma: no cover

--- a/src/coordinax/__init__.py
+++ b/src/coordinax/__init__.py
@@ -10,6 +10,7 @@ __all__ = (  # distances
     "cartesian_chart",
     "guess_chart",
     "cdict",
+    "carray",
     "pt_map",
     "jac_pt_map",
     "cart1d",
@@ -100,6 +101,7 @@ from coordinax.angles import Angle
 from coordinax.charts import (
     CartesianProductChart,
     NoGlobalCartesianChartError,
+    carray,
     cart1d,
     cart2d,
     cart3d,

--- a/src/coordinax/_src/charts/__init__.py
+++ b/src/coordinax/_src/charts/__init__.py
@@ -15,6 +15,7 @@ from .d4 import *
 from .d6 import *
 from .dn import *
 from .jacobian import *
+from .register_carray import *
 from .register_cdict import *
 from .register_guess import *
 from .register_ptmap import *

--- a/src/coordinax/_src/charts/jacobian.py
+++ b/src/coordinax/_src/charts/jacobian.py
@@ -55,7 +55,7 @@ import coordinaxs.api.charts as cxcapi
 from .d2 import Cart2D, Polar2D
 from coordinax._src.base import AbstractChart
 from coordinax._src.custom_types import CDict, OptUSys
-from coordinax.internal import pack_to_qmatrix, tree_cast_int_bool_to_float
+from coordinax.internal import tree_cast_int_bool_to_float
 
 # ===================================================================
 # Partial function
@@ -212,7 +212,7 @@ def jac_pt_map(
 
     **Quantity-valued branch** (at least one value carries a unit)
         Packs *at* into a 1-D ``QuantityMatrix`` via
-        ``pack_to_qmatrix(at, keys=from_chart.components)``, promotes any
+        ``carray(at, from_chart.components)``, promotes any
         integer or boolean leaves to the default floating-point dtype (other
         dtypes, including complex, are left unchanged and will raise a
         ``TypeError`` from ``jax.jacfwd`` if passed), then computes
@@ -274,7 +274,7 @@ def jac_pt_map(
     jac_pt_map_fn = jax.jacfwd(pt_map_fn)
 
     # Pack the input CDict to a QuantityMatrix
-    at_in = pack_to_qmatrix(at, keys=from_chart.components)
+    at_in = cxcapi.carray(at, from_chart.components)
     at_in = tree_cast_int_bool_to_float(at_in)
 
     # Compute Jacobian as QuantityMatrix

--- a/src/coordinax/_src/charts/register_carray.py
+++ b/src/coordinax/_src/charts/register_carray.py
@@ -1,0 +1,87 @@
+"""``carray`` dispatch implementations — pack component dicts into a QuantityMatrix."""
+
+__all__ = ()
+
+from typing import Final
+
+import plum
+import unxts.linalg as ul
+
+import quaxed.numpy as jnp
+import unxt as u
+from unxt.quantity import AllowValue
+
+from coordinax._src.base import AbstractChart
+from coordinax._src.custom_types import CDict
+
+DMLS: Final = u.unit("")
+
+
+@plum.dispatch
+def carray(p: CDict, keys: tuple[str, ...], /) -> ul.QM:
+    """Pack a component dict into a 1-D ``QM`` with per-component native units.
+
+    Unitless components are treated as dimensionless, so quantity- and
+    array-valued components can be packed together.
+
+    >>> import unxt as u
+    >>> import coordinax as cx
+    >>> p = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
+    >>> cx.carray(p, ("x", "y", "z"))
+    QM([1., 2., 3.], '(km, km, km)')
+
+    """
+    units = tuple(u_ if (u_ := u.unit_of(p[k])) is not None else DMLS for k in keys)
+    vals = [
+        u.ustrip(AllowValue, unit, p[k]) for k, unit in zip(keys, units, strict=True)
+    ]
+    return ul.QM(jnp.stack(vals, axis=-1), unit=units)
+
+
+@plum.dispatch
+def carray(p: CDict, chart: AbstractChart, /) -> ul.QM:
+    """Pack a component dict using ``chart.components`` as the keys.
+
+    >>> import unxt as u
+    >>> import coordinax as cx
+    >>> p = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
+    >>> cx.carray(p, cx.cart3d)
+    QM([1., 2., 3.], '(km, km, km)')
+
+    """
+    return carray(p, chart.components)  # ty: ignore[missing-argument]
+
+
+@plum.dispatch
+def carray(p: CDict, keys: tuple[str, ...], usys: u.AbstractUnitSystem, /) -> ul.QM:
+    """Pack a component dict, resolving each component's unit from ``usys``.
+
+    >>> import unxt as u
+    >>> import coordinax as cx
+    >>> p = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km")}
+    >>> cx.carray(p, ("x", "y"), u.unitsystems.si)
+    QM([1000., 2000.], '(m, m)')
+
+    """
+    units = tuple(
+        usys[dim] if (dim := u.dimension_of(p[k])) is not None else DMLS for k in keys
+    )
+    vals = [
+        u.ustrip(AllowValue, unit, p[k]) for k, unit in zip(keys, units, strict=True)
+    ]
+    return ul.QM(jnp.stack(vals, axis=-1), unit=units)
+
+
+@plum.dispatch
+def carray(p: CDict, keys: tuple[str, ...], unit: u.AbstractUnit, /) -> ul.QM:
+    """Pack a component dict into a single shared ``unit`` (all components converted).
+
+    >>> import unxt as u
+    >>> import coordinax as cx
+    >>> p = {"x": u.Q(1.0, "km"), "y": u.Q(200.0, "m")}
+    >>> cx.carray(p, ("x", "y"), u.unit("km"))
+    QM([1. , 0.2], '(km, km)')
+
+    """
+    vals = [u.ustrip(AllowValue, unit, p[k]) for k in keys]
+    return ul.QM(jnp.stack(vals, axis=-1), unit=(unit,) * len(keys))

--- a/src/coordinax/_src/charts/register_carray.py
+++ b/src/coordinax/_src/charts/register_carray.py
@@ -73,6 +73,20 @@ def carray(p: CDict, keys: tuple[str, ...], usys: u.AbstractUnitSystem, /) -> ul
 
 
 @plum.dispatch
+def carray(p: CDict, chart: AbstractChart, usys: u.AbstractUnitSystem, /) -> ul.QM:
+    """Pack a component dict, using ``chart.components`` and units from ``usys``.
+
+    >>> import unxt as u
+    >>> import coordinax as cx
+    >>> p = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
+    >>> cx.carray(p, cx.cart3d, u.unitsystems.si)
+    QM([1000., 2000., 3000.], '(m, m, m)')
+
+    """
+    return carray(p, chart.components, usys)  # ty: ignore[too-many-positional-arguments]
+
+
+@plum.dispatch
 def carray(p: CDict, keys: tuple[str, ...], unit: u.AbstractUnit, /) -> ul.QM:
     """Pack a component dict into a single shared ``unit`` (all components converted).
 
@@ -85,3 +99,17 @@ def carray(p: CDict, keys: tuple[str, ...], unit: u.AbstractUnit, /) -> ul.QM:
     """
     vals = [u.ustrip(AllowValue, unit, p[k]) for k in keys]
     return ul.QM(jnp.stack(vals, axis=-1), unit=(unit,) * len(keys))
+
+
+@plum.dispatch
+def carray(p: CDict, chart: AbstractChart, unit: u.AbstractUnit, /) -> ul.QM:
+    """Pack a component dict, using ``chart.components`` and a shared ``unit``.
+
+    >>> import unxt as u
+    >>> import coordinax as cx
+    >>> p = {"x": u.Q(1.0, "km"), "y": u.Q(200.0, "m"), "z": u.Q(0.0, "m")}
+    >>> cx.carray(p, cx.cart3d, u.unit("km"))
+    QM([1. , 0.2, 0. ], '(km, km, km)')
+
+    """
+    return carray(p, chart.components, unit)  # ty: ignore[too-many-positional-arguments]

--- a/src/coordinax/_src/internal/pack_utils.py
+++ b/src/coordinax/_src/internal/pack_utils.py
@@ -13,14 +13,10 @@ Two packing modes are supported:
 __all__ = (
     "pack_uniform_unit",
     "pack_nonuniform_unit",
-    "pack_with_usys",
-    "pack_to_qmatrix",
 )
 
 from jaxtyping import Array, ArrayLike
 from typing import Any, Final, overload
-
-import unxts.linalg as ul
 
 import quaxed.numpy as jnp
 import unxt as u
@@ -103,64 +99,3 @@ def pack_nonuniform_unit(
         u.ustrip(AllowValue, unit, p[k]) for k, unit in zip(keys, units, strict=True)
     ]
     return jnp.stack(vals, axis=-1), units  # ty: ignore[invalid-return-type]
-
-
-def pack_with_usys(
-    p: CDict, /, keys: tuple[str, ...], usys: u.AbstractUnitSystem
-) -> tuple[Array, tuple[u.AbstractUnit, ...]]:
-    """Pack a component dictionary into an array with per-component units."""
-    units = tuple(
-        usys[dim] if (dim := u.dimension_of(p[k])) is not None else DMLS for k in keys
-    )
-    vals = [
-        u.ustrip(AllowValue, unit, p[k]) for k, unit in zip(keys, units, strict=True)
-    ]
-    return jnp.stack(vals, axis=-1), units  # ty: ignore[invalid-return-type]
-
-
-def pack_to_qmatrix(
-    p: CDict, /, keys: tuple[CKey, ...] | None = None
-) -> ul.QuantityMatrix:
-    """Pack a component dictionary into a 1-D `QuantityMatrix`.
-
-    Components are ordered according to ``keys`` and stacked along the trailing
-    axis, each carrying its own unit. Unitless components are treated as
-    dimensionless, so a mix of quantity-valued and plain-array components can be
-    packed together — the result is always a
-    {class}`~unxts.linalg.QuantityMatrix`.
-
-    Parameters
-    ----------
-    p
-        Component dictionary to pack.
-    keys
-        Ordered keys to extract and stack.
-
-    Returns
-    -------
-    QuantityMatrix
-        The packed 1-D quantity matrix, with one unit per component.
-
-    Examples
-    --------
-    >>> import jax.numpy as jnp
-    >>> import unxt as u
-    >>> from coordinax.internal import pack_to_qmatrix
-
-    >>> p = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
-    >>> pack_to_qmatrix(p, ("x", "y", "z"))
-    QM([1., 2., 3.], '(km, km, km)')
-
-    """
-    # Dict sorter
-    if keys is None:
-        keys = tuple(p.keys())
-    # Extract units and values, casting to DMLS when no unit is found.  This
-    # allows unitless values to be packed alongside quantity-valued ones, which
-    # is a common use case for chart data.
-    units = tuple(u_ if (u_ := u.unit_of(p[k])) is not None else DMLS for k in keys)
-    vals = [
-        u.ustrip(AllowValue, unit, p[k]) for k, unit in zip(keys, units, strict=True)
-    ]
-    # Return as QuantityMatrix
-    return ul.QuantityMatrix(jnp.stack(vals, axis=-1), unit=units)

--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -13,11 +13,11 @@ import quaxed.numpy as qnp
 import unxt as u
 
 import coordinax.angles as cxa
+import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
 from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.custom_types import CDict, OptUSys
 from coordinax._src.metric.matrix import DenseMetric
-from coordinax.internal import pack_to_qmatrix
 
 
 @plum.dispatch
@@ -98,8 +98,8 @@ def angle_between(
     g = _as_quantity_matrix(
         mm.matrix if isinstance(mm, DenseMetric) else mm.to_dense().matrix  # ty: ignore[unresolved-attribute]
     )
-    u_qm = pack_to_qmatrix(uvec, keys=chart.components)
-    v_qm = pack_to_qmatrix(vvec, keys=chart.components)
+    u_qm = cxcapi.carray(uvec, chart.components)
+    v_qm = cxcapi.carray(vvec, chart.components)
 
     inner = u_qm @ (g @ v_qm)
     uu = u_qm @ (g @ u_qm)

--- a/src/coordinax/charts.py
+++ b/src/coordinax/charts.py
@@ -78,6 +78,7 @@ __all__ = (
     "cartesian_chart",
     "guess_chart",
     "cdict",
+    "carray",
     "jac_pt_map",
     "pt_map",
     # ===========================================
@@ -227,7 +228,13 @@ with install_import_hook("coordinax.charts"):
         sph1,
         sph2,
     )
-    from coordinaxs.api.charts import cartesian_chart, cdict, guess_chart, pt_map
+    from coordinaxs.api.charts import (
+        carray,
+        cartesian_chart,
+        cdict,
+        guess_chart,
+        pt_map,
+    )
 
 
 del install_import_hook

--- a/src/coordinax/internal.py
+++ b/src/coordinax/internal.py
@@ -27,8 +27,6 @@ __all__ = (
     "tree_cast_int_bool_to_float",
     "pack_uniform_unit",
     "pack_nonuniform_unit",
-    "pack_with_usys",
-    "pack_to_qmatrix",
     "pos_named_objs",
     "jax_scalar_handler",
     # Types
@@ -43,9 +41,7 @@ with install_import_hook("coordinax.internal"):
     from coordinax._src.internal import (
         jax_scalar_handler,
         pack_nonuniform_unit,
-        pack_to_qmatrix,
         pack_uniform_unit,
-        pack_with_usys,
         pos_named_objs,
         tree_cast_int_bool_to_float,
     )


### PR DESCRIPTION
Adds a public **`carray`** `plum.dispatch` — the packing complement of `cdict` (`cdict`: array/QM → component dict; `carray`: component dict → `QuantityMatrix`). It consolidates the array-packing helpers behind one entry point:

```python
carray(p, keys) / carray(p, chart)   # per-component units (dimensionless fallback)
carray(p, keys, usys)                # units resolved from a unit system
carray(p, keys, unit)                # a single shared unit
```

**This PR (the lossless part):**
- Migrate the `pack_to_qmatrix` callers (jacobian, angle_between) to `carray(p, keys)` — behaviourally identical — and remove `pack_to_qmatrix`.
- Remove **`pack_with_usys`** (no in-tree callers, only docs); the perf guide now uses `carray(..., usys).value`.

**Deliberately deferred to a follow-up:** migrating `pack_uniform_unit` / `pack_nonuniform_unit`'s ~16 (mostly hot-path) callers. Those return `(array, units)` with **`None` for unitless** components, which `carray`'s dimensionless (`DMLS`) model can't represent losslessly — so it needs its own careful, perf-reviewed pass (I'll use `carray.resolve_method` pre-dispatch in the hot loops as you suggested).

**Perf:** the two migrated sites are trace-time (`jacobian` under `jacfwd`) / non-hot (`angle_between`), so the added plum-dispatch resolution is negligible.

**Tests:** carray api doctests + charts/manifolds/internal suites + the perf-guide examples — **975 passed, 0 failed**. ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)