### PR TITLE
♻️ refactor(internal): migrate pack_nonuniform_unit callers to carray

### DIFF
--- a/docs/api/internal.md
+++ b/docs/api/internal.md
@@ -21,28 +21,28 @@ These utilities are primarily useful when implementing downstream transforms, Ja
 
 ```python
 import unxt as u
+import coordinax as cx
 import coordinax.charts as cxc
-from coordinax.internal import pack_nonuniform_unit, pack_uniform_unit
+from coordinax.internal import pack_uniform_unit
 
 p = {"x": u.Q(1, "km"), "y": u.Q(200, "m"), "z": u.Q(3, "km")}
 
 vals, unit = pack_uniform_unit(p, ("x", "y", "z"))
 restored = cxc.cdict(vals, unit, ("x", "y", "z"))
 
-vals2, units2 = pack_nonuniform_unit(p, ("x", "y", "z"))
+qm = cx.carray(p, ("x", "y", "z"))
 ```
 
-Use `pack_uniform_unit` when all components should be expressed in a shared unit before stacking into an array. Use `pack_nonuniform_unit` when each component should retain its own unit metadata.
+Use `pack_uniform_unit` when all components should be expressed in a shared unit before stacking into an array. Use `cx.carray` when each component should retain its own unit metadata (it returns a `QuantityMatrix` carrying a per-component unit tuple).
 
 ## Functional API
 
 - `pack_uniform_unit`: stack a component dictionary into an array using a shared reference unit
-- `pack_nonuniform_unit`: stack a component dictionary into an array while preserving a per-component unit tuple
+- `cx.carray`: pack a component dictionary into a `QuantityMatrix` preserving per-component units
 
 ## Available Objects
 
 - `pack_uniform_unit`: pack values into an array with one shared unit
-- `pack_nonuniform_unit`: pack values into an array with per-component units
 
 ## Notes
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1002,8 +1002,7 @@ These names are importable and supported for inter-package use, but they are **n
 Semi-public API:
 
 - `pack_uniform_unit`: stack component data into an array using a shared unit
-- `pack_nonuniform_unit`: stack component data into an array while preserving per-component units
-- `carray`: pack a component dictionary into a `QuantityMatrix` (the complement of `cdict`; unitless components are treated as dimensionless; a unit system or shared unit may be supplied)
+- `carray`: pack a component dictionary into a `QuantityMatrix` (the complement of `cdict`, preserving per-component units; unitless components are treated as dimensionless; a unit system or shared unit may be supplied)
 - `tree_cast_int_bool_to_float`: promote integer/boolean PyTree leaves to floating point (e.g. for `jax.jacfwd` inputs)
 - `pos_named_objs`, `jax_scalar_handler`: wadler-lindig rendering helpers used by `__pdoc__` implementations
 - `CDict`, `OptUSys`: the component-dictionary and optional-unit-system type aliases

--- a/packages/coordinaxs.api/src/coordinaxs/api/charts.py
+++ b/packages/coordinaxs.api/src/coordinaxs/api/charts.py
@@ -17,6 +17,8 @@ import plum
 from ._custom_types import CDict
 
 if TYPE_CHECKING:
+    import unxts.linalg  # noqa: ICN001
+
     import coordinax.charts  # noqa: ICN001
 
 
@@ -346,7 +348,7 @@ def cdict(_: Any, /) -> CDict:
 
 
 @plum.dispatch.abstract
