### PR TITLE
🔧 deps: import unxts.hypothesis directly instead of the unxt_hypothesis shim

### DIFF
--- a/packages/coordinaxs.astro/pyproject.toml
+++ b/packages/coordinaxs.astro/pyproject.toml
@@ -29,14 +29,14 @@ requires-python = ">=3.12"
 [project.optional-dependencies]
 astropy = ["astropy>=7.2.0"]
 # This distribution also ships the `coordinaxs.hypothesis.astro` strategy tree,
-# which imports `hypothesis`, `unxt_hypothesis`, and `coordinaxs.hypothesis`.
+# which imports `hypothesis`, `unxts.hypothesis`, and `coordinaxs.hypothesis`.
 # Those are not needed to `import coordinaxs.astro`, so they are declared here
 # rather than as hard dependencies:
 #   pip install "coordinaxs.astro[hypothesis]"
 hypothesis = [
   "coordinaxs.hypothesis>=0.24",
   "hypothesis>=6.148.7",
-  "unxt-hypothesis>=2.0",
+  "unxts.hypothesis>=2.0",
 ]
 
 [project.entry-points."coordinaxs.frames"]

--- a/packages/coordinaxs.astro/src/coordinaxs/hypothesis/astro/dm.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/hypothesis/astro/dm.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 
 from hypothesis import strategies as st
 
-import unxt_hypothesis as ust
+import unxts.hypothesis as ust
 
 import coordinaxs.astro as cxastro
 
@@ -22,7 +22,7 @@ def distance_moduli(draw: st.DrawFn, /, **kwargs: Any) -> cxastro.DistanceModulu
     draw
         Hypothesis draw function. Automatically provided by hypothesis.
     **kwargs
-        Additional keyword arguments passed to `unxt_hypothesis.quantities`.
+        Additional keyword arguments passed to `unxts.hypothesis.quantities`.
         Common options include 'dtype', 'shape', 'elements', 'unique'. The
         arguments 'unit' and 'quantity_cls' are set automatically and should not
         be provided. Note that DistanceModulus always has units of 'mag'.

--- a/packages/coordinaxs.astro/src/coordinaxs/hypothesis/astro/plx.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/hypothesis/astro/plx.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 from hypothesis import strategies as st
 
 import unxt as u
-import unxt_hypothesis as ust
+import unxts.hypothesis as ust
 
 import coordinaxs.astro as cxastro
 from coordinaxs.hypothesis.distances import make_nonnegative
