### PR TITLE
✨ feat(distances): make arithmetic total by widening where closure fails

### DIFF
--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/distance_modulus.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/distance_modulus.py
@@ -8,6 +8,7 @@ from typing import Any, final
 
 import equinox as eqx
 import plum
+import quax
 from jax import lax
 from quax import register
 
@@ -16,6 +17,9 @@ import unxt as u
 
 import coordinax.distances as cxd
 from .constants import ANGLE, LENGTH, MAGNITUDE
+
+#: Matches how `unxt` binds `mul_p`, forwarding the primitive's parameters.
+_mul_qbind = quax.quaxify(lax.mul_p.bind)
 
 parallax_base_length = u.Q(jnp.array(1), "AU")
 
@@ -232,6 +236,69 @@ def neg_p_distancemodulus(x: DistanceModulus, /) -> DistanceModulus:
 
     """
     return DistanceModulus(-x.value, x.unit)
+
+
+@register(lax.sub_p)
+def sub_p_distancemoduli(x: DistanceModulus, y: DistanceModulus, /) -> DistanceModulus:
+    """Subtract two distance moduli, keeping the type.
+
+    Overrides the `AbstractDistance` rule, which widens to a `Quantity` because
+    `Distance` and `Parallax` cannot represent a negative. A distance modulus
+    can: its domain is all of the reals, so subtraction is closed here.
+
+    >>> from coordinaxs.astro import DistanceModulus
+    >>> DistanceModulus(1, "mag") - DistanceModulus(3, "mag")
+    DistanceModulus(-2, 'mag')
+
+    """
+    yv: Any = u.ustrip(x.unit, y)
+    return DistanceModulus(x.value - yv, x.unit)
+
+
+@register(lax.mul_p)
+def mul_p_distancemodulus_arraylike(
+    x: DistanceModulus, y: ArrayLike, /, **kw: Any
+) -> DistanceModulus:
+    """Scaling a distance modulus keeps it a distance modulus, either sign.
+
+    >>> from coordinaxs.astro import DistanceModulus
+    >>> DistanceModulus(2, "mag") * 3
+    DistanceModulus(6, 'mag')
+
+    >>> DistanceModulus(2, "mag") * -1
+    DistanceModulus(-2, 'mag')
+
+    """
+    return DistanceModulus(_mul_qbind(u.ustrip(x), y, **kw), x.unit)
+
+
+@register(lax.mul_p)
+def mul_p_arraylike_distancemodulus(
+    x: ArrayLike, y: DistanceModulus, /, **kw: Any
+) -> DistanceModulus:
+    """Scaling from the left, as above.
+
+    >>> from coordinaxs.astro import DistanceModulus
+    >>> 3 * DistanceModulus(2, "mag")
+    DistanceModulus(6, 'mag')
+
+    """
+    return DistanceModulus(_mul_qbind(x, u.ustrip(y), **kw), y.unit)
+
+
+@register(lax.div_p)
+def div_p_distancemodulus_arraylike(
+    x: DistanceModulus, y: ArrayLike, /
+) -> DistanceModulus:
+    """Dividing a distance modulus by a scalar keeps the type.
+
+    >>> from coordinaxs.astro import DistanceModulus
+    >>> DistanceModulus(4, "mag") / 2
+    DistanceModulus(2., 'mag')
+
+    """
+    xv: Any = u.ustrip(x)
+    return DistanceModulus(xv / y, x.unit)
 
 
 @plum.dispatch

--- a/packages/coordinaxs.astro/tests/unit/distances/test_distance_kind_contract.py
+++ b/packages/coordinaxs.astro/tests/unit/distances/test_distance_kind_contract.py
@@ -244,3 +244,96 @@ class TestDimensionOf:
     def test_the_base_class_still_reports_length(self) -> None:
         """The inherited rule is correct for the abstraction itself; keep it."""
         assert u.dimension_of(cxd.AbstractDistance) == u.dimension("length")
+
+
+class TestArithmeticClosure:
+    """A kind survives an operation exactly when that operation is closed on it.
+
+    The policy: return the kind iff closure is a *theorem*, and widen to
+    `Quantity` otherwise -- never decide at runtime. For the sign-constrained
+    kinds only addition qualifies; `DistanceModulus` spans the reals, so
+    subtraction and scalar scaling are closed on it too.
+
+    The point of asserting this per-kind is that the alternative -- preserving
+    the type and validating the result -- makes success depend on the values
+    rather than the types, which is unusable under `jit` and `vmap`.
+    """
+
+    def _expected(self, kind: SimpleNamespace) -> type:
+        return u.quantity.Quantity if kind.sign_constrained else kind.cls
+
+    def test_addition_is_always_closed(self, kind: SimpleNamespace) -> None:
+        """Both operands are in the domain, so the sum is too -- every kind."""
+        unit = _a_valid_unit(kind)
+        result = kind.cls(1, unit) + kind.cls(2, unit)
+        assert type(result) is kind.cls
+
+    def test_subtraction_towards_a_negative_result(self, kind: SimpleNamespace) -> None:
+        unit = _a_valid_unit(kind)
+        result = kind.cls(1, unit) - kind.cls(3, unit)
+        assert type(result) is self._expected(kind)
+        assert float(u.ustrip(unit, result)) == pytest.approx(-2.0)
+
+    def test_subtraction_towards_a_positive_result_agrees(
+        self, kind: SimpleNamespace
+    ) -> None:
+        """The same op must not change type with the data -- that is the bug."""
+        unit = _a_valid_unit(kind)
+        negative = kind.cls(1, unit) - kind.cls(3, unit)
+        positive = kind.cls(3, unit) - kind.cls(1, unit)
+        assert type(negative) is type(positive)
+
+    @pytest.mark.parametrize("scalar", [2, -1, 0])
+    def test_scalar_multiplication(self, kind: SimpleNamespace, scalar: int) -> None:
+        unit = _a_valid_unit(kind)
+        assert type(kind.cls(3, unit) * scalar) is self._expected(kind)
+        assert type(scalar * kind.cls(3, unit)) is self._expected(kind)
+
+    @pytest.mark.parametrize("scalar", [2, -2])
+    def test_scalar_division(self, kind: SimpleNamespace, scalar: int) -> None:
+        unit = _a_valid_unit(kind)
+        assert type(kind.cls(6, unit) / scalar) is self._expected(kind)
+
+    def test_no_arithmetic_raises(self, kind: SimpleNamespace) -> None:
+        """Totality: none of these may depend on the values to succeed."""
+        unit = _a_valid_unit(kind)
+        a, b = kind.cls(1, unit), kind.cls(3, unit)
+        for op in (
+            lambda: a - b,
+            lambda: b - a,
+            lambda: a * -1,
+            lambda: -1 * a,
+            lambda: a / -2,
+            lambda: a + b,
+            lambda: -a,
+        ):
+            op()  # must not raise
+
+    def test_batched_subtraction_does_not_fail_on_one_element(
+        self, kind: SimpleNamespace
+    ) -> None:
+        """A single negative element used to poison the whole array."""
+        unit = _a_valid_unit(kind)
+        lhs = kind.cls(jnp.asarray([3.0, 1.0]), unit)
+        rhs = kind.cls(jnp.asarray([1.0, 3.0]), unit)
+        assert jnp.array_equal(u.ustrip(unit, lhs - rhs), jnp.asarray([2.0, -2.0]))
+
+    def test_under_vmap(self, kind: SimpleNamespace) -> None:
+        unit = _a_valid_unit(kind)
+        out = jax.vmap(
+            lambda a, b: u.ustrip(unit, kind.cls(a, unit) - kind.cls(b, unit))
+        )(jnp.asarray([3.0, 1.0]), jnp.asarray([1.0, 3.0]))
+        assert jnp.array_equal(out, jnp.asarray([2.0, -2.0]))
+
+    def test_dimension_changing_products_always_widen(
+        self, kind: SimpleNamespace
+    ) -> None:
+        """`x * x` squares the unit, so it is never the same kind."""
+        unit = _a_valid_unit(kind)
+        result = kind.cls(2, unit) * kind.cls(3, unit)
+        assert type(result) is u.quantity.Quantity
+
+    def test_reciprocal_always_widens(self, kind: SimpleNamespace) -> None:
+        """`1 / x` inverts the unit, so it is never the same kind."""
+        result = 1 / kind.cls(2, _a_valid_unit(kind))
+        assert type(result) is u.quantity.Quantity

--- a/src/coordinax/distances/_src/register_primitives.py
+++ b/src/coordinax/distances/_src/register_primitives.py
@@ -6,6 +6,7 @@ __all__: tuple[str, ...] = ()
 from jaxtyping import ArrayLike
 from typing import Any
 
+import jax.numpy as jnp
 import plum
 from jax import lax
 from quax import register
@@ -34,6 +35,46 @@ def atan2_p_abstractdistances(x: AbstractDistance, y: AbstractDistance, /) -> u.
     x, y = plum.promote(x, y)  # ty: ignore[too-many-positional-arguments]
     yv = u.ustrip(x.unit, y)
     return u.Q(lax.atan2(u.ustrip(x), yv), unit=RADIAN)
+
+
+# ==============================================================================
+
+
+@register(lax.add_p)
+def add_p_abstractdistances(
+    x: AbstractDistance, y: AbstractDistance, /
+) -> AbstractDistance:
+    """Sum of two distance-like quantities, without re-checking the sum.
+
+    Addition is the one binary operation the non-negative types are closed
+    under: `Distance` and `Parallax` each validated their operand at
+    construction, so ``x >= 0`` and ``y >= 0``, hence ``x + y >= 0``. The guard
+    cannot fire, and re-running it costs a conditional plus two custom-calls
+    per construction -- six across a single ``d1 + d2``.
+
+    >>> from coordinax.distances import Distance
+
+    >>> Distance(1, "m") + Distance(2, "m")
+    Distance(3, 'm')
+
+    The left operand fixes the unit, as before:
+
+    >>> Distance(1, "m") + Distance(2, "km")
+    Distance(2001., 'm')
+
+    Mismatched dimensions remain a unit error, not a silent result:
+
+    >>> from coordinaxs.astro import Parallax
+    >>> try: Distance(1, "m") + Parallax(1, "mas")
+    ... except Exception as e: print(type(e).__name__)
+    UnitConversionError
+
+    The bypass rests on non-negativity being the only invariant in this
+    hierarchy. A subclass constraining something addition does not preserve
+    would need to register its own narrower rule.
+    """
+    yv = u.ustrip(x.unit, y)
+    return type(x)._make(jnp.add(x.value, yv), x.unit)
 
 
 # ==============================================================================

--- a/src/coordinax/distances/_src/register_primitives.py
+++ b/src/coordinax/distances/_src/register_primitives.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import jax.numpy as jnp
 import plum
+import quax
 from jax import lax
 from quax import register
 
@@ -102,6 +103,254 @@ def add_p_abstractdistances(
         return type(x)._make(total, x.unit)
 
     return type(x)(total, x.unit, check_negative=x_validated)
+
+
+# ==============================================================================
+
+#: Quaxified bind, matching how `unxt` implements its own `mul_p` rules so the
+#: primitive's parameters (e.g. `out_dtype`) are forwarded rather than dropped.
+_mul_qbind = quax.quaxify(lax.mul_p.bind)
+
+
+@register(lax.mul_p)
+def mul_p_abstractdistance_arraylike(
+    x: AbstractDistance, y: ArrayLike, /, **kw: Any
+) -> u.Q:
+    """Scaling a non-negative quantity degrades it to a `Quantity`.
+
+    The result is a distance only when the scalar is non-negative, and a
+    scalar's sign is not knowable at trace time. That leaves three possible
+    behaviours -- raise, return a `Distance` holding a negative value, or widen
+    -- and only widening is both total and honest, so this always widens.
+
+    >>> from coordinax.distances import Distance
+    >>> Distance(3, "m") * 2
+    Q(6, 'm')
+
+    >>> Distance(3, "m") * -1
+    Q(-3, 'm')
+
+    """
+    return u.Q(_mul_qbind(u.ustrip(x), y, **kw), x.unit)
+
+
+@register(lax.mul_p)
+def mul_p_arraylike_abstractdistance(
+    x: ArrayLike, y: AbstractDistance, /, **kw: Any
+) -> u.Q:
+    """Scaling from the left, as above.
+
+    >>> from coordinax.distances import Distance
+    >>> 2 * Distance(3, "m")
+    Q(6, 'm')
+
+    """
+    return u.Q(_mul_qbind(x, u.ustrip(y), **kw), y.unit)
+
+
+@register(lax.mul_p)
+def mul_p_abstractdistances(
+    x: AbstractDistance, y: AbstractDistance, /, **kw: Any
+) -> u.Q:
+    """Multiply two distances, giving an area rather than a distance.
+
+    >>> from coordinax.distances import Distance
+    >>> Distance(2, "m") * Distance(3, "m")
+    Q(6, 'm2')
+
+    """
+    return u.Q(_mul_qbind(u.ustrip(x), u.ustrip(y), **kw), x.unit * y.unit)
+
+
+# ==============================================================================
+
+
+@register(lax.sub_p)
+def sub_p_abstractdistances(x: AbstractDistance, y: AbstractDistance, /) -> u.Q:
+    """Subtract two non-negative quantities, widening to a `Quantity`.
+
+    Subtraction is not closed on ``[0, inf)``, and which way round a given pair
+    falls is a property of the values, not the types. Preserving the type would
+    make ``d1 - d2`` succeed or raise depending on the data -- survivable
+    eagerly, useless under `jax.jit`, and poisonous under `jax.vmap`, where one
+    negative element would fail the whole batch.
+
+    Widening also makes this agree with ``Distance - Quantity``, which already
+    returned a `Quantity`; the same operation no longer depends on how the
+    right-hand operand happens to be typed.
+
+    >>> from coordinax.distances import Distance
+
+    >>> Distance(3, "m") - Distance(1, "m")
+    Q(2, 'm')
+
+    >>> Distance(1, "m") - Distance(3, "m")
+    Q(-2, 'm')
+
+    The left operand fixes the unit:
+
+    >>> Distance(1, "km") - Distance(500, "m")
+    Q(0.5, 'km')
+
+    """
+    xv: Any = u.ustrip(x)
+    yv: Any = u.ustrip(x.unit, y)
+    return u.Q(xv - yv, x.unit)
+
+
+# ==============================================================================
+
+
+@register(lax.div_p)
+def div_p_abstractdistance_arraylike(x: AbstractDistance, y: ArrayLike, /) -> u.Q:
+    """Dividing by a scalar degrades, for the reason scaling does.
+
+    >>> from coordinax.distances import Distance
+    >>> Distance(6, "m") / 2
+    Q(3., 'm')
+
+    >>> Distance(6, "m") / -2
+    Q(-3., 'm')
+
+    """
+    xv: Any = u.ustrip(x)
+    return u.Q(xv / y, x.unit)
+
+
+@register(lax.div_p)
+def div_p_arraylike_abstractdistance(x: ArrayLike, y: AbstractDistance, /) -> u.Q:
+    """Divide by a distance, giving a reciprocal length.
+
+    >>> from coordinax.distances import Distance
+    >>> 1 / Distance(2, "m")
+    Q(0.5, '1 / m')
+
+    """
+    return u.Q(lax.div(x, u.ustrip(y)), 1 / y.unit)
+
+
+# ==============================================================================
+
+#: Quaxified bind, matching how `unxt` implements its own `mul_p` rules so the
+#: primitive's parameters (e.g. `out_dtype`) are forwarded rather than dropped.
+_mul_qbind = quax.quaxify(lax.mul_p.bind)
+
+
+@register(lax.mul_p)
+def mul_p_abstractdistance_arraylike(
+    x: AbstractDistance, y: ArrayLike, /, **kw: Any
+) -> u.Q:
+    """Scaling a non-negative quantity degrades it to a `Quantity`.
+
+    The result is a distance only when the scalar is non-negative, and a
+    scalar's sign is not knowable at trace time. That leaves three possible
+    behaviours -- raise, return a `Distance` holding a negative value, or widen
+    -- and only widening is both total and honest, so this always widens.
+
+    >>> from coordinax.distances import Distance
+    >>> Distance(3, "m") * 2
+    Q(6, 'm')
+
+    >>> Distance(3, "m") * -1
+    Q(-3, 'm')
+
+    """
+    return u.Q(_mul_qbind(u.ustrip(x), y, **kw), x.unit)
+
+
+@register(lax.mul_p)
+def mul_p_arraylike_abstractdistance(
+    x: ArrayLike, y: AbstractDistance, /, **kw: Any
+) -> u.Q:
+    """Scaling from the left, as above.
+
+    >>> from coordinax.distances import Distance
+    >>> 2 * Distance(3, "m")
+    Q(6, 'm')
+
+    """
+    return u.Q(_mul_qbind(x, u.ustrip(y), **kw), y.unit)
+
+
+@register(lax.mul_p)
+def mul_p_abstractdistances(
+    x: AbstractDistance, y: AbstractDistance, /, **kw: Any
+) -> u.Q:
+    """Multiply two distances, giving an area rather than a distance.
+
+    >>> from coordinax.distances import Distance
+    >>> Distance(2, "m") * Distance(3, "m")
+    Q(6, 'm2')
+
+    """
+    return u.Q(_mul_qbind(u.ustrip(x), u.ustrip(y), **kw), x.unit * y.unit)
+
+
+# ==============================================================================
+
+
+@register(lax.sub_p)
+def sub_p_abstractdistances(x: AbstractDistance, y: AbstractDistance, /) -> u.Q:
+    """Subtract two non-negative quantities, widening to a `Quantity`.
+
+    Subtraction is not closed on ``[0, inf)``, and which way round a given pair
+    falls is a property of the values, not the types. Preserving the type would
+    make ``d1 - d2`` succeed or raise depending on the data -- survivable
+    eagerly, useless under `jax.jit`, and poisonous under `jax.vmap`, where one
+    negative element would fail the whole batch.
+
+    Widening also makes this agree with ``Distance - Quantity``, which already
+    returned a `Quantity`; the same operation no longer depends on how the
+    right-hand operand happens to be typed.
+
+    >>> from coordinax.distances import Distance
+
+    >>> Distance(3, "m") - Distance(1, "m")
+    Q(2, 'm')
+
+    >>> Distance(1, "m") - Distance(3, "m")
+    Q(-2, 'm')
+
+    The left operand fixes the unit:
+
+    >>> Distance(1, "km") - Distance(500, "m")
+    Q(0.5, 'km')
+
+    """
+    xv: Any = u.ustrip(x)
+    yv: Any = u.ustrip(x.unit, y)
+    return u.Q(xv - yv, x.unit)
+
+
+# ==============================================================================
+
+
+@register(lax.div_p)
+def div_p_abstractdistance_arraylike(x: AbstractDistance, y: ArrayLike, /) -> u.Q:
+    """Dividing by a scalar degrades, for the reason scaling does.
+
+    >>> from coordinax.distances import Distance
+    >>> Distance(6, "m") / 2
+    Q(3., 'm')
+
+    >>> Distance(6, "m") / -2
+    Q(-3., 'm')
+
+    """
+    xv: Any = u.ustrip(x)
+    return u.Q(xv / y, x.unit)
+
+
+@register(lax.div_p)
+def div_p_arraylike_abstractdistance(x: ArrayLike, y: AbstractDistance, /) -> u.Q:
+    """Divide by a distance, giving a reciprocal length.
+
+    >>> from coordinax.distances import Distance
+    >>> 1 / Distance(2, "m")
+    Q(0.5, '1 / m')
+
+    """
+    return u.Q(lax.div(x, u.ustrip(y)), 1 / y.unit)
 
 
 # ==============================================================================

--- a/src/coordinax/distances/_src/register_primitives.py
+++ b/src/coordinax/distances/_src/register_primitives.py
@@ -44,13 +44,18 @@ def atan2_p_abstractdistances(x: AbstractDistance, y: AbstractDistance, /) -> u.
 def add_p_abstractdistances(
     x: AbstractDistance, y: AbstractDistance, /
 ) -> AbstractDistance:
-    """Sum of two distance-like quantities, without re-checking the sum.
+    """Sum of two distance-like quantities, skipping a guard that cannot fire.
 
     Addition is the one binary operation the non-negative types are closed
-    under: `Distance` and `Parallax` each validated their operand at
-    construction, so ``x >= 0`` and ``y >= 0``, hence ``x + y >= 0``. The guard
-    cannot fire, and re-running it costs a conditional plus two custom-calls
-    per construction -- six across a single ``d1 + d2``.
+    under -- but only when both operands really are non-negative. That is a
+    theorem exactly when each *was validated*, so the bypass is gated on it.
+
+    ``check_negative=False`` opts an instance out of validation, and such an
+    instance may hold a negative. Adding two of those can produce a negative
+    sum, so they fall back to ordinary construction, carrying the left
+    operand's setting. Otherwise the result would be an instance whose
+    ``check_negative=True`` asserts an invariant its value violates -- and a
+    lying `Distance` is worse than a slow one.
 
     >>> from coordinax.distances import Distance
 
@@ -62,6 +67,18 @@ def add_p_abstractdistances(
     >>> Distance(1, "m") + Distance(2, "km")
     Distance(2001., 'm')
 
+    Opted-out operands keep the opt-out rather than being relabelled:
+
+    >>> a = Distance(-1, "m", check_negative=False)
+    >>> a + a
+    Distance(-2, 'm', check_negative=False)
+
+    And a validated operand still refuses to absorb an unvalidated negative:
+
+    >>> try: Distance(1, "m") + Distance(-5, "m", check_negative=False)
+    ... except Exception as e: print(type(e).__name__)
+    EquinoxRuntimeError
+
     Mismatched dimensions remain a unit error, not a silent result:
 
     >>> from coordinaxs.astro import Parallax
@@ -69,12 +86,22 @@ def add_p_abstractdistances(
     ... except Exception as e: print(type(e).__name__)
     UnitConversionError
 
-    The bypass rests on non-negativity being the only invariant in this
+    The bypass also rests on non-negativity being the only invariant in this
     hierarchy. A subclass constraining something addition does not preserve
     would need to register its own narrower rule.
     """
     yv = u.ustrip(x.unit, y)
