### PR TITLE
♻️ refactor(manifolds): classify the orthogonal two-sphere charts as diagonal

### DIFF
--- a/src/coordinax/_src/spherical/register_metric.py
+++ b/src/coordinax/_src/spherical/register_metric.py
@@ -26,7 +26,9 @@ from unxt.quantity import AllowValue
 import coordinaxs.api.charts as cxcapi
 from .chart import (
     AbstractSphericalHyperSphere,
+    LonCosLatSphericalTwoSphere,
     NonCanonicalTwoSphere,
+    RelabeledTwoSphere,
     SphericalTwoSphere,
 )
 from .manifold import HyperSphericalManifold
@@ -112,13 +114,12 @@ def metric_matrix(
 
 @plum.dispatch
 def metric_representation(
-    M: HyperSphericalManifold, chart: NonCanonicalTwoSphere, /
+    M: HyperSphericalManifold, chart: LonCosLatSphericalTwoSphere, /
 ) -> type[DenseMetric]:
-    """Non-canonical two-sphere charts return a `DenseMetric`.
+    """`LonCosLat` is non-orthogonal, so its round metric is genuinely dense.
 
-    Their round metric is obtained by pullback (see `metric_matrix`); it is
-    diagonal for LonLat/Math but genuinely dense for LonCosLat, so all three use
-    `DenseMetric`.
+    Its off-diagonal is ``g_01 = lon_coslat * tan(lat)``, nonzero away from the
+    equator.
 
     >>> import coordinax.charts as cxc
     >>> import coordinax.manifolds as cxm
@@ -131,53 +132,30 @@ def metric_representation(
 
 
 @plum.dispatch
-def metric_matrix(
-    M: HyperSphericalManifold, point: CDict, chart: NonCanonicalTwoSphere, /
-) -> DenseMetric:
-    r"""Round metric on a non-canonical two-sphere chart (pullback).
+def metric_representation(
+    M: HyperSphericalManifold, chart: RelabeledTwoSphere, /
+) -> type[DiagonalMetric]:
+    """`LonLat` and `Math` relabel the canonical angles but stay orthogonal.
 
-    The nested sine-product used by the canonical dispatch assumes the
-    components are polar angles in nested order; that is false for these charts
-    (LonLat, Math swap/relabel the polar and azimuthal angles; LonCosLat is
-    non-orthogonal). The metric is instead pulled back from the canonical chart:
-    ``g = Jc^T diag(1, sin^2 theta) Jc``, where ``Jc`` is the Jacobian of the
-    coordinate map ``chart -> SphericalTwoSphere``.
+    Their round metrics are exactly diagonal -- ``diag(cos^2(lat), 1)`` and
+    ``diag(sin^2(phi), 1)`` -- so `DiagonalMetric` is the accurate
+    classification and gives callers the O(n) diagonal path.
 
-    >>> import math
-    >>> import unxt as u
     >>> import coordinax.charts as cxc
     >>> import coordinax.manifolds as cxm
-
-    LonLat at lat=40 deg: ``g = diag(cos^2(lat), 1)``:
-
-    >>> at = {"lon": u.Q(0.6, "rad"), "lat": u.Q(math.radians(40), "rad")}
-    >>> g = cxm.metric_matrix(cxm.S2, at, cxc.lonlat_sph2)
-    >>> [round(float(g.matrix.value[i, i]), 4) for i in (0, 1)]
-    [0.5868, 1.0]
-
-    Leading axes are batch; the two component axes trail:
-
-    >>> import jax.numpy as jnp
-    >>> at = {"lon": u.Q(jnp.zeros((5,)), "rad"), "lat": u.Q(jnp.zeros((5,)), "rad")}
-    >>> cxm.metric_matrix(cxm.S2, at, cxc.lonlat_sph2).matrix.value.shape
-    (5, 2, 2)
-
-    .. warning::
-
-        ``LonCosLat`` is **not a chart at the poles**: ``lon_coslat = lon *
-        cos(lat)`` collapses every longitude onto ``0`` at ``lat = +-pi/2``, so
-        the map is not injective there.  Away from the poles ``g_LL =
-        cos^2(lat) * sec^2(lat)`` is exactly ``1`` and ``det g`` is exactly
-        ``1``; evaluated *at* a pole that product becomes ``0 * inf`` and the
-        returned matrix is degenerate (``det g == 0``) rather than the limiting
-        identity.  Precision degrades within roughly ``1e-10`` rad of the pole,
-        where the chart's condition number ``~ lon_coslat^2 tan^2(lat)`` exceeds
-        what float64 can carry.  ``LonLat`` and ``Math`` are genuinely singular
-        at their poles too, but there the degenerate metric *is* the correct
-        limit.
+    >>> cxm.metric_representation(cxm.S2, cxc.lonlat_sph2)
+    <class 'coordinax._src.metric.matrix.DiagonalMetric'>
 
     """
-    del M
+    del M, chart
+    return DiagonalMetric
+
+
+def _round_metric_values(point: CDict, chart: NonCanonicalTwoSphere) -> jnp.ndarray:
+    """Dense ``(*batch, n, n)`` round-metric values via pullback.
+
+    Shared by the `LonCosLat` (dense) and `Relabeled` (diagonal) rules below.
+    """
     keys = chart.components
     n = len(keys)
     # Components trail: (*batch, n).
@@ -204,7 +182,101 @@ def metric_matrix(
     # `jacfwd` on a batched input would differentiate every output w.r.t. every
     # batch element, so map it per point and restore the leading batch axes.
     batch = x.shape[:-1]
-    g = jax.vmap(pullback)(x.reshape(-1, n)).reshape(*batch, n, n)
+    return jax.vmap(pullback)(x.reshape(-1, n)).reshape(*batch, n, n)
 
+
+@plum.dispatch
+def metric_matrix(
+    M: HyperSphericalManifold, point: CDict, chart: LonCosLatSphericalTwoSphere, /
+) -> DenseMetric:
+    r"""Round metric on the non-orthogonal `LonCosLat` chart (pullback).
+
+    The nested sine-product used by the canonical dispatch assumes the
+    components are polar angles in nested order; that is false for these charts
+    (LonLat, Math swap/relabel the polar and azimuthal angles; LonCosLat is
+    non-orthogonal). The metric is instead pulled back from the canonical chart:
+    ``g = Jc^T diag(1, sin^2 theta) Jc``, where ``Jc`` is the Jacobian of the
+    coordinate map ``chart -> SphericalTwoSphere``.
+
+    >>> import math
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    ``g = [[1, a], [a, 1 + a^2]]`` with ``a = lon_coslat * tan(lat)``; note the
+    nonzero off-diagonal, and that ``det g == 1`` (the area element is
+    ``dL dlat``):
+
+    >>> at = {"lon_coslat": u.Q(0.4, "rad"), "lat": u.Q(0.7, "rad")}
+    >>> g = cxm.metric_matrix(cxm.S2, at, cxc.loncoslat_sph2)
+    >>> [round(float(v), 4) for v in g.matrix.value.ravel()]
+    [1.0, 0.3369, 0.3369, 1.1135]
+    >>> round(float(math.prod([0.4, math.tan(0.7)])), 4)
+    0.3369
+
+    Leading axes are batch; the two component axes trail:
+
+    >>> import jax.numpy as jnp
+    >>> at = {"lon_coslat": u.Q(jnp.zeros((5,)), "rad"),
+    ...       "lat": u.Q(jnp.zeros((5,)), "rad")}
+    >>> cxm.metric_matrix(cxm.S2, at, cxc.loncoslat_sph2).matrix.value.shape
+    (5, 2, 2)
+
+    .. warning::
+
+        ``LonCosLat`` is **not a chart at the poles**: ``lon_coslat = lon *
+        cos(lat)`` collapses every longitude onto ``0`` at ``lat = +-pi/2``, so
+        the map is not injective there.  Away from the poles ``g_LL =
+        cos^2(lat) * sec^2(lat)`` is exactly ``1`` and ``det g`` is exactly
+        ``1``; evaluated *at* a pole that product becomes ``0 * inf`` and the
+        returned matrix is degenerate (``det g == 0``) rather than the limiting
+        identity.  Precision degrades within roughly ``1e-10`` rad of the pole,
+        where the chart's condition number ``~ lon_coslat^2 tan^2(lat)`` exceeds
+        what float64 can carry.  ``LonLat`` and ``Math`` are genuinely singular
+        at their poles too, but there the degenerate metric *is* the correct
+        limit.
+
+    """
+    del M
+    n = len(chart.components)
+    g = _round_metric_values(point, chart)
     dmls = ul.UnitsMatrix.full((n, n), "")  # angles -> angles, so g is dimensionless
     return DenseMetric(ul.QM(g, unit=dmls))
+
+
+@plum.dispatch
+def metric_matrix(
+    M: HyperSphericalManifold, point: CDict, chart: RelabeledTwoSphere, /
+) -> DiagonalMetric:
+    r"""Round metric on an orthogonal relabelled two-sphere chart.
+
+    ``LonLat`` and ``Math`` relabel/swap the canonical angles, so the nested
+    sine-product does not apply, but they stay orthogonal: the pullback is
+    exactly diagonal, so only the diagonal is kept.
+
+    - ``LonLat`` ``(lon, lat)``: ``diag(cos^2(lat), 1)``
+    - ``Math`` ``(theta, phi)``: ``diag(sin^2(phi), 1)``
+
+    >>> import math
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> at = {"lon": u.Q(0.6, "rad"), "lat": u.Q(math.radians(40), "rad")}
+    >>> g = cxm.metric_matrix(cxm.S2, at, cxc.lonlat_sph2)
+    >>> [round(float(v), 4) for v in g.diagonal.value]
+    [0.5868, 1.0]
+
+    Leading axes are batch; the component axis trails:
+
+    >>> import jax.numpy as jnp
+    >>> at = {"lon": u.Q(jnp.zeros((5,)), "rad"), "lat": u.Q(jnp.zeros((5,)), "rad")}
+    >>> cxm.metric_matrix(cxm.S2, at, cxc.lonlat_sph2).diagonal.value.shape
+    (5, 2)
+
+    """
+    del M
+    n = len(chart.components)
+    g = _round_metric_values(point, chart)
+    diag = jnp.diagonal(g, axis1=-2, axis2=-1)
+    return DiagonalMetric(ul.QM(diag, unit=ul.UnitsMatrix.full(n, "")))

--- a/src/coordinax/_src/spherical/scale_factors.py
+++ b/src/coordinax/_src/spherical/scale_factors.py
@@ -17,7 +17,7 @@ from .manifold import HyperSphericalManifold
 from .metric import RoundMetric
 from coordinax._src.base import AbstractChart
 from coordinax._src.custom_types import CDict, OptUSys
-from coordinax._src.metric.matrix import DenseMetric
+from coordinax._src.metric.matrix import DiagonalMetric
 
 
 @plum.dispatch
@@ -66,17 +66,13 @@ def scale_factors(
     rad = u.unit("rad")
     ang_unit = usys["angle"] if usys is not None else rad
     at_rad = {k: u.uconvert_value(rad, ang_unit, v) for k, v in at.items()}
+    # `metric_matrix` already returns a DiagonalMetric for these charts, so the
+    # diagonal *is* the answer -- no dense matrix is ever formed.
     g = cast(
-        "DenseMetric",
+        "DiagonalMetric",
         cxmapi.metric_matrix(HyperSphericalManifold(metric.ndim), at_rad, chart),
     )
-    # `.matrix` is typed `QuantityMatrix | Array`; this rule always builds the
-    # former, but handle both so the diagonal extraction is total.
-    gm = g.matrix
-    diag = jnp.diagonal(
-        gm.value if isinstance(gm, ul.QuantityMatrix) else gm, axis1=-2, axis2=-1
-    )
-    return ul.QuantityMatrix(diag, unit=ul.UnitsMatrix.full(len(chart.components), ""))
+    return cast("ul.QuantityMatrix", g.diagonal)
 
 
 @plum.dispatch

--- a/tests/unit/manifolds/test_metric_pullback_consistency.py
+++ b/tests/unit/manifolds/test_metric_pullback_consistency.py
@@ -194,6 +194,16 @@ class TestPullbackMetricUnits:
 # ---------------------------------------------------------------------------
 
 
+def _dense_values(g):
+    """Full ``(*batch, n, n)`` values from a Diagonal *or* Dense metric.
+
+    The orthogonal charts (LonLat, Math) return a `DiagonalMetric`; only the
+    non-orthogonal LonCosLat returns a `DenseMetric`.
+    """
+    m = g.to_dense().matrix
+    return jnp.asarray(getattr(m, "value", m))
+
+
 def _embedding_metric(chart, coords_rad):
     """Induced metric of ``chart`` from the unit-sphere R³ embedding, via J^T J."""
     keys = chart.components
@@ -225,8 +235,10 @@ class TestNonCanonicalTwoSphereMetric:
     def test_metric_matches_embedding(self, chart, coords):
         pt = {k: u.Q(v, "rad") for k, v in coords.items()}
         g = cxmapi.metric_matrix(cxm.S2, pt, chart)
-        assert isinstance(g, DenseMetric)
-        got = jnp.asarray(g.matrix.value)
+        # LonLat/Math are orthogonal -> Diagonal; LonCosLat is not -> Dense.
+        expect = DenseMetric if chart is cxc.loncoslat_sph2 else DiagonalMetric
+        assert isinstance(g, expect)
+        got = _dense_values(g)
         ref = _embedding_metric(chart, coords)
         assert jnp.allclose(got, ref, atol=1e-9), f"{got}\n!=\n{ref}"
 
@@ -234,8 +246,8 @@ class TestNonCanonicalTwoSphereMetric:
         """Integer-valued angles are promoted to float so the pullback jacfwd works."""
         pt = {"lon": u.Q(0, "rad"), "lat": u.Q(0, "rad")}  # integer magnitudes
         g = cxmapi.metric_matrix(cxm.S2, pt, cxc.lonlat_sph2)
-        assert isinstance(g, DenseMetric)
-        assert bool(jnp.all(jnp.isfinite(g.matrix.value)))
+        assert isinstance(g, DiagonalMetric)
+        assert bool(jnp.all(jnp.isfinite(_dense_values(g))))
 
     @pytest.mark.parametrize(
         ("chart", "at", "expected"),
@@ -262,7 +274,7 @@ class TestNonCanonicalTwoSphereMetric:
         """They must agree with the diagonal of the full metric."""
         at = {k: u.Q(v, "rad") for k, v in zip(keys, (0.4, 0.8), strict=True)}
         h = jnp.asarray(cxm.scale_factors(chart, at=at).value)
-        g = jnp.asarray(cxmapi.metric_matrix(cxm.S2, at, chart).matrix.value)
+        g = _dense_values(cxmapi.metric_matrix(cxm.S2, at, chart))
         assert jnp.allclose(h, jnp.diagonal(g), atol=1e-12)
 
     def test_scale_factors_refused_for_non_orthogonal_chart(self):
@@ -348,18 +360,18 @@ class TestNonCanonicalTwoSphereBatching:
         """A batched point equals stacking the per-point metrics."""
         vals = jnp.array([0.3, 0.5, 0.7])
         pt = {k: u.Q(vals, "rad") for k in keys}
-        gb = jnp.asarray(cxmapi.metric_matrix(cxm.S2, pt, chart).matrix.value)
+        gb = _dense_values(cxmapi.metric_matrix(cxm.S2, pt, chart))
         assert gb.shape == (3, 2, 2)
         for i in range(3):
             gi = cxmapi.metric_matrix(cxm.S2, {k: v[i] for k, v in pt.items()}, chart)
-            assert jnp.allclose(gb[i], jnp.asarray(gi.matrix.value), atol=1e-12)
+            assert jnp.allclose(gb[i], _dense_values(gi), atol=1e-12)
 
     @pytest.mark.parametrize(("chart", "keys"), _BATCH_CASES)
     def test_multidim_batch_shape(self, chart, keys):
         """Leading axes are batch, the two component axes trail."""
         pt = {k: u.Q(jnp.full((2, 3), 0.4), "rad") for k in keys}
         g = cxmapi.metric_matrix(cxm.S2, pt, chart)
-        assert jnp.asarray(g.matrix.value).shape == (2, 3, 2, 2)
+        assert _dense_values(g).shape == (2, 3, 2, 2)
 
 
 class TestLonCosLatPoleIsSingular:
@@ -378,7 +390,7 @@ class TestLonCosLatPoleIsSingular:
         for lat in (0.0, 0.5, 1.0, 1.5, math.pi / 2 - 1e-6):
             pt = {"lon_coslat": u.Q(0.4, "rad"), "lat": u.Q(lat, "rad")}
             g = cxmapi.metric_matrix(cxm.S2, pt, cxc.loncoslat_sph2)
-            assert jnp.allclose(jnp.asarray(g.matrix.value)[0, 0], 1.0, atol=1e-9)
+            assert jnp.allclose(_dense_values(g)[0, 0], 1.0, atol=1e-9)
 
     def test_det_is_one_away_from_the_pole(self):
         """sqrt(det g) == 1: the area element is dL dlat in this chart."""
@@ -398,3 +410,34 @@ class TestLonCosLatPoleIsSingular:
         assert bool(jnp.all(jnp.isfinite(g)))
         # Degenerate: det == 0, whereas the limit along lat -> pi/2 is 1.
         assert jnp.allclose(jnp.linalg.det(g), 0.0, atol=1e-12)
+
+
+class TestDiagonalMetricDensifiesBatched:
+    """`DiagonalMetric.to_dense` must handle a batched diagonal.
+
+    Reachable now that the orthogonal two-sphere charts return a
+    `DiagonalMetric`: `jnp.diag` is 1-D only, so a batched diagonal used to
+    raise instead of densifying to ``(*batch, n, n)``.
+    """
+
+    def test_batched_diagonal_densifies(self):
+        pt = {
+            "lon": u.Q(jnp.array([0.3, 0.5]), "rad"),
+            "lat": u.Q(jnp.array([0.4, 0.6]), "rad"),
+        }
+        g = cxmapi.metric_matrix(cxm.S2, pt, cxc.lonlat_sph2)
+        assert isinstance(g, DiagonalMetric)
+        dense = _dense_values(g)
+        assert dense.shape == (2, 2, 2)
+        for i in range(2):
+            gi = cxmapi.metric_matrix(
+                cxm.S2, {k: v[i] for k, v in pt.items()}, cxc.lonlat_sph2
+            )
+            assert jnp.allclose(dense[i], _dense_values(gi), atol=1e-12)
+
+    def test_bare_array_diagonal_densifies_batched(self):
+        """The un-united branch of `to_dense` must broadcast too."""
+        d = DiagonalMetric(jnp.array([[1.0, 4.0], [9.0, 16.0]]))
+        m = d.to_dense().matrix
+        assert jnp.asarray(m).shape == (2, 2, 2)
+        assert jnp.allclose(jnp.asarray(m)[1], jnp.array([[9.0, 0.0], [0.0, 16.0]]))


### PR DESCRIPTION
Follow-up to #592, found by a math audit of that PR.

**Stacked on #621 and #624** — those two are merged into this branch, so its diff will shrink to just the last commit once they land. Merge order: #621, #624, then this.

## The problem

#592 returns `DenseMetric` for all three non-canonical two-sphere charts, with the docstring noting that `LonLat`/`Math` are diagonal but bundling them with `LonCosLat` anyway. That classification is lossy: it costs those two charts the O(n) diagonal path `DiagonalMetric` exists to provide, and it advertises a sparsity structure the metric doesn't have.

`LonLat` and `Math` are exactly orthogonal — `max|g₀₁| = 0.00e+00` over a grid of points, not merely small:

```
LonLat (lon, lat)   ->  diag(cos²(lat), 1)
Math   (theta, phi) ->  diag(sin²(phi), 1)
```

## Changes

- `metric_representation` returns `DiagonalMetric` for `RelabeledTwoSphere`, `DenseMetric` only for the genuinely non-orthogonal `LonCosLat`.
- `metric_matrix` keeps only the diagonal for the relabelled charts.
- The pullback body becomes `_round_metric_values`, shared by both rules — it has two real callers now, so the helper earns its keep.
- `scale_factors` for those charts simplifies to returning `.diagonal` directly; no dense matrix is formed anywhere on that path.

## Bonus: `DiagonalMetric.to_dense` was not batch-safe

It used `jnp.diag`, which is 1-D only, so a batched diagonal raised:

```
ValueError: QuantityMatrix value has ndim=1, fewer than the 2-D unit structure ((, ), (, ))
```

This was latent — nothing produced a batched `DiagonalMetric` before. It becomes reachable both here and via #618 (which makes the canonical `sph2` chart return a correctly-shaped batched diagonal). Now broadcasts to `(*batch, n, n)`; both the united and bare-array branches are covered by tests.

## Verification

Tests updated to be representation-agnostic (a `_dense_values` helper), plus new coverage for batched densification. Existing value assertions — embedding agreement, batch-vs-elementwise, pole properties — all still pass unchanged.

Full suite: 1985 passed, 8 skipped. `ruff` clean; `ty` back to the 2 pre-existing `redundant-cast` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)