### PR TITLE
🐛 fix(manifolds): batch-safe two-sphere pullback metric; pin the pole behaviour

### DIFF
--- a/src/coordinax/_src/spherical/register_metric.py
+++ b/src/coordinax/_src/spherical/register_metric.py
@@ -152,21 +152,54 @@ def metric_matrix(
     >>> [round(float(g.matrix.value[i, i]), 4) for i in (0, 1)]
     [0.5868, 1.0]
 
+    Leading axes are batch; the two component axes trail:
+
+    >>> import jax.numpy as jnp
+    >>> at = {"lon": u.Q(jnp.zeros((5,)), "rad"), "lat": u.Q(jnp.zeros((5,)), "rad")}
+    >>> cxm.metric_matrix(cxm.S2, at, cxc.lonlat_sph2).matrix.value.shape
+    (5, 2, 2)
+
+    .. warning::
+
+        ``LonCosLat`` is **not a chart at the poles**: ``lon_coslat = lon *
+        cos(lat)`` collapses every longitude onto ``0`` at ``lat = +-pi/2``, so
+        the map is not injective there.  Away from the poles ``g_LL =
+        cos^2(lat) * sec^2(lat)`` is exactly ``1`` and ``det g`` is exactly
+        ``1``; evaluated *at* a pole that product becomes ``0 * inf`` and the
+        returned matrix is degenerate (``det g == 0``) rather than the limiting
+        identity.  Precision degrades within roughly ``1e-10`` rad of the pole,
+        where the chart's condition number ``~ lon_coslat^2 tan^2(lat)`` exceeds
+        what float64 can carry.  ``LonLat`` and ``Math`` are genuinely singular
+        at their poles too, but there the degenerate metric *is* the correct
+        limit.
+
     """
     del M
     keys = chart.components
-    x0 = tree_cast_int_bool_to_float(
-        jnp.stack([jnp.asarray(u.ustrip(AllowValue, RAD, point[k])) for k in keys])
+    n = len(keys)
+    # Components trail: (*batch, n).
+    x = tree_cast_int_bool_to_float(
+        jnp.stack(
+            [jnp.asarray(u.ustrip(AllowValue, RAD, point[k])) for k in keys], axis=-1
+        )
     )
 
-    def to_canon(x: jnp.ndarray) -> jnp.ndarray:
-        p = {k: u.Q(x[i], RAD) for i, k in enumerate(keys)}
+    def to_canon(xi: jnp.ndarray) -> jnp.ndarray:
+        p = {k: u.Q(xi[i], RAD) for i, k in enumerate(keys)}
         s = cast("CDict", cxcapi.pt_map(p, chart, SphericalTwoSphere()))
         return jnp.stack([u.ustrip(RAD, s["theta"]), u.ustrip(RAD, s["phi"])])
 
-    jc = jax.jacfwd(to_canon)(x0)  # (2, n)
-    theta = to_canon(x0)[0]
-    g_can = jnp.diag(jnp.stack([jnp.ones_like(theta), jnp.sin(theta) ** 2]))
-    n = len(keys)
+    def pullback(xi: jnp.ndarray) -> jnp.ndarray:
+        """Metric at a single point ``xi`` of shape ``(n,)``."""
+        jc = jax.jacfwd(to_canon)(xi)  # (2, n)
+        theta = to_canon(xi)[0]
+        g_can = jnp.diag(jnp.stack([jnp.ones_like(theta), jnp.sin(theta) ** 2]))
+        return jc.T @ g_can @ jc
+
+    # `jacfwd` on a batched input would differentiate every output w.r.t. every
+    # batch element, so map it per point and restore the leading batch axes.
+    batch = x.shape[:-1]
+    g = jax.vmap(pullback)(x.reshape(-1, n)).reshape(*batch, n, n)
+
     dmls = ul.UnitsMatrix.full((n, n), "")  # angles -> angles, so g is dimensionless
-    return DenseMetric(ul.QM(jc.T @ g_can @ jc, unit=dmls))
+    return DenseMetric(ul.QM(g, unit=dmls))

--- a/src/coordinax/_src/spherical/register_metric.py
+++ b/src/coordinax/_src/spherical/register_metric.py
@@ -184,9 +184,11 @@ def metric_matrix(
         )
     )
 
+    canonical = SphericalTwoSphere()
+
     def to_canon(xi: jnp.ndarray) -> jnp.ndarray:
         p = {k: u.Q(xi[i], RAD) for i, k in enumerate(keys)}
-        s = cast("CDict", cxcapi.pt_map(p, chart, SphericalTwoSphere()))
+        s = cast("CDict", cxcapi.pt_map(p, chart, canonical))
         return jnp.stack([u.ustrip(RAD, s["theta"]), u.ustrip(RAD, s["phi"])])
 
     def pullback(xi: jnp.ndarray) -> jnp.ndarray:

--- a/tests/unit/manifolds/test_metric_pullback_consistency.py
+++ b/tests/unit/manifolds/test_metric_pullback_consistency.py
@@ -10,6 +10,8 @@ These tests assert that both paths agree numerically at sample points and
 across a range of angles verified with Hypothesis.
 """
 
+import math
+
 import hypothesis.strategies as st
 import jax
 import jax.numpy as jnp
@@ -305,3 +307,70 @@ class TestLorentzianAmbient:
 
     def test_riemannian_ambient_signature_unaffected(self, unit_sphere_embedded):
         assert unit_sphere_embedded.metric.signature == (1, 1)
+
+
+_BATCH_CASES = [
+    (cxc.lonlat_sph2, ("lon", "lat")),
+    (cxc.math_sph2, ("theta", "phi")),
+    (cxc.loncoslat_sph2, ("lon_coslat", "lat")),
+]
+
+
+class TestNonCanonicalTwoSphereBatching:
+    """The pullback metric must batch like element-wise evaluation."""
+
+    @pytest.mark.parametrize(("chart", "keys"), _BATCH_CASES)
+    def test_batch_matches_elementwise(self, chart, keys):
+        """A batched point equals stacking the per-point metrics."""
+        vals = jnp.array([0.3, 0.5, 0.7])
+        pt = {k: u.Q(vals, "rad") for k in keys}
+        gb = jnp.asarray(cxmapi.metric_matrix(cxm.S2, pt, chart).matrix.value)
+        assert gb.shape == (3, 2, 2)
+        for i in range(3):
+            gi = cxmapi.metric_matrix(cxm.S2, {k: v[i] for k, v in pt.items()}, chart)
+            assert jnp.allclose(gb[i], jnp.asarray(gi.matrix.value), atol=1e-12)
+
+    @pytest.mark.parametrize(("chart", "keys"), _BATCH_CASES)
+    def test_multidim_batch_shape(self, chart, keys):
+        """Leading axes are batch, the two component axes trail."""
+        pt = {k: u.Q(jnp.full((2, 3), 0.4), "rad") for k in keys}
+        g = cxmapi.metric_matrix(cxm.S2, pt, chart)
+        assert jnp.asarray(g.matrix.value).shape == (2, 3, 2, 2)
+
+
+class TestLonCosLatPoleIsSingular:
+    """`loncoslat` is not a chart at the poles; pin what happens there.
+
+    ``lon_coslat = lon * cos(lat)`` collapses every longitude onto ``0`` at
+    ``lat = +-pi/2``, so the map is not injective and the coordinates are not a
+    chart there. Away from the pole ``g_LL = cos^2(lat) * sec^2(lat) == 1``
+    exactly; at the pole that product is evaluated as ``0 * inf`` and collapses.
+    We pin the honest behaviour rather than fabricate a value at a point where
+    the chart is not defined.
+    """
+
+    def test_g_LL_is_one_away_from_the_pole(self):
+        """Analytically g_LL == 1 everywhere the chart is valid."""
+        for lat in (0.0, 0.5, 1.0, 1.5, math.pi / 2 - 1e-6):
+            pt = {"lon_coslat": u.Q(0.4, "rad"), "lat": u.Q(lat, "rad")}
+            g = cxmapi.metric_matrix(cxm.S2, pt, cxc.loncoslat_sph2)
+            assert jnp.allclose(jnp.asarray(g.matrix.value)[0, 0], 1.0, atol=1e-9)
+
+    def test_det_is_one_away_from_the_pole(self):
+        """sqrt(det g) == 1: the area element is dL dlat in this chart."""
+        for lat in (-1.0, 0.0, 0.7, 1.2):
+            pt = {"lon_coslat": u.Q(0.4, "rad"), "lat": u.Q(lat, "rad")}
+            g = jnp.asarray(
+                cxmapi.metric_matrix(cxm.S2, pt, cxc.loncoslat_sph2).matrix.value
+            )
+            assert jnp.allclose(jnp.linalg.det(g), 1.0, atol=1e-9)
+
+    def test_pole_is_degenerate_not_nan(self):
+        """At the pole the result is finite but singular -- a known limitation."""
+        pt = {"lon_coslat": u.Q(0.0, "rad"), "lat": u.Q(math.pi / 2, "rad")}
+        g = jnp.asarray(
+            cxmapi.metric_matrix(cxm.S2, pt, cxc.loncoslat_sph2).matrix.value
+        )
+        assert bool(jnp.all(jnp.isfinite(g)))
+        # Degenerate: det == 0, whereas the limit along lat -> pi/2 is 1.
+        assert jnp.allclose(jnp.linalg.det(g), 0.0, atol=1e-12)


### PR DESCRIPTION
Follow-up to #592 (now merged). Found by a math audit of that PR.

The metric *values* from #592 are correct — I verified them against hand-derived closed forms, the area element, chart-invariant arc length, and the tensor transformation law between non-canonical chart pairs, all to machine precision. These are two edge issues it left behind.

## 1. Batching — a real bug

`jax.jacfwd` is applied to the whole stacked point, so a batched input differentiates every output w.r.t. every batch element:

```python
metric_matrix(cxm.S2, {"lon": u.Q(jnp.array([0.3,0.5,0.7]),"rad"), "lat": ...}, cxc.lonlat_sph2)
# TypeError: dot_general requires contracting dimensions to have the same shape, got (3,) and (2,)
```

All three non-canonical charts raise. `vmap` *around* the call already worked; only the direct-batch path was broken.

**Fix:** stack components on the trailing axis, `vmap` the per-point pullback over the flattened leading batch, reshape to `(*batch, n, n)` — the convention the other `metric_matrix` rules use and the shape #604 settled on for the embedded metric.

The batch-invariance property test from #612 would not have caught this: it covers only the Euclidean curvilinear charts. (The canonical `sph2` chart has a *separate* batching bug, fixed in #618.)

## 2. Poles — documented, not a value change

`LonCosLat` is **not a chart at the poles**: `lon_coslat = lon * cos(lat)` collapses every longitude onto `0` at `lat = ±π/2`, so the map is not injective there.

Away from the poles `g_LL = cos²(lat)·sec²(lat)` is exactly `1` and `det g` is exactly `1` (the area element is `dL dlat`). Evaluated *at* a pole that product is `0 · inf`, and the returned matrix is degenerate (`det g == 0`) rather than the limiting identity.

I checked whether routing the pullback through the R³ embedding instead of the canonical angles would preserve the cancellation. **It does not** — both formulations lose it identically, because `theta = pi/2 - lat` is exactly `0` there and `sin²(theta)` annihilates the compensating `sec²(lat)` blow-up:

| `π/2 − lat` | via angles `g_LL` | via R³ `g_LL` |
|---|---|---|
| 1e-6 | 1.0000000000 | 1.0000000000 |
| 1e-10 | 0.9999975925 | 0.9999975925 |
| 0 | 0.0000000000 | 0.0000000000 |

Rather than fabricate a value at a point where the chart is not a chart, this documents the behaviour (a `.. warning::` on the dispatch) and pins it with tests: `g_LL == 1` and `det g == 1` away from the pole, finite-but-degenerate at it. Precision degrades within ~1e-10 rad of the pole, where the condition number `~ lon_coslat² tan²(lat)` exceeds what float64 carries.

`LonLat` and `Math` are singular at their poles too, but there the degenerate metric *is* the correct limit — no issue.

## Verification

New tests: batch-vs-elementwise for all three charts, multi-dim `(2,3)` batch shape, and the three pole properties. Unbatched results unchanged; `jit` still works.

Full suite: 2001 passed, 8 skipped. `ruff`/`ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)