### PR TITLE
♻️ refactor(vectors): collapse the frame-aware from_ overloads

### DIFF
--- a/src/coordinax/vectors/_src/point.py
+++ b/src/coordinax/vectors/_src/point.py
@@ -432,8 +432,9 @@ def from_(cls: type[Point], obj: Point, frame: cxf.AbstractReferenceFrame, /) ->
 
     An existing frame is replaced, not merged:
 
-    >>> cx.Point.from_(cx.Point.from_(d, cxf.alice), cxf.noframe).frame
-    NoFrame()
+    >>> p_alice = cx.Point.from_(d, cxf.alice)
+    >>> cx.Point.from_(p_alice, cxf.noframe).frame == cxf.noframe
+    True
 
     """
     return replace(obj, frame=frame)

--- a/src/coordinax/vectors/_src/point.py
+++ b/src/coordinax/vectors/_src/point.py
@@ -400,57 +400,49 @@ def from_(
 
 # -------------------------------------
 # Frame-aware constructors
+#
+# Every constructor above also accepts a trailing `AbstractReferenceFrame`.
+# The frame is not part of the construction itself — it is attached to the
+# result — so each overload below builds the point from the leading arguments
+# and then rebinds the frame.
 
 
 @Point.from_.dispatch  # ty: ignore[unresolved-attribute]
-def from_(
-    cls: type[Point],
-    obj: Point,
-    frame: cxf.AbstractReferenceFrame,
-    /,
-) -> Point:
+def from_(cls: type[Point], obj: Point, frame: cxf.AbstractReferenceFrame, /) -> Point:
     """Construct a point from another point, replacing its frame.
 
-    >>> import coordinax as cx
-    >>> import coordinax.frames as cxf
+    Every constructor above also accepts a trailing frame, which is attached to
+    the constructed point:
 
-    >>> p = cx.Point.from_([1, 0, 0], "km")
-    >>> p2 = cx.Point.from_(p, cxf.alice)
-    >>> p2.frame
+    >>> import coordinax as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.frames as cxf
+    >>> import coordinax.representations as cxr
+    >>> import unxt as u
+
+    >>> d = {"x": u.Q(1, "km"), "y": u.Q(2, "km"), "z": u.Q(3, "km")}
+    >>> for args in [(cx.Point.from_(d),), (d,), (d, cxc.cart3d),
+    ...              (d, cxc.cart3d, cxr.point), ([1, 2, 3], "km")]:
+    ...     print(cx.Point.from_(*args, cxf.alice).frame)
+    Alice()
+    Alice()
+    Alice()
+    Alice()
     Alice()
 
