### PR TITLE
🐛 fix(manifolds): respect the chart in pullback-metric scale factors

### DIFF
--- a/src/coordinax/_src/manifolds/scale_factors.py
+++ b/src/coordinax/_src/manifolds/scale_factors.py
@@ -3,9 +3,6 @@
 __all__: tuple[str, ...] = ()
 
 
-from typing import TYPE_CHECKING, cast
-
-import jax.numpy as jnp
 import plum
 
 import unxt as u
@@ -18,9 +15,6 @@ from coordinax._src.custom_types import CDict, OptUSys
 from coordinax._src.embedded.manifold import EmbeddedManifold
 from coordinax._src.embedded.metric import PullbackMetric
 from coordinax._src.metric.matrix import DiagonalMetric
-
-if TYPE_CHECKING:
-    from coordinax._src.metric.matrix import DenseMetric
 
 DMLS = u.unit("")
 
@@ -128,11 +122,5 @@ def scale_factors(
         ambient=embed_map.ambient.M,
         embed_map=embed_map,
     )
-    dense = cast("DenseMetric", cxmapi.metric_matrix(M, at, chart))
-    # `.matrix` is typed `QuantityMatrix | Array`; the embedded rule always
-    # builds the united form, which is what carries the per-entry units.
-    g = cast("ul.QM", dense.matrix)
-    return ul.QM(
-        jnp.diagonal(g.value, axis1=-2, axis2=-1),
-        unit=ul.UnitsMatrix(tuple(g.unit[i, i] for i in range(len(chart.components)))),
-    )
+    mm = cxmapi.metric_matrix(M, at, chart)
+    return as_quantity_matrix(mm.matrix).diag()  # ty: ignore[unresolved-attribute]

--- a/src/coordinax/_src/manifolds/scale_factors.py
+++ b/src/coordinax/_src/manifolds/scale_factors.py
@@ -3,22 +3,24 @@
 __all__: tuple[str, ...] = ()
 
 
-import jax
+from typing import TYPE_CHECKING, cast
+
 import jax.numpy as jnp
 import plum
 
-import quaxed.numpy as qnp
 import unxt as u
 import unxts.linalg as ul
 
-import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
 from ._utils import as_quantity_matrix
 from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.custom_types import CDict, OptUSys
+from coordinax._src.embedded.manifold import EmbeddedManifold
 from coordinax._src.embedded.metric import PullbackMetric
-from coordinax._src.euclidean.scale_factors import _column_squared_norms
 from coordinax._src.metric.matrix import DiagonalMetric
+
+if TYPE_CHECKING:
+    from coordinax._src.metric.matrix import DenseMetric
 
 DMLS = u.unit("")
 
@@ -87,12 +89,17 @@ def scale_factors(
     at: CDict,
     usys: OptUSys = None,
 ) -> ul.QM:
-    """Return scale factors for a pullback (induced) metric via Jacobian pullback.
+    """Return scale factors for a pullback (induced) metric.
 
-    Computes the Jacobian of the composed embedding ``intrinsic →
-    Cartesian ambient`` to obtain a unit-consistent Jacobian where every
-    entry has the same unit (``ambient_cart_unit / intrinsic_unit``).
-    The squared column norms then give the scale factors with correct units.
+    The scale factors of an induced metric are the diagonal of that metric, so
+    this delegates to the ``EmbeddedManifold`` ``metric_matrix`` rule rather
+    than re-deriving the Jacobian. That keeps one implementation of the
+    pullback, and inherits its handling of a non-intrinsic ``chart``, of a
+    non-Euclidean ambient metric (the ambient Gram carries the signature), and
+    of batched points.
+
+    Points are interpreted in the passed *chart*, which need not be the
+    embedding's own intrinsic chart.
 
     >>> import jax.numpy as jnp
     >>> import unxt as u
