### PR TITLE
♻️ refactor(vectors): drop dead constants and duplicate type aliases

### DIFF
--- a/src/coordinax/vectors/_src/__init__.py
+++ b/src/coordinax/vectors/_src/__init__.py
@@ -2,7 +2,6 @@
 
 from .base import *
 from .bundle import *
-from .constants import *
 from .custom_types import *
 from .mixins import *
 from .point import *

--- a/src/coordinax/vectors/_src/base.py
+++ b/src/coordinax/vectors/_src/base.py
@@ -418,7 +418,7 @@ class AbstractVector(
         dynamic = jtu.map(lambda x: getattr(x, method)(*args, **kwargs), dynamic)
         return eqx.combine(dynamic, static)
 
-    def astype(self, dtype: Any, /, **kwargs: Any) -> "AbstractVector":
+    def astype(self, dtype: Any, /, **kwargs: Any) -> "Self":
         """Cast the vector to a new dtype.
 
         Examples
@@ -439,9 +439,7 @@ class AbstractVector(
             [1. 2. 3.]>
 
         """
-        dynamic, static = eqx.partition(self, lambda x: hasattr(x, "astype"))
-        dynamic = jtu.map(lambda x: x.astype(dtype, **kwargs), dynamic)
-        return eqx.combine(dynamic, static)
+        return self._tree_apply("astype", dtype, **kwargs)
 
     # -------------------------------
 

--- a/src/coordinax/vectors/_src/constants.py
+++ b/src/coordinax/vectors/_src/constants.py
@@ -1,9 +1,0 @@
-"""Internal custom types for coordinax."""
-
-__all__ = ("LENGTH", "SPEED", "ACCELERATION")
-
-import unxt as u
-
-LENGTH = u.dimension("length")
-ACCELERATION = u.dimension("acceleration")
-SPEED = u.dimension("speed")

--- a/src/coordinax/vectors/_src/custom_types.py
+++ b/src/coordinax/vectors/_src/custom_types.py
@@ -1,21 +1,10 @@
 """Custom types for coordinax.vectors."""
 
-__all__ = ("Shape", "HasShape", "CKey", "CDict")
+__all__ = ("Shape", "HasShape", "CKey", "CDict", "OptUSys")
 
-from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, runtime_checkable
+from typing import Protocol, TypeAlias, runtime_checkable
 
-import unxt as u
-
-CKey: TypeAlias = str
-if TYPE_CHECKING:
-    # Typed for static checkers only.
-    CDict: TypeAlias = dict[CKey, Any]
-else:
-    # A parametric `dict[...]` annotation makes every plum signature
-    # using CDict "unfaithful", disabling plum's method cache (a full
-    # ~200x slower resolution per call). The bare `dict` keeps the cache;
-    # the TYPE_CHECKING branch above preserves the static type.
-    CDict: TypeAlias = dict
+from coordinax._src.custom_types import CDict, CKey, OptUSys
 
 Shape: TypeAlias = tuple[int, ...]
 
@@ -28,6 +17,3 @@ class HasShape(Protocol):
     def shape(self) -> Shape:
         """The shape of the object."""
         raise NotImplementedError  # pragma: no cover
-
-
-OptUSys: TypeAlias = u.AbstractUnitSystem | None


### PR DESCRIPTION
Over-engineering audit of `coordinax.vectors`, part 1/5 — dead code.

- **`vectors/_src/constants.py` deleted.** `LENGTH`, `SPEED`, and `ACCELERATION` had no consumers inside `coordinax.vectors`; they are separately defined (and used) in `representations`, `transforms`, and `distances`.
- **`vectors/_src/custom_types.py` de-duplicated.** It re-defined `CKey`, `CDict`, and `OptUSys` verbatim from `coordinax._src.custom_types`, down to the plum method-cache comment. Now imports them; keeps only its own `Shape` / `HasShape`.
- **`AbstractVector.astype`** still carried its own `eqx.partition` / `jtu.map` / `eqx.combine` copy; routed through the existing `_tree_apply` helper like every other array method. Its return annotation narrows from `AbstractVector` to `Self`, matching what it actually returns.

No behaviour change. Full suite green (`8017 passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)