-def carray(p: Any, /, *args: Any) -> Any:
+def carray(p: Any, /, *args: Any) -> "unxts.linalg.QuantityMatrix":
     """Pack a component dictionary into a ``QuantityMatrix`` (complement of `cdict`).
 
     Parameters

--- a/src/coordinax/_src/embedded/metric.py
+++ b/src/coordinax/_src/embedded/metric.py
@@ -12,10 +12,10 @@ import unxts.linalg as ul
 import quaxed.numpy as qnp
 import unxt as u
 
+import coordinaxs.api.charts as cxcapi
 from .embedmap import AbstractEmbeddingMap
 from coordinax._src.base import AbstractMetricField
 from coordinax._src.custom_types import CDict, OptUSys
-from coordinax.internal import pack_nonuniform_unit
 
 DMLS = u.unit("")
 
@@ -49,7 +49,8 @@ def _jacobian_embed_map(
     ambient_keys = embed_map.ambient.components
 
     # Pack `at` → plain array + per-component from-units
-    xat, ufrom = pack_nonuniform_unit(at, intrinsic_keys)
+    _qm: ul.QM = cxcapi.carray(at, intrinsic_keys)  # ty: ignore[invalid-assignment]
+    xat, ufrom = _qm.value, _qm.unit.to_tuple()
 
     # Run embedding once to determine output units
     at_ambient = embed_fn(at, usys=usys)

--- a/src/coordinax/_src/embedded/register_metric.py
+++ b/src/coordinax/_src/embedded/register_metric.py
@@ -28,10 +28,10 @@ import unxts.linalg as ul
 import quaxed.numpy as qnp
 import unxt as u
 
+import coordinaxs.api.charts as cxcapi
 from .manifold import EmbeddedManifold
 from coordinax._src.base import AbstractChart  # type: ignore[type-arg]
 from coordinax._src.metric.matrix import AbstractMetricMatrix, DenseMetric
-from coordinax.internal import pack_nonuniform_unit
 from coordinaxs.api.manifolds import metric_matrix, pt_embed
 
 DMLS = u.unit("")
@@ -171,7 +171,8 @@ def metric_matrix(
     cart_chart = M.embed_map.ambient.cartesian
     cart_keys = cart_chart.components
 
-    xat, ufrom = pack_nonuniform_unit(point, chart_keys)
+    _qm: ul.QM = cxcapi.carray(point, chart_keys)  # ty: ignore[invalid-assignment]
+    xat, ufrom = _qm.value, _qm.unit.to_tuple()
     ufrom_ = tuple(uf if uf is not None else DMLS for uf in ufrom)
 
     # `pt_embed` is the composition chart → intrinsic → ambient → Cartesian; it

--- a/src/coordinax/_src/internal/pack_utils.py
+++ b/src/coordinax/_src/internal/pack_utils.py
@@ -1,21 +1,15 @@
 """Helpers for packing component dictionaries into arrays while tracking units.
 
