### PR TITLE
🐛 fix(astro): evaluate the distance modulus about its zero point

### DIFF
--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/distance_modulus.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/distance_modulus.py
@@ -16,6 +16,50 @@ from .constants import ANGLE, LENGTH, MAGNITUDE
 
 parallax_base_length = u.Q(jnp.array(1), "AU")
 
+#: The distance-modulus zero point: dm == 0 at d == 10 pc, by definition.
+_DM_ZERO_POINT_PC = 10.0
+
+
+def _distance_modulus_from_pc(d_pc: ArrayLike, /) -> ArrayLike:
+    """Distance modulus in mag, from a distance already stripped to parsecs.
+
+    ``dm = 5 log10(d / 10 pc)`` -- the textbook form, scaled inside the log
+    rather than corrected after it.
+
+    The algebraically equal ``5 * log10(d_pc) - 5`` is less accurate near the
+    zero point. ``log10(d_pc)`` carries a relative error, so for d ~ 10 pc
+    (where log10 ~ 1) ``5 * log10(...)`` carries an absolute error of ~5 eps;
+    the following ``- 5`` is exact by Sterbenz and so cannot recover it, while
+    the result itself is heading to zero. Scaling the argument instead leaves
+    only the ~eps/ln(10) of the single division, ~2 eps after the factor of 5.
+
+    Worst-case absolute error over d in {9, 9.9, ..., 50} pc, float32,
+    measured through this code path (``ustrip`` contributes, so an isolated
+    snippet reads several orders low):
+
+    ==============================  =========  =========
+    form                            abs. err   runtime
+    ==============================  =========  =========
+    ``5 * log10(d_pc) - 5``          4.48e-07     1.000x
+    this form                        1.37e-07     0.985x
+    ``5 * (log10(d_pc) - 1)``        4.66e-07     1.000x
+    ``(5/ln10) * log1p((d-10)/10)``  1.01e-07     1.980x
+    ==============================  =========  =========
+
+    3.3x more accurate at no cost. XLA strength-reduces the division to a
+    multiply, so this lowers to the same three f32 ops as the original
+    (multiply, log, multiply); over 60 paired in-process rounds it came out
+    marginally ahead and won 31 of them, i.e. indistinguishable.
+
+    Not uniformly better: at d = 9 pc this form carries 7.4e-08 against the
+    subtractive form's 3.1e-08. The gain is concentrated where dm -> 0, which
+    is where absolute error matters and where the subtractive form is worst.
+
+    The ``log1p`` form is better still -- and much better in the 9.9-10.1 pc
+    band -- but is genuinely 2x slower, so it is not used here.
+    """
+    return 5 * jnp.log10(d_pc / _DM_ZERO_POINT_PC)
+
 
 @final
 class DistanceModulus(cxd.AbstractDistance):
