### PR TITLE
⚡️ perf(vectors): take AbstractVector.shape off the quaxed dispatch path

### DIFF
--- a/src/coordinax/vectors/_src/base.py
+++ b/src/coordinax/vectors/_src/base.py
@@ -15,6 +15,7 @@ import numpy as np
 import plum
 import quax_blocks
 import wadler_lindig as wl
+from jax.numpy import broadcast_shapes
 from quax import ArrayValue
 
 import dataclassish
@@ -320,7 +321,12 @@ class AbstractVector(
     @property
     def shape(self) -> tuple[int, ...]:
         """Return the batch shape of the vector."""
-        return jnp.broadcast_shapes(*(v.shape for v in self.data.values()))
+        # `jax.numpy.broadcast_shapes`, not the `quaxed` one: the arguments are
+        # plain shape tuples, never array values, so the quax wrapper can never
+        # fire and only costs dispatch (~3.4us per call). The list comprehension
+        # likewise beats a generator here — `f(*[...])` skips the iterator
+        # protocol that `f(*(...))` pays for.
+        return broadcast_shapes(*[v.shape for v in self.data.values()])
 
     # ===============================================================
     # Array API

--- a/src/coordinax/vectors/_src/base.py
+++ b/src/coordinax/vectors/_src/base.py
@@ -321,11 +321,7 @@ class AbstractVector(
     @property
     def shape(self) -> tuple[int, ...]:
         """Return the batch shape of the vector."""
-        # `jax.numpy.broadcast_shapes`, not the `quaxed` one: the arguments are
-        # plain shape tuples, never array values, so the quax wrapper can never
-        # fire and only costs dispatch (~3.4us per call). The list comprehension
-        # likewise beats a generator here — `f(*[...])` skips the iterator
-        # protocol that `f(*(...))` pays for.
+        # jax.numpy, not quaxed: the args are plain shape tuples, never arrays.
         return broadcast_shapes(*[v.shape for v in self.data.values()])
 
     # ===============================================================


### PR DESCRIPTION
Follow-up to #644, which merged while I was benchmarking it. The relocation itself was perf-neutral (see below), but it left two things on the table on the line it rewrote.

### `quaxed.numpy.broadcast_shapes` can never fire here

`shape` broadcasts **plain shape tuples** — never array values — so the quax wrapper has nothing to dispatch on and only costs dispatch. `bundle.py` already imports `jax.numpy` for exactly this reason.

| call, three scalar shapes | |
|---|---|
| `quaxed.numpy.broadcast_shapes` | 6.22 µs |
| `jax.numpy.broadcast_shapes` | 2.82 µs |
| `numpy.broadcast_shapes` | 1.53 µs |

### The generator was a small regression

#644 turned a list comprehension into a generator expression while hoisting. `f(*[...])` beats `f(*(...))` for small *n* — star-unpacking a generator pays the iterator protocol. Isolated: 3396 ns vs 3560 ns.

### Net

Best-of-15 × 20 000 iterations on `cx.Point.from_([1., 2., 3.], "m")`, measured in one quiet window:

| | `p.shape` |
|---|---|
| before #644 | 11.02 µs |
| after #644 | 11.18 µs |
| **this PR** | **7.73 µs** |

**~30% faster than pre-#644**, on a property that `Coordinate.__init__`, the broadcast checks, and any user batching code all hit.

### What I checked and did *not* change

The rest of #644 measured clean, for the record: relocating `shape`/`aval`/`__pdoc__` four levels up the MRO costs nothing (attribute lookup 41.4–42.5 ns on both sides — CPython's type attribute cache absorbs it), `aval()` was unchanged at ~87 µs, and `repr`/`str` were unchanged to three digits.

`aval()` has the same `broadcast_shapes`-on-tuples call, but there it is bundled with `jnp.shape` / `jnp.result_type` over `Quantity` leaves where the quaxed dispatch *is* doing real work (`map(jnp.shape, fvs)` alone is 33.7 µs vs 3.7 µs for the plain `.shape` attribute). That is a bigger prize — ~50 µs of the ~90 µs — but it needs its own correctness argument, so it is not in this PR.

Full suite green: `8011 passed, 9 skipped, 1 xfailed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)