### PR TITLE
🐛 fix(manifolds): make the hyperspherical round metric batch-safe

### DIFF
--- a/src/coordinax/_src/metric/matrix.py
+++ b/src/coordinax/_src/metric/matrix.py
@@ -52,16 +52,18 @@ def _sine_product_diagonal(thetas: Array, scale: Any, /) -> Array:
 
     Parameters
     ----------
-    thetas : Array, shape ``(k,)``
+    thetas : Array, shape ``(k, *batch)``
         Polar angles $\theta_1, \dots, \theta_k$ in radians (the *last*
-        azimuthal angle $\phi$ is excluded by the caller).
-    scale : scalar
+        azimuthal angle $\phi$ is excluded by the caller), stacked along the
+        *leading* axis.  Any trailing axes are batch.
+    scale : scalar or Array, shape ``(*batch,)``
         Scale factor $R$ (sphere radius) or $r$ (radial coordinate).
 
     Returns
     -------
-    Array, shape ``(k+1,)``
-        The metric diagonal.
+    Array, shape ``(*batch, k+1)``
+        The metric diagonal, with the component axis trailing (the convention
+        every other ``metric_matrix`` rule follows).
 
     Examples
     --------
@@ -79,10 +81,20 @@ def _sine_product_diagonal(thetas: Array, scale: Any, /) -> Array:
     >>> _sine_product_diagonal(jnp.array([jnp.pi / 6]), 2.0)
     Array([4., 1.], dtype=float64)
 
+    Batched polar angles — components trail, each row independent:
+
+    >>> _sine_product_diagonal(jnp.array([[jnp.pi / 2, jnp.pi / 6]]), 1.0)
+    Array([[1.  , 1.  ],
+           [1.  , 0.25]], dtype=float64)
+
     """
     sin2 = qnp.sin(thetas) ** 2
-    cumprod = jnp.concat([jnp.ones(1, dtype=sin2.dtype), jnp.cumprod(sin2)])
-    return scale**2 * cumprod
+    # cumprod along the *component* axis only; a bare `jnp.cumprod` flattens,
+    # which silently multiplies across the batch.
+    ones = jnp.ones((1, *sin2.shape[1:]), dtype=sin2.dtype)
+    cumprod = jnp.concat([ones, jnp.cumprod(sin2, axis=0)], axis=0)
+    # Move the component axis to the back: (k+1, *batch) -> (*batch, k+1).
+    return jnp.moveaxis(scale**2 * cumprod, 0, -1)
 
 
 # ---------------------------------------------------------------------------

--- a/src/coordinax/_src/metric/matrix.py
+++ b/src/coordinax/_src/metric/matrix.py
@@ -92,7 +92,7 @@ def _sine_product_diagonal(thetas: Array, scale: Any, /) -> Array:
     # cumprod along the *component* axis only; a bare `jnp.cumprod` flattens,
     # which silently multiplies across the batch.
     ones = jnp.ones((1, *sin2.shape[1:]), dtype=sin2.dtype)
-    cumprod = jnp.concat([ones, jnp.cumprod(sin2, axis=0)], axis=0)
+    cumprod = jnp.concatenate([ones, jnp.cumprod(sin2, axis=0)], axis=0)
     # Move the component axis to the back: (k+1, *batch) -> (*batch, k+1).
     return jnp.moveaxis(scale**2 * cumprod, 0, -1)
 

--- a/src/coordinax/_src/spherical/register_metric.py
+++ b/src/coordinax/_src/spherical/register_metric.py
@@ -92,19 +92,16 @@ def metric_matrix(
 
     """
     components = chart.components
-    # All angular components except the last (azimuthal) are polar angles
-    theta_keys = components[:-1]
-    if theta_keys:
-        thetas = jnp.stack(
-            [
-                u.ustrip(AllowValue, u.uconvert_value(RAD, RAD, point[k]))
-                for k in theta_keys
-            ]
-        )
-    else:
-        thetas = jnp.array([])
-    diag = _sine_product_diagonal(thetas, 1.0)
-    return DiagonalMetric(diag)
+    vals = [
+        jnp.asarray(u.ustrip(AllowValue, u.uconvert_value(RAD, RAD, point[k])))
+        for k in components
+    ]
+    # All angular components except the last (azimuthal) are polar angles.
+    # Stack on the leading axis; `_sine_product_diagonal` moves it to the back.
+    # The no-polar-angle case (S¹) still needs the batch shape, which only the
+    # azimuthal component carries -- hence the empty stack rather than `[]`.
+    thetas = jnp.stack(vals[:-1]) if len(vals) > 1 else jnp.zeros((0, *vals[-1].shape))
+    return DiagonalMetric(_sine_product_diagonal(thetas, 1.0))
 
 
 @plum.dispatch

--- a/src/coordinax/_src/spherical/register_metric.py
+++ b/src/coordinax/_src/spherical/register_metric.py
@@ -100,7 +100,13 @@ def metric_matrix(
     # Stack on the leading axis; `_sine_product_diagonal` moves it to the back.
     # The no-polar-angle case (S¹) still needs the batch shape, which only the
     # azimuthal component carries -- hence the empty stack rather than `[]`.
-    thetas = jnp.stack(vals[:-1]) if len(vals) > 1 else jnp.zeros((0, *vals[-1].shape))
+    thetas = (
+        jnp.stack(vals[:-1])
+        if len(vals) > 1
+        # dtype from the input, not the environment default: otherwise the
+        # empty stack decides the result dtype for S¹.
+        else jnp.zeros((0, *vals[-1].shape), dtype=vals[-1].dtype)
+    )
     return DiagonalMetric(_sine_product_diagonal(thetas, 1.0))
 
 

--- a/tests/unit/manifolds/test_metric_matrix_batch_invariant.py
+++ b/tests/unit/manifolds/test_metric_matrix_batch_invariant.py
@@ -15,8 +15,11 @@ unbatched evaluation, both of which this catches.
 
 import hypothesis.strategies as st
 import numpy as np
+import pytest
 from hypothesis import given, settings
 from hypothesis.extra.numpy import array_shapes
+
+import unxt as u
 
 import coordinax.charts as cxc
 import coordinax.manifolds as cxm
@@ -69,3 +72,22 @@ def test_curvilinear_metric_batches_like_elementwise(data):
             gbv[idx], np.asarray(getattr(gi, "value", gi)), rtol=1e-5
         )
         assert getattr(gb, "unit", None) == getattr(gi, "unit", None)
