### PR TITLE
🐛 fix(astro): dimension_of lied about Parallax and DistanceModulus

### DIFF
--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/constants.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/constants.py
@@ -2,11 +2,19 @@
 
 __all__ = ("ANGLE", "LENGTH", "MAGNITUDE")
 
+from typing import cast
+
 import unxt as u
 
-ANGLE = u.dimension("angle")
-LENGTH = u.dimension("length")
+# The casts are load-bearing: `u.dimension` / `u.dimension_of` are typed as
+# returning `object`, so without them the annotations below do not hold and
+# anything returning one of these from a `-> u.AbstractDimension` function
+# fails to type-check.
+ANGLE: u.AbstractDimension = cast("u.AbstractDimension", u.dimension("angle"))
+LENGTH: u.AbstractDimension = cast("u.AbstractDimension", u.dimension("length"))
 # Magnitude has no dedicated astropy physical type; it resolves to
 # ``PhysicalType('unknown')``. Named here so the distance-modulus branches can
 # reject known-but-unsupported dimensions (time, mass, ...) with a clear error.
-MAGNITUDE = u.dimension_of(u.Q(1.0, "mag"))
+MAGNITUDE: u.AbstractDimension = cast(
+    "u.AbstractDimension", u.dimension_of(u.Q(1.0, "mag"))
+)

--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/distance_modulus.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/distance_modulus.py
@@ -7,6 +7,7 @@ from jaxtyping import Array, ArrayLike, Shaped
 from typing import Any, final
 
 import equinox as eqx
+import plum
 from jax import lax
 from quax import register
 