-The helpers in this module are used when chart- or vector-like data is most
-conveniently manipulated as a stacked JAX array, but unit metadata still needs
-to be preserved across the pack/unpack boundary.
-
-Two packing modes are supported:
-
-- uniform-unit packing, where all entries are converted into one shared unit
-- non-uniform packing, where each entry keeps its own unit metadata
+`pack_uniform_unit` converts all entries of a component dict into one shared
+unit and returns a stacked JAX array, preserving the ``None``-for-unitless
+convention that keeps genuinely unitless components as raw arrays. For
+non-uniform (per-component) unit packing into a ``QuantityMatrix``, use the
+:func:`coordinaxs.api.charts.carray` dispatch.
 """
 
-__all__ = (
-    "pack_uniform_unit",
-    "pack_nonuniform_unit",
-)
+__all__ = ("pack_uniform_unit",)
 
-from jaxtyping import Array, ArrayLike
+from jaxtyping import ArrayLike
 from typing import Any, Final, overload
 
 import quaxed.numpy as jnp
@@ -79,23 +73,3 @@ def pack_uniform_unit(
     unit = v0.unit if unitful else DMLS
     vals = [u.ustrip(AllowValue, unit, p[k]) for k in keys]
     return jnp.stack(vals, axis=-1), unit if unitful else None  # ty: ignore[invalid-return-type]
-
-
-def pack_nonuniform_unit(
-    p: CDict, /, keys: tuple[str, ...]
-) -> tuple[Array, tuple[u.AbstractUnit | None, ...]]:
-    """Pack a component dictionary into an array with per-component units.
-
-    Unlike `pack_uniform_unit`, this helper does not choose a single reference
-    unit. Each requested component is stripped in its own native unit and the
-    resulting unit tuple is returned alongside the stacked values.
-
-    This is the appropriate packing mode when different coordinates naturally
-    have different physical dimensions or when preserving the original unit of
-    each component is important.
-    """
-    units = tuple(u.unit_of(p[k]) for k in keys)
-    vals = [
-        u.ustrip(AllowValue, unit, p[k]) for k, unit in zip(keys, units, strict=True)
-    ]
-    return jnp.stack(vals, axis=-1), units  # ty: ignore[invalid-return-type]

--- a/src/coordinax/_src/manifolds/norm.py
+++ b/src/coordinax/_src/manifolds/norm.py
@@ -19,7 +19,6 @@ from coordinax._src.charts import Cart0D, Cart1D, Cart2D, Cart3D, CartND
 from coordinax._src.custom_types import CDict, OptUSys
 from coordinax._src.euclidean import FlatMetric
 from coordinax._src.internal import (
-    pack_nonuniform_unit,
     pack_uniform_unit,
 )
 
@@ -148,8 +147,7 @@ def norm(G: Array, v: CDict, /) -> Array | u.AbstractQuantity:
     # Pack CDict of quantities into a QuantityMatrix, preserving per-component
     # units.  Then compute v^T G v via QuantityMatrix ops, which handle all unit
     # conversions correctly (including mixed-unit components like m/s and 1/s).
-    v_vec, units = pack_nonuniform_unit(v, keys)
-    v_qm = ul.QuantityMatrix(v_vec, unit=units)
+    v_qm: ul.QM = cxcapi.carray(v, keys)  # ty: ignore[invalid-assignment]
     return jnp.sqrt(jnp.dot(v_qm, jnp.matmul(G, v_qm)))
 
 
@@ -252,8 +250,7 @@ def norm(
     # then compute sqrt(vᵀ G v) via QuantityMatrix/AbstractMetricMatrix arithmetic,
     # which handles all unit conversions correctly (including mixed-unit
     # components like m/s and rad/s).
-    v_vec, units = pack_nonuniform_unit(v, keys)
-    v_qm = ul.QuantityMatrix(v_vec, unit=units)
+    v_qm: ul.QM = cxcapi.carray(v, keys)  # ty: ignore[invalid-assignment]
     return jnp.sqrt(v_qm @ (mm @ v_qm))
 
 

--- a/src/coordinax/_src/manifolds/scale_factors.py
+++ b/src/coordinax/_src/manifolds/scale_factors.py
@@ -19,7 +19,6 @@ from coordinax._src.custom_types import CDict, OptUSys
 from coordinax._src.embedded.metric import PullbackMetric
 from coordinax._src.euclidean.scale_factors import _column_squared_norms
 from coordinax._src.metric.matrix import DiagonalMetric
-from coordinax.internal import pack_nonuniform_unit
 
 DMLS = u.unit("")
 
@@ -119,7 +118,8 @@ def scale_factors(
     cart_chart = ambient_chart.cartesian
     cart_keys = cart_chart.components
 
-    xat, ufrom = pack_nonuniform_unit(at, intrinsic_keys)
+    _qm: ul.QM = cxcapi.carray(at, intrinsic_keys)  # ty: ignore[invalid-assignment]
+    xat, ufrom = _qm.value, _qm.unit.to_tuple()
     ufrom_ = tuple(uf if uf is not None else DMLS for uf in ufrom)
 
     # Evaluate once to determine Cartesian output units

--- a/src/coordinax/internal.py
+++ b/src/coordinax/internal.py
@@ -26,7 +26,6 @@ Contents:
 __all__ = (
     "tree_cast_int_bool_to_float",
     "pack_uniform_unit",
-    "pack_nonuniform_unit",
     "pos_named_objs",
     "jax_scalar_handler",
     # Types
@@ -40,7 +39,6 @@ with install_import_hook("coordinax.internal"):
     from coordinax._src.custom_types import CDict, OptUSys
     from coordinax._src.internal import (
         jax_scalar_handler,
-        pack_nonuniform_unit,
         pack_uniform_unit,
         pos_named_objs,
         tree_cast_int_bool_to_float,

--- a/src/coordinax/representations/_src/tangent_map.py
+++ b/src/coordinax/representations/_src/tangent_map.py
@@ -13,12 +13,12 @@ import quaxed.numpy as qnp
 import unxt as u
 
 import coordinax.charts as cxc
+import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.representations as cxrapi
 from .basis import CoordinateBasis, PhysicalBasis, coord_basis
 from .custom_types import CDict, OptUSys
 from .geom import TangentGeometry
 from .rep import Representation
-from coordinax.internal import pack_nonuniform_unit
 
 # ---------------------------------------------------------------------------
 # Validation helpers
@@ -78,8 +78,7 @@ def _apply_jac(
 
     """
     if all(isinstance(v[k], u.AbstractQuantity) for k in from_components):
-        v_arr, v_units = pack_nonuniform_unit(v, keys=from_components)
-        v_qm = ul.QuantityMatrix(v_arr, unit=v_units)
+        v_qm: ul.QM = cxcapi.carray(v, from_components)  # ty: ignore[invalid-assignment]
         w = qnp.matmul(J, v_qm)  # (n_out,) QuantityMatrix
         return {key: u.Q(w.value[i], w.unit[i]) for i, key in enumerate(to_components)}
 

