### PR TITLE
♻️ refactor(vectors): hoist shared rendering and shape logic onto AbstractVector

### DIFF
--- a/src/coordinax/vectors/_src/base.py
+++ b/src/coordinax/vectors/_src/base.py
@@ -32,7 +32,6 @@ from .custom_types import HasShape
 from coordinax.internal import pos_named_objs
 
 if TYPE_CHECKING:
-    from jaxtyping import Array
     from typing import Self
 
 Ks = TypeVar("Ks", bound=tuple[str, ...])
@@ -677,7 +676,7 @@ def vector_comps_unit_docs(vector: AbstractVector) -> tuple[str, str]:
 
 def vector_values_str(vector: AbstractVector, **kwargs: Any) -> str:
     r"""Return the formatted array string ``'\\n    [values]'`` (no closing ``>``)."""
-    vals: list[Array] = [
+    vals = [
         jnp.asarray(u.ustrip(u.unit_of(v), v) if uq.is_any_quantity(v) else v)
         for comp in vector.chart.components
         for v in (vector.data[comp],)

--- a/src/coordinax/vectors/_src/base.py
+++ b/src/coordinax/vectors/_src/base.py
@@ -11,6 +11,7 @@ from typing_extensions import TypeIs, TypeVar
 import equinox as eqx
 import jax
 import jax.tree as jtu
+import numpy as np
 import plum
 import quax_blocks
 import wadler_lindig as wl
@@ -19,6 +20,7 @@ from quax import ArrayValue
 import dataclassish
 import quaxed.numpy as jnp
 import unxt as u
+import unxt.quantity as uq
 from dataclassish import field_items
 
 import coordinax.charts as cxc
@@ -27,8 +29,10 @@ import coordinax.manifolds as cxm
 import coordinax.representations as cxr
 import coordinax.transforms as cxfm
 from .custom_types import HasShape
+from coordinax.internal import pos_named_objs
 
 if TYPE_CHECKING:
+    from jaxtyping import Array
     from typing import Self
 
 Ks = TypeVar("Ks", bound=tuple[str, ...])
@@ -92,7 +96,7 @@ class AbstractVector(
     M : coordinax.manifolds.AbstractManifold
         The manifold on which the vector lives.
     shape : tuple[int, ...]
-        The batch shape of the vector (abstract; implemented by subclasses).
+        The batch shape of the vector, broadcast across the component leaves.
 
     See Also
     --------
@@ -302,11 +306,22 @@ class AbstractVector(
         msg = f"Refusing to materialise `{type(self).__name__}`."
         raise RuntimeError(msg)
 
+    # TODO: generalize to work with FourVector, and Space
+    def aval(self) -> jax.core.ShapedArray:  # ty: ignore[possibly-missing-submodule]
+        """Return the vector as an abstract JAX array.
+
+        The shape is ``(*batch, n_components)`` and the dtype is promoted
+        across the component leaves.
+        """
+        fvs = self.data.values()
+        shape = (*jnp.broadcast_shapes(*map(jnp.shape, fvs)), len(fvs))
+        dtype = jnp.result_type(*map(jnp.dtype, fvs))
+        return jax.core.ShapedArray(shape, dtype)  # ty: ignore[possibly-missing-submodule]
+
     @property
-    @abc.abstractmethod
     def shape(self) -> tuple[int, ...]:
-        """Return the shape of the vector."""
-        raise NotImplementedError  # pragma: no cover
+        """Return the batch shape of the vector."""
+        return jnp.broadcast_shapes(*(v.shape for v in self.data.values()))
 
     # ===============================================================
     # Array API
@@ -481,6 +496,41 @@ class AbstractVector(
         return self._tree_apply("to_device", device)
 
     # ===============================================================
+    # Wadler-Lindig API
+
+    def __pdoc__(self, *, vector_form: bool = False, **kw: Any) -> wl.AbstractDoc:
+        """Return the Wadler-Lindig document for the vector.
+
+        Parameters
+        ----------
+        vector_form
+            If True, return the compact angle-bracket vector form; otherwise
+            the constructor-style document.
+        **kw
+            Additional keyword arguments passed to the Wadler-Lindig formatter.
+
+        """
+        if vector_form:
+            return vectorform_pdoc(self, **kw)
+
+        # Prefer to use short names (e.g. Quantity -> Q) and compact unit forms
+        kw.setdefault("use_short_name", True)
+        kw.setdefault("named_unit", False)
+        kw.setdefault("include_params", False)
+        kw.setdefault("canonical", True)
+
+        docs = pos_named_objs(
+            dataclassish.field_items(self), ["data"], self.__dataclass_fields__, **kw
+        )
+        return wl.bracketed(
+            begin=wl.TextDoc(f"{type(self).__name__}("),
+            docs=docs,
+            sep=wl.comma,
+            end=wl.TextDoc(")"),
+            indent=kw.get("indent", 4),
+        )
+
+    # ===============================================================
     # Python API
 
     def __hash__(self) -> int:
@@ -586,3 +636,86 @@ class AbstractVector(
         # Otherwise, apply the transformation and return a new point
         new = cxfm.act(op, t, self)
         return dataclassish.replace(new, frame=toframe)  # ty: ignore[invalid-return-type]
+
+
+# ===================================================================
+# Vector-form rendering
+#
+# Shared by every vector-like: `Point`, `Tangent`, and (for its base point)
+# `Coordinate`. Only `.chart` and `.data` are needed.
+
+
+def vector_comps_unit_docs(vector: AbstractVector) -> tuple[str, str]:
+    """Return ``(comps_doc, unit_doc)`` strings for a vector header.
+
+    ``comps_doc`` is the parenthesised component list, e.g. ``(x, y, z)`` or
+    ``(x[m], y[m/s], z[m/s])`` when units differ per component.
+    ``unit_doc`` is the bracketed shared unit string, e.g. ``[m]``, or an
+    empty string when units are absent or differ per component.
+    """
+    comps = vector.chart.components
+    units = [
+        cast("u.AbstractUnit", u.unit_of(v))
+        if uq.is_any_quantity(v := vector.data[comp])
+        else None
+        for comp in comps
+    ]
+
+    # One shared unit across every component: hoist it out of the component
+    # list into the trailing ``[unit]``.
+    if units and units[0] is not None and all(un == units[0] for un in units):
+        return f"({', '.join(comps)})", f"[{units[0]}]"
+
+    # Otherwise annotate each component that has a unit. This also covers the
+    # all-unitless case, where it degrades to a bare component list.
+    inner = ", ".join(
+        f"{c}[{un}]" if un is not None else c
+        for c, un in zip(comps, units, strict=True)
+    )
+    return f"({inner})", ""
+
+
+def vector_values_str(vector: AbstractVector, **kwargs: Any) -> str:
+    r"""Return the formatted array string ``'\\n    [values]'`` (no closing ``>``)."""
+    vals: list[Array] = [
+        jnp.asarray(u.ustrip(u.unit_of(v), v) if uq.is_any_quantity(v) else v)
+        for comp in vector.chart.components
+        for v in (vector.data[comp],)
+    ]
+
+    # If there are no component leaves to display, return an empty string so
+    # the caller can append the closing ``>`` directly after the header.
+    if not vals:
+        return ""
+
+    stacked = jnp.stack(jnp.broadcast_arrays(*vals), axis=-1)
+    val_str = np.array2string(
+        np.asarray(stacked),
+        precision=kwargs.get("precision", 3),
+        threshold=kwargs.get("threshold", 1000),
+    )
+    return f"\n    {val_str.replace(chr(10), chr(10) + '    ')}"
+
+
+def vectorform_pdoc(vector: AbstractVector, **kwargs: Any) -> wl.AbstractDoc:
+    """Return the compact angle-bracket document for a vector.
+
+    Parameters
+    ----------
+    vector
+        The vector to render.
+    **kwargs
+        Additional keyword arguments passed to the Wadler-Lindig formatter
+        (e.g. ``precision``, ``threshold``, ``canonical``).
+
+    """
+    kwargs.setdefault("canonical", True)
+    comps_doc, unit_doc = vector_comps_unit_docs(vector)
+
+    header = (
+        f"<{type(vector).__name__}: chart={type(vector.chart).__name__} {comps_doc}"
+    )
+    if unit_doc:
+        header = f"{header} {unit_doc}"
+
+    return wl.TextDoc(header + vector_values_str(vector, **kwargs) + ">")

--- a/src/coordinax/vectors/_src/bundle.py
+++ b/src/coordinax/vectors/_src/bundle.py
@@ -25,9 +25,14 @@ import coordinax.frames as cxf
 import coordinax.manifolds as cxm
 import coordinax.representations as cxr
 import coordinax.transforms as cxfm
-from .base import AbstractVector
-from .point import Point, _vector_comps_unit_docs, _vector_values_str
-from .tangent import Tangent, _vectorform_pdoc as _vec_vectorform_pdoc
+from .base import (
+    AbstractVector,
+    vector_comps_unit_docs,
+    vector_values_str,
+    vectorform_pdoc as _vec_vectorform_pdoc,
+)
+from .point import Point
+from .tangent import Tangent
 from coordinax.internal import OptUSys
 
 ChartT = TypeVar(
@@ -47,8 +52,8 @@ def vectorform_pdoc(pv: "Coordinate", **kwargs: Any) -> wl.AbstractDoc:
     kwargs.setdefault("canonical", True)
     chart_name = type(pv.point.chart).__name__
     rep_name = wl.pformat(pv.point.rep, **kwargs)
-    comps_doc, unit_doc = _vector_comps_unit_docs(pv.point)
-    values_str = _vector_values_str(pv.point, **kwargs)
+    comps_doc, unit_doc = vector_comps_unit_docs(pv.point)
+    values_str = vector_values_str(pv.point, **kwargs)
 
     header = f"<Coordinate: chart={chart_name}, rep={rep_name} {comps_doc}"
     if unit_doc:

--- a/src/coordinax/vectors/_src/point.py
+++ b/src/coordinax/vectors/_src/point.py
@@ -5,20 +5,14 @@ __all__ = ("Point",)
 
 from dataclasses import replace
 
-from jaxtyping import Array, ArrayLike
+from jaxtyping import ArrayLike
 from typing import TYPE_CHECKING, Any, Generic, cast, final, override
 from typing_extensions import TypeVar
 
 import equinox as eqx
-import jax
-import numpy as np
 import quax_blocks
-import wadler_lindig as wl
 
-import dataclassish
-import quaxed.numpy as jnp
 import unxt as u
-import unxt.quantity as uq
 
 import coordinax.charts as cxc
 import coordinax.frames as cxf
@@ -26,7 +20,6 @@ import coordinax.representations as cxr
 from .base import AbstractVector
 from .custom_types import CKey, HasShape
 from .mixins import AstropyRepresentationAPIMixin
-from coordinax.internal import pos_named_objs
 
 if TYPE_CHECKING:
     from .custom_types import CDict
@@ -159,60 +152,6 @@ class Point(
         if isinstance(key, str):
             return self.data[key]
         return replace(self, data={k: v[key] for k, v in self.data.items()})  # ty: ignore[invalid-return-type]
-
-    # ===============================================================
-    # Quax API
-
-    # TODO: generalize to work with FourVector, and Space
-    def aval(self) -> jax.core.ShapedArray:  # ty: ignore[possibly-missing-submodule]
-        """Return the vector as a JAX array."""
-        fvs = self.data.values()
-        shape = (*jnp.broadcast_shapes(*map(jnp.shape, fvs)), len(fvs))
-        dtype = jnp.result_type(*map(jnp.dtype, fvs))
-        return jax.core.ShapedArray(shape, dtype)  # ty: ignore[possibly-missing-submodule]
-
-    @property
-    def shape(self) -> tuple[int, ...]:
-        """Return the shape of the vector."""
-        shapes = [v.shape for v in self.data.values()]
-        return jnp.broadcast_shapes(*shapes)
-
-    # ===============================================================
-    # Wadler-Lindig API
-
-    def __pdoc__(self, *, vector_form: bool = False, **kw: Any) -> wl.AbstractDoc:
-        """Return the Wadler-Lindig docstring for the vector.
-
-        Parameters
-        ----------
-        vector_form
-            If True, return the vector form of the docstring.
-        short_arrays
-            If True, use short arrays for the docstring.
-        **kw
-            Additional keyword arguments to pass to the Wadler-Lindig docstring
-            formatter.
-
-        """
-        if vector_form:
-            return vectorform_pdoc(self, **kw)
-
-        # Prefer to use short names (e.g. Quantity -> Q) and compact unit forms
-        kw.setdefault("use_short_name", True)
-        kw.setdefault("named_unit", False)
-        kw.setdefault("include_params", False)
-        kw.setdefault("canonical", True)
-
-        docs = pos_named_objs(
-            dataclassish.field_items(self), ["data"], self.__dataclass_fields__, **kw
-        )
-        return wl.bracketed(
-            begin=wl.TextDoc(f"{self.__class__.__name__}("),
-            docs=docs,
-            sep=wl.comma,
-            end=wl.TextDoc(")"),
-            indent=kw.get("indent", 4),
-        )
 
 
 # ===================================================================
@@ -592,107 +531,3 @@ def from_(
     """
     p = cls.from_(obj, unit)
     return replace(p, frame=frame)
-
-
-# ===============================================
-
-
-def _vector_comps_unit_docs(vector: AbstractVector) -> tuple[str, str]:
-    """Return ``(comps_doc, unit_doc)`` strings for a vector header.
-
-    ``comps_doc`` is the parenthesised component list, e.g. ``(x, y, z)`` or
-    ``(x[m], y[m/s], z[m/s])`` when units differ per component.
-    ``unit_doc`` is the bracketed shared unit string, e.g. ``[m]``, or an
-    empty string when units are absent or differ per component.
-    """
-    comps = vector.chart.components
-    unit_vals = [
-        cast("u.AbstractUnit", u.unit_of(v))
-        if uq.is_any_quantity(v := vector.data[comp])
-        else None
-        for comp in comps
-    ]
-
-    unit_doc = ""
-    if unit_vals and all(u_ is not None for u_ in unit_vals):
-        unit0 = unit_vals[0]
-        if all(u_ == unit0 for u_ in unit_vals):
-            unit_doc = f"[{unit0}]"
-            comps_doc = f"({', '.join(comps)})"
-        else:
-            comps_doc = (
-                "("
-                + ", ".join(
-                    f"{c}[{u_}]" for c, u_ in zip(comps, unit_vals, strict=True)
-                )
-                + ")"
-            )
-    elif any(u_ is not None for u_ in unit_vals):
-        comps_doc = (
-            "("
-            + ", ".join(
-                f"{c}[{u_}]" if u_ is not None else c
-                for c, u_ in zip(comps, unit_vals, strict=True)
-            )
-            + ")"
-        )
-    else:
-        comps_doc = f"({', '.join(comps)})"
-
-    return comps_doc, unit_doc
-
-
-def _vector_values_str(vector: AbstractVector, **kwargs: Any) -> str:
-    r"""Return the formatted array string ``'\\n    [values]'`` (no closing ``>``)."""
-    comps = vector.chart.components
-    vals: list[Array] = [
-        jnp.asarray(u.ustrip(u.unit_of(v), v) if uq.is_any_quantity(v) else v)
-        for comp in comps
-        for v in (vector.data[comp],)
-    ]
-
-    # If there are no component leaves to display, return an empty string so
-    # the caller can append the closing ``>`` directly after the header.
-    if not vals:
-        return ""
-
-    stacked = jnp.stack(jnp.broadcast_arrays(*vals), axis=-1)
-    val_str = np.array2string(
-        np.asarray(stacked),
-        precision=kwargs.get("precision", 3),
-        threshold=kwargs.get("threshold", 1000),
-    )
-    return f"\n    {val_str.replace(chr(10), chr(10) + '    ')}"
-
-
-def vectorform_pdoc(
-    vector: Point[Any, Any],
-    *,
-    class_name: str | None = None,
-    **kwargs: Any,
-) -> wl.AbstractDoc:
-    """Return the Wadler-Lindig docstring for the vector.
-
-    Parameters
-    ----------
-    vector
-        The vector to generate the docstring for.
-    class_name
-        Override the class name used in the header.  Defaults to
-        ``type(vector).__name__``.
-    **kwargs
-        Additional keyword arguments passed to the Wadler-Lindig formatter
-        (e.g. ``precision``, ``threshold``, ``canonical``).
-
-    """
-    kwargs.setdefault("canonical", True)
-    cls_name = class_name if class_name is not None else vector.__class__.__name__
-    chart_name = type(vector.chart).__name__
-    comps_doc, unit_doc = _vector_comps_unit_docs(vector)
-    values_str = _vector_values_str(vector, **kwargs)
-
-    header = f"<{cls_name}: chart={chart_name} {comps_doc}"
-    if unit_doc:
-        header = f"{header} {unit_doc}"
-
-    return wl.TextDoc(header + values_str + ">")

--- a/src/coordinax/vectors/_src/tangent.py
+++ b/src/coordinax/vectors/_src/tangent.py
@@ -11,11 +11,7 @@ from typing_extensions import TypeVar
 
 import equinox as eqx
 import quax_blocks
-import wadler_lindig as wl
-from jax.core import ShapedArray
 
-import dataclassish
-import quaxed.numpy as jnp
 import unxt as u
 
 import coordinax.charts as cxc
@@ -24,8 +20,7 @@ import coordinax.representations as cxr
 from .base import AbstractVector
 from .custom_types import CKey, HasShape
 from .mixins import AstropyRepresentationAPIMixin
-from .point import _frame_converter, _vector_comps_unit_docs, _vector_values_str
-from coordinax.internal import pos_named_objs
+from .point import _frame_converter
 
 if TYPE_CHECKING:
     from coordinax.internal import CDict
@@ -147,73 +142,6 @@ class Tangent(
         if isinstance(key, str):
             return self.data[key]
         return replace(self, data={k: v[key] for k, v in self.data.items()})  # ty: ignore[invalid-return-type,not-subscriptable]
-
-    # ===============================================================
-    # Quax API
-
-    def aval(self) -> ShapedArray:
-        """Return the vector as a JAX abstract array."""
-        fvs = self.data.values()
-        shape = (*jnp.broadcast_shapes(*map(jnp.shape, fvs)), len(fvs))
-        dtype = jnp.result_type(*map(jnp.dtype, fvs))
-        return ShapedArray(shape, dtype)
-
-    @property
-    def shape(self) -> tuple[int, ...]:
-        """Return the batch shape of the vector."""
-        shapes = [v.shape for v in self.data.values()]
-        return jnp.broadcast_shapes(*shapes)
-
-    # ===============================================================
-    # Wadler-Lindig API
-
-    def __pdoc__(self, *, vector_form: bool = False, **kw: Any) -> wl.AbstractDoc:
-        """Return the Wadler-Lindig docstring for the vector.
-
-        Parameters
-        ----------
-        vector_form
-            If True, return the compact vector-form representation.
-        **kw
-            Additional keyword arguments forwarded to the formatter.
-
-        """
-        if vector_form:
-            return _vectorform_pdoc(self, **kw)
-
-        kw.setdefault("use_short_name", True)
-        kw.setdefault("named_unit", False)
-        kw.setdefault("include_params", False)
-        kw.setdefault("canonical", True)
-
-        docs = pos_named_objs(
-            dataclassish.field_items(self), ["data"], self.__dataclass_fields__, **kw
-        )
-        return wl.bracketed(
-            begin=wl.TextDoc(f"{self.__class__.__name__}("),
-            docs=docs,
-            sep=wl.comma,
-            end=wl.TextDoc(")"),
-            indent=kw.get("indent", 4),
-        )
-
-
-def _vectorform_pdoc(
-    vector: Tangent[Any, Any, Any, Any], *, class_name: str | None = None, **kwargs: Any
-) -> wl.AbstractDoc:
-    """Return the compact vector-form docstring for a Tangent."""
-    kwargs.setdefault("canonical", True)
-    cls_name = class_name if class_name is not None else vector.__class__.__name__
-    chart_name = type(vector.chart).__name__
-    # Reuse Point's helper (works on any object with .chart and .data)
-    comps_doc, unit_doc = _vector_comps_unit_docs(vector)
-    values_str = _vector_values_str(vector, **kwargs)
-
-    header = f"<{cls_name}: chart={chart_name} {comps_doc}"
-    if unit_doc:
-        header = f"{header} {unit_doc}"
-
-    return wl.TextDoc(header + values_str + ">")
 
 
 # ===================================================================


### PR DESCRIPTION
Over-engineering audit of `coordinax.vectors`, part 2/5 — triplicated pretty-printing.

`Point` and `Tangent` carried byte-identical `aval`, `shape`, and `__pdoc__` implementations, and the compact angle-bracket renderer existed **three** times: `point.vectorform_pdoc`, `tangent._vectorform_pdoc`, and a `Coordinate` variant in `bundle.py` that imported helpers from both of the others.

All of it depends only on `.chart` and `.data`, which every `AbstractVector` has, so it now lives once in `base.py`:

- `AbstractVector.aval` / `.shape` are concrete (`shape` was `abstractmethod`); `Coordinate` keeps its bundle-aware overrides.
- `AbstractVector.__pdoc__` covers both the vector form and the constructor-style form; `Coordinate` keeps its override.
- `vector_comps_unit_docs`, `vector_values_str`, and `vectorform_pdoc` are module-level in `base.py`.

Two small cuts along the way:

- the `class_name` override parameter on the renderers had no caller anywhere in the repo;
- `vector_comps_unit_docs` had three branches, but the mixed-unit formatter (`f"{c}[{unit}]" if unit is not None else c`) already renders the all-unitless case, so one of them was unreachable-by-equivalence.

No behaviour change — `repr`/`str` output is byte-identical. Full suite green (`8017 passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)