+
+
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
+def test_sphere_diagonal_preserves_input_dtype(dtype):
+    """The diagonal's dtype comes from the point, not the environment default.
+
+    S¹ has no polar angles, so the diagonal is built from an *empty* stack. If
+    that stack is created without an explicit dtype it picks up JAX's default
+    and decides the result dtype, silently promoting (x64 on) or demoting
+    (x64 off) the caller's angles.
+    """
+    at = {"phi": u.Q(np.asarray(0.7, dtype=dtype), "rad")}
+    assert cxmapi.metric_matrix(cxm.S1, at, cxc.sph1).diagonal.dtype == dtype
+
+    at2 = {
+        "theta": u.Q(np.asarray(0.7, dtype=dtype), "rad"),
+        "phi": u.Q(np.asarray(0.3, dtype=dtype), "rad"),
+    }
+    assert cxmapi.metric_matrix(cxm.S2, at2, cxc.sph2).diagonal.dtype == dtype

--- a/tests/unit/manifolds/test_metric_matrix_batch_invariant.py
+++ b/tests/unit/manifolds/test_metric_matrix_batch_invariant.py
@@ -31,6 +31,12 @@ CURVILINEAR = [
     (cxm.R3, cxc.sph3d),
     (cxm.R3, cxc.math_sph3d),
     (cxm.R3, cxc.lonlat_sph3d),
+    # The intrinsic hypersphere charts share the same cumulative-sine diagonal
+    # and were missed by the #591 sweep: `jnp.cumprod` without an axis flattens,
+    # so a batched point multiplied *across* the batch and returned shape
+    # (1 + k*B,) instead of (*batch, k+1).
+    (cxm.S1, cxc.sph1),
+    (cxm.S2, cxc.sph2),
 ]
 
 # Bounded so squared lengths can't overflow into inf/nan noise; sign is
@@ -52,10 +58,14 @@ def test_curvilinear_metric_batches_like_elementwise(data):
     gb = cxmapi.metric_matrix(manifold, point, chart).diagonal
     assert gb.shape == (*shape, n)
 
-    gbv = np.asarray(gb.value)
+    # The Euclidean rules return a united QuantityMatrix; the intrinsic sphere
+    # rules return a bare (dimensionless) Array. Compare whichever is carried.
+    gbv = np.asarray(getattr(gb, "value", gb))
     for idx in np.ndindex(shape):
         pt = {k: v[idx] for k, v in point.items()}
         gi = cxmapi.metric_matrix(manifold, pt, chart).diagonal
         # Same arithmetic on the same values: rows must match, units unchanged.
-        np.testing.assert_allclose(gbv[idx], np.asarray(gi.value), rtol=1e-5)
-        assert gb.unit == gi.unit
+        np.testing.assert_allclose(
+            gbv[idx], np.asarray(getattr(gi, "value", gi)), rtol=1e-5
+        )
+        assert getattr(gb, "unit", None) == getattr(gi, "unit", None)


### PR DESCRIPTION
## Summary

`_sine_product_diagonal` calls `jnp.cumprod(sin2)` with no axis. On a batched point that flattens, so the cumulative product runs **across the batch** and the result has shape `(1 + k*B,)` instead of `(*batch, k+1)`:

```python
pt = {"theta": u.Q(jnp.array([0.3, 0.5, 0.7]), "rad"),
      "phi":   u.Q(jnp.array([1.0, 1.1, 1.2]), "rad")}
metric_matrix(cxm.S2, pt, cxc.sph2).diagonal
# shape (4,) -> [1, 0.0873, 0.0201, 0.0083]
```

Element-wise truth is `[1, 0.0873]`, `[1, 0.2299]`, `[1, 0.4150]`. Every entry past the first row is wrong, and silently so — no shape error, just a plausible-looking short vector that downstream code will happily consume.

## Fix

Take the cumulative product along the component axis and move that axis to the back, matching the `(*batch, n)` convention the other `metric_matrix` rules follow. The no-polar-angle case (S¹) sources its batch shape from the azimuthal component, so the caller stacks an empty `(0, *batch)` array rather than `[]`.

This is the same defect #591 fixed for the Euclidean curvilinear charts. The intrinsic hypersphere charts share the helper and were missed by that sweep.

## Verification

`S1` and `S2` are now in the #612 batch-invariance property test, which is what should have caught this. That test needed one tweak: it assumed a united `QuantityMatrix`, but the intrinsic sphere rules return a bare dimensionless `Array`, so it now compares whichever is carried. (That units asymmetry between the Euclidean and intrinsic-sphere rules is left alone here — it is a separate question.)

Checked directly: batched `(3,)` and `(2,3)` points now match element-wise evaluation exactly; unbatched results unchanged; S¹ batches to `(B, 1)`.

Full suite: 1992 passed, 8 skipped. `ruff`/`ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)