### PR TITLE
🐛 fix(manifolds): scale factors exist for the orthogonal two-sphere charts

### DIFF
--- a/src/coordinax/_src/spherical/chart.py
+++ b/src/coordinax/_src/spherical/chart.py
@@ -18,6 +18,7 @@ __all__ = (
     "MathSphericalTwoSphere",
     "math_sph2",
     "NonCanonicalTwoSphere",
+    "RelabeledTwoSphere",
 )
 
 
@@ -395,9 +396,17 @@ math_sph2: Final = MathSphericalTwoSphere(M=S2)
 """Standard spherical coordinates on the two-sphere with mathematics convention."""
 
 
-NonCanonicalTwoSphere = (
-    LonLatSphericalTwoSphere | LonCosLatSphericalTwoSphere | MathSphericalTwoSphere
-)
+RelabeledTwoSphere = LonLatSphericalTwoSphere | MathSphericalTwoSphere
+"""Two-sphere charts that relabel or swap the canonical angles.
+
+Their components are not nested polar angles, so the nested sine-product does
+not give their round metric -- but they remain *orthogonal*, so the metric is
+diagonal and scale factors are well defined.  Contrast
+`LonCosLatSphericalTwoSphere`, which is genuinely non-orthogonal.
+"""
+
+
+NonCanonicalTwoSphere = RelabeledTwoSphere | LonCosLatSphericalTwoSphere
 """Two-sphere charts whose components are not nested polar angles.
 
 These relabel or swap the polar and azimuthal angles (``LonLat``, ``Math``) or

--- a/src/coordinax/_src/spherical/scale_factors.py
+++ b/src/coordinax/_src/spherical/scale_factors.py
@@ -2,6 +2,8 @@
 
 __all__: tuple[str, ...] = ()
 
+from typing import cast
+
 import plum
 import unxts.linalg as ul
 
@@ -9,27 +11,77 @@ import quaxed.numpy as jnp
 import unxt as u
 from unxt.quantity import AllowValue
 
-from .chart import NonCanonicalTwoSphere
+import coordinaxs.api.manifolds as cxmapi
+from .chart import LonCosLatSphericalTwoSphere, RelabeledTwoSphere
+from .manifold import HyperSphericalManifold
 from .metric import RoundMetric
 from coordinax._src.base import AbstractChart
 from coordinax._src.custom_types import CDict, OptUSys
+from coordinax._src.metric.matrix import DenseMetric
 
 
 @plum.dispatch
 def scale_factors(
     metric: RoundMetric,
-    chart: NonCanonicalTwoSphere,
+    chart: RelabeledTwoSphere,
     /,
     *,
     at: CDict,
     usys: OptUSys = None,
 ) -> ul.QuantityMatrix:
-    """Non-canonical two-sphere charts have no nested-sine scale factors."""
+    r"""Scale factors for the orthogonal relabelled two-sphere charts.
+
+    ``LonLat`` and ``Math`` relabel/swap the canonical angles, so the nested
+    sine-product does not apply -- but they stay *orthogonal*, so the metric is
+    diagonal and its diagonal is the answer:
+
+    - ``LonLat`` ``(lon, lat)``: ``diag(cos^2(lat), 1)``
+    - ``Math`` ``(theta, phi)``: ``diag(sin^2(phi), 1)``
+
+    Taken from `metric_matrix` rather than re-derived, so there is one source of
+    truth for the pullback.
+
+    >>> import math
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> at = {"lon": u.Q(0.6, "rad"), "lat": u.Q(math.radians(40), "rad")}
+    >>> h = cxm.scale_factors(cxm.RoundMetric(2), cxc.lonlat_sph2, at=at)
+    >>> [round(float(v), 4) for v in h.value]
+    [0.5868, 1.0]
+
+    """
+    del usys
+    g = cast(
+        "DenseMetric",
+        cxmapi.metric_matrix(HyperSphericalManifold(metric.ndim), at, chart),
+    )
+    # `.matrix` is typed `QuantityMatrix | Array`; this rule always builds the
+    # former, but handle both so the diagonal extraction is total.
+    gm = g.matrix
+    diag = jnp.diagonal(
+        gm.value if isinstance(gm, ul.QuantityMatrix) else gm, axis1=-2, axis2=-1
+    )
+    return ul.QuantityMatrix(diag, unit=ul.UnitsMatrix.full(len(chart.components), ""))
+
+
+@plum.dispatch
+def scale_factors(
+    metric: RoundMetric,
+    chart: LonCosLatSphericalTwoSphere,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> ul.QuantityMatrix:
+    """`LonCosLat` is non-orthogonal, so it has no scale factors at all."""
     del metric, at, usys
     msg = (
-        "scale_factors is only defined for the canonical nested-angle spherical "
-        f"chart; {type(chart).__name__} has no nested-sine scale factors. "
-        "Use coordinax.manifolds.metric_matrix instead."
+        "scale_factors is a diagonal (orthogonal-frame) concept and "
+        f"{type(chart).__name__} is non-orthogonal: its round metric has a "
+        "nonzero off-diagonal (g_01 = lon_coslat * tan(lat)), so no set of "
+        "per-axis factors reproduces it. Use coordinax.manifolds.metric_matrix."
     )
     raise NotImplementedError(msg)
 

--- a/src/coordinax/_src/spherical/scale_factors.py
+++ b/src/coordinax/_src/spherical/scale_factors.py
@@ -51,11 +51,24 @@ def scale_factors(
     >>> [round(float(v), 4) for v in h.value]
     [0.5868, 1.0]
 
+    Bare angle values are interpreted via ``usys["angle"]`` when a unit system
+    is supplied:
+
+    >>> usys = u.unitsystem("m", "s", "kg", "deg")
+    >>> h = cxm.scale_factors(cxm.RoundMetric(2), cxc.lonlat_sph2,
+    ...                       at={"lon": 30.0, "lat": 40.0}, usys=usys)
+    >>> [round(float(v), 4) for v in h.value]
+    [0.5868, 1.0]
+
     """