@@ -107,44 +114,25 @@ def scale_factors(
     >>> cxm.scale_factors(M.metric, cxc.sph2, at=at)
     QM([4., 4.], '(m2 / rad2, m2 / rad2)')
 
+    A chart other than the embedding's intrinsic one:
+
+    >>> at = {"lon": u.Angle(0.0, "rad"), "lat": u.Angle(0.0, "rad")}
+    >>> cxm.scale_factors(M.metric, cxc.lonlat_sph2, at=at)
+    QM([4., 4.], '(m2 / rad2, m2 / rad2)')
+
     """
+    del usys
     embed_map = metric.embed_map
-    ambient_chart = embed_map.ambient
-    intrinsic_keys = embed_map.intrinsic.components
-
-    # Use Cartesian ambient chart for a unit-consistent Jacobian.
-    # Every column of J_cart has the same per-column unit (cart_unit / intrinsic_unit),
-    # which makes _column_squared_norms well-defined with correct units.
-    cart_chart = ambient_chart.cartesian
-    cart_keys = cart_chart.components
-
-    _qm: ul.QM = cxcapi.carray(at, intrinsic_keys)  # ty: ignore[invalid-assignment]
-    xat, ufrom = _qm.value, _qm.unit.to_tuple()
-    ufrom_ = tuple(uf if uf is not None else DMLS for uf in ufrom)
-
-    # Evaluate once to determine Cartesian output units
-    at_ambient = embed_map.embed(at, usys=usys)
-    at_cart = cxcapi.pt_map(at_ambient, ambient_chart, cart_chart)
-    uto_ = ul.cdict_units(at_cart, cart_keys)
-    uto_ = tuple(ut if ut is not None else DMLS for ut in uto_)
-
-    # Build the unit matrix: J_cart.unit[k][i] = cart_unit_k / intrinsic_unit_i
-    unit_matrix = ul.UnitsMatrix(
-        tuple(tuple(tj / fi for fi in ufrom_) for tj in uto_)  # ty: ignore[unsupported-operator]
+    M = EmbeddedManifold(
+        intrinsic=embed_map.intrinsic.M,
+        ambient=embed_map.ambient.M,
+        embed_map=embed_map,
     )
-
-    def _embed_cart(x_arr: jnp.ndarray) -> jnp.ndarray:
-        q = {k: u.Q(x_arr[i], ufrom_[i]) for i, k in enumerate(intrinsic_keys)}
-        q_ambient = embed_map.embed(q, usys=usys)
-        q_cart = cxcapi.pt_map(q_ambient, ambient_chart, cart_chart)
-        vals = [
-            u.ustrip(uto_[j], q_cart[k])  # ty: ignore[not-subscriptable]
-            if isinstance(q_cart[k], u.AbstractQuantity)  # ty: ignore[not-subscriptable]
-            else qnp.asarray(q_cart[k])  # ty: ignore[not-subscriptable]
-            for j, k in enumerate(cart_keys)
-        ]
-        return qnp.stack(vals)
-
-    J_arr = jax.jacfwd(_embed_cart)(xat)  # (n_cart, n_intrinsic)
-    J_cart = ul.QM(J_arr, unit=unit_matrix)
-    return _column_squared_norms(J_cart)
+    dense = cast("DenseMetric", cxmapi.metric_matrix(M, at, chart))
+    # `.matrix` is typed `QuantityMatrix | Array`; the embedded rule always
+    # builds the united form, which is what carries the per-entry units.
+    g = cast("ul.QM", dense.matrix)
+    return ul.QM(
+        jnp.diagonal(g.value, axis1=-2, axis2=-1),
+        unit=ul.UnitsMatrix(tuple(g.unit[i, i] for i in range(len(chart.components)))),
+    )

--- a/src/coordinax/_src/manifolds/scale_factors.py
+++ b/src/coordinax/_src/manifolds/scale_factors.py
@@ -114,12 +114,34 @@ def scale_factors(
     >>> cxm.scale_factors(M.metric, cxc.lonlat_sph2, at=at)
     QM([4., 4.], '(m2 / rad2, m2 / rad2)')
 
+    The delegate reads the ambient Gram off the ambient *manifold*, so an
+    ``ambient_metric`` that disagrees with it cannot be honoured. That is
+    refused rather than answered with the diagonal of a different metric:
+
+    >>> pb = cxm.PullbackMetric(cxm.TwoSphereIn3D(radius=1.0), cxm.RoundMetric(3))
+    >>> try: cxm.scale_factors(pb, cxc.sph2, at=at)
+    ... except NotImplementedError as e: print(e)
+    the pullback of RoundMetric(ndim=3) cannot be evaluated: the ambient
+    manifold Rn(3) of chart Spherical3D... carries FlatMetric(ndim=3)
+
     """
     del usys
     embed_map = metric.embed_map
+    ambient = embed_map.ambient.M
+    # `metric_matrix` below evaluates the ambient Gram on `ambient`, i.e. with
+    # `ambient.metric` — the only ambient metric this route can apply. An
+    # `EmbeddedManifold`'s own `metric` always agrees (it is built from
+    # `ambient.metric`); a hand-built `PullbackMetric` need not.
+    if metric.ambient_metric != ambient.metric:
+        msg = (
+            f"the pullback of {metric.ambient_metric} cannot be evaluated: the "
+            f"ambient manifold {ambient} of chart {embed_map.ambient} carries "
+            f"{ambient.metric}"
+        )
+        raise NotImplementedError(msg)
     M = EmbeddedManifold(
         intrinsic=embed_map.intrinsic.M,
-        ambient=embed_map.ambient.M,
+        ambient=ambient,
         embed_map=embed_map,
     )
     mm = cxmapi.metric_matrix(M, at, chart)

--- a/tests/unit/manifolds/test_scale_factors_dispatch.py
+++ b/tests/unit/manifolds/test_scale_factors_dispatch.py
@@ -178,6 +178,24 @@ class TestScaleFactorsPullbackMetric:
         g = mm_dispatch(M, pt, cxc.lonlat_sph2)
         assert h.unit[0] == g.matrix.unit[0, 0]
 
+    def test_ambient_metric_the_route_cannot_apply_is_refused(self):
+        """A hand-built pullback can name an ambient metric this route can't use.
+
+        The delegate evaluates the Gram on the ambient *manifold*, so only
+        ``embed_map.ambient.M.metric`` is reachable. Returning the diagonal of
+        that other metric instead would be the silent-wrong-answer this class
+        exists to guard against.
+        """
+        pb = cxm.PullbackMetric(
+            cxm.TwoSphereIn3D(radius=u.Q(2.0, "m")), cxm.RoundMetric(3)
+        )
+        at = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0.0, "rad")}
+        with pytest.raises(NotImplementedError, match="cannot be evaluated"):
+            cxm.scale_factors(pb, cxc.sph2, at=at)
+
+        # An `EmbeddedManifold`'s own metric always agrees, so it never trips.
+        assert self._sphere().metric.ambient_metric == cxc.sph3d.M.metric
+
     def test_batched_point(self):
         """A batched point returns (*batch, n), not a shape error."""
         M = self._sphere()

