### PR TITLE
⚡️ perf(hypothesis): stop composing astropy units for un-dimensioned quantities

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/annotations/strategy.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/annotations/strategy.py
@@ -7,6 +7,7 @@ import inspect
 
 from typing import (
     Any,
+    Final,
     TypeVar,
     _GenericAlias,  # ty: ignore[unresolved-import]
     get_origin,
@@ -27,6 +28,16 @@ from .wrap import AbstractNotIntrospectable
 T = TypeVar("T")
 
 xps = make_strategies_namespace(jnp)
+
+# Fallback unit strategy for quantity annotations that pin no dimension.
+# ``ust.units()`` re-runs astropy's ``UnitBase.compose()`` on every draw, which is
+# uncached and costs ~0.25s for exotic dimensions (e.g. "molar heat capacity") --
+# enough to trip ``HealthCheck.too_slow`` on its own. When the annotation tells us
+# nothing about the dimension any valid unit will do, so sample the canonical unit
+# of each named dimension instead.
+ANY_UNITS: Final = st.sampled_from(
+    [u.unit(u.dimension(name)._unit) for name in ust.DIMENSION_NAMES]  # ty: ignore[unresolved-attribute]
+)
 
 
 @ft.lru_cache(maxsize=256)
@@ -90,7 +101,7 @@ def strategy_for_annotation(
     try:
         dim = u.dimension_of(ann)
     except (eqx.EquinoxTracetimeError, ValueError):
-        dim = ust.units()
+        dim = ANY_UNITS
 
     # Determine the quantity class and whether to use static values
     # Check if ann is a subclass of StaticQuantity or if it's a parametrized

--- a/packages/coordinaxs.hypothesis/tests/unit/utils/annotations/test_strategy_for_annotation.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/utils/annotations/test_strategy_for_annotation.py
@@ -4,6 +4,7 @@ import jaxtyping
 
 import jax.numpy as jnp
 import unxt as u
+import unxts.hypothesis as ust
 from hypothesis import given, strategies as st
 from unxts.parametric import PQ
 
@@ -142,3 +143,28 @@ class TestStrategyForAnnotation:
         assert isinstance(value, u.Q)
         assert value.shape == ()
         assert u.dimension_of(value) == u.dimension("length")
+
+    @given(st.data())
+    def test_undimensioned_quantity_uses_canonical_units(
+        self, data: st.DataObject
+    ) -> None:
+        """Test an annotation pinning no dimension draws canonical units only.
+
+        Deriving units with ``unxts.hypothesis.units()`` re-runs astropy's
+        ``UnitBase.compose()`` on every draw. That is uncached and costs ~0.25s
+        for exotic dimensions (e.g. "molar heat capacity"), which was enough on
+        its own to trip ``HealthCheck.too_slow`` in any strategy reaching this
+        fallback -- notably ``charts(filter=cxc.Abstract3D)``, via the
+        un-dimensioned ``ProlateSpheroidal3D.Delta``. Sampling one canonical unit
+        per named dimension avoids composing anything.
+        """
+        canonical = {u.unit(u.dimension(name)._unit) for name in ust.DIMENSION_NAMES}
+
+        ann = jaxtyping.Real[u.quantity.StaticQuantity, ""]
+        wrapped = wrap_if_not_inspectable(ann)
+        meta = parse_jaxtyping_annotation(ann)
+
+        value = data.draw(strategy_for_annotation(wrapped, meta=meta))
+
+        assert isinstance(value, u.quantity.StaticQuantity)
+        assert value.unit in canonical

--- a/packages/coordinaxs.hypothesis/tests/unit/utils/annotations/test_strategy_for_annotation.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/utils/annotations/test_strategy_for_annotation.py
@@ -1,6 +1,7 @@
 """Tests for strategy_for_annotation utility function."""
 
 import jaxtyping
+from typing import Final
 
 import jax.numpy as jnp
 import unxt as u
@@ -15,6 +16,14 @@ from coordinaxs.hypothesis.utils._src.annotations.jaxtyping_utils import (
     strategy_for_annotation,
     wrap_if_not_inspectable,
 )
+
+# The canonical unit of each named dimension. Derived here rather than imported
+# from ``annotations.strategy`` so the assertion below pins the contract instead
+# of comparing the implementation against itself.
+CANONICAL_UNITS: Final = {
+    u.unit(u.dimension(name)._unit)  # ty: ignore[unresolved-attribute]
+    for name in ust.DIMENSION_NAMES
+}
 
 
 class TestAnnotationProcessing:
@@ -158,8 +167,6 @@ class TestStrategyForAnnotation:
         un-dimensioned ``ProlateSpheroidal3D.Delta``. Sampling one canonical unit
         per named dimension avoids composing anything.
         """
-        canonical = {u.unit(u.dimension(name)._unit) for name in ust.DIMENSION_NAMES}
-
         ann = jaxtyping.Real[u.quantity.StaticQuantity, ""]
         wrapped = wrap_if_not_inspectable(ann)
         meta = parse_jaxtyping_annotation(ann)
@@ -167,4 +174,4 @@ class TestStrategyForAnnotation:
         value = data.draw(strategy_for_annotation(wrapped, meta=meta))
 
         assert isinstance(value, u.quantity.StaticQuantity)
-        assert value.unit in canonical
+        assert value.unit in CANONICAL_UNITS


### PR DESCRIPTION
## Problem

`packages/coordinaxs.hypothesis/tests/unit/charts/test_charts_specific.py::test_filter_keyword_still_handles_dimensional_flags` fails intermittently on `main`, roughly one run in 6-16 and seed-dependent:

```
hypothesis.errors.FailedHealthCheck: Input generation is slow: Hypothesis only
generated 9 valid inputs after 1.22 seconds (10 invalid inputs).
  chart | 19 | 100% | 0.199, 0.204, 0.212, 0.231, 0.241  (slowest draws, seconds)
```

Reproduce with `--hypothesis-seed=22342406212106965785130693739344461066`.

## Root cause

Not the filter. `chart_classes` already narrows the pool up front via `st.sampled_from(get_all_subclasses(..., filter=...))`, so all 7 candidates are concrete `Abstract3D` and nothing is rejected. The reported invalid inputs are incidental — the health check keys purely on `total_draw_time > 1.0s`.

Of those 7, only `ProlateSpheroidal3D` takes a required init param:

```python
Delta: Annotated[Real[StaticQuantity, ""], Is[lambda x: x.value > 0]]
```

It pins no physical dimension, so `u.dimension_of` raises and `strategy_for_annotation` fell back to `ust.units()` — sample *any* of the 134 named dimensions. `units()` delegates to `derived_units()`, which calls astropy's `UnitBase.compose()` on every draw. That is uncached (measured at 0.25s on repeat calls, so not a cold-start effect) and costs **0.20-0.29s** for exotic dimensions — "molar heat capacity", "electron flux", "luminous efficacy", "thermal conductivity", "photon flux density wav" — against ~3ms for common ones. Two or three of those in one run exhaust the budget.

## Fix

When the annotation says nothing about the dimension, any valid unit will do, so sample the canonical unit of each named dimension instead of composing. The pool is 134 units built once at import in 5ms.

Measured over `charts(filter=cxc.Abstract3D)`:

| | draw time | draws | slowest single draw |
|---|---|---|---|
| before | 4.81s | 78 | 0.63s |
| after | 0.50s | 137 | 0.16s |

## Scope

Other paths were checked and are not exposed: `charts()` and `manifolds()` draw 100 examples in 0.47s and 0.50s respectively. unxt's own `register_type_strategy(u.Q, ...)` still routes through the uncached `compose()`, but nothing in these strategies reaches it at cost — caching it properly belongs upstream in `unxts`, and is worth doing there since it would fix this class of slowness for every consumer.

## Testing

- Failing seed passes; 20 consecutive runs of `test_charts_specific.py` pass (previously ~1-in-6 to 1-in-16 failure).
- `packages/coordinaxs.hypothesis`: 629 passed.
- `tests/`: 2114 passed. One failure, `tests/usage/charts/test_ptmap.py::TestCartesianRoundTrip3D::test_sph3d_roundtrip` — pre-existing and unrelated, confirmed failing deterministically on pristine `main` with this branch stashed. Flagging separately; it looks like a real bug rather than tolerance noise.

The regression guard asserts canonical units rather than wall-clock time, since #622 deliberately removed the ad-hoc timing suite. That tests the mechanism rather than the symptom, but it is deterministic and it does fail on revert — `ust.units()` draws non-canonical units ~47% of the time, so the assertion dies within a few examples. Verified by reverting the one-line change: fails 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)