-    del usys
+    # `metric_matrix` interprets bare angle values as radians, so normalise
+    # `at` through the chart's angle unit first (radians when no `usys`).
+    rad = u.unit("rad")
+    ang_unit = usys["angle"] if usys is not None else rad
+    at_rad = {k: u.uconvert_value(rad, ang_unit, v) for k, v in at.items()}
     g = cast(
         "DenseMetric",
-        cxmapi.metric_matrix(HyperSphericalManifold(metric.ndim), at, chart),
+        cxmapi.metric_matrix(HyperSphericalManifold(metric.ndim), at_rad, chart),
     )
     # `.matrix` is typed `QuantityMatrix | Array`; this rule always builds the
     # former, but handle both so the diagonal extraction is total.

--- a/tests/unit/manifolds/test_metric_pullback_consistency.py
+++ b/tests/unit/manifolds/test_metric_pullback_consistency.py
@@ -10,6 +10,8 @@ These tests assert that both paths agree numerically at sample points and
 across a range of angles verified with Hypothesis.
 """
 
+import math
+
 import hypothesis.strategies as st
 import jax
 import jax.numpy as jnp
@@ -236,14 +238,38 @@ class TestNonCanonicalTwoSphereMetric:
         assert bool(jnp.all(jnp.isfinite(g.matrix.value)))
 
     @pytest.mark.parametrize(
-        "chart", [cxc.lonlat_sph2, cxc.loncoslat_sph2, cxc.math_sph2]
+        ("chart", "at", "expected"),
+        [
+            # LonLat (lon, lat) -> diag(cos^2 lat, 1)
+            (cxc.lonlat_sph2, {"lon": 0.6, "lat": 0.7}, (math.cos(0.7) ** 2, 1.0)),
+            # Math (theta=azimuth, phi=polar) -> diag(sin^2 phi, 1)
+            (cxc.math_sph2, {"theta": 0.6, "phi": 0.9}, (math.sin(0.9) ** 2, 1.0)),
+        ],
     )
-    def test_scale_factors_not_defined(self, chart):
-        """scale_factors is undefined for non-canonical charts (use metric_matrix)."""
-        keys = chart.components
-        at = {k: u.Q(0.4, "rad") for k in keys}
-        with pytest.raises(NotImplementedError, match="canonical"):
-            cxm.scale_factors(chart, at=at)
+    def test_scale_factors_defined_for_orthogonal_charts(self, chart, at, expected):
+        """LonLat and Math are orthogonal, so scale factors exist."""
+        h = cxm.scale_factors(chart, at={k: u.Q(v, "rad") for k, v in at.items()})
+        assert jnp.allclose(jnp.asarray(h.value), jnp.asarray(expected), atol=1e-9)
+
+    @pytest.mark.parametrize(
+        ("chart", "keys"),
+        [
+            (cxc.lonlat_sph2, ("lon", "lat")),
+            (cxc.math_sph2, ("theta", "phi")),
+        ],
+    )
+    def test_scale_factors_match_metric_diagonal(self, chart, keys):
+        """They must agree with the diagonal of the full metric."""
+        at = {k: u.Q(v, "rad") for k, v in zip(keys, (0.4, 0.8), strict=True)}
+        h = jnp.asarray(cxm.scale_factors(chart, at=at).value)
+        g = jnp.asarray(cxmapi.metric_matrix(cxm.S2, at, chart).matrix.value)
+        assert jnp.allclose(h, jnp.diagonal(g), atol=1e-12)
+
+    def test_scale_factors_refused_for_non_orthogonal_chart(self):
+        """LonCosLat is genuinely non-orthogonal: no per-axis factors exist."""
+        at = {"lon_coslat": u.Q(0.4, "rad"), "lat": u.Q(0.7, "rad")}
+        with pytest.raises(NotImplementedError, match="non-orthogonal"):
+            cxm.scale_factors(cxc.loncoslat_sph2, at=at)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #592, found by a math audit of that PR.

## The problem

#592 refuses `scale_factors` for all three non-canonical two-sphere charts with:

> scale_factors is only defined for the canonical nested-angle spherical chart

That statement is **false**. `LonLat` and `Math` merely *relabel* the canonical angles — they stay orthogonal, and their metrics are exactly diagonal. Measured over a grid of points:

| chart | `max｜g₀₁｜` | orthogonal? |
|---|---|---|
| `lonlat_sph2` | `0.00e+00` | yes |
| `math_sph2` | `0.00e+00` | yes |
| `loncoslat_sph2` | `3.09e+00` | **no** |

Exactly zero, not merely small. So

```
LonLat (lon, lat)   ->  diag(cos²(lat), 1)
Math   (theta, phi) ->  diag(sin²(phi), 1)
```

and their scale factors are perfectly well defined. Refusing them withdrew working functionality on a wrong premise.

Only `LonCosLat` genuinely lacks scale factors: it is non-orthogonal, with off-diagonal `g₀₁ = lon_coslat · tan(lat)` analytically, so no set of per-axis factors can reproduce its metric.

## The fix

Split the dispatch:

- **`RelabeledTwoSphere`** (`LonLat | Math`) returns the metric diagonal, taken from `metric_matrix` rather than re-derived — the pullback stays the single source of truth.
- **`LonCosLat`** still raises `NotImplementedError`, but with a message stating the real reason (non-orthogonality) instead of asserting that only the canonical chart has scale factors.

## Verification

New tests pin the closed-form values (`diag(cos²lat, 1)` and `diag(sin²φ, 1)`), agreement with the diagonal of the full `metric_matrix`, and the refusal for `LonCosLat`.

Full suite: 1993 passed, 8 skipped. `ruff` clean; `ty` back to the 2 pre-existing `redundant-cast` warnings.

(One pre-existing failure, `tests/usage/charts/test_ptmap.py::TestCartesianRoundTrip3D::test_sph3d_roundtrip`, reproduces identically on unmodified `main` — a float32 hypothesis draw near the origin, unrelated to this change.)

## Related

Stacked-ish with #621 (batch-safety + pole behaviour). Both touch `spherical/`, though different functions; whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)