@@ -124,12 +168,12 @@ def from_(
     dim = u.dimension_of(q)
 
     if dim == LENGTH:  # distance
-        dm = 5 * jnp.log10(q.ustrip("pc")) - 5
+        dm = _distance_modulus_from_pc(q.ustrip("pc"))
         return cls(jnp.asarray(dm, **kw), "mag")
 
     if dim == ANGLE:  # parallax
         d = parallax_base_length / jnp.tan(q)  # [AU]
-        dm = 5 * jnp.log10(d.ustrip("pc")) - 5
+        dm = _distance_modulus_from_pc(d.ustrip("pc"))
         return cls(jnp.asarray(dm, **kw), "mag")
 
     if dim == MAGNITUDE:  # already a distance modulus (magnitude)

--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/distance_modulus.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/distance_modulus.py
@@ -17,7 +17,10 @@ from .constants import ANGLE, LENGTH, MAGNITUDE
 parallax_base_length = u.Q(jnp.array(1), "AU")
 
 #: The distance-modulus zero point: dm == 0 at d == 10 pc, by definition.
-_DM_ZERO_POINT_PC = 10.0
+#: An `int`, so an integer-dtype distance keeps the dtype the pre-#634 form gave
+#: it: under ``JAX_ENABLE_X64`` an int32 divided by a weak float widens to
+#: float64, by a weak int stays float32. Float inputs are unaffected either way.
+_DM_ZERO_POINT_PC = 10
 
 
 def _distance_modulus_from_pc(d_pc: ArrayLike, /) -> ArrayLike:

--- a/packages/coordinaxs.astro/tests/unit/distances/test_distance_modulus.py
+++ b/packages/coordinaxs.astro/tests/unit/distances/test_distance_modulus.py
@@ -1,6 +1,11 @@
 """Unit tests for coordinax.distances.DistanceModulus using hypothesis strategies."""
 
+import decimal
+
+from typing import ClassVar
+
 import jax.numpy as jnp
+import numpy as np
 import plum
 import pytest
 from hypothesis import given, settings
@@ -84,3 +89,69 @@ class TestDistanceModulusPlumConvert:
         """Can convert DistanceModulus to Parallax."""
         plx = plum.convert(dm, cxastro.Parallax)
         assert isinstance(plx, cxastro.Parallax)
+
+
+class TestDistanceModulusAccuracyNearZeroPoint:
+    """`dm = 5 log10(d/10pc)` is evaluated about its zero point.
+
+    The algebraically equal `5*log10(d_pc) - 5` loses absolute precision for
+    d ~ 10 pc, where dm -> 0: the multiply-by-5 lands while log10 ~ 1, and the
+    exact `- 5` that follows cannot recover what it cost.
+
+    These assert in **float32**. The effect is a few eps, so under the float64
+    the suite normally runs (`JAX_ENABLE_X64=1`) both forms agree to ~1e-16 and
+    no reachable tolerance separates them -- a float64 test here would pass
+    whichever form is installed and guard nothing. JAX preserves input dtype,
+    so passing float32 in is enough.
+
+    Bounds below were measured through this exact code path (not an idealised
+    snippet -- `ustrip` contributes) and each sits strictly between the two
+    forms' error at that point, so reverting the implementation fails here.
+    """
+
+    #: (d [pc], bound, measured error of the subtractive form at that d).
+    NEAR_ZERO_POINT: ClassVar = [
+        pytest.param(9.9, 1.0e-7, 2.28e-7, id="9.9pc"),
+        pytest.param(9.999, 1.0e-7, 1.92e-7, id="9.999pc"),
+        pytest.param(10.001, 1.0e-7, 2.14e-7, id="10.001pc"),
+        pytest.param(10.01, 1.2e-7, 3.51e-7, id="10.01pc"),
+        pytest.param(10.1, 2.0e-7, 4.48e-7, id="10.1pc"),
+    ]
+
+    #: Worst absolute error over the sampled band, per form (measured).
+    WORST_ERROR_BOUND = 2.0e-7  # this form: 1.37e-7; subtractive form: 4.48e-7
+
+    @staticmethod
+    def _exact_dm(d_pc: float) -> float:
+        """Dm for the exact value the float32 holds, at 60 decimal digits."""
+        decimal.getcontext().prec = 60
+        d = decimal.Decimal(float(np.float32(d_pc)))
+        return float(5 * (d / decimal.Decimal(10)).ln() / decimal.Decimal(10).ln())
+
+    @classmethod
+    def _abs_error(cls, d_pc: float) -> float:
+        got = cxastro.DistanceModulus.from_(u.Q(np.float32(d_pc), "pc")).ustrip("mag")
+        assert got.dtype == np.float32, "float32 lost; this test would prove nothing"
+        return abs(float(got) - cls._exact_dm(d_pc))
+
+    @pytest.mark.parametrize(("d_pc", "bound", "subtractive_error"), NEAR_ZERO_POINT)
+    def test_float32_absolute_error(
+        self, d_pc: float, bound: float, subtractive_error: float
+    ) -> None:
+        """Error stays under a bound the subtractive form cannot meet."""
+        assert self._abs_error(d_pc) < bound
+        # Guard the guard: a bound the old form also met would test nothing.
+        assert bound < subtractive_error
+
+    def test_worst_error_across_the_band(self) -> None:
+        """Worst-case error over the band beats the subtractive form's 4.48e-7."""
+        worst = max(
+            self._abs_error(d)
+            for d in (9.0, 9.9, 9.99, 9.999, 10.001, 10.01, 10.1, 11.0, 50.0)
+        )
+        assert worst < self.WORST_ERROR_BOUND
+
+    def test_zero_point_is_exactly_zero(self) -> None:
+        """dm(10 pc) is exactly 0, not merely close to it."""
+        got = cxastro.DistanceModulus.from_(u.Q(10.0, "pc")).ustrip("mag")
+        assert float(got) == 0.0

--- a/packages/coordinaxs.astro/tests/unit/distances/test_distance_modulus.py
+++ b/packages/coordinaxs.astro/tests/unit/distances/test_distance_modulus.py
@@ -124,9 +124,10 @@ class TestDistanceModulusAccuracyNearZeroPoint:
     @staticmethod
     def _exact_dm(d_pc: float) -> float:
         """Dm for the exact value the float32 holds, at 60 decimal digits."""
-        decimal.getcontext().prec = 60
-        d = decimal.Decimal(float(np.float32(d_pc)))
-        return float(5 * (d / decimal.Decimal(10)).ln() / decimal.Decimal(10).ln())
+        with decimal.localcontext() as ctx:  # don't leak `prec` to other tests
+            ctx.prec = 60
+            d = decimal.Decimal(float(np.float32(d_pc)))
+            return float(5 * (d / decimal.Decimal(10)).ln() / decimal.Decimal(10).ln())
 
     @classmethod
     def _abs_error(cls, d_pc: float) -> float:


### PR DESCRIPTION
`dm = 5*log10(d_pc) - 5` loses absolute precision exactly where the distance modulus is small.

For d ~ 10 pc, `log10(d_pc) ~ 1`, so `5 * log10(...)` carries an absolute error of ~5 eps. The `- 5` that follows is *exact* (Sterbenz), so it cannot recover what the multiply cost — while the result itself is heading to zero. Scaling inside the log instead, `5*log10(d_pc/10)`, leaves only the ~eps/ln(10) of one division, ~2 eps after the factor of 5. It's also the form the textbook writes.

Both sites that build a dm from a length are changed: the direct one and the parallax route.

## Accuracy

Worst-case absolute error, float32, measured **through this code path** — an isolated snippet reads several orders low because `ustrip` contributes:

| form | abs. err | runtime |
|---|---|---|
| `5*log10(d_pc) - 5` (before) | 4.48e-07 | 1.000x |
| **`5*log10(d_pc/10)` (this PR)** | **1.37e-07** | **0.985x** |
| `5*(log10(d_pc) - 1)` | 4.66e-07 | 1.000x |
| `(5/ln10)*log1p((d-10)/10)` | 1.01e-07 | 1.980x |

**3.3x more accurate at no cost.**

Not uniformly better, and worth knowing: at d = 9 pc this form carries 7.4e-08 against the subtractive form's 3.1e-08. The gain is concentrated where dm → 0 — which is where absolute error is what matters, and where the subtractive form is at its worst.

The `log1p` form is better again, and *far* better in the 9.9–10.1 pc band (~1e-11 vs ~5e-8), but it is genuinely 2x slower. Rejected on that basis.

## Performance

Per the no-regression requirement, measured rather than assumed. XLA strength-reduces `/10.0` to a multiply, so this lowers to the **same three f32 ops** as before (multiply, log, multiply) — confirmed in the optimized HLO.

Timed with both formulas live in one process, alternating, 60 paired rounds over 4e6 float32 points:

```
old: median 2.3931 ms   p25 2.1489   p75 2.6937
new: median 2.3579 ms   p25 2.0885   p75 2.7673
new/old = 0.985x ; new faster in 31/60 paired rounds
```

31/60 is exactly the coin-flip you'd expect from indistinguishable implementations. Separate-process timings of the same two swing up to 20% in *either* direction — that's process noise, and I'd disregard it; the paired numbers are the ones to read.

## Tests

`TestDistanceModulusAccuracyNearZeroPoint`, asserting in **float32 on purpose**.

I first wrote these in float64 and **they passed against the old formula** — under the suite's `JAX_ENABLE_X64=1` both forms agree to ~1e-16 and no reachable tolerance separates them, so a float64 test here guards nothing. JAX preserves input dtype, so feeding float32 in is enough (the test asserts `got.dtype == np.float32`, else it would prove nothing).

Each bound sits strictly between the two forms' measured error at that point, and each case also asserts `bound < subtractive_error` so a bound the old form could also meet fails loudly. Verified by mutating the implementation back: **6 failures**, all pass on restore.

Reference values come from `decimal` at 60 digits, generated rather than typed — my first hand-entered table was wrong in the 6th digit.

308 tests pass in `packages/coordinaxs.astro`; 397 across everything touching distances.

## On the rest of the audit

The audit's top two line-count findings are **dropped** under the correctness/performance priority, not deferred:

- *Route all conversions through a canonical parsec hop* would compose two lossy operations where the code now does one, plus a round-trip. Numerical regression bought with line count.
- *Replace the `if dim == LENGTH/ANGLE/MAGNITUDE` chains with plum dispatch* moves per-call work into dispatch resolution on a constructor path.

I also predicted the inverse direction `10**(1 + dm/5)` would absorb small dm and measured it: **it doesn't** — at dm=1e-8 both forms return the correctly-rounded float32 value, and the alternative is 1.3x better worst-case (noise) for an extra multiply. Left alone.

Remaining safe items — dead `custom_types.py`, an unused `TypeVar`, a shadowed `jax.numpy` import, duplicated `constants.py` — are pure deletions with no numerical or runtime effect, and will follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)