### PR TITLE
🐛 fix(distances): negating a Parallax raised instead of degrading

### DIFF
--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/distance_modulus.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/distance_modulus.py
@@ -7,6 +7,8 @@ from jaxtyping import Array, ArrayLike, Shaped
 from typing import Any, final
 
 import equinox as eqx
+from jax import lax
+from quax import register
 
 import quaxed.numpy as jnp
 import unxt as u
@@ -159,3 +161,24 @@ def from_(
     """
     d = 10 ** (1 + dm.ustrip("mag") / 5)
     return cls(jnp.asarray(d, **kw), "pc")
+
+
+@register(lax.neg_p)
+def neg_p_distancemodulus(x: DistanceModulus, /) -> DistanceModulus:
+    """Negation of a distance modulus stays a distance modulus.
+
+    This overrides the `AbstractDistance` rule, which degrades to a `Quantity`
+    because `Distance` and `Parallax` are non-negative by construction. A
+    distance modulus is not: ``dm = 5 log10(d / 10 pc)`` maps d in (0, inf)
+    onto all of the reals, and a negative value is the ordinary way to say
+    "nearer than 10 pc". Negation is closed here, so the type survives it.
+
+    >>> from coordinaxs.astro import DistanceModulus
+    >>> -DistanceModulus(10, "mag")
+    DistanceModulus(-10, 'mag')
+
+    >>> -DistanceModulus(-5, "mag")
+    DistanceModulus(5, 'mag')
+
+    """
+    return DistanceModulus(-x.value, x.unit)

--- a/packages/coordinaxs.astro/tests/unit/distances/test_distance_kind_contract.py
+++ b/packages/coordinaxs.astro/tests/unit/distances/test_distance_kind_contract.py
@@ -20,18 +20,40 @@ import jax.numpy as jnp
 import pytest
 from hypothesis import given, settings
 
+import unxt as u
+
 import coordinax.distances as cxd
 import coordinaxs.astro as cxastro
 import coordinaxs.hypothesis.astro as cxastrost
 import coordinaxs.hypothesis.distances as cxdst
 
+#: `sign_constrained` records whether the kind's domain excludes negatives.
+#: `Distance` and `Parallax` are non-negative by construction, so negating one
+#: cannot yield a value of the same type. `DistanceModulus` is two-sided --
+#: dm = 5 log10(d/10pc) maps d in (0, inf) onto all of the reals, and a
+#: negative dm is the ordinary way to say "nearer than 10 pc".
 KINDS = {
-    "distance": SimpleNamespace(cls=cxd.Distance, strategy=cxdst.distances),
-    "distance_modulus": SimpleNamespace(
-        cls=cxastro.DistanceModulus, strategy=cxastrost.distance_moduli
+    "distance": SimpleNamespace(
+        cls=cxd.Distance, strategy=cxdst.distances, sign_constrained=True
     ),
-    "parallax": SimpleNamespace(cls=cxastro.Parallax, strategy=cxastrost.parallaxes),
+    "distance_modulus": SimpleNamespace(
+        cls=cxastro.DistanceModulus,
+        strategy=cxastrost.distance_moduli,
+        sign_constrained=False,
+    ),
+    "parallax": SimpleNamespace(
+        cls=cxastro.Parallax, strategy=cxastrost.parallaxes, sign_constrained=True
+    ),
 }
+
+
+def _a_valid_unit(kind: SimpleNamespace) -> str:
+    """A unit the kind's `__check_init__` accepts."""
+    return {
+        cxd.Distance: "kpc",
+        cxastro.Parallax: "mas",
+        cxastro.DistanceModulus: "mag",
+    }[kind.cls]
 
 
 @pytest.fixture(params=sorted(KINDS), scope="module")
@@ -141,3 +163,50 @@ class TestJAX:
         value = data.draw(kind.strategy(shape=(3,)))
         result = jax.vmap(lambda x: x + x)(value)
         assert result.shape == (3,)
+
+
+class TestNegation:
+    """Negation degrades exactly for the kinds that constrain sign.
+
+    Regression: the `neg_p` rule was registered on the concrete `Distance`
+    rather than on `AbstractDistance`, so `-Parallax(...)` fell through to
+    unxt's type-preserving rule, rebuilt a `Parallax` holding a negative value,
+    and tripped that class's own `check_negative` guard -- it raised
+    `EquinoxRuntimeError` rather than returning anything.
+    """
+
+    def test_degrades_iff_sign_constrained(self, kind: SimpleNamespace) -> None:
+        """A sign-constrained kind yields `Quantity`; a two-sided one keeps its type."""
+        result = -kind.cls(10, _a_valid_unit(kind))
+
+        if kind.sign_constrained:
+            assert type(result) is u.Q
+        else:
+            assert type(result) is kind.cls
+
+    def test_negation_preserves_magnitude_and_unit(self, kind: SimpleNamespace) -> None:
+        unit = _a_valid_unit(kind)
+        result = -kind.cls(10, unit)
+        assert result.value == -10
+        assert result.unit == u.unit(unit)
+
+    def test_survives_jit(self, kind: SimpleNamespace) -> None:
+        """`check_negative` is an `error_if`, so jit is where it would fire."""
+        result = jax.jit(lambda x: -x)(kind.cls(10, _a_valid_unit(kind)))
+        expected = u.Q if kind.sign_constrained else kind.cls
+        assert type(result) is expected
+
+    def test_survives_vmap(self, kind: SimpleNamespace) -> None:
+        value = kind.cls(jnp.asarray([1.0, 2.0]), _a_valid_unit(kind))
+        result = jax.vmap(lambda x: -x)(value)
+        assert jnp.array_equal(result.value, jnp.asarray([-1.0, -2.0]))
+
+    def test_two_sided_kinds_negate_back(self, kind: SimpleNamespace) -> None:
+        """Where negation is closed it is also an involution."""
+        if kind.sign_constrained:
+            pytest.skip("negation is not closed on this kind")
+        original = kind.cls(-5, _a_valid_unit(kind))
+        once = -original
+        twice = -once
+        assert type(twice) is kind.cls
+        assert jnp.array_equal(twice.value, original.value)

--- a/packages/coordinaxs.astro/tests/unit/distances/test_distance_kind_contract.py
+++ b/packages/coordinaxs.astro/tests/unit/distances/test_distance_kind_contract.py
@@ -187,7 +187,7 @@ class TestNegation:
     def test_negation_preserves_magnitude_and_unit(self, kind: SimpleNamespace) -> None:
         unit = _a_valid_unit(kind)
         result = -kind.cls(10, unit)
-        assert result.value == -10
+        assert jnp.array_equal(result.value, -10)
         assert result.unit == u.unit(unit)
 
     def test_survives_jit(self, kind: SimpleNamespace) -> None:

--- a/src/coordinax/distances/_src/register_primitives.py
+++ b/src/coordinax/distances/_src/register_primitives.py
@@ -15,7 +15,6 @@ from unxt.quantity import Quantity
 
 from .base import AbstractDistance
 from .constants import ONE, RADIAN
-from .measures import Distance
 
 
 # TODO: can this be done with promotion/conversion instead?
@@ -134,13 +133,25 @@ def integer_pow_p_abstractdistance(x: AbstractDistance, /, *, y: Any) -> Quantit
 
 
 @register(lax.neg_p)
-def neg_p_distance(x: Distance, /) -> u.Q:
-    """Negation of a Distance degrades to a Quantity.
+def neg_p_abstractdistance(x: AbstractDistance, /) -> u.Q:
+    """Negation of a distance-like quantity degrades to a Quantity.
+
+    `Distance` and `Parallax` are non-negative by construction, so their
+    negation is not a value of the same type -- it has to degrade.
 
     >>> from coordinax.distances import Distance
     >>> q = Distance(10, "m")
     >>> -q
     Q(-10, 'm')
+
+    This holds for every sign-constrained subclass, not just `Distance`:
+
+    >>> from coordinaxs.astro import Parallax
+    >>> -Parallax(1, "mas")
+    Q(-1, 'mas')
+
+    `DistanceModulus` overrides this: its domain is all of the reals, so
+    negation stays closed and it keeps its own type.
 
     """
     return u.Q(-x.value, x.unit)


### PR DESCRIPTION
`neg_p` was registered on the concrete `Distance` rather than on `AbstractDistance`, so `-Parallax(1, "mas")` never reached it. It fell through to unxt's type-preserving rule, which rebuilt a `Parallax` holding a negative value and tripped that class's own `check_negative` guard — so **negating a parallax raised `EquinoxRuntimeError`** rather than returning anything.

```python
>>> -Parallax(1, "mas")          # before
EquinoxRuntimeError: Parallax must be non-negative.

>>> -Parallax(1, "mas")          # after
Q(-1, 'mas')
```

The rule now takes `AbstractDistance` — the level the sign constraint actually lives at. `Distance` and `Parallax` are both non-negative by construction, so negation cannot yield a value of their own type and has to degrade to `Quantity`.

## `DistanceModulus` deliberately keeps its type

A blanket rule on the base class would have been a regression, so `DistanceModulus` gets an explicit narrower one. Its domain is *not* sign-constrained:

| d | dm |
|---|---|
| 0.1 pc | −10.000 mag |
| 1 pc | −5.000 mag |
| 10 pc | +0.000 mag |
| 100 pc | +5.000 mag |

`dm = 5 log10(d / 10 pc)` maps d ∈ (0, ∞) onto all of ℝ, and a negative dm is the ordinary way to say "nearer than 10 pc". Negation is closed, so the type survives it — and negation remains an involution, which the tests assert.

## Behaviour and performance

| | before | after |
|---|---|---|
| `-Distance(10, "m")` | `Q(-10, 'm')` | `Q(-10, 'm')` |
| `-Parallax(1, "mas")` | **raises** | `Q(-1, 'mas')` |
| `-DistanceModulus(10, "mag")` | `DistanceModulus(-10, 'mag')` | `DistanceModulus(-10, 'mag')` |

`Distance`: rule body untouched, and quax dispatch resolves at trace time, so runtime is unchanged by construction.

`DistanceModulus` is the only case whose compiled path changes (explicit rule instead of unxt's generic one). Measured: **same 4 f32 HLO ops, same result type, 0.95× runtime** over 4e6 points. No regression.

## Tests

In `test_distance_kind_contract.py`, which already exists to contrast the three kinds. `sign_constrained` joins each kind's spec, so the expectation is stated once in the table and read from it rather than repeated per class — including under `jit` and `vmap`, since `check_negative` is an `error_if` and jit is where it fires.

Mutation-checked: narrowing the rule back to `Distance` fails 4 parallax cases; all pass on restore. 488 tests pass across the distances surface. The two remaining `ty` warnings are pre-existing (confirmed by stashing).

## Not fixed here — needs a policy decision, not a bug fix

The same failure mode reaches further than negation. Any **same-type** operation that can produce a negative falls through to unxt and trips the guard:

```
-Parallax(1, "mas")                      raised   <- fixed here
Distance(1, "m") - Distance(2, "m")      raises
Parallax(1, "mas") - Parallax(2, "mas")  raises
Distance(10, "m") * -1                   raises
Distance(1, "m") - u.Q(2, "m")           -> Q     (promotion degrades first)
```

`Distance(1,"m") - Distance(2,"m")` raising is routine usage, and note the inconsistency: `D - D` raises while `D - Q` returns a `Quantity`. Three spellings of one operation, three behaviours.

Subtraction could degrade by the same argument used here. **Multiplication cannot be settled mechanically** — the scalar's sign isn't known at trace time, so "always degrade" would turn `Distance * 2` into a `Quantity`.

Astropy's precedent is to validate only in `__new__` and let derived values through unchecked, which would fix all of these at once but is a different design from the one in place. That's your call rather than mine, so this PR fixes only the case that has an unambiguous answer.

> Note: touches `register_primitives.py`, which #635 also edits (removing a dead `TypeVar`). Trivial overlap; happy to rebase whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)