@@ -229,3 +230,26 @@ def neg_p_distancemodulus(x: DistanceModulus, /) -> DistanceModulus:
 
     """
     return DistanceModulus(-x.value, x.unit)
+
+
+@plum.dispatch
+def dimension_of(obj: type[DistanceModulus], /) -> u.AbstractDimension:
+    """Return the magnitude dimension: a distance modulus is not a length.
+
+    See `coordinaxs.astro._src.parallax.dimension_of` -- same correction, for
+    the same reason: the inherited `type[AbstractDistance]` rule reports length,
+    while every `DistanceModulus` instance reports magnitude.
+
+    >>> import unxt as u
+    >>> from coordinaxs.astro import DistanceModulus
+    >>> u.dimension_of(DistanceModulus)
+    PhysicalType('unknown')
+
+    Which is what the instances say (astropy has no dedicated physical type for
+    magnitude, so it resolves to ``'unknown'``):
+
+    >>> u.dimension_of(DistanceModulus(10, "mag"))
+    PhysicalType('unknown')
+
+    """
+    return MAGNITUDE

--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/parallax.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/parallax.py
@@ -8,6 +8,7 @@ from jaxtyping import Array, ArrayLike, Shaped
 from typing import Any, final
 
 import equinox as eqx
+import plum
 
 import quaxed.numpy as jnp
 import unxt as u
@@ -180,3 +181,27 @@ def from_(cls: type[cxd.Distance], p: Parallax, /, **kw: Any) -> cxd.Distance:
     d = parallax_base_length / jnp.tan(p)  # [AU]
     unit = u.unit_of(d)
     return cls(jnp.asarray(d.ustrip(unit), **kw), unit)
+
+
+@plum.dispatch
+def dimension_of(obj: type[Parallax], /) -> u.AbstractDimension:
+    """Return the angle dimension: a parallax is an angle, not a length.
+
+    `coordinax.distances` registers `dimension_of` for
+    `type[AbstractDistance]` returning length, which is right for
+    `AbstractDistance` itself and for `Distance` but wrong for this subclass --
+    every `Parallax` *instance* reports angle, so the class-level answer has to
+    agree with it.
+
+    >>> import unxt as u
+    >>> from coordinaxs.astro import Parallax
+    >>> u.dimension_of(Parallax)
+    PhysicalType('angle')
+
+    Which is what the instances say:
+
+    >>> u.dimension_of(Parallax(1, "mas"))
+    PhysicalType('angle')
+
+    """
+    return ANGLE

--- a/packages/coordinaxs.astro/tests/unit/distances/test_distance_kind_contract.py
+++ b/packages/coordinaxs.astro/tests/unit/distances/test_distance_kind_contract.py
@@ -27,6 +27,7 @@ import coordinaxs.astro as cxastro
 import coordinaxs.hypothesis.astro as cxastrost
 import coordinaxs.hypothesis.distances as cxdst
 
+#: `dimension` is what both the class and its instances must report.
 #: `sign_constrained` records whether the kind's domain excludes negatives.
 #: `Distance` and `Parallax` are non-negative by construction, so negating one
 #: cannot yield a value of the same type. `DistanceModulus` is two-sided --
@@ -34,15 +35,22 @@ import coordinaxs.hypothesis.distances as cxdst
 #: negative dm is the ordinary way to say "nearer than 10 pc".
 KINDS = {
     "distance": SimpleNamespace(
-        cls=cxd.Distance, strategy=cxdst.distances, sign_constrained=True
+        cls=cxd.Distance,
+        strategy=cxdst.distances,
+        dimension=u.dimension("length"),
+        sign_constrained=True,
     ),
     "distance_modulus": SimpleNamespace(
         cls=cxastro.DistanceModulus,
         strategy=cxastrost.distance_moduli,
+        dimension=u.dimension_of(u.Q(1.0, "mag")),
         sign_constrained=False,
     ),
     "parallax": SimpleNamespace(
-        cls=cxastro.Parallax, strategy=cxastrost.parallaxes, sign_constrained=True
+        cls=cxastro.Parallax,
+        strategy=cxastrost.parallaxes,
+        dimension=u.dimension("angle"),
+        sign_constrained=True,
     ),
 }
 
@@ -210,3 +218,29 @@ class TestNegation:
         twice = -once
         assert type(twice) is kind.cls
         assert jnp.array_equal(twice.value, original.value)
+
+
+class TestDimensionOf:
+    """`dimension_of` agrees whether asked about the class or an instance.
+
+    Regression: `coordinax.distances` registers `dimension_of` for
+    `type[AbstractDistance]` returning length. That is right for
+    `AbstractDistance` and for `Distance`, but it was inherited by `Parallax`
+    (angle) and `DistanceModulus` (magnitude), so asking those two classes
+    their dimension gave `length` while every instance of them said otherwise.
+    """
+
+    def test_class_matches_its_declared_dimension(self, kind: SimpleNamespace) -> None:
+        assert u.dimension_of(kind.cls) == kind.dimension
+
+    @given(data=st.data())
+    def test_instance_matches_its_class(
+        self, kind: SimpleNamespace, data: st.DataObject
+    ) -> None:
+        """The point of the fix: the two answers cannot disagree."""
+        instance = data.draw(kind.strategy())
+        assert u.dimension_of(instance) == u.dimension_of(kind.cls)
+
+    def test_the_base_class_still_reports_length(self) -> None:
+        """The inherited rule is correct for the abstraction itself; keep it."""
+        assert u.dimension_of(cxd.AbstractDistance) == u.dimension("length")


### PR DESCRIPTION
`coordinax.distances` registers `dimension_of` for `type[AbstractDistance]` returning length. Right for `AbstractDistance` itself and for `Distance` — but `Parallax` and `DistanceModulus` inherited it, so the class and its own instances disagreed:

| | class says | instance says |
|---|---|---|
| `Distance` | length | length ✓ |
| `Parallax` | **length** | **angle** |
| `DistanceModulus` | **length** | **unknown** (mag) |

`u.dimension_of` is public API, and `coordinaxs.hypothesis`'s `strategy_for_annotation` calls it on a bare annotation — which for these two classes means asking for *length* units to build a type whose `__check_init__` rejects them.

Each subclass now registers its own dispatch, beside the class it describes. The `type[AbstractDistance]` rule is deliberately untouched: it's correct for the abstraction and for `Distance`, and a test pins that.

## astro's `constants.py`

Gains the annotations and `cast()` calls the `coordinax.distances` copy already had. Without them `ANGLE` infers as `object` and returning it from a `-> u.AbstractDimension` function doesn't type-check.

These are the same casts I proposed deleting as noise in #635 and restored when ty rejected it. The comment now records *why* they're there, so the next person doesn't repeat my mistake.

## Performance

`dimension_of` on an **instance** measured **0.7–7% slower** across three alternating rounds (median ~4%), from the larger plum method table.

In absolute terms that's ~5 µs: the call costs ~130 µs, essentially all of it astropy `PhysicalType` lookup. Correcting a class-level answer requires registering *something*, so some table growth is the floor. The only way to avoid it entirely would be a `ClassVar` dimension protocol read by the existing rule — not worth introducing a new convention to save 5 µs on an introspection helper, but noted if `dimension_of` ever becomes hot.

Flagging it because you asked for no regressions; happy to take the `ClassVar` route instead if you'd rather.

## Tests

Joined the `dimension` column of the kind table in `test_distance_kind_contract.py`, so the class answer, the instance answer, and their *agreement* are asserted from one place. Mutation-checked: dropping the two dispatches fails 4 cases. 396 tests pass across astro + distances doctests.

---

## The rest of the audit

Measured, and **no change warranted** — recording so it isn't re-litigated:

**`check_negative` is the module's dominant cost.** Construction is 3.5× slower under jit (8 f32 HLO ops vs 2) and 5.6× eager; a `Distance` costs 19× a bare `Quantity` eagerly. It's validation, so it stays — but I tried to make it cheaper and couldn't:

| predicate | time |
|---|---|
| `jnp.any(jnp.less(v,0))` (current) | **0.372 ms** |
| `jnp.any(v < 0)` | 0.421 ms |
| `jnp.min(v) < 0` | 0.703 ms |

The current form is already the fastest, and `jnp.min` is undefined on empty arrays where `any` correctly returns `False`. The cost is `eqx.error_if`'s `cond`, not the comparison. Two hypotheses of mine also died here: `ustrip(own_unit)` and `asarray(same)` both return the *same object*, so there's no redundant copying in `from_`.

**The maths is sound.** Round-trip relative error, float64:

| path | worst | ULP |
|---|---|---|
| d → p → d | 2.78e-16 | 1.3 |
| d → dm → d | 1.04e-15 | 4.7 |
| d → p → dm → d | 1.04e-15 | 4.7 |

~1 ULP in float32. `1AU/tan(p)` is the right choice — bit-identical to the small-angle `1AU/p` for p ≤ 1 mas, and still correct at 1000 mas where the approximation drifts 7.8e-12. `atan2(1AU, d)` is correct for the reverse and robust at d=0 and d→∞.

**One thing I considered and rejected.** Four of six internal conversions provably cannot produce a negative (`10**x > 0` always; `atan2(1AU, ·) ∈ (0,π)` always), so they pay `check_negative` for nothing. Passing `check_negative=False` there would recover ~3.5× on those paths — but it's a stored static field that shows in `repr`, so `Distance.from_(Q(10,"mag"))` would start printing `Distance(1000., 'pc', check_negative=False)`. Not worth a user-visible wart; it needs a way to skip the check without changing the field, which is a design change rather than a fix.

**Semantic sharp edge, not fixed.** `dex` compares equal to `mag` as a `PhysicalType`, so `Distance.from_(u.Q(10, "dex"))` silently takes the distance-modulus branch and returns `0.0001 pc`. The arithmetic is self-consistent (astropy maps mag = −2.5 dex), so it's a coercion rather than a miscalculation — but a `dex` value isn't a distance modulus, and it's accepted without complaint. Worth a decision on whether the magnitude branch should require `mag` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)