### PR TITLE
✅ test(manifolds): share the metric-matrix contract between both representations

### DIFF
--- a/tests/unit/manifolds/test_metric_matrix_dispatch.py
+++ b/tests/unit/manifolds/test_metric_matrix_dispatch.py
@@ -255,62 +255,52 @@ class TestDiagonalMetricOffDiagonal:
 
 
 class TestMetricMatrixJIT:
-    """metric_matrix must be JIT-compilable for all dispatch paths."""
+    """`metric_matrix` must be JIT-compilable on every dispatch path.
 
-    def test_jit_euclidean_cart3d(self):
+    One table: each row is a manifold, its chart, a point in that chart, and
+    the metric diagonal expected there. The six cases previously wrote out
+    their own `@jax.jit` closure differing only in the component names.
+    """
+
+    @pytest.mark.parametrize(
+        ("manifold", "chart", "point", "expected"),
+        [
+            pytest.param(cxm.R1, cxc.cart1d, {"x": 0}, jnp.ones(1), id="cart1d"),
+            pytest.param(
+                cxm.R2, cxc.cart2d, {"x": 0, "y": 0}, jnp.ones(2), id="cart2d"
+            ),
+            pytest.param(
+                cxm.R3, cxc.cart3d, {"x": 1, "y": 2, "z": 3}, jnp.ones(3), id="cart3d"
+            ),
+            pytest.param(
+                cxm.R3, cxc.cartnd, {"q": [1, 2, 3]}, jnp.ones(3), id="cartnd"
+            ),
+            pytest.param(
+                cxm.MinkowskiManifold(),
+                cxc.minkowskict,
+                {"ct": 0, "x": 0, "y": 0, "z": 0},
+                jnp.array([-1, 1, 1, 1]),
+                id="minkowski",
+            ),
+            pytest.param(
+                cxm.S2,
+                cxc.sph2,
+                {"theta": jnp.pi / 2, "phi": 0},
+                jnp.array([1, 1]),
+                id="hyperspherical",
+            ),
+        ],
+    )
+    def test_jit(self, manifold, chart, point, expected) -> None:
+        keys = tuple(point)
+
         @jax.jit
-        def compute(x, y, z):
-            pt = {"x": x, "y": y, "z": z}
-            return cxmapi.metric_matrix(cxm.R3, pt, cxc.cart3d).diagonal
+        def compute(*values):
+            pt = dict(zip(keys, values, strict=True))
+            return cxmapi.metric_matrix(manifold, pt, chart).diagonal
 
-        result = compute(jnp.array(1), jnp.array(2), jnp.array(3))
-        assert jnp.allclose(result, jnp.ones(3))
-
-    def test_jit_euclidean_cartnd(self):
-        @jax.jit
-        def compute(q):
-            return cxmapi.metric_matrix(cxm.R3, {"q": q}, cxc.cartnd).diagonal
-
-        result = compute(jnp.array([1, 2, 3]))
-        assert jnp.allclose(result, jnp.ones(3))
-
-    def test_jit_minkowski(self):
-        M = cxm.MinkowskiManifold()
-        chart = cxc.minkowskict
-
-        @jax.jit
-        def compute(ct, x, y, z):
-            pt = {"ct": ct, "x": x, "y": y, "z": z}
-            return cxmapi.metric_matrix(M, pt, chart).diagonal
-
-        result = compute(jnp.array(0), jnp.array(0), jnp.array(0), jnp.array(0))
-        assert jnp.allclose(result, jnp.array([-1, 1, 1, 1]))
-
-    def test_jit_hyperspherical(self):
-        @jax.jit
-        def compute(theta, phi):
-            return cxmapi.metric_matrix(
-                cxm.S2, {"theta": theta, "phi": phi}, cxc.sph2
-            ).diagonal
-
-        result = compute(jnp.array(jnp.pi / 2), jnp.array(0))
-        assert jnp.allclose(result, jnp.array([1, 1]), atol=1e-6)
-
-    def test_jit_cart1d(self):
-        @jax.jit
-        def compute(x):
-            return cxmapi.metric_matrix(cxm.R1, {"x": x}, cxc.cart1d).diagonal
-
-        result = compute(jnp.array(0))
-        assert jnp.allclose(result, jnp.ones(1))
-
-    def test_jit_cart2d(self):
-        @jax.jit
-        def compute(x, y):
-            return cxmapi.metric_matrix(cxm.R2, {"x": x, "y": y}, cxc.cart2d).diagonal
-
-        result = compute(jnp.array(0), jnp.array(0))
-        assert jnp.allclose(result, jnp.ones(2))
+        result = compute(*(jnp.asarray(v) for v in point.values()))
+        assert jnp.allclose(result, expected, atol=1e-6)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/manifolds/test_metric_matrix_types.py
+++ b/tests/unit/manifolds/test_metric_matrix_types.py
@@ -1,13 +1,16 @@
-"""Contract tests for DiagonalMetric and DenseMetric.
+"""Contract tests for `DiagonalMetric` and `DenseMetric`.
 