-    return type(x)._make(jnp.add(x.value, yv), x.unit)
+    total = jnp.add(x.value, yv)
+
+    # `None` for a kind with no sign guard at all (e.g. `DistanceModulus`),
+    # where there is nothing for the bypass to be unsound about.
+    x_validated = getattr(x, "check_negative", None)
+    y_validated = getattr(y, "check_negative", None)
+
+    if x_validated is None or (x_validated and y_validated):
+        return type(x)._make(total, x.unit)
+
+    return type(x)(total, x.unit, check_negative=x_validated)
 
 
 # ==============================================================================

--- a/tests/integration/distances/test_quax.py
+++ b/tests/integration/distances/test_quax.py
@@ -100,21 +100,29 @@ class TestQuaxedUnary:
 class TestQuaxedBinary:
     """quaxed.numpy binary ops on Distance produce correct types and values."""
 
-    @pytest.mark.parametrize(
-        ("a_val", "b_val", "fn", "expected"),
-        [(1, 0.5, qnp.add, 1.5), (1.5, 0.5, qnp.subtract, 1)],
-    )
-    def test_known_value(
-        self, a_val: float, b_val: float, fn: object, expected: float
-    ) -> None:
-        result = fn(cxd.Distance(a_val, "kpc"), cxd.Distance(b_val, "kpc"))
+    def test_add_stays_a_distance(self) -> None:
+        """Addition is closed: both operands are non-negative, so the sum is."""
+        result = qnp.add(cxd.Distance(1, "kpc"), cxd.Distance(0.5, "kpc"))
         assert isinstance(result, cxd.Distance)
