### PR TITLE
🐛 fix(manifolds): make DiagonalMetric.to_dense and the product metric batch-safe

### DIFF
--- a/src/coordinax/_src/metric/matrix.py
+++ b/src/coordinax/_src/metric/matrix.py
@@ -207,7 +207,10 @@ class DiagonalMetric(AbstractMetricMatrix):
             # the scale-factor computation in _dot_general_2d_1d can always
             # convert every term to the reference unit ref[i] = g[i,0]*v[0].
             n = self.ndim
-            dense_val = jnp.diag(self.diagonal.value)
+            # Batch-safe diagonal embedding: `jnp.diag` would *extract* a
+            # diagonal from a batched (..., n) array instead of building one.
+            dv = self.diagonal.value
+            dense_val = dv[..., :, None] * jnp.eye(n, dtype=dv.dtype)
             du = self.diagonal.unit._units  # shape (n,)
             row_units = tuple(
                 tuple(du[i] if i == j else (du[i] * du[j]) ** 0.5 for j in range(n))
@@ -216,7 +219,8 @@ class DiagonalMetric(AbstractMetricMatrix):
             return DenseMetric(
                 ul.QuantityMatrix(dense_val, unit=ul.UnitsMatrix(row_units))
             )
-        return DenseMetric(jnp.diag(self.diagonal))
+        d = jnp.asarray(self.diagonal)
+        return DenseMetric(d[..., :, None] * jnp.eye(d.shape[-1], dtype=d.dtype))
 
     def __matmul__(
         self, other: "Array | ul.QuantityMatrix | u.AbstractQuantity", /

--- a/src/coordinax/_src/product/register_metric.py
+++ b/src/coordinax/_src/product/register_metric.py
@@ -115,18 +115,26 @@ def metric_matrix(
         for fm, fc, fp in zip(M.factors, chart.factors, parts, strict=True)
     ]
 
-    n = sum(block.shape[0] for block in factor_blocks)
+    # Component dimension is the last axis (leading axes are batch); factor
+    # blocks may carry different batch shapes (e.g. a constant identity block
+    # vs a position-dependent one), so broadcast them to a common batch shape.
+    n = sum(block.shape[-1] for block in factor_blocks)
     dtype = jnp.result_type(*(block.value.dtype for block in factor_blocks))
-    value = jnp.zeros((n, n), dtype=dtype)
+    batch_shape = jnp.broadcast_shapes(
+        *(block.value.shape[:-2] for block in factor_blocks)
+    )
+    value = jnp.zeros((*batch_shape, n, n), dtype=dtype)
 
     # Place each factor's numeric block and its (intra-block) units; record the
-    # index range of each block for the cross-factor pass below.
+    # index range of each block for the cross-factor pass below. Units are
+    # batch-independent (per component-pair), so the unit loop is unchanged.
     units: list[list[Any]] = [[u.unit("") for _ in range(n)] for _ in range(n)]
     block_ranges: list[range] = []
     offset = 0
     for block in factor_blocks:
-        block_n = block.shape[0]
-        value = value.at[offset : offset + block_n, offset : offset + block_n].set(
+        block_n = block.shape[-1]
+        # `.set` broadcasts an unbatched (d, d) block over the batch slice.
+        value = value.at[..., offset : offset + block_n, offset : offset + block_n].set(
             block.value
         )
         for i in range(block_n):

--- a/src/coordinax/_src/product/register_metric.py
+++ b/src/coordinax/_src/product/register_metric.py
@@ -40,7 +40,7 @@ def _mm_to_qm(mm: DenseMetric | DiagonalMetric) -> ul.QuantityMatrix:
         mat = mm.matrix
     if isinstance(mat, ul.QuantityMatrix):
         return mat
-    n = mat.shape[0]
+    n = mat.shape[-1]  # component axis (leading axes are batch)
     unit_tup = tuple(tuple(u.unit("") for _ in range(n)) for _ in range(n))
     return ul.QuantityMatrix(mat, unit=ul.UnitsMatrix(unit_tup))
 

--- a/tests/unit/manifolds/test_metric_matrix_types.py
+++ b/tests/unit/manifolds/test_metric_matrix_types.py
@@ -71,6 +71,16 @@ class TestDiagonalMetric:
         off_diag_mask = ~jnp.eye(n, dtype=bool)
         assert jnp.allclose(dense.matrix[off_diag_mask], 0)
 
+    def test_to_dense_batched_builds_diagonal(self) -> None:
+        """to_dense embeds a batched (B, n) diagonal into (B, n, n) matrices."""
+        # jnp.diag would *extract* a diagonal from a batched array; must build one.
+        diag = jnp.array([[1.0, 4.0, 9.0], [1.0, 16.0, 25.0]])  # (2, 3)
+        dense = DiagonalMetric(diag).to_dense()
+        m = jnp.asarray(dense.matrix)
+        assert m.shape == (2, 3, 3)
+        assert jnp.allclose(jnp.diagonal(m, axis1=-2, axis2=-1), diag)
+        assert jnp.allclose(m[0][~jnp.eye(3, dtype=bool)], 0)
+
     def test_matmul(self, diag_metric):
         n = diag_metric.ndim
         v = jnp.ones(n)

--- a/tests/unit/manifolds/test_metrics.py
+++ b/tests/unit/manifolds/test_metrics.py
@@ -13,6 +13,7 @@ import unxt as u
 import coordinax.charts as cxc
 import coordinax.manifolds as cxm
 from coordinax._src.metric.matrix import DenseMetric, DiagonalMetric
+from coordinax._src.product.register_metric import _mm_to_qm
 from coordinaxs.api.manifolds import metric_matrix as mm_dispatch
 
 
@@ -477,3 +478,9 @@ class TestProductMetric:
             assert jnp.allclose(
                 m[i], jnp.asarray(mm_dispatch(ps.M, single, ps).matrix.value)
             )
+
+    def test_mm_to_qm_batched_plain_array(self):
+        """A batched plain-array factor block sizes units from the last axis."""
+        qm = _mm_to_qm(DenseMetric(jnp.broadcast_to(jnp.eye(3), (5, 3, 3))))
+        assert qm.shape == (5, 3, 3)
+        assert qm.unit.shape == (3, 3)

--- a/tests/unit/manifolds/test_metrics.py
+++ b/tests/unit/manifolds/test_metrics.py
@@ -452,3 +452,28 @@ class TestProductMetric:
             factors=(cxm.S2, cxm.R1), factor_names=("S2", "R1")
         )
         assert isinstance(M.metric, cxm.ProductMetric)
+
+    def test_product_metric_is_batch_safe(self):
+        """The block-diagonal assembly handles batched points (a batched factor)."""
+        ps = cxc.CartesianProductChart((cxc.cart3d, cxc.sph3d), ("q", "p"))
+
+        def b(x, un):
+            return u.Q(jnp.array([x, x * 1.3]), un)
+
+        pt = {
+            "q.x": b(1.0, "m"),
+            "q.y": b(2.0, "m"),
+            "q.z": b(3.0, "m"),
+            "p.r": b(2.0, "m"),
+            "p.theta": b(0.6, "rad"),
+            "p.phi": b(0.4, "rad"),
+        }
+        g = mm_dispatch(ps.M, pt, ps)
+        m = jnp.asarray(g.matrix.value)
+        assert m.shape == (2, 6, 6)
+        # each batch row equals the metric at that single point
+        for i in (0, 1):
+            single = {k: u.Q(v.value[i], u.unit_of(v)) for k, v in pt.items()}
+            assert jnp.allclose(
+                m[i], jnp.asarray(mm_dispatch(ps.M, single, ps).matrix.value)
+            )


### PR DESCRIPTION
## Summary

Two linked batch-safety bugs, now reachable because curvilinear factor metrics return **batched** diagonals (#591). Both give a `(B, n)` diagonal that the downstream code mis-handles.

### 1. `DiagonalMetric.to_dense()`
Used `jnp.diag(self.diagonal.value)` — but `jnp.diag` on a batched `(B, n)` array **extracts** a diagonal instead of **building** an `(B, n, n)` matrix, so:
```python
DiagonalMetric(ul.QuantityMatrix(jnp.array([[1.,4.,9.],[1.,16.,25.]]), unit=…)).to_dense()
# ValueError: QuantityMatrix value has ndim=1, fewer than the 2-D unit structure …
```
Fixed with a batch-safe embedding `diag[..., :, None] * eye(n)` (both the `QuantityMatrix` and plain-array branches).

### 2. Product `metric_matrix` block assembly
Read `block.shape[0]` (the **batch** axis) for the component count and used `jnp.zeros((n, n))` with no batch dims, so a batched point crashed. Now uses `block.shape[-1]`, broadcasts a common batch shape across factor blocks (they can differ — a constant identity block vs a position-dependent one), and places blocks with a leading-ellipsis slice.

## Verification
The batched `cart3d × sph3d` product metric is now `(B, 6, 6)` and each batch row equals the metric computed at that single point; unbatched output unchanged. New tests for both; `tests/unit/manifolds` passes (383); `metric/matrix.py` doctests pass; `ruff`/`ty` clean.

This is the batch-safety follow-up I flagged in #604, unblocked by #591 merging. (The embedded-metric batch case is folded into #604.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)