-Tests cover:
-- pytree flatten/unflatten round-trip (equinox Module)
-- ``to_dense``
-- ``__matmul__``
-- ``inverse``
-- ``determinant``
-- JIT and vmap compatibility
+Both are metric-matrix representations with the same public surface -- `ndim`,
+`to_dense`, `__matmul__`, `inverse`, `determinant`, and pytree/jit/vmap
+behaviour. That surface is asserted once in `TestMetricContract`, against
+`to_dense()` as the common reference, and parametrized over both types.
+
+What is left per-class is what only that representation can say: that
+`DiagonalMetric.to_dense()` is zero off the diagonal and inverts element-wise,
+and that `DenseMetric.to_dense()` is the object itself.
 """
+
+__all__: tuple[str, ...] = ()
 
 import jax
 import jax.numpy as jnp
@@ -17,7 +20,6 @@ from coordinax._src.metric.matrix import DenseMetric, DiagonalMetric
 
 # ---------------------------------------------------------------------------
 # Fixtures
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture(
@@ -36,40 +38,113 @@ def dense_metric(request):
     return DenseMetric(request.param)
 
 
+@pytest.fixture(
+    params=[
+        DiagonalMetric(jnp.array([1, 4, 9])),
+        DiagonalMetric(jnp.array([1])),
+        DiagonalMetric(jnp.array([2, 3])),
+        DenseMetric(jnp.eye(3)),
+        DenseMetric(jnp.array([[4.0, 0.0], [0.0, 9.0]])),
+        DenseMetric(jnp.eye(1)),
+    ],
+    ids=["diag-3d", "diag-1d", "diag-2d", "dense-I3", "dense-diag2", "dense-I1"],
+)
+def metric(request):
+    """Every metric representation, across every shape either is built with."""
+    return request.param
+
+
 # ---------------------------------------------------------------------------
-# DiagonalMetric
+# The shared surface
+
+
+class TestMetricContract:
+    """What both representations must do, checked against `to_dense()`."""
+
+    def test_ndim_matches_dense_shape(self, metric) -> None:
+        """The trailing two axes are (ndim, ndim); leading axes are batch.
+
+        Only the trailing axes are constrained: `DiagonalMetric` supports a
+        batched `(..., n)` diagonal, whose `to_dense()` is `(..., n, n)` --
+        see `test_to_dense_batched_builds_diagonal`.
+        """
+        matrix = jnp.asarray(metric.to_dense().matrix)
+        assert matrix.shape[-2:] == (metric.ndim, metric.ndim)
+
+    def test_pytree_roundtrip(self, metric) -> None:
+        """Flatten/unflatten recovers an equal object."""
+        leaves, treedef = jax.tree_util.tree_flatten(metric)
+        restored = jax.tree_util.tree_unflatten(treedef, leaves)
+        assert jnp.allclose(restored.to_dense().matrix, metric.to_dense().matrix)
+
+    def test_is_a_dynamic_pytree(self, metric) -> None:
+        """The matrix data is a JAX leaf, not the metric object itself.
+
+        `len(leaves) > 0` alone would not show this: an unregistered object
+        flattens to `[itself]`, one leaf, and would pass. So assert the leaf
+        is an array and the metric is not its own leaf.
+        """
+        leaves, _ = jax.tree_util.tree_flatten(metric)
+        assert leaves, "metric flattened to no leaves at all"
+        assert metric not in leaves, "metric is an opaque leaf, not a pytree"
+        assert all(isinstance(leaf, jnp.ndarray) for leaf in leaves)
+
+    def test_matmul_agrees_with_dense(self, metric) -> None:
+        v = jnp.arange(1, metric.ndim + 1, dtype=float)
+        assert jnp.allclose(metric @ v, metric.to_dense().matrix @ v)
+
+    def test_inverse_roundtrip_is_identity(self, metric) -> None:
+        """G @ g^-1 == I."""
+        product = metric.to_dense().matrix @ metric.inverse.to_dense().matrix
+        assert jnp.allclose(product, jnp.eye(metric.ndim), atol=1e-5)
+
+    def test_determinant_agrees_with_dense(self, metric) -> None:
+        expected = jnp.linalg.det(metric.to_dense().matrix)
+        assert jnp.allclose(metric.determinant, expected, atol=1e-5)
+
+    def test_jit_matmul_agrees_with_eager(self, metric) -> None:
+        v = jnp.ones(metric.ndim)
+
+        @jax.jit
+        def apply(g, v):
+            return g @ v
+
+        assert jnp.allclose(apply(metric, v), metric @ v)
+
+    def test_jit_determinant_agrees_with_eager(self, metric) -> None:
+        @jax.jit
+        def det(g):
+            return g.determinant
+
+        assert jnp.allclose(det(metric), metric.determinant)
+
+    def test_vmap_matmul(self, metric) -> None:
+        """Vmap over a batch of vectors."""
+        batch = jnp.ones((4, metric.ndim))
+        result = jax.vmap(lambda v: metric @ v)(batch)
+        assert result.shape == (4, metric.ndim)
+        assert jnp.allclose(result[0], metric @ jnp.ones(metric.ndim))
+
+
 # ---------------------------------------------------------------------------
+# Representation-specific
 
 
 class TestDiagonalMetric:
-    """Contract tests for DiagonalMetric."""
+    """What only the diagonal representation can assert."""
 
-    def test_ndim(self, diag_metric):
+    def test_ndim_is_the_diagonal_length(self, diag_metric) -> None:
         assert diag_metric.ndim == diag_metric.diagonal.shape[-1]
 
-    def test_pytree_roundtrip(self, diag_metric):
-        """flatten/unflatten must recover an equal object."""
-        leaves, treedef = jax.tree_util.tree_flatten(diag_metric)
-        restored = jax.tree_util.tree_unflatten(treedef, leaves)
-        assert jnp.allclose(restored.diagonal, diag_metric.diagonal)
-
-    def test_to_dense_shape(self, diag_metric):
-        n = diag_metric.ndim
+    def test_to_dense_puts_the_diagonal_on_the_diagonal(self, diag_metric) -> None:
         dense = diag_metric.to_dense()
         assert isinstance(dense, DenseMetric)
-        assert dense.matrix.shape == (n, n)
-
-    def test_to_dense_diagonal_entries(self, diag_metric):
-        """Diagonal entries of to_dense() match the stored diagonal."""
-        dense = diag_metric.to_dense()
         assert jnp.allclose(jnp.diag(dense.matrix), diag_metric.diagonal)
 
-    def test_to_dense_off_diagonal_zero(self, diag_metric):
-        """Off-diagonal entries of to_dense() are zero."""
-        n = diag_metric.ndim
+    def test_to_dense_is_zero_off_the_diagonal(self, diag_metric) -> None:
         dense = diag_metric.to_dense()
-        off_diag_mask = ~jnp.eye(n, dtype=bool)
-        assert jnp.allclose(dense.matrix[off_diag_mask], 0)
+        off_diagonal = ~jnp.eye(diag_metric.ndim, dtype=bool)
+        assert jnp.allclose(dense.matrix[off_diagonal], 0)
 
     def test_to_dense_batched_builds_diagonal(self) -> None:
         """to_dense embeds a batched (B, n) diagonal into (B, n, n) matrices."""
@@ -81,169 +156,95 @@ class TestDiagonalMetric:
         assert jnp.allclose(jnp.diagonal(m, axis1=-2, axis2=-1), diag)
         assert jnp.allclose(m[0][~jnp.eye(3, dtype=bool)], 0)
 
-    def test_matmul(self, diag_metric):
-        n = diag_metric.ndim
-        v = jnp.ones(n)
-        result = diag_metric @ v
+    def test_matmul_scales_componentwise(self, diag_metric) -> None:
+        """G @ 1 is the diagonal itself."""
+        result = diag_metric @ jnp.ones(diag_metric.ndim)
         assert jnp.allclose(result, diag_metric.diagonal)
 
-    def test_matmul_matches_dense(self, diag_metric):
-        n = diag_metric.ndim
-        v = jnp.arange(1, n + 1)
-        assert jnp.allclose(diag_metric @ v, diag_metric.to_dense() @ v)
-
-    def test_inverse_shape(self, diag_metric):
+    def test_inverse_stays_diagonal(self, diag_metric) -> None:
         inv = diag_metric.inverse
         assert isinstance(inv, DiagonalMetric)
         assert inv.diagonal.shape == diag_metric.diagonal.shape
 
-    def test_inverse_values(self, diag_metric):
+    def test_inverse_is_reciprocal_elementwise(self, diag_metric) -> None:
         assert jnp.allclose(diag_metric.inverse.diagonal, 1 / diag_metric.diagonal)
 
-    def test_inverse_roundtrip(self, diag_metric):
-        """G * g⁻¹ ≈ I element-wise."""
-        product = diag_metric.diagonal * diag_metric.inverse.diagonal
-        assert jnp.allclose(product, jnp.ones(diag_metric.ndim))
-
-    def test_determinant(self, diag_metric):
+    def test_determinant_is_the_product(self, diag_metric) -> None:
         assert jnp.allclose(diag_metric.determinant, jnp.prod(diag_metric.diagonal))
-
-    def test_jit_matmul(self, diag_metric):
-        n = diag_metric.ndim
-        v = jnp.ones(n)
-
-        @jax.jit
-        def apply(d, v):
-            return d @ v
-
-        result = apply(diag_metric, v)
-        assert jnp.allclose(result, diag_metric.diagonal)
-
-    def test_jit_determinant(self, diag_metric):
-        @jax.jit
-        def det(d):
-            return d.determinant
-
-        assert jnp.allclose(det(diag_metric), diag_metric.determinant)
-
-    def test_vmap_matmul(self, diag_metric):
-        """Vmap over batch of vectors."""
-        n = diag_metric.ndim
-        batch = jnp.ones((4, n))
-
-        result = jax.vmap(lambda v: diag_metric @ v)(batch)
-        assert result.shape == (4, n)
-        assert jnp.allclose(result[0], diag_metric.diagonal)
-
-    def test_is_not_static(self):
-        """DiagonalMetric is a dynamic pytree, not a static leaf."""
-        d = DiagonalMetric(jnp.array([1, 2]))
-        leaves, _ = jax.tree_util.tree_flatten(d)
-        assert len(leaves) > 0, "diagonal should be a dynamic JAX leaf"
-
-
-# ---------------------------------------------------------------------------
-# DenseMetric
-# ---------------------------------------------------------------------------
 
 
 class TestDenseMetric:
-    """Contract tests for DenseMetric."""
+    """What only the dense representation can assert."""
 
-    def test_ndim(self, dense_metric):
+    def test_ndim_is_the_matrix_width(self, dense_metric) -> None:
         assert dense_metric.ndim == dense_metric.matrix.shape[-1]
 
-    def test_pytree_roundtrip(self, dense_metric):
-        leaves, treedef = jax.tree_util.tree_flatten(dense_metric)
-        restored = jax.tree_util.tree_unflatten(treedef, leaves)
-        assert jnp.allclose(restored.matrix, dense_metric.matrix)
-
-    def test_to_dense_is_self(self, dense_metric):
+    def test_to_dense_is_self(self, dense_metric) -> None:
+        """No copy: the dense representation is already dense."""
         assert dense_metric.to_dense() is dense_metric
 
-    def test_matmul_identity(self):
-        n = 3
-        g = DenseMetric(jnp.eye(n))
-        v = jnp.arange(1, n + 1)
-        assert jnp.allclose(g @ v, v)
 
-    def test_matmul_diagonal(self):
-        g = DenseMetric(jnp.array([[4, 0], [0, 9]]))
-        v = jnp.array([1, 1])
-        assert jnp.allclose(g @ v, jnp.array([4, 9]))
+class TestDenseMetricKnownValues:
+    """Closed-form anchors, so the contract is not only self-referential."""
 
-    def test_inverse_identity(self):
-        g = DenseMetric(jnp.eye(3))
-        assert jnp.allclose(g.inverse.matrix, jnp.eye(3))
+    @pytest.mark.parametrize(
+        ("matrix", "vector", "expected"),
+        [
+            pytest.param(jnp.eye(3), jnp.arange(1, 4), jnp.arange(1, 4), id="identity"),
+            pytest.param(
+                jnp.array([[4, 0], [0, 9]]),
+                jnp.array([1, 1]),
+                jnp.array([4, 9]),
+                id="diagonal",
+            ),
+        ],
+    )
+    def test_matmul(self, matrix, vector, expected) -> None:
+        assert jnp.allclose(DenseMetric(matrix) @ vector, expected)
 
-    def test_inverse_diagonal(self):
-        g = DenseMetric(jnp.array([[4, 0], [0, 9]]))
-        expected = jnp.array([[0.25, 0], [0, 1 / 9]])
-        assert jnp.allclose(g.inverse.matrix, expected)
+    @pytest.mark.parametrize(
+        ("matrix", "expected"),
+        [
+            pytest.param(jnp.eye(3), jnp.eye(3), id="identity"),
+            pytest.param(
+                jnp.array([[4, 0], [0, 9]]),
+                jnp.array([[0.25, 0], [0, 1 / 9]]),
+                id="diagonal",
+            ),
+        ],
+    )
+    def test_inverse(self, matrix, expected) -> None:
+        assert jnp.allclose(DenseMetric(matrix).inverse.matrix, expected)
 
-    def test_inverse_roundtrip(self, dense_metric):
-        n = dense_metric.ndim
-        product = dense_metric.matrix @ dense_metric.inverse.matrix
-        assert jnp.allclose(product, jnp.eye(n), atol=1e-5)
-
-    def test_determinant_identity(self):
-        assert jnp.allclose(DenseMetric(jnp.eye(3)).determinant, 1)
-
-    def test_determinant_diagonal(self):
-        g = DenseMetric(jnp.array([[2, 0], [0, 3]]))
-        assert jnp.allclose(g.determinant, 6)
-
-    def test_jit_matmul(self, dense_metric):
-        n = dense_metric.ndim
-        v = jnp.ones(n)
-
-        @jax.jit
-        def apply(g, v):
-            return g @ v
-
-        result = apply(dense_metric, v)
-        assert result.shape == (n,)
-
-    def test_jit_determinant(self, dense_metric):
-        @jax.jit
-        def det(g):
-            return g.determinant
-
-        assert jnp.isfinite(det(dense_metric))
-
-    def test_vmap_matmul(self, dense_metric):
-        n = dense_metric.ndim
-        batch = jnp.ones((4, n))
-
-        result = jax.vmap(lambda v: dense_metric @ v)(batch)
-        assert result.shape == (4, n)
-
-    def test_is_not_static(self):
-        g = DenseMetric(jnp.eye(2))
-        leaves, _ = jax.tree_util.tree_flatten(g)
-        assert len(leaves) > 0
+    @pytest.mark.parametrize(
+        ("matrix", "expected"),
+        [
+            pytest.param(jnp.eye(3), 1, id="identity"),
+            pytest.param(jnp.array([[2, 0], [0, 3]]), 6, id="diagonal"),
+        ],
+    )
+    def test_determinant(self, matrix, expected) -> None:
+        assert jnp.allclose(DenseMetric(matrix).determinant, expected)
 
 
 # ---------------------------------------------------------------------------
-# DiagonalMetric ↔ DenseMetric consistency
-# ---------------------------------------------------------------------------
+# Cross-representation
 
 
 class TestDiagonalDenseConsistency:
-    """DiagonalMetric.to_dense() must agree with DenseMetric on operations."""
+    """`DiagonalMetric.to_dense()` agrees with `DenseMetric` on operations."""
 
-    def test_matmul_consistency(self):
+    def test_matmul_consistency(self) -> None:
         diag = DiagonalMetric(jnp.array([2, 3, 4]))
-        dense = diag.to_dense()
         v = jnp.array([1, 2, 3])
-        assert jnp.allclose(diag @ v, dense @ v)
+        assert jnp.allclose(diag @ v, diag.to_dense() @ v)
 
-    def test_determinant_consistency(self):
+    def test_determinant_consistency(self) -> None:
         diag = DiagonalMetric(jnp.array([2, 3]))
-        dense = diag.to_dense()
-        assert jnp.allclose(diag.determinant, dense.determinant)
+        assert jnp.allclose(diag.determinant, diag.to_dense().determinant)
 
-    def test_inverse_consistency(self):
+    def test_inverse_consistency(self) -> None:
+        """Inverting then densifying equals densifying then inverting."""
         diag = DiagonalMetric(jnp.array([2, 5]))
         assert jnp.allclose(
             jnp.diag(diag.inverse.to_dense().matrix),

--- a/tests/unit/manifolds/test_metric_matrix_types.py
+++ b/tests/unit/manifolds/test_metric_matrix_types.py
@@ -86,8 +86,12 @@ class TestMetricContract:
         """
         leaves, _ = jax.tree_util.tree_flatten(metric)
         assert leaves, "metric flattened to no leaves at all"