--- a/src/coordinax/transforms/_src/actions/register_apply.py
+++ b/src/coordinax/transforms/_src/actions/register_apply.py
@@ -268,4 +268,4 @@ def act(
     # Act on the CDict
     nv = cxfmapi.act(op, tau, v, chart, rep, **kw)
     # Repack CDict → QuantityMatrix
-    return cxcapi.carray(nv, chart.components)  # ty: ignore[invalid-return-type]
+    return cast("ul.QuantityMatrix", cxcapi.carray(nv, chart.components))

--- a/src/coordinax/transforms/_src/actions/register_apply.py
+++ b/src/coordinax/transforms/_src/actions/register_apply.py
@@ -13,10 +13,11 @@ from unxt import AbstractQuantity as AbcQ
 
 import coordinax.charts as cxc
 import coordinax.representations as cxr
+import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.transforms as cxfmapi
 from .base import AbstractTransform
 from .custom_types import CDict
-from coordinax.internal import pack_nonuniform_unit, pack_uniform_unit
+from coordinax.internal import pack_uniform_unit
 
 # A "point-like" input the entry funnel accepts. Faithful (each member and the
 # union), so the normalizer methods below stay in plum's method cache.
@@ -267,5 +268,4 @@ def act(
     # Act on the CDict
     nv = cxfmapi.act(op, tau, v, chart, rep, **kw)
     # Repack CDict → QuantityMatrix
-    arr, units = pack_nonuniform_unit(nv, keys=chart.components)
-    return ul.QuantityMatrix(arr, unit=units)
+    return cxcapi.carray(nv, chart.components)  # ty: ignore[invalid-return-type]

--- a/src/coordinax/vectors/_src/register_unxt.py
+++ b/src/coordinax/vectors/_src/register_unxt.py
@@ -218,7 +218,7 @@ def point_to_q(obj: Point, /) -> u.AbstractQuantity:
     QM([1, 2, 3], '(km, deg, m)')
 
     """
-    # Pack the the data into value, unit tuple
+    # Pack the data into value, unit tuple
     qm = cast("ul.QM", cxcapi.carray(obj.data, obj.chart.components))
     vals, units = qm.value, qm.unit.to_tuple()
 

--- a/src/coordinax/vectors/_src/register_unxt.py
+++ b/src/coordinax/vectors/_src/register_unxt.py
@@ -6,15 +6,17 @@ from dataclasses import replace
 from enum import Enum
 
 from collections.abc import Mapping
-from typing import Any, Literal, cast, final
+from typing import TYPE_CHECKING, Any, Literal, cast, final
 
 import plum
-import unxts.linalg as ul
 
 import unxt as u
 
+import coordinaxs.api.charts as cxcapi
 from .point import Point
-from coordinax.internal import pack_nonuniform_unit
+
+if TYPE_CHECKING:
+    import unxts.linalg as ul
 
 
 @final
@@ -217,7 +219,8 @@ def point_to_q(obj: Point, /) -> u.AbstractQuantity:
 
     """
     # Pack the the data into value, unit tuple
-    vals, units = pack_nonuniform_unit(obj.data, obj.chart.components)
+    qm = cast("ul.QM", cxcapi.carray(obj.data, obj.chart.components))
+    vals, units = qm.value, qm.unit.to_tuple()
 
     # Special case for homogeneous units (e.g. all angles in deg): we can
     # convert to a single unit and return a quantity with that unit.
@@ -225,4 +228,4 @@ def point_to_q(obj: Point, /) -> u.AbstractQuantity:
         unit = u.unit("") if units[0] is None else units[0]
         return u.Q(vals, unit)
 
-    return ul.QuantityMatrix(vals, units)
+    return qm

--- a/tests/unit/charts/test_jacobian_pt_map.py
+++ b/tests/unit/charts/test_jacobian_pt_map.py
@@ -822,7 +822,7 @@ class TestJacobianPtMapCDictArrayBranch:
     Plain-array CDicts require usys because the branch forwards to the plain-Array
     dispatch which requires a unit system.
 
-    Note: Cart2D→Polar2D has its own CDict dispatch that always calls pack_to_qmatrix,
+    Note: Cart2D→Polar2D has its own CDict dispatch that always calls carray,
     so plain-array CDicts for that pair fail even before the is_array check.
     """
 

--- a/tests/unit/charts/test_jacobian_pt_map.py
+++ b/tests/unit/charts/test_jacobian_pt_map.py
@@ -817,13 +817,13 @@ class TestJacobianPtMapArrayInput:
 class TestJacobianPtMapCDictArrayBranch:
     """CDict with plain array values — the is_array=True branch in the generic dispatch.
 
-    The generic CDict dispatch (for chart pairs without a dedicated CDict overload,
-    e.g. Cart3D→Sph3D) branches on whether values are quantities or plain arrays.
-    Plain-array CDicts require usys because the branch forwards to the plain-Array
-    dispatch which requires a unit system.
+    The CDict dispatch branches on whether values are quantities or plain arrays.
+    The plain-array branch stacks the values and forwards to the Array dispatch,
+    so whether usys is required is decided by that dispatch, not by this branch.
 
-    Note: Cart2D→Polar2D has its own CDict dispatch that always calls carray,
-    so plain-array CDicts for that pair fail even before the is_array check.
+    Note: for pairs with an analytical Array dispatch (e.g. Cart2D→Polar2D) a
+    plain-array CDict works without usys; for pairs that fall through to the
+    generic Array path (e.g. Cart3D→Sph3D) usys must be supplied.
     """
 
     def test_generic_pair_with_usys(self) -> None:

--- a/tests/unit/manifolds/test_norm.py
+++ b/tests/unit/manifolds/test_norm.py
@@ -6,7 +6,6 @@ Coverage includes Euclidean and spherical metric behavior, plus JIT/vmap usage.
 import jax
 import jax.numpy as jnp
 import pytest
-import unxts.linalg as ul
 
 import quaxed.numpy as qnp
 import unxt as u
@@ -14,7 +13,6 @@ import unxt as u
 import coordinax.charts as cxc
 import coordinax.manifolds as cxm
 import coordinaxs.api.manifolds as cxmapi
-from coordinax.internal import pack_nonuniform_unit
 
 # =============================================================================
 # cxm.norm() standalone function
@@ -600,11 +598,10 @@ class TestProductMetricInterBlockUnits:
             "sph.phi": u.Q(v_phi, "rad/s"),
             "line.x": u.Q(v_x, "m/s"),
         }
-        vv, units = pack_nonuniform_unit(v, chart.components)
         expected_sq = (
             radius**2 * v_theta**2 + radius**2 * jnp.sin(theta) ** 2 * v_phi**2 + v_x**2
         )
-        result = cxm.norm(gm, ul.QuantityMatrix(vv, unit=units))
+        result = cxm.norm(gm, cxc.carray(v, chart.components))
         assert qnp.allclose(
             result, u.Q(jnp.sqrt(expected_sq), "m/s"), atol=u.Q(1e-5, "m/s")
         )


### PR DESCRIPTION
Follow-up to #611 (which added `carray`, now merged).

## What

Route every `pack_nonuniform_unit(...)` + `QuantityMatrix(...)` call pair through the `carray` dispatch and drop the now-redundant `pack_nonuniform_unit` helper. `carray` already produces exactly what those pairs rebuilt by hand: a `QuantityMatrix` carrying a per-component unit tuple, with unitless components treated as dimensionless.

Call sites migrated: `tangent_map`, `norm` (x2), `scale_factors`, `embedded/metric`, `embedded/register_metric`, `vectors/register_unxt`, `transforms/register_apply`, plus the `test_norm` and docs references.

## What is kept and why

`pack_uniform_unit` stays. Its `None`-for-unitless convention -- genuinely unitless components stay as raw arrays rather than becoming dimensionless quantities, mirroring the generic engine's attach/strip-leaf policy -- is load-bearing for the linear/rotate/norm packing paths and is not expressible through `carray`'s dimensionless-by-default packing.

## Perf

`carray` adds one plum dispatch resolution per call: ~5 us eager (~0.7% of the packing work, which is dominated by `jnp.stack` + unit ops) and **zero under jit/jacfwd**, where these call sites actually live. No `resolve_method` pre-dispatch is warranted.

## Validation

Full suite: **8474 passed, 7 skipped, 1 xfailed** (`uv run --no-sync pytest`). ty, ruff, and all pre-commit hooks pass. Rebased onto current `main` (post-#611, post-#616 chart-aware metric); the `metric_matrix` overlap was resolved keeping #616's passed-chart logic.

Net: 14 files, +41 / -70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)