### PR TITLE
📝 docs(release): record the pending-publisher setup the coordinaxs.* packages need

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,9 +9,31 @@ This workspace contains six packages that can be released:
 - `coordinaxs.hypothesis` - hypothesis testing strategies
 - `coordinaxs.interop.astropy` - Astropy interoperability package
 
-> **Note:** `coordinaxs.curveframes` requires a one-time PyPI setup before its first automated release: register its **PyPI (and TestPyPI) trusted publisher** for the `cd-publish.yml` workflow, exactly as done for the other packages. The release automation is already wired for it.
-
 All releases are automated via GitHub Actions.
+
+---
+
+## One-time registry setup (required for the `coordinaxs.*` packages)
+
+Only `coordinax` is registered on PyPI and TestPyPI. Every `coordinaxs.*` name is still unregistered, so `cd-publish.yml` fails its upload with:
+
+```text
+400 Non-user identities cannot create new projects.
+```
+
+The OIDC exchange succeeds — the trusted publisher on the `coordinax` project covers this workflow — but that identity is not allowed to create a _new_ project, so nothing can be uploaded under a name PyPI has never seen. This is a registry-side setting; no repository change can work around it.
+
+Before the first release of each of `coordinaxs.api`, `coordinaxs.astro`, `coordinaxs.curveframes`, `coordinaxs.hypothesis`, and `coordinaxs.interop.astropy`, add a **pending publisher** on both <https://test.pypi.org/manage/account/publishing/> and <https://pypi.org/manage/account/publishing/>:
+
+| Field           | Value                                          |
+| --------------- | ---------------------------------------------- |
+| Project name    | the package name, e.g. `coordinaxs.hypothesis` |
+| Owner           | `GalacticDynamics`                             |
+| Repository name | `coordinax`                                    |
+| Workflow name   | `cd-publish.yml`                               |
+| Environment     | `testpypi` on TestPyPI, `pypi` on PyPI         |
+
+The pending publisher becomes a normal trusted publisher on the first successful upload. Until then, every push to `main` that touches one of these packages will red-X `CD Publish`.
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,13 +15,13 @@ All releases are automated via GitHub Actions.
 
 ## One-time registry setup (required for the `coordinaxs.*` packages)
 
-Only `coordinax` is registered on PyPI and TestPyPI. Every `coordinaxs.*` name is still unregistered, so `cd-publish.yml` fails its upload with:
+Only `coordinax` is registered on PyPI and TestPyPI. No `coordinaxs.*` name exists on either registry, and none has a **pending publisher** standing by to create it on first upload, so `cd-publish.yml` fails with:
 
 ```text
 400 Non-user identities cannot create new projects.
 ```
 
-The OIDC exchange succeeds — the trusted publisher on the `coordinax` project covers this workflow — but that identity is not allowed to create a _new_ project, so nothing can be uploaded under a name PyPI has never seen. This is a registry-side setting; no repository change can work around it.
+The OIDC exchange succeeds — the trusted publisher on the `coordinax` project covers this workflow, so a token is minted — but the resulting identity is not a user account, and non-user identities may only create a project when a pending publisher is already registered for that exact name. Watch the name: the pending publisher must match the `name` in the package's `pyproject.toml`, or the upload fails with the same 400. This is a registry-side setting; no repository change can work around it.
 
 Before the first release of each of `coordinaxs.api`, `coordinaxs.astro`, `coordinaxs.curveframes`, `coordinaxs.hypothesis`, and `coordinaxs.interop.astropy`, add a **pending publisher** on both <https://test.pypi.org/manage/account/publishing/> and <https://pypi.org/manage/account/publishing/>:
 


### PR DESCRIPTION
## What

[CD Publish run 30663644441](https://github.com/GalacticDynamics/coordinax/actions/runs/30663644441/job/91265456886) failed uploading `coordinaxs.hypothesis` to TestPyPI:

```
400 Non-user identities cannot create new projects.
```

This is not a code failure and it is not specific to that run — it hits every push to `main` that touches any `coordinaxs.*` package. Recent `CD Publish` history alternates green/red exactly along that split: the green runs are all `coordinax`.

## Root cause

None of the namespace names have ever been registered:

| name | PyPI | TestPyPI |
| --- | --- | --- |
| `coordinax` | 200 | 200 |
| `coordinaxs.api` | 404 | 404 |
| `coordinaxs.astro` | 404 | 404 |
| `coordinaxs.curveframes` | 404 | 404 |
| `coordinaxs.hypothesis` | 404 | 404 |
| `coordinaxs.interop.astropy` | 404 | 404 |

The OIDC token exchange *succeeds* — hence the failure surfaces as a 400 on upload rather than a 403 on auth — because the `coordinax` project already carries a trusted publisher for `cd-publish.yml` + the `testpypi` environment. That identity just isn't permitted to create a project it doesn't own.

## What this PR does

Nothing in the repository can fix this; the missing piece is a **pending publisher** per name on each registry, which only a maintainer account can create. So this PR fixes the documentation that got it wrong.

`RELEASING.md` claimed only `coordinaxs.curveframes` needed one-time setup, "exactly as done for the other packages" — but none of the five were ever set up. Replaced with the concrete field values for the pending-publisher form.

## Action required (not in this PR)

For each of the five names, add a pending publisher on both <https://test.pypi.org/manage/account/publishing/> and <https://pypi.org/manage/account/publishing/>:

- Project name: the package name as declared in `pyproject.toml`, e.g. `coordinaxs.hypothesis` (PyPI keeps the dotted name; normalization applies only to lookup)
- Owner: `GalacticDynamics`
- Repository: `coordinax`
- Workflow: `cd-publish.yml`
- Environment: `testpypi` on TestPyPI, `pypi` on PyPI

After that, the next push to `main` publishes and the pending publishers convert to ordinary trusted publishers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