-        assert metric not in leaves, "metric is an opaque leaf, not a pytree"
-        assert all(isinstance(leaf, jnp.ndarray) for leaf in leaves)
+        # `is`, not `in`: containment would compare with `==`, which on a JAX
+        # leaf can return an array rather than a bool.
+        assert not any(leaf is metric for leaf in leaves), (
+            "metric is an opaque leaf, not a registered pytree"
+        )
+        assert all(isinstance(leaf, jax.Array) for leaf in leaves)
 
     def test_matmul_agrees_with_dense(self, metric) -> None:
         v = jnp.arange(1, metric.ndim + 1, dtype=float)


### PR DESCRIPTION
`DiagonalMetric` and `DenseMetric` are two representations of the same thing, and `test_metric_matrix_types.py` tested them as if they were unrelated: the same fourteen checks — ndim, pytree round-trip, matmul, inverse, determinant, jit ×2, vmap, dynamic-pytree — written once per class, each with its own literals.

```
211 lines removed, 188 added  (-23)
404 passed  ->  420 passed
```

## The contract compares against `to_dense()`

That choice does more than deduplicate. It makes the assertions say what they mean:

```python
def test_determinant_agrees_with_dense(self, metric):
    expected = jnp.linalg.det(metric.to_dense().matrix)
    assert jnp.allclose(metric.determinant, expected, atol=1e-5)
```

rather than restating each representation's own formula back at it (`determinant == jnp.prod(diagonal)` only re-derives the implementation).

It's parametrized over both types across all six shapes the two fixtures covered between them.

## What stays per-class

Only what that representation can claim: `DiagonalMetric.to_dense()` is zero off the diagonal and inverts element-wise; `DenseMetric.to_dense()` returns the object itself.

The closed-form Dense anchors (identity, `diag(4,9)`, `diag(2,3)`) stay as three small parametrized tables. Without them the contract would only ever compare a representation against itself, which is a weaker thing than it looks.

## Coverage

The +16 is real. The contract runs 9 assertions across 6 representations where the old classes ran 14 across 3 each, so several combinations are newly covered — notably **`DenseMetric.determinant` was previously only asserted to be *finite* under jit**, never checked against a value.

Also in this PR: `TestMetricMatrixJIT` in `test_metric_matrix_dispatch.py` was six `@jax.jit` closures differing only in which component names they unpacked. Now one table of (manifold, chart, point, expected diagonal).

> Touches the same area as #613 / #616 / #621 / #624 / #627 — happy to rebase this after those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)