--- a/tests/unit/manifolds/test_scale_factors_dispatch.py
+++ b/tests/unit/manifolds/test_scale_factors_dispatch.py
@@ -2,6 +2,7 @@
 
 import jax
 import jax.numpy as jnp
+import pytest
 
 import unxt as u
 import unxts.linalg as ul
@@ -135,3 +136,88 @@ class TestScaleFactorsGeneric:
         assert jnp.allclose(result.value, expected, atol=1e-6)
         assert result.unit[0] == u.unit("m2 / rad2")
         assert result.unit[1] == u.unit("m2 / rad2")
+
+
+class TestScaleFactorsPullbackMetric:
+    """`scale_factors` on a `PullbackMetric` must agree with `metric_matrix`.
+
+    It used to read the point with ``embed_map.intrinsic.components`` and ignore
+    the passed ``chart`` -- the same defect #604 fixed for ``metric_matrix``.
+    It also dropped the ambient Gram and was not batch-safe.
+    """
+
+    @staticmethod
+    def _sphere(radius=u.Q(2.0, "m")):
+        return cxm.EmbeddedManifold(
+            intrinsic=cxm.S2, ambient=cxm.R3, embed_map=cxm.TwoSphereIn3D(radius=radius)
+        )
+
+    @pytest.mark.parametrize(
+        ("chart", "at"),
+        [
+            (cxc.sph2, {"theta": jnp.pi / 2, "phi": 0.0}),
+            (cxc.lonlat_sph2, {"lon": 0.0, "lat": 0.0}),
+            (cxc.math_sph2, {"theta": 0.0, "phi": jnp.pi / 2}),
+            (cxc.loncoslat_sph2, {"lon_coslat": 0.0, "lat": 0.0}),
+        ],
+    )
+    def test_matches_metric_matrix_diagonal(self, chart, at):
+        """Any valid intrinsic chart, not just the embedding's own."""
+        M = self._sphere()
+        pt = {k: u.Angle(v, "rad") for k, v in at.items()}
+        h = jnp.asarray(cxm.scale_factors(M.metric, chart, at=pt).value)
+        g = jnp.asarray(mm_dispatch(M, pt, chart).matrix.value)
+        assert jnp.allclose(h, jnp.diagonal(g, axis1=-2, axis2=-1), atol=1e-6)
+        # Every point above is on the equator of a radius-2 sphere -> 4 m2/rad2.
+        assert jnp.allclose(h, jnp.asarray([4.0, 4.0]), atol=1e-5)
+
+    def test_units_match_metric_matrix(self):
+        M = self._sphere()
+        pt = {"lon": u.Angle(0.0, "rad"), "lat": u.Angle(0.0, "rad")}
+        h = cxm.scale_factors(M.metric, cxc.lonlat_sph2, at=pt)
+        g = mm_dispatch(M, pt, cxc.lonlat_sph2)
+        assert h.unit[0] == g.matrix.unit[0, 0]
+
+    def test_batched_point(self):
+        """A batched point returns (*batch, n), not a shape error."""
+        M = self._sphere()
+        pt = {
+            "lon": u.Angle(jnp.array([0.0, 0.3, 0.6]), "rad"),
+            "lat": u.Angle(jnp.array([0.0, 0.2, 0.4]), "rad"),
+        }
+        h = jnp.asarray(cxm.scale_factors(M.metric, cxc.lonlat_sph2, at=pt).value)
+        assert h.shape == (3, 2)
+        for i in range(3):
+            hi = cxm.scale_factors(
+                M.metric, cxc.lonlat_sph2, at={k: v[i] for k, v in pt.items()}
+            )
+            assert jnp.allclose(h[i], jnp.asarray(hi.value), atol=1e-6)
+
+    @pytest.mark.parametrize(
+        ("name", "ct_of", "x_of", "expected"),
+        [
+            ("timelike", lambda s: s, lambda s: s * 0, -1.0),
+            ("spacelike", lambda s: s * 0, lambda s: s, 1.0),
+            ("null", lambda s: s, lambda s: s, 0.0),
+        ],
+        ids=lambda v: v if isinstance(v, str) else "",
+    )
+    def test_lorentzian_ambient_keeps_the_signature(self, name, ct_of, x_of, expected):
+        """Squared column norms are always positive; the ambient Gram is not."""
+        del name
+        embed_map = cxm.CustomEmbeddingMap(
+            intrinsic=cxc.cart1d,
+            ambient=cxc.minkowskict,
+            embed_fn=lambda p, *, usys=None: {
+                "ct": ct_of(p["x"]),
+                "x": x_of(p["x"]),
+                "y": p["x"] * 0,
+                "z": p["x"] * 0,
+            },
+            project_fn=lambda p, *, usys=None: {"x": p["ct"]},
+        )
+        M = cxm.EmbeddedManifold(
+            intrinsic=cxm.R1, ambient=cxm.minkowski4d, embed_map=embed_map
+        )
+        h = cxm.scale_factors(M.metric, cxc.cart1d, at={"x": u.Q(1.0, "m")})
+        assert jnp.allclose(jnp.asarray(h.value).ravel()[0], expected, atol=1e-9)