-    >>> # Replace an existing frame
-    >>> p3 = cx.Point.from_(p2, cxf.noframe)
-    >>> p3.frame == cxf.noframe
-    True
+    An existing frame is replaced, not merged:
+
+    >>> cx.Point.from_(cx.Point.from_(d, cxf.alice), cxf.noframe).frame
+    NoFrame()
 
     """
     return replace(obj, frame=frame)
 
 
 @Point.from_.dispatch  # ty: ignore[unresolved-attribute]
-def from_(
-    cls: type[Point],
-    obj: Any,
-    frame: cxf.AbstractReferenceFrame,
-    /,
-) -> Point:
-    """Construct a point from any object with a frame.
-
-    >>> import coordinax as cx
-    >>> import coordinax.frames as cxf
-    >>> import unxt as u
-
-    >>> p = cx.Point.from_(
-    ...     {"x": u.Q(1, "km"), "y": u.Q(0, "km"), "z": u.Q(0, "km")},
-    ...     cxf.alice,
-    ... )
-    >>> p.frame
-    Alice()
-
-    """
-    p = cls.from_(obj)
-    return replace(p, frame=frame)
+def from_(cls: type[Point], obj: Any, frame: cxf.AbstractReferenceFrame, /) -> Point:
+    """Construct a point from any object, with a frame."""
+    return replace(cls.from_(obj), frame=frame)
 
 
 @Point.from_.dispatch  # ty: ignore[unresolved-attribute]
@@ -461,23 +453,8 @@ def from_(
     frame: cxf.AbstractReferenceFrame,
     /,
 ) -> Point:
-    """Construct a point from an object, chart, and frame.
-
-    >>> import coordinax as cx
-    >>> import coordinax.frames as cxf
-    >>> import coordinax.charts as cxc
-    >>> import unxt as u
-
-    >>> d = {"x": u.Q(1, "km"), "y": u.Q(2, "km"), "z": u.Q(3, "km")}
-    >>> p = cx.Point.from_(d, cxc.cart3d, cxf.alice)
-    >>> p.chart
-    Cart3D(M=Rn(3))
-    >>> p.frame
-    Alice()
-
-    """
-    p = cls.from_(obj, chart)
-    return replace(p, frame=frame)
+    """Construct a point from an object and chart, with a frame."""
+    return replace(cls.from_(obj, chart), frame=frame)
 
 
 @Point.from_.dispatch  # ty: ignore[unresolved-attribute]
@@ -489,26 +466,8 @@ def from_(
     frame: cxf.AbstractReferenceFrame,
     /,
 ) -> Point:
-    """Construct a point from an object, chart, representation, and frame.
-
-    >>> import coordinax as cx
-    >>> import coordinax.frames as cxf
-    >>> import coordinax.charts as cxc
-    >>> import coordinax.representations as cxr
-    >>> import unxt as u
-
-    >>> d = {"x": u.Q(1, "km"), "y": u.Q(2, "km"), "z": u.Q(3, "km")}
-    >>> p = cx.Point.from_(d, cxc.cart3d, cxr.point, cxf.alice)
-    >>> p.chart
-    Cart3D(M=Rn(3))
-    >>> p.rep
-    point
-    >>> p.frame
-    Alice()
-
-    """
-    p = cls.from_(obj, chart, rep)
-    return replace(p, frame=frame)
+    """Construct a point from an object, chart, and representation, with a frame."""
+    return replace(cls.from_(obj, chart, rep), frame=frame)
 
 
 @Point.from_.dispatch  # ty: ignore[unresolved-attribute]
@@ -519,15 +478,5 @@ def from_(
     frame: cxf.AbstractReferenceFrame,
     /,
 ) -> Point:
-    """Construct a point from an array, unit, and frame.
-
-    >>> import coordinax as cx
-    >>> import coordinax.frames as cxf
-
-    >>> p = cx.Point.from_([1, 0, 0], "km", cxf.alice)
-    >>> p.frame
-    Alice()
-
-    """
-    p = cls.from_(obj, unit)
-    return replace(p, frame=frame)
+    """Construct a point from an array and unit, with a frame."""
+    return replace(cls.from_(obj, unit), frame=frame)

--- a/src/coordinax/vectors/_src/tangent.py
+++ b/src/coordinax/vectors/_src/tangent.py
@@ -346,24 +346,8 @@ def from_(
     frame: cxf.AbstractReferenceFrame,
     /,
 ) -> Tangent:
-    """Construct a Tangent from an array, unit, chart, Representation, and frame.
-
-    >>> import coordinax as cx
-    >>> import coordinax.charts as cxc
-    >>> import coordinax.representations as cxr
-    >>> import coordinax.frames as cxf
-
-    >>> v = cx.Tangent.from_(
-    ...     [1.0, 2.0, 3.0], "m/s", cxc.cart3d, cxr.coord_vel, cxf.alice
-    ... )
-    >>> v.basis == cxr.coord_basis
-    True
-    >>> v.frame
-    Alice()
-
-    """
-    v = cls.from_(u.Q(obj, u.unit(unit)), chart, rep)
-    return replace(v, frame=frame)
+    """Construct a Tangent from an array, unit, chart, Representation, and frame."""
+    return replace(cls.from_(u.Q(obj, u.unit(unit)), chart, rep), frame=frame)
 
 
 @Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
@@ -425,6 +409,10 @@ def from_(
 
 # -----------------------------------------
 # Frame-aware constructors
+#
+# The frame is not part of the construction itself — it is attached to the
+# result — so each overload below builds the tangent from the leading
+# arguments and then rebinds the frame.
 
 
 @Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
@@ -433,18 +421,26 @@ def from_(
 ) -> Tangent:
     """Construct a Tangent from another Tangent, replacing its frame.
 