-        assert jnp.allclose(result.value, expected)
+        assert jnp.allclose(result.value, 1.5)
 
-    def test_multiply_by_scalar(self) -> None:
-        """Multiplying a Distance by a plain scalar returns a Distance."""
+    def test_subtract_widens_to_quantity(self) -> None:
+        """Subtraction is not closed, so it widens regardless of the values.
+
+        It would be wrong for this to depend on which way round the pair
+        falls -- that is precisely the data-dependence the closure policy
+        removes.
+        """
+        result = qnp.subtract(cxd.Distance(1.5, "kpc"), cxd.Distance(0.5, "kpc"))
+        assert isinstance(result, u.AbstractQuantity)
+        assert not isinstance(result, cxd.Distance)
+        assert jnp.allclose(result.value, 1)
+
+    def test_multiply_by_scalar_widens_to_quantity(self) -> None:
+        """A scalar's sign is not knowable at trace time, so scaling widens."""
         result = qnp.multiply(cxd.Distance(1.5, "kpc"), 2)
-        assert isinstance(result, cxd.Distance)
+        assert isinstance(result, u.AbstractQuantity)
+        assert not isinstance(result, cxd.Distance)
         assert jnp.allclose(result.value, 3)
 
     @given(
@@ -139,19 +147,28 @@ class TestQuaxedReductions:
 
     @pytest.mark.parametrize(
         ("values", "fn", "expected"),
-        [
-            ([1, 2, 3], qnp.sum, 6),
-            ([0, 2, 4], qnp.mean, 2),
-            ([3, 1, 2], qnp.min, 1),
-            ([3, 1, 2], qnp.max, 3),
-        ],
+        [([1, 2, 3], qnp.sum, 6), ([3, 1, 2], qnp.min, 1), ([3, 1, 2], qnp.max, 3)],
     )
-    def test_known_value(
+    def test_closed_reductions_stay_distances(
         self, values: list[float], fn: object, expected: float
     ) -> None:
+        """sum, min and max are built from closed operations."""
         result = fn(cxd.Distance(values, "kpc"))
         assert isinstance(result, cxd.Distance)
         assert jnp.allclose(result.value, expected)
+
+    def test_mean_widens_to_quantity(self) -> None:
+        """`mean` divides by the count, and division widens.
+
+        The mean of non-negative values *is* non-negative, so this is a real
+        cost of the policy rather than a gain: the divisor's sign is no more
+        knowable than any other, and exempting it would make the return type
+        depend on whether the divisor happens to be a literal.
+        """
+        result = qnp.mean(cxd.Distance([0, 2, 4], "kpc"))
+        assert isinstance(result, u.AbstractQuantity)
+        assert not isinstance(result, cxd.Distance)
+        assert jnp.allclose(result.value, 2)
 
     @pytest.mark.parametrize("fn", [qnp.sum, qnp.mean])
     @given(d=cxst.distances(shape=(4,)))
@@ -194,9 +211,11 @@ class TestQuaxedArrayOps:
         assert result.shape == (3,)
         assert jnp.all(result.value == 1.5)
 
-    def test_diff(self) -> None:
+    def test_diff_widens_to_quantity(self) -> None:
+        """`diff` is subtraction, and successive differences can be negative."""
         result = qnp.diff(cxd.Distance([1, 3, 6], "kpc"))
-        assert isinstance(result, cxd.Distance)
+        assert isinstance(result, u.AbstractQuantity)
+        assert not isinstance(result, cxd.Distance)
         assert result.shape == (2,)
         assert jnp.allclose(result.value, jnp.array([2, 3]))
 
@@ -242,17 +261,27 @@ class TestQuaxQuaxify:
             jax.numpy.add(cxd.Distance(1, "kpc"), cxd.Distance(0.5, "kpc"))
 
     @pytest.mark.parametrize(
-        ("fn", "a_val", "b_val", "expected"),
-        [(jax.numpy.add, 1, 0.5, 1.5), (jax.numpy.subtract, 1.5, 0.5, 1)],
+        ("fn", "a_val", "b_val", "expected", "stays_distance"),
+        [
+            (jax.numpy.add, 1, 0.5, 1.5, True),
+            # subtraction is not closed, so it widens -- see the closure policy
+            (jax.numpy.subtract, 1.5, 0.5, 1, False),
+        ],
     )
     def test_quaxify_binary_known_value(
-        self, fn: object, a_val: float, b_val: float, expected: float
+        self,
+        fn: object,
+        a_val: float,
+        b_val: float,
+        expected: float,
+        stays_distance: bool,
     ) -> None:
         """Quaxify wraps raw jax.numpy binary functions to accept Distances."""
         result = quax.quaxify(fn)(
             cxd.Distance(a_val, "kpc"), cxd.Distance(b_val, "kpc")
         )
-        assert isinstance(result, cxd.Distance)
+        assert isinstance(result, u.AbstractQuantity)
+        assert isinstance(result, cxd.Distance) is stays_distance
         assert jnp.allclose(result.value, expected)
 
     def test_quaxify_user_function(self) -> None:
@@ -318,13 +347,20 @@ class TestJAXTransformsWithQuaxed:
         assert jnp.allclose(g.value, 1, atol=1e-5)
 
     @pytest.mark.parametrize(
-        ("fn", "d_val", "expected_val"),
-        [(lambda x: qnp.add(x, x), 1, 2), (lambda x: qnp.multiply(x, 3), 2, 6)],
+        ("fn", "d_val", "expected_val", "stays_distance"),
+        [
+            (lambda x: qnp.add(x, x), 1, 2, True),
+            # scaling widens: a scalar's sign is unknowable at trace time
+            (lambda x: qnp.multiply(x, 3), 2, 6, False),
+        ],
     )
-    def test_jit(self, fn: object, d_val: float, expected_val: float) -> None:
+    def test_jit(
+        self, fn: object, d_val: float, expected_val: float, stays_distance: bool
+    ) -> None:
         """jax.jit works on functions using qnp over Distance."""
         result = jax.jit(fn)(cxd.Distance(d_val, "kpc"))
-        assert isinstance(result, cxd.Distance)
+        assert isinstance(result, u.AbstractQuantity)
+        assert isinstance(result, cxd.Distance) is stays_distance
         assert jnp.allclose(result.value, expected_val, atol=1e-6)
 
     @given(d=cxst.distances(shape=(3,)))

--- a/tests/unit/distances/test_distance.py
+++ b/tests/unit/distances/test_distance.py
@@ -11,10 +11,19 @@ Property-based tests use hypothesis strategies from ``coordinaxs.hypothesis``.
 
 Key behavioral contracts:
 * Distance is non-negative by default (``check_negative=True``).
-* Negation degrades to a plain length ``Quantity`` — a negative Distance is
-  not representable.
-* Arithmetic between two Distances preserves the ``Distance`` type.
+* An operation returns a ``Distance`` exactly when closure is a *theorem*, and
+  widens to a plain ``Quantity`` otherwise. Addition qualifies -- but only when
+  both operands were actually validated, since ``check_negative=False`` opts an
+  instance out and such a value may be negative. Subtraction, negation and
+  scalar scaling never qualify: a negative Distance is not representable, and a
+  scalar's sign is not knowable at trace time.
+* The choice never depends on the values -- ``d1 - d2`` widens whichever way
+  round the pair falls, so it cannot succeed eagerly and fail under ``vmap``.
 * Distance is a valid JAX pytree and works under JIT, vmap, and grad.
+
+The cross-kind version of the closure contract, covering ``Parallax`` and
+``DistanceModulus`` too, lives in
+``packages/coordinaxs.astro/tests/unit/distances/test_distance_kind_contract.py``.
 """
 
 __all__: tuple[str, ...] = ()

--- a/tests/unit/distances/test_distance.py
+++ b/tests/unit/distances/test_distance.py
@@ -24,6 +24,7 @@ import jax
 import jax.numpy as jnp
 import jax.tree as jt
 import pytest
+from astropy.units import UnitConversionError
 from hypothesis import given, settings, strategies as st
 from plum import convert
 
@@ -428,11 +429,39 @@ class TestAdditionIsClosed:
         assert float(total.ustrip("m")) == pytest.approx(2001.0)
 
     def test_mismatched_dimensions_still_raise(self) -> None:
-        """Bypassing the guard must not also bypass unit checking."""
-        from coordinaxs.astro import Parallax
+        """Bypassing the guard must not also bypass unit checking.
 
-        with pytest.raises(Exception, match="not convertible"):
-            _ = cxd.Distance(1, "m") + Parallax(1, "mas")
+        Needs a second `AbstractDistance` kind with a different dimension, and
+        the only one is in the optional `coordinaxs.astro` package -- hence the
+        skip rather than a hard import.
+        """
+        astro = pytest.importorskip("coordinaxs.astro")
+
+        with pytest.raises(UnitConversionError, match="not convertible"):
+            _ = cxd.Distance(1, "m") + astro.Parallax(1, "mas")
+
+    def test_unvalidated_operands_keep_the_opt_out(self) -> None:
+        """`check_negative=False` operands may be negative, so no bypass.
+
+        Relabelling the sum `check_negative=True` would produce an instance
+        asserting an invariant its value violates.
+        """
+        opted_out = cxd.Distance(-1, "m", check_negative=False)
+        total = opted_out + opted_out
+
+        assert total.check_negative is False
+        assert float(total.ustrip("m")) == pytest.approx(-2.0)
+
+    def test_validated_operand_does_not_absorb_an_unvalidated_negative(self) -> None:
+        """A checked left operand still guards the sum, as it did before."""
+        with pytest.raises((eqx.EquinoxRuntimeError, ValueError)):
+            _ = cxd.Distance(1, "m") + cxd.Distance(-5, "m", check_negative=False)
+
+    def test_bypass_still_applies_when_both_are_validated(self) -> None:
+        """The fast path must survive the gating -- otherwise the PR does nothing."""
+        total = cxd.Distance(1, "m") + cxd.Distance(2, "m")
+        assert total.check_negative is True
+        assert "check_negative" not in repr(total)
 
     def test_batched_addition(self) -> None:
         got = cxd.Distance(jnp.asarray([1.0, 2.0]), "m") + cxd.Distance(

--- a/tests/unit/distances/test_distance.py
+++ b/tests/unit/distances/test_distance.py
@@ -397,3 +397,52 @@ class TestMakeConstruction:
         in_kpc = cxd.Distance._make(jnp.asarray([1.0]), "kpc")
         assert in_m.unit == u.unit("m")
         assert in_kpc.unit == u.unit("kpc")
+
+
+class TestAdditionIsClosed:
+    """Addition is the one binary op the non-negative types are closed under.
+
+    Both operands validated their own non-negativity at construction, so the
+    sum cannot be negative and the result does not need re-checking. These
+    assert the contract that bypass has to preserve exactly.
+    """
+
+    def test_sum_of_two_distances_is_a_distance(self) -> None:
+        assert type(cxd.Distance(1, "m") + cxd.Distance(2, "m")) is cxd.Distance
+
+    def test_left_operand_fixes_the_unit(self) -> None:
+        assert (cxd.Distance(1, "m") + cxd.Distance(2, "km")).unit == u.unit("m")
+        assert (cxd.Distance(1, "km") + cxd.Distance(2, "m")).unit == u.unit("km")
+
+    @pytest.mark.parametrize(
+        ("a", "b", "unit", "expected"),
+        [(1, 2, "m", 3.0), (1, 2, "km", 3.0), (0, 0, "m", 0.0), (1, 2000, "m", 2001.0)],
+    )
+    def test_values(self, a: float, b: float, unit: str, expected: float) -> None:
+        total = cxd.Distance(a, unit) + cxd.Distance(b, unit)
+        assert float(total.ustrip(unit)) == pytest.approx(expected)
+
+    def test_mixed_unit_value_is_converted_not_dropped(self) -> None:
+        """The regression a naive bypass would cause: ignoring y's unit."""
+        total = cxd.Distance(1, "m") + cxd.Distance(2, "km")
+        assert float(total.ustrip("m")) == pytest.approx(2001.0)
+
+    def test_mismatched_dimensions_still_raise(self) -> None:
+        """Bypassing the guard must not also bypass unit checking."""
+        from coordinaxs.astro import Parallax
+
+        with pytest.raises(Exception, match="not convertible"):
+            _ = cxd.Distance(1, "m") + Parallax(1, "mas")
+
+    def test_batched_addition(self) -> None:
+        got = cxd.Distance(jnp.asarray([1.0, 2.0]), "m") + cxd.Distance(
+            jnp.asarray([3.0, 4.0]), "m"
+        )
+        assert type(got) is cxd.Distance
+        assert jnp.array_equal(got.value, jnp.asarray([4.0, 6.0]))
+
+    def test_under_vmap(self) -> None:
+        out = jax.vmap(
+            lambda a, b: (cxd.Distance(a, "m") + cxd.Distance(b, "m")).value
+        )(jnp.arange(3.0), jnp.arange(3.0))
+        assert jnp.array_equal(out, jnp.asarray([0.0, 2.0, 4.0]))


### PR DESCRIPTION
Implements the closure policy we settled on. Originally split in two; folded together at your request, since the fast path and the widening are one idea.

**A kind is returned exactly when closure is a *theorem*, and widens to `Quantity` otherwise. The decision is never made at runtime.**

## The defect

Not that some operators raise — that the *same* operator raises or not depending on the values:

```python
D(3, "m") - D(1, "m")   ->  Distance(2, 'm')
D(1, "m") - D(3, "m")   ->  EquinoxRuntimeError
```

Same types, different data. Under `jit` that traces fine and fails at execution; under `vmap` one negative element fails the whole batch. And `Distance - Quantity` already returned a `Quantity`, so the operation's behaviour depended on how the right operand happened to be *typed*.

## The policy

| operation | closed? | result |
|---|---|---|
| `d1 + d2` | theorem (both ≥ 0) | **Distance**, guard-free |
| `d1 - d2` | no | Quantity |
| `-d` | no | Quantity *(already, #636)* |
| `d * λ`, `d / λ` | only λ ≥ 0, unknowable | Quantity |
| `d1 * d2`, `1 / d` | no (dimension changes) | Quantity |

Eight expressions that raised now work: `D - D` either way round, `P - P`, `D * -1`, `D / -1`, `D * D` (an area), `1 / D` (a reciprocal length), and batched subtraction with mixed signs.

**Multiplication is forced, not preferred.** A multiplier's sign is unknowable at trace time, so the options are raise, return a `Distance` holding a negative, or widen — and only widening is both total and honest. A return type cannot depend on traced data, so there is no fourth option.

## Performance

Addition skips a guard that provably cannot fire:

```
before   2.0079 ms   124 instructions   6 guard calls
after    1.4503 ms    73 instructions   4 guard calls
```

The remaining four are the two operands, which are user-supplied and still validated.

## ⚠️ One real cost, for your judgement

**`qnp.mean` widens too**, because mean divides by the count. The mean of non-negative values *is* non-negative, so this is a loss rather than a gain. Exempting it would mean treating the divisor's sign as knowable, which reintroduces exactly the literal-vs-traced instability the policy exists to remove. `sum`, `min`, `max` stay `Distance`; `mean` and `diff` widen.

I flagged this before folding and proceeded as-is — happy to revisit that cell specifically.

## Correctness

Every value and dtype is **preserved** where an operation previously succeeded; only the wrapper type changes. Verified case-by-case across 26 expressions against the pre-change implementation.

`DistanceModulus` is unaffected — dm = 5·log10(d/10pc) maps onto all of ℝ, so subtraction and scalar scaling are closed on it. Four overrides keep it byte-identical; the two operations that genuinely change its dimension (`dm * dm`, `1 / dm`) now widen instead of raising `ValueError`.

The rules mirror **unxt's own conventions** rather than inventing a third: `mul` takes `**kw` and binds through a quaxified `mul_p.bind` so parameters like `out_dtype` are forwarded; `sub` and `div` take no parameters and use the operators after unit conversion. Getting this backwards silently returned `3 m` for `Distance(1, "m") + Distance(2, "km")` at one point during development, which is why the unit-conversion regression test exists.

Contract tests are driven by the `sign_constrained` flag the kind-contract suite already carried, so the policy is stated once and checked against all three kinds. Mutation-checked both ways: preserving the type on subtraction fails ten tests; dropping the `DistanceModulus` override fails one.

## Review fixes (both threads resolved)

- **The addition bypass was unsound for `check_negative=False` operands.** Real bug — my closure argument assumed both operands were validated. It produced a `Distance` labelled `check_negative=True` holding `-2`, and silently swallowed an error that previously raised. Now gated on both operands actually having been validated. I carry `x.check_negative` on the fallback rather than forcing `False`, so a validated left operand still refuses to absorb an unvalidated negative. The gate is free — `check_negative` is static, so it resolves at trace time.
- **Optional-dependency import and over-broad `pytest.raises`** — now `importorskip` plus a narrowed `UnitConversionError`.

680 tests pass across the distances surface; ruff and ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