### PR DESCRIPTION
`scale_factors(PullbackMetric, chart, ...)` reads the point with `embed_map.intrinsic.components` and never uses the `chart` it is handed — the same defect #604 fixed for `metric_matrix`.

## Three bugs

**1. The chart is ignored.** On an S² embedding:

```python
M = cxm.EmbeddedManifold(intrinsic=cxm.S2, ambient=cxm.R3,
                         embed_map=cxm.TwoSphereIn3D(radius=u.Q(2.0, "m")))

cxm.scale_factors(M.metric, cxc.lonlat_sph2, at={"lon": ..., "lat": ...})
# KeyError: 'theta'

cxm.scale_factors(M.metric, cxc.math_sph2, at={"theta": 0.0, "phi": pi/2})
# QM([4., 0.])      <- silently WRONG
# metric_matrix(M, same_point, math_sph2) -> diag [4., 4.]
```

The `math_sph2` case is the dangerous one: its component names collide with `sph2`'s, so the point is silently reinterpreted in the wrong chart and a plausible-looking answer comes back. `lonlat` and `loncoslat` at least fail loudly.

**2. The ambient Gram is dropped.** `_column_squared_norms` sums squares, which is always positive. For a timelike worldline in a Minkowski ambient:

| worldline | `metric_matrix` | `scale_factors` (before) |
|---|---|---|
| timelike | `-1` | **`+1`** |
| spacelike | `+1` | `+1` |
| null | `0` | `0` |

It reports a timelike direction as spacelike — exactly what #614 called out when it added `G` to the metric rule.

**3. Not batch-safe.** A batched point raises, from `jacfwd` producing a cross-batch Jacobian:

```
ValueError: QuantityMatrix value trailing shape (3, 1) does not match the unit structure shape (4, 1)
```

## The fix

The scale factors of an induced metric **are** the diagonal of that metric. Rather than fix three bugs in a duplicate Jacobian implementation, delegate to the `EmbeddedManifold` `metric_matrix` rule and take its diagonal.

All three defects go away by construction, the two implementations can no longer drift apart again, and the duplicated jacfwd/unit-matrix block goes with them — along with its now-dead `jax`, `qnp`, `cxcapi` and `_column_squared_norms` imports. Net **-12 lines** in `scale_factors.py`.

## Verification

New tests: agreement with `metric_matrix`'s diagonal across all four intrinsic two-sphere charts (`sph2`, `lonlat`, `math`, `loncoslat`), matching units, batched points matching element-wise evaluation, and the three Lorentzian signature cases.

Full suite: 1986 passed, 8 skipped. `ruff` clean; `ty` back to the 2 pre-existing `redundant-cast` warnings.

(Deselected `tests/usage/charts/test_ptmap.py::TestCartesianRoundTrip3D::test_sph3d_roundtrip` — a float32 hypothesis draw near the origin that fails identically on unmodified `main`.)

## Related

Fifth follow-up from the #592 math audit: #618, #621, #624, #627, and issue #628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)