+    Every constructor above also accepts a trailing frame, which is attached to
+    the constructed tangent:
+
     >>> import coordinax as cx
     >>> import coordinax.charts as cxc
     >>> import coordinax.representations as cxr
     >>> import coordinax.frames as cxf
     >>> import unxt as u
 
-    >>> v = cx.Tangent.from_(
-    ...     {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")},
-    ...     cxc.cart3d, cxr.coord_basis, cxr.vel,
-    ... )
-    >>> v2 = cx.Tangent.from_(v, cxf.alice)
-    >>> v2.frame
+    >>> d = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")}
+    >>> for args in [(cx.Tangent.from_(d),), (d,), (d, cxc.cart3d),
+    ...              (d, cxc.cart3d, cxr.coord_basis, cxr.vel),
+    ...              ([1.0, 2.0, 3.0], "m/s"),
+    ...              ([1.0, 2.0, 3.0], "m/s", cxc.cart3d, cxr.coord_vel)]:
+    ...     print(cx.Tangent.from_(*args, cxf.alice).frame)
+    Alice()
+    Alice()
+    Alice()
+    Alice()
+    Alice()
     Alice()
 
     """
@@ -455,20 +451,8 @@ def from_(
 def from_(
     cls: type[Tangent], obj: Any, frame: cxf.AbstractReferenceFrame, /
 ) -> Tangent:
-    """Construct a Tangent from data with a frame (chart and rep inferred).
-
-    >>> import coordinax as cx
-    >>> import coordinax.frames as cxf
-    >>> import unxt as u
-
-    >>> d = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")}
-    >>> v = cx.Tangent.from_(d, cxf.alice)
-    >>> v.frame
-    Alice()
-
-    """
-    v = cls.from_(obj)
-    return replace(v, frame=frame)
+    """Construct a Tangent from data with a frame (chart and rep inferred)."""
+    return replace(cls.from_(obj), frame=frame)
 
 
 @Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
@@ -479,21 +463,8 @@ def from_(
     frame: cxf.AbstractReferenceFrame,
     /,
 ) -> Tangent:
-    """Construct a Tangent from data, chart, and frame (basis/semantic inferred).
-
-    >>> import coordinax as cx
-    >>> import coordinax.charts as cxc
-    >>> import coordinax.frames as cxf
-    >>> import unxt as u
-
-    >>> d = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")}
-    >>> v = cx.Tangent.from_(d, cxc.cart3d, cxf.alice)
-    >>> v.frame
-    Alice()
-
-    """
-    v = cls.from_(obj, chart)
-    return replace(v, frame=frame)
+    """Construct a Tangent from data and chart, with a frame."""
+    return replace(cls.from_(obj, chart), frame=frame)
 
 
 @Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
@@ -506,22 +477,8 @@ def from_(
     frame: cxf.AbstractReferenceFrame,
     /,
 ) -> Tangent:
-    """Construct a Tangent from data, chart, basis, semantic, and frame.
-
-    >>> import coordinax as cx
-    >>> import coordinax.charts as cxc
-    >>> import coordinax.representations as cxr
-    >>> import coordinax.frames as cxf
-    >>> import unxt as u
-
-    >>> d = {"x": u.Q(1.0, "m/s"), "y": u.Q(2.0, "m/s"), "z": u.Q(3.0, "m/s")}
-    >>> v = cx.Tangent.from_(d, cxc.cart3d, cxr.coord_basis, cxr.vel, cxf.alice)
-    >>> v.frame
-    Alice()
-
-    """
-    v = cls.from_(obj, chart, basis, semantic)
-    return replace(v, frame=frame)
+    """Construct a Tangent from data, chart, basis, and semantic, with a frame."""
+    return replace(cls.from_(obj, chart, basis, semantic), frame=frame)
 
 
 @Tangent.from_.dispatch  # ty: ignore[unresolved-attribute]
@@ -532,15 +489,5 @@ def from_(
     frame: cxf.AbstractReferenceFrame,
     /,
 ) -> Tangent:
-    """Construct a Tangent from an array, unit, and frame.
-
-    >>> import coordinax as cx
-    >>> import coordinax.frames as cxf
-
-    >>> v = cx.Tangent.from_([1.0, 2.0, 3.0], "m/s", cxf.alice)
-    >>> v.frame
-    Alice()
-
-    """
-    v = cls.from_(obj, unit)
-    return replace(v, frame=frame)
+    """Construct a Tangent from an array and unit, with a frame."""
+    return replace(cls.from_(obj, unit), frame=frame)

--- a/tests/unit/vectors/test_point.py
+++ b/tests/unit/vectors/test_point.py
@@ -23,21 +23,8 @@ class TestPointFrame:
         p = cx.Point.from_([1, 0, 0], "km")
         assert p.frame == cxf.noframe
 
-    def test_from_array_unit_with_frame(self):
-        """Point.from_(array, unit, frame) sets frame."""
-        p = cx.Point.from_([1, 0, 0], "km", cxf.alice)
-        assert p.frame == cxf.alice
-
-    def test_from_vector_frame_dispatch(self):
-        """Point.from_(vector, frame) wraps vector data with given frame."""
-        vec = cx.Point.from_([1, 0, 0], "km")
-        p = cx.Point.from_(vec, cxf.alice)
-        assert p.frame == cxf.alice
-        assert p.data == vec.data
-        assert p.chart == vec.chart
-
     def test_from_point_frame_replaces_frame(self):
-        """Point.from_(point, frame) returns same data with new frame."""
+        """Point.from_(point, frame) replaces (not merges) an existing frame."""
         p1 = cx.Point.from_([1, 0, 0], "km", cxf.alice)
         p2 = cx.Point.from_(p1, cxf.noframe)
         assert p2.frame == cxf.noframe
@@ -76,6 +63,33 @@ class TestPointFrame:
             frame=cxf.alice,
         )
         assert isinstance(p.frame, cxf.AbstractReferenceFrame)
+
+
+# Every ``Point.from_`` overload documented in ``point.py`` also accepts a
+# trailing frame; each row is the leading-argument shape for one such
+# overload, so that every dispatch signature is actually exercised.
+_D = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
+_POINT = cx.Point.from_(_D, cxc.cart3d)
+
+POINT_FROM_WITH_FRAME_CASES = [
+    pytest.param((_POINT,), id="point"),
+    pytest.param((_D,), id="dict"),
+    pytest.param((_D, cxc.cart3d), id="dict-chart"),
+    pytest.param((_D, cxc.cart3d, cxr.point), id="dict-chart-rep"),
+    pytest.param(([1.0, 2.0, 3.0], "km"), id="array-unit"),
+]
+
+
+@pytest.mark.parametrize("args", POINT_FROM_WITH_FRAME_CASES)
+def test_point_from_with_frame(args):
+    """Every ``Point.from_`` overload accepts a trailing frame."""
+    p = cx.Point.from_(*args, cxf.alice)
+    assert isinstance(p, cx.Point)
+    assert p.frame == cxf.alice
+    assert p.chart == cxc.cart3d
+    assert p["x"] == u.Q(1.0, "km")
+    assert p["y"] == u.Q(2.0, "km")
+    assert p["z"] == u.Q(3.0, "km")
 
 
 class TestPointEquality:

--- a/tests/unit/vectors/test_tangent.py
+++ b/tests/unit/vectors/test_tangent.py
@@ -356,12 +356,6 @@ class TestVectorFromConstructors:
         assert v.basis == cxr.coord_basis
         assert v.semantic == cxr.vel
 
-    def test_from_dict_chart_basis_semantic_frame(self):
-        """Tangent.from_(dict, chart, basis, semantic, frame) sets frame."""
-        data = _cart3d_vel_data()
-        v = cx.Tangent.from_(data, cxc.cart3d, cxr.coord_basis, cxr.vel, cxf.alice)
-        assert v.frame == cxf.alice
-
     def test_from_array_unit_chart_basis_semantic(self):
         """Tangent.from_(array, unit, chart, basis, semantic) constructs correctly."""
         v = cx.Tangent.from_(
@@ -386,29 +380,39 @@ class TestVectorFromConstructors:
         with pytest.raises(TypeError):
             cx.Tangent.from_(data, cxc.cart3d, cxr.point)
 
-    def test_from_vector_frame_dispatch(self):
-        """Tangent.from_(vector, frame) sets frame on the vector."""
-        data = _cart3d_vel_data()
-        v = cx.Tangent.from_(data, cxc.cart3d, cxr.coord_basis, cxr.vel)
-        v2 = cx.Tangent.from_(v, cxf.alice)
-        assert v2.frame == cxf.alice
-        assert v2.basis == v.basis
-        assert v2.semantic == v.semantic
 
-    def test_from_any_frame_dispatch(self):
-        """Tangent.from_(dict, frame) infers chart/basis/semantic and sets frame."""
-        data = _cart3d_vel_data()
-        v = cx.Tangent.from_(data, cxf.alice)
-        assert isinstance(v, cx.Tangent)
-        assert v.frame == cxf.alice
+# Every ``Tangent.from_`` overload documented in ``tangent.py`` also accepts a
+# trailing frame; each row is the leading-argument shape for one such
+# overload, so that every dispatch signature is actually exercised.
+_VEL = cx.Tangent.from_(_cart3d_vel_data(), cxc.cart3d, cxr.coord_basis, cxr.vel)
 
-    def test_from_dict_chart_frame(self):
-        """Tangent.from_(dict, chart, frame) infers basis/semantic and sets frame."""
-        data = _cart3d_vel_data()
-        v = cx.Tangent.from_(data, cxc.cart3d, cxf.alice)
-        assert isinstance(v, cx.Tangent)
-        assert v.chart == cxc.cart3d
-        assert v.frame == cxf.alice
+TANGENT_FROM_WITH_FRAME_CASES = [
+    pytest.param((_VEL,), id="tangent"),
+    pytest.param((_cart3d_vel_data(),), id="dict"),
+    pytest.param((_cart3d_vel_data(), cxc.cart3d), id="dict-chart"),
+    pytest.param(
+        (_cart3d_vel_data(), cxc.cart3d, cxr.coord_basis, cxr.vel),
+        id="dict-chart-basis-semantic",
+    ),
+    pytest.param(([1.0, 2.0, 3.0], "m/s"), id="array-unit"),
+    pytest.param(
+        ([1.0, 2.0, 3.0], "m/s", cxc.cart3d, cxr.coord_vel), id="array-unit-chart-rep"
+    ),
+]
+
+
+@pytest.mark.parametrize("args", TANGENT_FROM_WITH_FRAME_CASES)
+def test_tangent_from_with_frame(args):
+    """Every ``Tangent.from_`` overload accepts a trailing frame."""
+    v = cx.Tangent.from_(*args, cxf.alice)
+    assert isinstance(v, cx.Tangent)
+    assert v.frame == cxf.alice
+    assert v.chart == cxc.cart3d
+    assert v.basis == cxr.coord_basis
+    assert v.semantic == cxr.vel
+    assert v["x"] == u.Q(1.0, "m/s")
+    assert v["y"] == u.Q(2.0, "m/s")
+    assert v["z"] == u.Q(3.0, "m/s")
 
 
 # ======================================================================


### PR DESCRIPTION
Over-engineering audit of `coordinax.vectors`, part 5/5 — the `from_` frame variants.

Eleven `from_` overloads (five on `Point`, six on `Tangent`) exist purely to accept a trailing `AbstractReferenceFrame`. Each has the same two-line body — build from the leading arguments, then `replace(..., frame=frame)` — wrapped in a docstring whose doctest asserts the same thing every time: that the result's `.frame` is `Alice()`.

**Every signature is kept, so this is not an API change.** What goes is the repetition around them:

- each body becomes one line (`return replace(cls.from_(...), frame=frame)`);
- the eleven near-identical doctests collapse into one per class, looping over the argument shapes and printing each resulting frame — so the same ground is still covered by Sybil, once instead of eleven times.

The overloads themselves remain covered by `tests/unit/vectors/test_point.py` and `test_tangent.py`, which exercise each frame-aware signature directly.

Worth saying plainly: unlike the other four PRs in this series, the saving here is documentation redundancy rather than logic — the bodies were already minimal. It is the weakest item of the audit; happy to drop it if you would rather keep a worked example on each overload.

Full suite green (`7958 passed`; the delta from `8017` is the collapsed doctest regions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)