@@ -37,7 +37,7 @@ def parallaxes(
         parallax must be non-negative, noisy measurements can yield negative
         values.
     **kwargs
-        Additional keyword arguments passed to `unxt_hypothesis.quantities`.
+        Additional keyword arguments passed to `unxts.hypothesis.quantities`.
         Common options include 'dtype', 'shape', 'elements', 'unique'. The
         arguments 'unit' and 'quantity_cls' are set automatically and should not
         be provided.

--- a/packages/coordinaxs.astro/tests/unit/test_frame_transforms.py
+++ b/packages/coordinaxs.astro/tests/unit/test_frame_transforms.py
@@ -10,7 +10,7 @@ from hypothesis import given, settings
 
 import quaxed.numpy as jnp
 import unxt as u
-import unxt_hypothesis as ust
+import unxts.hypothesis as ust
 
 import coordinax as cx
 import coordinax.frames as cxf

--- a/packages/coordinaxs.hypothesis/docs/index.md
+++ b/packages/coordinaxs.hypothesis/docs/index.md
@@ -179,7 +179,7 @@ def test_distance_range(dist):
 
 ### `distance_moduli(**kwargs)`
 
-Generate random `coordinaxs.astro.DistanceModulus` objects for testing. distance and angle strategiesategy builds on `unxts.hypothesis.quantities` to generate distance moduli (apparent minus absolute magnitude). Distance moduli are always in units of 'mag'. The strategy is useful for property-based testing of magnitude-based distance computations.
+Generate random `coordinaxs.astro.DistanceModulus` objects for testing. This strategy builds on `unxts.hypothesis.quantities` to generate distance moduli (apparent minus absolute magnitude). Distance moduli are always in units of 'mag'. The strategy is useful for property-based testing of magnitude-based distance computations.
 
 **Parameters:**
 

--- a/packages/coordinaxs.hypothesis/docs/index.md
+++ b/packages/coordinaxs.hypothesis/docs/index.md
@@ -64,12 +64,12 @@ def test_distance_property(dist):
 
 Generate random {class}`unxt.Angle` objects for testing.
 
-This strategy builds on {func}`unxt_hypothesis.quantities` to generate angles with optional wrapping bounds. The strategy is useful for property-based testing of angle-related computations.
+This strategy builds on {func}`unxts.hypothesis.quantities` to generate angles with optional wrapping bounds. The strategy is useful for property-based testing of angle-related computations.
 
 **Parameters:**
 
 - `wrap_to` (`SearchStrategy[tuple[Quantity, Quantity]] | None`): Optional hypothesis strategy that generates a tuple of (min_bound, max_bound) for angle wrapping. If None, generates angles without wrapping (default: None).
-- `**kwargs`: Additional keyword arguments passed to {func}`~unxt_hypothesis.quantities`. Common options include:
+- `**kwargs`: Additional keyword arguments passed to {func}`~unxts.hypothesis.quantities`. Common options include:
   - `units` (str): Unit for the angle (e.g., "rad", "deg")
   - `min_value` (float): Minimum value for the angle
   - `max_value` (float): Maximum value for the angle
@@ -123,12 +123,12 @@ def test_angle_2d(angle):
 
 Generate random `coordinax.distances.Distance` objects for testing.
 
-This strategy builds on `unxt_hypothesis.quantities` to generate distances with automatic handling of the non-negativity constraint. The strategy is useful for property-based testing of distance-related computations.
+This strategy builds on `unxts.hypothesis.quantities` to generate distances with automatic handling of the non-negativity constraint. The strategy is useful for property-based testing of distance-related computations.
 
 **Parameters:**
 
 - `check_negative` (bool | SearchStrategy[bool]): Whether to enforce non-negative distances. If `True` (default), generated distances will be >= 0. Can be a hypothesis strategy to vary this behavior across test examples.
-- `**kwargs`: Additional keyword arguments passed to `unxt_hypothesis.quantities`. Common options include:
+- `**kwargs`: Additional keyword arguments passed to `unxts.hypothesis.quantities`. Common options include:
   - `units` (str): Unit for the distance (e.g., "kpc", "m", "AU")
   - `shape` (int | tuple | SearchStrategy): Shape of the generated distance array
   - `elements` (SearchStrategy): Strategy for generating array elements. When `check_negative=True`, the min_value will be automatically adjusted to 0 if needed.
@@ -179,11 +179,11 @@ def test_distance_range(dist):
 
 ### `distance_moduli(**kwargs)`
 
-Generate random `coordinaxs.astro.DistanceModulus` objects for testing. distance and angle strategiesategy builds on `unxt_hypothesis.quantities` to generate distance moduli (apparent minus absolute magnitude). Distance moduli are always in units of 'mag'. The strategy is useful for property-based testing of magnitude-based distance computations.
+Generate random `coordinaxs.astro.DistanceModulus` objects for testing. distance and angle strategiesategy builds on `unxts.hypothesis.quantities` to generate distance moduli (apparent minus absolute magnitude). Distance moduli are always in units of 'mag'. The strategy is useful for property-based testing of magnitude-based distance computations.
 
 **Parameters:**
 
-- `**kwargs`: Additional keyword arguments passed to `unxt_hypothesis.quantities`. Common options include:
+- `**kwargs`: Additional keyword arguments passed to `unxts.hypothesis.quantities`. Common options include:
   - `shape` (int | tuple | SearchStrategy): Shape of the generated distance modulus array
   - `elements` (SearchStrategy): Strategy for generating array elements
 
@@ -222,12 +222,12 @@ def test_dm_range(dm):
 
 Generate random `coordinaxs.astro.Parallax` objects for testing.
 
-This strategy builds on `unxt_hypothesis.quantities` to generate parallaxes with automatic handling of the non-negativity constraint. While theoretically parallax must be non-negative (tan(p) = 1 AU / d), noisy direct measurements can yield negative values. The strategy is useful for property-based testing of parallax-based distance computations.
+This strategy builds on `unxts.hypothesis.quantities` to generate parallaxes with automatic handling of the non-negativity constraint. While theoretically parallax must be non-negative (tan(p) = 1 AU / d), noisy direct measurements can yield negative values. The strategy is useful for property-based testing of parallax-based distance computations.
 
 **Parameters:**
 
 - `check_negative` (bool | SearchStrategy[bool]): Whether to enforce non-negative parallaxes. If `True` (default), generated parallaxes will be >= 0. Can be a hypothesis strategy to vary this behavior across test examples. Set to `False` when testing handling of noisy measurements.
-- `**kwargs`: Additional keyword arguments passed to {func}`unxt_hypothesis.quantities`. Common options include:
+- `**kwargs`: Additional keyword arguments passed to {func}`unxts.hypothesis.quantities`. Common options include:
   - `units` (str): Unit for the parallax (e.g., "mas", "arcsec", "deg")
   - `shape` (int | tuple | SearchStrategy): Shape of the generated parallax array
   - `elements` (SearchStrategy): Strategy for generating array elements. When `check_negative=True`, the min_value will be automatically adjusted to 0 if needed.
@@ -278,9 +278,9 @@ def test_nearby_parallax(plx):
     assert 1.0 <= plx.to("mas").value <= 100.0
 ```
 
-## Integration with `unxt-hypothesis`
+## Integration with `unxts.hypothesis`
 
-The {mod}`coordinaxs.hypothesis` package builds on top of `unxt-hypothesis` strategies.
+The {mod}`coordinaxs.hypothesis` package builds on top of `unxts.hypothesis` strategies.
 
 For more advanced usage patterns, see the {doc}`Testing Guide </packages/coordinaxs.hypothesis/testing-guide>`.
 

--- a/packages/coordinaxs.hypothesis/docs/spec.md
+++ b/packages/coordinaxs.hypothesis/docs/spec.md
@@ -88,7 +88,7 @@ This module provides general-purpose strategies for generating valid `coordinax`
     Generate `unxt.Angle` values.
 
     Source:
-    - `coordinaxs.hypothesis.angles.angles` is re-exported from `unxt_hypothesis.angles`.
+    - `coordinaxs.hypothesis.angles.angles` is re-exported from `unxts.hypothesis.angles`.
 
     Signature:
     - `angles(*, wrap_to=None, **kwargs)`
@@ -104,7 +104,7 @@ This module provides general-purpose strategies for generating valid `coordinax`
     - Supports scalar and array-shaped outputs via `shape`.
 
     Failure behavior:
-    - Invalid unit/parameter combinations follow `unxt_hypothesis.quantities` validation and raise from that implementation.
+    - Invalid unit/parameter combinations follow `unxts.hypothesis.quantities` validation and raise from that implementation.
 
     Examples:
     - `@given(a=cxst.angles())`
@@ -144,7 +144,7 @@ This module provides general-purpose strategies for generating valid `coordinax`
 
     Failure behavior:
     - Invalid unit/parameter combinations follow
-          `unxt_hypothesis.quantities` validation and raise from that
+          `unxts.hypothesis.quantities` validation and raise from that
           implementation.
 
     Examples:
@@ -169,7 +169,7 @@ This module provides general-purpose strategies for generating valid `coordinax`
     Parameters:
     - `draw`: the Hypothesis draw function (provided automatically inside an
           `@st.composite` strategy).
-    - `**kwargs`: keyword arguments destined for `unxt_hypothesis.quantities`.
+    - `**kwargs`: keyword arguments destined for `unxts.hypothesis.quantities`.
           Only the `elements` entry is inspected/adjusted; all other keys are
           returned unchanged.
 

--- a/packages/coordinaxs.hypothesis/docs/testing-guide.md
+++ b/packages/coordinaxs.hypothesis/docs/testing-guide.md
@@ -283,13 +283,13 @@ def test_charts_like_polar(chart):
 
 ## Testing Coordinate Transformations
 
-## Integration with `unxt-hypothesis`
+## Integration with `unxts.hypothesis`
 
-The {mod}`coordinaxs.hypothesis` package builds on top of `unxt-hypothesis` strategies. You can use both packages together:
+The {mod}`coordinaxs.hypothesis` package builds on top of `unxts.hypothesis` strategies. You can use both packages together:
 
 ```python
 from hypothesis import given
-import unxt_hypothesis as ust
+import unxts.hypothesis as ust
 import coordinaxs.hypothesis.main as cxst
 import unxt as u
 

--- a/packages/coordinaxs.hypothesis/pyproject.toml
+++ b/packages/coordinaxs.hypothesis/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-dependencies = ["coordinax>=0.24", "hypothesis>=6.0", "unxt-hypothesis>=2.0"]
+dependencies = ["coordinax>=0.24", "hypothesis>=6.0", "unxts.hypothesis>=2.0"]
 description = "Hypothesis strategies for coordinax"
 dynamic = ["version"]
 license = "MIT"

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/angles/__init__.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/angles/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ("angles",)
 
-from unxt_hypothesis import angles
+from unxts.hypothesis import angles

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
@@ -14,7 +14,7 @@ import hypothesis.strategies as st
 import jax.numpy as jnp
 import plum
 import unxt as u
-import unxt_hypothesis as ust
+import unxts.hypothesis as ust
 from hypothesis.extra.array_api import make_strategies_namespace
 
 import coordinax.charts as cxc

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/distances/_src/dist.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/distances/_src/dist.py
@@ -6,7 +6,7 @@ __all__ = ("distances",)
 from typing import Any
 
 import unxt as u
-import unxt_hypothesis as ust
+import unxts.hypothesis as ust
 from hypothesis import strategies as st
 
 import coordinax.distances as cxd
@@ -36,7 +36,7 @@ def distances(
         generated distances will be >= 0. Can be a hypothesis strategy to vary
         this behavior across test examples.
     **kwargs
-        Additional keyword arguments passed to `unxt_hypothesis.quantities`.
+        Additional keyword arguments passed to `unxts.hypothesis.quantities`.
         Common options include 'dtype', 'shape', 'elements', 'unique'. The
         arguments 'unit' and 'quantity_cls' are set automatically and should not
         be provided.

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/distances/_src/utils.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/distances/_src/utils.py
@@ -28,7 +28,7 @@ def make_nonnegative(draw: st.DrawFn, /, **kwargs: Any) -> dict[str, Any]:
     draw
         Hypothesis draw function for drawing from strategies.
     **kwargs
-        Keyword arguments that will be passed to `unxt_hypothesis.quantities`.
+        Keyword arguments that will be passed to `unxts.hypothesis.quantities`.
         The `elements` parameter will be modified if present, or created if absent.
 
     Returns

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/annotations/strategy.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/annotations/strategy.py
@@ -18,7 +18,7 @@ import jax
 import jax.numpy as jnp
 import plum
 import unxt as u
-import unxt_hypothesis as ust
+import unxts.hypothesis as ust
 from hypothesis.extra.array_api import make_strategies_namespace
 
 from .meta import Metadata

--- a/packages/coordinaxs.interop.astropy/pyproject.toml
+++ b/packages/coordinaxs.interop.astropy/pyproject.toml
@@ -42,7 +42,7 @@ requires      = ["hatch-vcs", "hatchling"]
 
 
 [dependency-groups]
-test = ["hypothesis>=6.148.7", "pytest>=9.0.2", "unxt-hypothesis>=2.0"]
+test = ["hypothesis>=6.148.7", "pytest>=9.0.2", "unxts.hypothesis>=2.0"]
 
 
 [tool.hatch.build.targets.wheel]

--- a/packages/coordinaxs.interop.astropy/src/coordinaxs/interop/astropy/_src/qmatrix.py
+++ b/packages/coordinaxs.interop.astropy/src/coordinaxs/interop/astropy/_src/qmatrix.py
@@ -5,6 +5,7 @@ __all__: tuple[str, ...] = ()
 import astropy.units as apyu
 import numpy as np
 import plum
+
 import unxts.linalg as ul
 
 

--- a/packages/coordinaxs.interop.astropy/tests/test_angles.py
+++ b/packages/coordinaxs.interop.astropy/tests/test_angles.py
@@ -5,7 +5,7 @@ from astropy.coordinates import Angle as AstropyAngle
 from hypothesis import given
 from plum import convert
 
-import unxt_hypothesis as ust
+import unxts.hypothesis as ust
 
 import coordinax.angles as cxa
 import coordinaxs.interop.astropy  # noqa: F401

--- a/packages/coordinaxs.interop.astropy/tests/test_distances.py
+++ b/packages/coordinaxs.interop.astropy/tests/test_distances.py
@@ -6,7 +6,7 @@ from astropy.units import Quantity as AstropyQuantity
 from hypothesis import given, strategies as st
 from plum import convert
 
-import unxt_hypothesis as ust
+import unxts.hypothesis as ust
 
 import coordinaxs.interop.astropy  # noqa: F401
 from coordinax.distances import Distance

--- a/packages/coordinaxs.interop.astropy/tests/test_ptmap_cdict.py
+++ b/packages/coordinaxs.interop.astropy/tests/test_ptmap_cdict.py
@@ -28,7 +28,7 @@ import pytest
 from hypothesis import assume, given, settings, strategies as st
 
 import unxt as u
-import unxt_hypothesis as ust
+import unxts.hypothesis as ust
 
 import coordinax.charts as cxc
 from coordinaxs.interop.astropy import (

--- a/packages/coordinaxs.interop.astropy/tests/test_qmatrix.py
+++ b/packages/coordinaxs.interop.astropy/tests/test_qmatrix.py
@@ -5,9 +5,9 @@ import jax.numpy as jnp
 import numpy as np
 import plum
 import pytest
-import unxts.linalg as ul
 
 import unxt as u
+import unxts.linalg as ul
 
 
 class TestUnitsMatrixToStructuredUnit:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -472,7 +472,7 @@ known-first-party = [
   "optional_dependencies",
   "quaxed",
   "unxt",
-  "unxt_hypothesis",
+  "unxts",
   "xmmutablemap",
 ]
 known-local-folder = ["coordinax", "coordinaxs"]

--- a/src/coordinax/_src/charts/jacobian.py
+++ b/src/coordinax/_src/charts/jacobian.py
@@ -46,10 +46,10 @@ from typing import Any
 import jax
 import jax.numpy as jnp
 import plum
-import unxts.linalg as ul
 
 import quaxed.numpy as qnp
 import unxt as u
+import unxts.linalg as ul
 
 import coordinaxs.api.charts as cxcapi
 from .d2 import Cart2D, Polar2D

--- a/src/coordinax/_src/charts/register_carray.py
+++ b/src/coordinax/_src/charts/register_carray.py
@@ -5,10 +5,10 @@ __all__ = ()
 from typing import Final
 
 import plum
-import unxts.linalg as ul
 
 import quaxed.numpy as jnp
 import unxt as u
+import unxts.linalg as ul
 from unxt.quantity import AllowValue
 
 from coordinax._src.base import AbstractChart

--- a/src/coordinax/_src/charts/register_cdict.py
+++ b/src/coordinax/_src/charts/register_cdict.py
@@ -7,10 +7,10 @@ from jaxtyping import Array, ArrayLike
 from typing import cast
 
 import plum
-import unxts.linalg as ul
 
 import quaxed.numpy as jnp
 import unxt as u
+import unxts.linalg as ul
 
 import coordinaxs.api.charts as cxcapi
 from coordinax._src.base import AbstractChart

--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -9,10 +9,10 @@ from typing import Any, Final, cast
 
 import jax
 import plum
-import unxts.linalg as ul
 
 import quaxed.numpy as jnp
 import unxt as u
+import unxts.linalg as ul
 from unxt import AbstractQuantity as ABCQ  # noqa: N814
 
 import coordinaxs.api.charts as cxcapi

--- a/src/coordinax/_src/charts/scale_factors.py
+++ b/src/coordinax/_src/charts/scale_factors.py
@@ -4,9 +4,9 @@ __all__: tuple[str, ...] = ()
 
 
 import plum
-import unxts.linalg as ul
 
 import quaxed.numpy as jnp
+import unxts.linalg as ul
 
 from .d0 import Cart0D
 from .d1 import Cart1D

--- a/src/coordinax/_src/embedded/metric.py
+++ b/src/coordinax/_src/embedded/metric.py
@@ -7,10 +7,10 @@ import dataclasses
 from typing import final
 
 import jax
-import unxts.linalg as ul
 
 import quaxed.numpy as qnp
 import unxt as u
+import unxts.linalg as ul
 
 import coordinaxs.api.charts as cxcapi
 from .embedmap import AbstractEmbeddingMap

--- a/src/coordinax/_src/embedded/register_metric.py
+++ b/src/coordinax/_src/embedded/register_metric.py
@@ -23,10 +23,10 @@ __all__: tuple[str, ...] = ()
 import jax
 import jax.numpy as jnp
 import plum
-import unxts.linalg as ul
 
 import quaxed.numpy as qnp
 import unxt as u
+import unxts.linalg as ul
 
 import coordinaxs.api.charts as cxcapi
 from .manifold import EmbeddedManifold

--- a/src/coordinax/_src/euclidean/register_metric.py
+++ b/src/coordinax/_src/euclidean/register_metric.py
@@ -19,9 +19,9 @@ from typing import Any, cast
 
 import jax.numpy as jnp
 import plum
-import unxts.linalg as ul
 
 import unxt as u
+import unxts.linalg as ul
 
 import coordinaxs.api.charts as cxcapi
 from .manifold import EuclideanManifold

--- a/src/coordinax/_src/euclidean/scale_factors.py
+++ b/src/coordinax/_src/euclidean/scale_factors.py
@@ -5,10 +5,10 @@ __all__: tuple[str, ...] = ()
 from jaxtyping import Array
 
 import plum
-import unxts.linalg as ul
 
 import quaxed.numpy as jnp
 import unxt as u
+import unxts.linalg as ul
 from unxt.quantity import AllowValue, is_any_quantity
 
 import coordinaxs.api.charts as cxcapi

--- a/src/coordinax/_src/manifolds/_utils.py
+++ b/src/coordinax/_src/manifolds/_utils.py
@@ -4,9 +4,8 @@ __all__: tuple[str, ...] = ()
 
 from jaxtyping import Array
 
-import unxts.linalg as ul
-
 import unxt as u
+import unxts.linalg as ul
 
 DMLS = u.unit("")
 

--- a/src/coordinax/_src/manifolds/norm.py
+++ b/src/coordinax/_src/manifolds/norm.py
@@ -6,10 +6,10 @@ from jaxtyping import Array
 from typing import Any
 
 import plum
-import unxts.linalg as ul
 
 import quaxed.numpy as jnp
 import unxt as u
+import unxts.linalg as ul
 from unxt.quantity import is_any_quantity
 
 import coordinaxs.api.charts as cxcapi

--- a/src/coordinax/_src/manifolds/scale_factors.py
+++ b/src/coordinax/_src/manifolds/scale_factors.py
@@ -6,10 +6,10 @@ __all__: tuple[str, ...] = ()
 import jax
 import jax.numpy as jnp
 import plum
-import unxts.linalg as ul
 
 import quaxed.numpy as qnp
 import unxt as u
+import unxts.linalg as ul
 
 import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi

--- a/src/coordinax/_src/metric/matrix.py
+++ b/src/coordinax/_src/metric/matrix.py
@@ -18,10 +18,10 @@ from typing import Any, final
 import equinox as eqx
 import jax.numpy as jnp
 import quax
-import unxts.linalg as ul
 
 import quaxed.numpy as qnp
 import unxt as u
+import unxts.linalg as ul
 
 _det = quax.quaxify(ul.det)
 _inv = quax.quaxify(ul.inv)

--- a/src/coordinax/_src/minkowski/register_metric.py
+++ b/src/coordinax/_src/minkowski/register_metric.py
@@ -16,9 +16,9 @@ __all__: tuple[str, ...] = ()
 
 import jax.numpy as jnp
 import plum
-import unxts.linalg as ul
 
 import unxt as u
+import unxts.linalg as ul
 
 import coordinax.charts as cxc
 from .charts import MinkowskiCT

--- a/src/coordinax/_src/minkowski/scale_factors.py
+++ b/src/coordinax/_src/minkowski/scale_factors.py
@@ -4,6 +4,7 @@ __all__: tuple[str, ...] = ()
 
 import jax.numpy as jnp
 import plum
+
 import unxts.linalg as ul
 
 from .charts import MinkowskiCT

--- a/src/coordinax/_src/product/register_metric.py
+++ b/src/coordinax/_src/product/register_metric.py
@@ -17,9 +17,9 @@ from typing import Any
 
 import jax.numpy as jnp
 import plum
-import unxts.linalg as ul
 
 import unxt as u
+import unxts.linalg as ul
 
 from .chart import AbstractCartesianProductChart
 from .manifold import CartesianProductManifold

--- a/src/coordinax/_src/spherical/register_metric.py
+++ b/src/coordinax/_src/spherical/register_metric.py
@@ -18,9 +18,9 @@ from typing import cast
 import jax
 import jax.numpy as jnp
 import plum
-import unxts.linalg as ul
 
 import unxt as u
+import unxts.linalg as ul
 from unxt.quantity import AllowValue
 
 import coordinaxs.api.charts as cxcapi

--- a/src/coordinax/_src/spherical/scale_factors.py
+++ b/src/coordinax/_src/spherical/scale_factors.py
@@ -3,10 +3,10 @@
 __all__: tuple[str, ...] = ()
 
 import plum
-import unxts.linalg as ul
 
 import quaxed.numpy as jnp
 import unxt as u
+import unxts.linalg as ul
 from unxt.quantity import AllowValue
 
 from .chart import NonCanonicalTwoSphere

--- a/src/coordinax/representations/_src/basis_change.py
+++ b/src/coordinax/representations/_src/basis_change.py
@@ -8,10 +8,10 @@ from typing import Any, TypeVar
 import jax
 import jax.scipy.linalg
 import plum
-import unxts.linalg as ul
 
 import quaxed.numpy as jnp
 import unxt as u
+import unxts.linalg as ul
 from unxt.quantity import Quantity, is_any_quantity
 
 import coordinax.charts as cxc

--- a/src/coordinax/representations/_src/tangent_map.py
+++ b/src/coordinax/representations/_src/tangent_map.py
@@ -7,10 +7,10 @@ from typing import Any
 
 import jax.numpy as jnp
 import plum
-import unxts.linalg as ul
 
 import quaxed.numpy as qnp
 import unxt as u
+import unxts.linalg as ul
 
 import coordinax.charts as cxc
 import coordinaxs.api.charts as cxcapi

--- a/src/coordinax/transforms/_src/actions/register_apply.py
+++ b/src/coordinax/transforms/_src/actions/register_apply.py
@@ -6,9 +6,9 @@ from jaxtyping import Array, ArrayLike
 from typing import Any, TypeAlias, cast
 
 import plum
-import unxts.linalg as ul
 
 import unxt as u
+import unxts.linalg as ul
 from unxt import AbstractQuantity as AbcQ
 
 import coordinax.charts as cxc

--- a/src/coordinax/vectors/_src/register_unxt.py
+++ b/src/coordinax/vectors/_src/register_unxt.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast, final
 import plum
 
 import unxt as u
+import unxts.linalg as ul
 
 import coordinaxs.api.charts as cxcapi
 from .point import Point

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -10,7 +10,7 @@ __all__: tuple[str, ...] = ()
 
 from hypothesis import strategies as st
 
-import unxt_hypothesis as ust
+import unxts.hypothesis as ust
 
 
 def _m_qty(min_value: float, max_value: float):

--- a/tests/unit/charts/test_cdict.py
+++ b/tests/unit/charts/test_cdict.py
@@ -6,7 +6,7 @@ import pytest
 from hypothesis import given
 
 import unxt as u
-import unxt_hypothesis as ust
+import unxts.hypothesis as ust
 
 import coordinax.charts as cxc
 import coordinaxs.hypothesis.main as cxst

--- a/tests/unit/charts/test_checks.py
+++ b/tests/unit/charts/test_checks.py
@@ -7,7 +7,7 @@ import pytest
 from hypothesis import given, settings, strategies as st
 
 import unxt as u
-import unxt_hypothesis as ust
+import unxts.hypothesis as ust
 
 import coordinax.angles as cxa
 from coordinax._src.charts import checks

--- a/tests/unit/charts/test_guess_chart.py
+++ b/tests/unit/charts/test_guess_chart.py
@@ -20,7 +20,7 @@ import numpy as np
 import pytest
 from hypothesis import given, strategies as st
 
-import unxt_hypothesis as ust
+import unxts.hypothesis as ust
 
 import coordinax.charts as cxc
 import coordinaxs.hypothesis.main as cxst

--- a/tests/unit/charts/test_jacobian_pt_map.py
+++ b/tests/unit/charts/test_jacobian_pt_map.py
@@ -9,7 +9,6 @@ import jaxtyping
 import jax
 import jax.numpy as jnp
 import pytest
-import unxts.linalg as ul
 from hypothesis import given, settings
 from numpy.testing import assert_allclose
 from strategies import (
@@ -21,6 +20,7 @@ from strategies import (
 
 import quaxed.numpy as qnp
 import unxt as u
+import unxts.linalg as ul
 
 import coordinax.charts as cxc
 

--- a/tests/unit/manifolds/test_metrics.py
+++ b/tests/unit/manifolds/test_metrics.py
@@ -6,9 +6,9 @@ All tests in this file are RED until the metrics module is implemented.
 import jax
 import jax.numpy as jnp
 import pytest
-import unxts.linalg as ul
 
 import unxt as u
+import unxts.linalg as ul
 
 import coordinax.charts as cxc
 import coordinax.manifolds as cxm

--- a/tests/unit/manifolds/test_norm.py
+++ b/tests/unit/manifolds/test_norm.py
@@ -9,6 +9,7 @@ import pytest
 
 import quaxed.numpy as qnp
 import unxt as u
+import unxts.linalg as ul
 
 import coordinax.charts as cxc
 import coordinax.manifolds as cxm

--- a/tests/unit/manifolds/test_norm.py
+++ b/tests/unit/manifolds/test_norm.py
@@ -9,7 +9,6 @@ import pytest
 
 import quaxed.numpy as qnp
 import unxt as u
-import unxts.linalg as ul
 
 import coordinax.charts as cxc
 import coordinax.manifolds as cxm

--- a/tests/unit/manifolds/test_scale_factors_dispatch.py
+++ b/tests/unit/manifolds/test_scale_factors_dispatch.py
@@ -2,9 +2,9 @@
 
 import jax
 import jax.numpy as jnp
-import unxts.linalg as ul
 
 import unxt as u
+import unxts.linalg as ul
 
 import coordinax.charts as cxc
 import coordinax.manifolds as cxm

--- a/tests/unit/representations/test_change_basis.py
+++ b/tests/unit/representations/test_change_basis.py
@@ -6,9 +6,9 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-import unxts.linalg as ul
 
 import unxt as u
+import unxts.linalg as ul
 
 import coordinax as cx
 import coordinax.charts as cxc

--- a/tests/unit/transforms/conftest.py
+++ b/tests/unit/transforms/conftest.py
@@ -4,9 +4,9 @@ __all__: tuple[str, ...] = ()
 
 import jax.numpy as jnp
 import pytest
-import unxts.linalg as ul
 
 import unxt as u
+import unxts.linalg as ul
 
 import coordinax as cx
 import coordinax.frames as cxf

--- a/tests/unit/transforms/test_act.py
+++ b/tests/unit/transforms/test_act.py
@@ -21,10 +21,10 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-import unxts.linalg as ul
 from plum import NotFoundLookupError
 
 import unxt as u
+import unxts.linalg as ul
 
 import coordinax as cx
 import coordinax.charts as cxc

--- a/tests/unit/transforms/test_active_semantics.py
+++ b/tests/unit/transforms/test_active_semantics.py
@@ -7,7 +7,7 @@ from hypothesis import given, settings, strategies as st
 
 import quaxed.numpy as jnp
 import unxt as u
-import unxt_hypothesis as ust
+import unxts.hypothesis as ust
 
 import coordinax.charts as cxc
 import coordinax.frames as cxf

--- a/tests/usage/charts/test_jacobian.py
+++ b/tests/usage/charts/test_jacobian.py
@@ -19,7 +19,6 @@ __all__: tuple[str, ...] = ()
 import jax
 import jax.numpy as jnp
 import numpy as np
-import unxts.linalg as ul
 from hypothesis import given, settings
 from strategies import (
     any_angle_rad as _any_angle_rad,
@@ -30,6 +29,7 @@ from strategies import (
 
 import quaxed.numpy as qnp
 import unxt as u
+import unxts.linalg as ul
 
 import coordinax.charts as cxc
 

--- a/tests/usage/frames/test_act_usage.py
+++ b/tests/usage/frames/test_act_usage.py
@@ -21,9 +21,9 @@ __all__: tuple[str, ...] = ()
 import jax.numpy as jnp
 import numpy as np
 import pytest
-import unxts.linalg as ul
 
 import unxt as u
+import unxts.linalg as ul
 
 import coordinax as cx
 import coordinax.charts as cxc

--- a/uv.lock
+++ b/uv.lock
@@ -760,7 +760,7 @@ astropy = [
 hypothesis = [
     { name = "coordinaxs-hypothesis" },
     { name = "hypothesis" },
-    { name = "unxt-hypothesis" },
+    { name = "unxts-hypothesis" },
 ]
 
 [package.metadata]
@@ -769,7 +769,7 @@ requires-dist = [
     { name = "coordinax", editable = "." },
     { name = "coordinaxs-hypothesis", marker = "extra == 'hypothesis'", editable = "packages/coordinaxs.hypothesis" },
     { name = "hypothesis", marker = "extra == 'hypothesis'", specifier = ">=6.148.7" },
-    { name = "unxt-hypothesis", marker = "extra == 'hypothesis'", specifier = ">=2.0" },
+    { name = "unxts-hypothesis", marker = "extra == 'hypothesis'", specifier = ">=2.0" },
 ]
 provides-extras = ["astropy", "hypothesis"]
 
@@ -789,14 +789,14 @@ source = { editable = "packages/coordinaxs.hypothesis" }
 dependencies = [
     { name = "coordinax" },
     { name = "hypothesis" },
-    { name = "unxt-hypothesis" },
+    { name = "unxts-hypothesis" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "coordinax", editable = "." },
     { name = "hypothesis", specifier = ">=6.0" },
-    { name = "unxt-hypothesis", specifier = ">=2.0" },
+    { name = "unxts-hypothesis", specifier = ">=2.0" },
 ]
 
 [[package]]
@@ -816,7 +816,7 @@ dependencies = [
 test = [
     { name = "hypothesis" },
     { name = "pytest" },
-    { name = "unxt-hypothesis" },
+    { name = "unxts-hypothesis" },
 ]
 
 [package.metadata]
@@ -835,7 +835,7 @@ requires-dist = [
 test = [
     { name = "hypothesis", specifier = ">=6.148.7" },
     { name = "pytest", specifier = ">=9.0.2" },
-    { name = "unxt-hypothesis", specifier = ">=2.0" },
+    { name = "unxts-hypothesis", specifier = ">=2.0" },
 ]
 
 [[package]]
@@ -3323,18 +3323,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/05/4fdcf04277ca3237d19388ee0c4902f5c52061f713316a9a7d0808b30ebe/unxt_api-2.0.0.tar.gz", hash = "sha256:164ae14673bde98c7358fba12e3e94080a26c979c72e2e8ad1298fd1531026fb", size = 5462, upload-time = "2026-07-24T18:00:06.468Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/ac/b1faf16701501fde6241ab5df42f12a339d069b9d84b607f607d897fd1a9/unxt_api-2.0.0-py3-none-any.whl", hash = "sha256:10e19f7c31b29a8be6e54f266b0dd0bd8c861482ac1f46d0fecaddf5a29be160", size = 2946, upload-time = "2026-07-24T18:00:05.367Z" },
-]
-
-[[package]]
-name = "unxt-hypothesis"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "unxts-hypothesis" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/eb/ec964d9bcc23bde4578e33bc3aa8da19b2387ee56956c7d4f60134599e7b/unxt_hypothesis-2.0.0.tar.gz", hash = "sha256:b8bec434f2422d36ccc4d2cacb498cf8efd1f549933203af3d9516b3815ec59a", size = 4533, upload-time = "2026-07-24T18:00:04.425Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/f9/08b400a5c580d4803d87b2aae539b68e277547ecd7ed8e1717d38af6cdfd/unxt_hypothesis-2.0.0-py3-none-any.whl", hash = "sha256:fc640da7747cbe0f50154e681fe29ffe48d2e06076ff4a426c9d0a4440133846", size = 3770, upload-time = "2026-07-24T18:00:03.268Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`unxt_hypothesis` is a compatibility shim. Its own module docstring says so:

> Backward-compatible shim for unxt_hypothesis.
> The canonical package is now `unxts.hypothesis` (install: `pip install unxts.hypothesis`).

It re-exports the canonical package's nine public names and nothing else, so depending on it buys an extra distribution in the resolution graph and one more hop on every import.

```
uv lock  ->  Removed unxt-hypothesis v2.0.0
```

## What changed

- Every `import unxt_hypothesis as ust` becomes `import unxts.hypothesis as ust` — **including in `coordinaxs.hypothesis` and `coordinaxs.astro`'s own sources**, not just tests. The shim was on the runtime path, not merely the test path.
- The three `pyproject.toml` dependency declarations are renamed.
- Prose and `{func}` cross-references in `docs/index.md` and `docs/testing-guide.md` now name the canonical package.

## Why some untouched files are in the diff

The ruff isort `known-first-party` entry moves from `unxt_hypothesis` to `unxts` — the top-level package the new imports belong to. That also reclassifies the pre-existing `unxts.linalg` imports as first-party, so a number of modules get their import blocks reordered. That reordering is the entire diff in those files.

## Verification

1967 tests pass across the main suite and all five sub-packages. The two remaining ruff findings are pre-existing on `main`, in `packages/coordinaxs.curveframes/docs/visualizing.ipynb`.

This closes the follow-up promised in #620 and #623, which deliberately deferred the dependency rename so several in-flight test PRs wouldn't each churn `uv.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)