### PR TITLE
✨ feat(hypothesis): give charts coordinate domains, dispatched on chart type

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/__init__.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/__init__.py
@@ -1,11 +1,21 @@
 """Hypothesis strategies for coordinax."""
 
 __all__ = (
+    "Interval",
     "chart_classes",
     "chart_init_kwargs",
     "charts",
     "charts_like",
     "cdicts",
+    "component_domains",
 )
 
-from ._src import cdicts, chart_classes, chart_init_kwargs, charts, charts_like
+from ._src import (
+    Interval,
+    cdicts,
+    chart_classes,
+    chart_init_kwargs,
+    charts,
+    charts_like,
+    component_domains,
+)

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/__init__.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/__init__.py
@@ -10,6 +10,7 @@ from .charts import *
 from .charts import charts
 from .charts_product import *
 from .classes import *
+from .domains import *
 from .extend import *
 from .utils import *
 from coordinaxs.hypothesis.utils import get_all_subclasses

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
@@ -115,11 +115,15 @@ def _component_quantities(
         lo = -cap if lo is None else max(lo, -cap)
         hi = cap if hi is None else min(hi, cap)
 
-        # A magnitude *floor* only means something where the coordinate
-        # degenerates at zero -- a radius, not a Cartesian offset, for which
-        # x = 0 is an ordinary value. Applying it everywhere would carve a hole
-        # out of the middle of every free axis.
-        if floor > 0 and interval.min == 0.0 and interval.margin > 0:
+        # The floor is for coordinates that run from the origin to infinity --
+        # radii. `min == 0 and max is None` is exactly that half-line.
+        #
+        # Testing `margin > 0` instead would also catch POLAR, whose colatitude
+        # starts at zero but stops at pi: `magnitude=(0.5, 8)` would then shove
+        # theta 0.5 *radians* off the pole, coupling an angle to what the
+        # caller meant as a length scale. A bounded coordinate has no use for a
+        # magnitude floor.
+        if floor > 0 and interval.min == 0.0 and interval.max is None:
             lo = floor if lo is None else max(lo, floor)
 
     width = 32 if dtype is jnp.float32 else 64
@@ -162,7 +166,22 @@ def _bounded_elements(
         )
 
     if isinstance(elements, Mapping):
-        merged: dict[str, Any] = {str(k): v for k, v in elements.items()}
+        # The caller's keys win, but anything they leave out takes the same
+        # defaults the built strategy uses. Without this the underlying
+        # strategy reverts to allowing NaN and infinity, which no chart
+        # coordinate wants and which the domain bounds only hide while they
+        # happen to be finite -- measured 193 non-finite draws in 300 with
+        # `magnitude=None`.
+        #
+        # No `width` here: this mapping is forwarded to the array-API
+        # `_from_dtype`, which takes the three `allow_*` flags but derives the
+        # width from the dtype and rejects the keyword outright.
+        merged: dict[str, Any] = {
+            "allow_nan": False,
+            "allow_infinity": False,
+            "allow_subnormal": False,
+            **{str(k): v for k, v in elements.items()},
+        }
         if lo is not None:
             merged["min_value"] = (
                 lo if merged.get("min_value") is None else max(merged["min_value"], lo)

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
@@ -35,7 +35,7 @@ from coordinaxs.hypothesis.utils import (
 #: which is dimensionally fine but useless to any test that compares numbers:
 #: at 1.8e19 m a float32 ULP is ~2e12, so agreement to any absolute tolerance is
 #: meaningless. Pass ``magnitude=None`` to draw across the full range.
-DEFAULT_MAGNITUDE: float | tuple[float, float] = 1e3
+DEFAULT_MAGNITUDE = 1e3
 
 #: How a caller may specify element values: a strategy, a mapping of keyword
 #: arguments for `hypothesis.strategies.floats`, or nothing at all.
@@ -119,7 +119,7 @@ def _component_quantities(
         # degenerates at zero -- a radius, not a Cartesian offset, for which
         # x = 0 is an ordinary value. Applying it everywhere would carve a hole
         # out of the middle of every free axis.
-        if floor > 0 and interval.min == 0.0 and interval.exclude_min:
+        if floor > 0 and interval.min == 0.0 and interval.margin > 0:
             lo = floor if lo is None else max(lo, floor)
 
     width = 32 if dtype is jnp.float32 else 64

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
@@ -8,10 +8,12 @@ chart component schemas.
 
 __all__ = ("cdicts",)
 
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, TypeAlias
 
 import hypothesis.strategies as st
 import jax.numpy as jnp
+import numpy as np
 import plum
 import unxt as u
 import unxts.hypothesis as ust
@@ -19,12 +21,166 @@ from hypothesis.extra.array_api import make_strategies_namespace
 
 import coordinax.charts as cxc
 
+from .domains import FREE, Interval, component_domains
 from coordinaxs.hypothesis.utils import (
     CDict,
     Shape,
     draw_if_strategy,
     strip_return_annotation,
 )
+
+#: Cap on |value| in each component's canonical unit.
+#:
+#: Without one, draws span the representable range -- measured 1e-5 to 3e38 m --
+#: which is dimensionally fine but useless to any test that compares numbers:
+#: at 1.8e19 m a float32 ULP is ~2e12, so agreement to any absolute tolerance is
+#: meaningless. Pass ``magnitude=None`` to draw across the full range.
+DEFAULT_MAGNITUDE: float | tuple[float, float] = 1e3
+
+#: How a caller may specify element values: a strategy, a mapping of keyword
+#: arguments for `hypothesis.strategies.floats`, or nothing at all.
+#:
+#: Spelled as a real object rather than a string: these signatures are
+#: introspected at runtime by beartype and plum, which resolve a string
+#: annotation in the *caller's* namespace, where ``st`` is not bound.
+Elements: TypeAlias = st.SearchStrategy[float] | Mapping[str, Any] | None
+
+
+def _canonical_unit(interval: Interval, dim: Any, /) -> Any:
+    """Return the unit the magnitude cap is measured in.
+
+    Returns `None` when the dimension has no SI representative -- exotic
+    dimensions such as ``length / time**0.5`` resolve to
+    ``PhysicalType('unknown')``, which is not in the registry. The caller then
+    caps in the drawn unit instead, which still bounds the magnitude even
+    though the bound is not physically canonical.
+    """
+    if interval.unit is not None:
+        return u.unit(interval.unit)
+    if dim is None:
+        return None
+    try:
+        return u.unitsystems.si[dim]
+    except KeyError:
+        return None
+
+
+def _snap_inward(value: float | None, width: int, /, *, up: bool) -> float | None:
+    """Round *value* to a float of *width* bits, moving into the interval.
+
+    Hypothesis rejects bounds that are not exactly representable at the
+    requested width, and rounding the wrong way would widen the domain back
+    over the singularity it was drawn to avoid -- so lower bounds round up and
+    upper bounds round down.
+    """
+    if value is None:
+        return None
+    dtype = np.float32 if width == 32 else np.float64
+    snapped = float(dtype(value))
+    if up and snapped < value:
+        snapped = float(np.nextafter(dtype(snapped), dtype(np.inf)))
+    elif not up and snapped > value:
+        snapped = float(np.nextafter(dtype(snapped), dtype(-np.inf)))
+    return snapped
+
+
+@st.composite
+def _component_quantities(
+    draw: st.DrawFn,
+    *,
+    interval: Interval,
+    dim: Any,
+    unit: Any,
+    dtype: Any,
+    shape: Shape,
+    elements: Elements,
+    magnitude: float | tuple[float, float] | None,
+) -> Any:
+    """One component, bounded by its domain and the magnitude cap."""
+    if unit is None:  # dimensionless / no dimension recorded
+        return draw(
+            ust.quantities(unit=dim, dtype=dtype, shape=shape, elements=elements)
+        )
+
+    lo, hi = interval.bounds_in(unit)
+
+    if magnitude is not None:
+        floor, cap = (
+            (0.0, magnitude) if isinstance(magnitude, int | float) else magnitude
+        )
+        canon = _canonical_unit(interval, dim)
+        if canon is not None:
+            floor = float(u.ustrip(unit, u.Q(floor, canon)))
+            cap = float(u.ustrip(unit, u.Q(cap, canon)))
+        lo = -cap if lo is None else max(lo, -cap)
+        hi = cap if hi is None else min(hi, cap)
+
+        # A magnitude *floor* only means something where the coordinate
+        # degenerates at zero -- a radius, not a Cartesian offset, for which
+        # x = 0 is an ordinary value. Applying it everywhere would carve a hole
+        # out of the middle of every free axis.
+        if floor > 0 and interval.min == 0.0 and interval.exclude_min:
+            lo = floor if lo is None else max(lo, floor)
+
+    width = 32 if dtype is jnp.float32 else 64
+    lo = _snap_inward(lo, width, up=True)
+    hi = _snap_inward(hi, width, up=False)
+
+    elements = _bounded_elements(elements, lo=lo, hi=hi, width=width)
+
+    return draw(ust.quantities(unit=unit, dtype=dtype, shape=shape, elements=elements))
+
+
+def _bounded_elements(
+    elements: Elements,
+    /,
+    *,
+    lo: float | None,
+    hi: float | None,
+    width: int,
+) -> Elements:
+    """Confine *elements* to ``[lo, hi]``, however it was supplied.
+
+    Three cases, and the middle one is why this is worth separating:
+
+    - Nothing given: build the strategy straight from the bounds.
+    - Kwargs for `hypothesis.strategies.floats`: intersect the bounds
+      *exactly*. No filtering, so no rejection, no `filter_too_much`, and no
+      distorted distribution.
+    - An opaque strategy: it can only be filtered. Filtering rather than
+      overriding means an out-of-domain range fails loudly instead of silently
+      yielding coordinates the chart cannot represent.
+    """
+    if elements is None:
+        return st.floats(
+            min_value=lo,
+            max_value=hi,
+            allow_nan=False,
+            allow_infinity=False,
+            allow_subnormal=False,
+            width=width,
+        )
+
+    if isinstance(elements, Mapping):
+        merged: dict[str, Any] = {str(k): v for k, v in elements.items()}
+        if lo is not None:
+            merged["min_value"] = (
+                lo if merged.get("min_value") is None else max(merged["min_value"], lo)
+            )
+        if hi is not None:
+            merged["max_value"] = (
+                hi if merged.get("max_value") is None else min(merged["max_value"], hi)
+            )
+        return merged
+
+    if lo is None and hi is None:
+        return elements
+
+    def _in_domain(v: float) -> bool:
+        return (lo is None or v >= lo) and (hi is None or v <= hi)
+
+    return elements.filter(_in_domain)
+
 
 # Create array API strategies namespace for JAX
 xps = make_strategies_namespace(jnp)
@@ -123,7 +279,8 @@ def cdicts(
     *,
     dtype: Any | st.SearchStrategy = jnp.float32,
     shape: int | tuple[int, ...] | st.SearchStrategy[tuple[int, ...]] = (),
-    elements: st.SearchStrategy[float] | None = None,
+    elements: Elements = None,
+    magnitude: float | tuple[float, float] | None = DEFAULT_MAGNITUDE,
 ) -> CDict:
     """Generate a valid CDict matching chart components and role constraints.
 
@@ -139,8 +296,17 @@ def cdicts(
         Shape for array components; int, tuple of ints, or a strategy. Default
         is scalar (``shape=()``).
     elements
-        Strategy for generating individual float values. If ``None``, uses
-        finite floats.
+        Strategy for generating individual float values. If ``None``, one is
+        built from the component's domain. If given, it is *intersected* with
+        the domain rather than overriding it, so an out-of-domain range fails
+        loudly instead of yielding invalid coordinates.
+    magnitude
+        Bound on ``|value|`` in each component's canonical unit. A scalar is
+        the upper cap; a ``(floor, cap)`` pair also keeps radial coordinates
+        away from the origin, which is what a test needing well-conditioned
+        points wants -- a Jacobian entry scaling like ``1/r`` is unusable at
+        ``r = 1e-3``. The floor is ignored for coordinates that do not
+        degenerate at zero. `None` removes the bound entirely.
 
     Returns
     -------
@@ -162,16 +328,31 @@ def cdicts(
     # Draw shape if it's a strategy
     shape: Shape = draw_if_strategy(draw, shape)
 
-    # Build data dictionary
+    domains = component_domains(chart)
     data: CDict = {}
 
     for cname, cdim in zip(chart.components, chart.coord_dimensions, strict=True):
-        # Get the dimension of the component
         dim = u.dimension(cdim) if isinstance(cdim, str) and cdim is not None else cdim
+        interval = domains.get(cname, FREE)
 
-        # Generate quantity for this component
+        # Draw the unit first, then express the domain *in that unit*. Passing
+        # the dimension straight to `ust.quantities` would let it pick a unit
+        # internally, leaving no way to convert the bounds -- and a bound is
+        # only meaningful alongside the unit it is measured in. Drawing the
+        # unit here keeps the unit diversity (which exercises unit handling)
+        # while making the physical constraint hold whatever is drawn.
+        unit = draw(ust.units(dim)) if dim is not None else None
+
         data[cname] = draw(
-            ust.quantities(unit=dim, dtype=dtype, shape=shape, elements=elements)
+            _component_quantities(
+                interval=interval,
+                dim=dim,
+                unit=unit,
+                dtype=dtype,
+                shape=shape,
+                elements=elements,
+                magnitude=magnitude,
+            )
         )
 
     return data

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/domains.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/domains.py
@@ -46,77 +46,49 @@ class Interval:
         constrains a draw made in ``cycle``.
     min, max
         Bounds, or `None` for unbounded on that side.
-    exclude_min, exclude_max
-        Whether the corresponding bound is open.
     margin
-        How far to stay clear of an *excluded* bound, in ``unit``.
+        How far to stay clear of each finite bound, in ``unit``. A non-zero
+        margin is what "open interval" means here -- there is no separate
+        exclusive flag, because a bound excluded by zero distance is no use.
 
-        Strict inequality is not enough to be useful. ``theta = 1e-30 rad``
-        satisfies ``theta > 0`` and is still numerically *at* the pole: the
-        Jacobian there is singular to working precision. The margin is the
-        difference between mathematically legal and numerically usable, and it
-        is why filtering with ``assume`` cannot substitute for this -- the
-        rejection region is not measure-zero.
+        Strict inequality alone is not enough. ``theta = 1e-30 rad`` satisfies
+        ``theta > 0`` and is still numerically *at* the pole: the Jacobian
+        there is singular to working precision. The margin is the difference
+        between mathematically legal and numerically usable, and it is why
+        filtering with ``assume`` cannot substitute for this -- the rejection
+        region is not measure-zero.
 
     """
 
     unit: str | None = None
     min: float | None = None
     max: float | None = None
-    exclude_min: bool = False
-    exclude_max: bool = False
     margin: float = 0.0
 
     def bounds_in(self, unit: Any, /) -> tuple[float | None, float | None]:
-        """Return ``(lo, hi)`` expressed in *unit*, margins already applied.
-
-        Conversion is monotonic for every unit pair reachable here (they differ
-        by a positive scale factor), but the result is sorted anyway so that a
-        sign-flipping unit could not silently invert the interval.
-        """
+        """Return ``(lo, hi)`` expressed in *unit*, margins already applied."""
         if self.unit is None:
             return self.min, self.max
 
-        lo = (
-            None
-            if self.min is None
-            else self.min + (self.margin if self.exclude_min else 0.0)
-        )
-        hi = (
-            None
-            if self.max is None
-            else self.max - (self.margin if self.exclude_max else 0.0)
-        )
+        def to_unit(v: float | None, shift: float) -> float | None:
+            if v is None:
+                return None
+            return float(u.ustrip(unit, u.Q(v + shift, self.unit)))
 
-        def to_unit(v: float | None) -> float | None:
-            return None if v is None else float(u.ustrip(unit, u.Q(v, self.unit)))
-
-        lo, hi = to_unit(lo), to_unit(hi)
-        if lo is not None and hi is not None and lo > hi:
-            lo, hi = hi, lo
-        return lo, hi
+        return to_unit(self.min, self.margin), to_unit(self.max, -self.margin)
 
 
 #: Strictly positive radius. Unbounded above; `magnitude` caps it in practice.
-RADIAL = Interval("m", min=0.0, exclude_min=True, margin=1e-3)
+RADIAL = Interval("m", min=0.0, margin=1e-3)
 
 #: Polar / colatitude angle, open at both poles where the chart degenerates.
-POLAR = Interval(
-    "rad", min=0.0, max=math.pi, exclude_min=True, exclude_max=True, margin=0.05
-)
+POLAR = Interval("rad", min=0.0, max=math.pi, margin=0.05)
 
 #: Azimuth. Closed: no singularity at either end, they are the same ray.
 AZIMUTH = Interval("rad", min=-math.pi, max=math.pi)
 
 #: Latitude, open at the poles for the same reason as `POLAR`.
-LATITUDE = Interval(
-    "rad",
-    min=-math.pi / 2,
-    max=math.pi / 2,
-    exclude_min=True,
-    exclude_max=True,
-    margin=0.05,
-)
+LATITUDE = Interval("rad", min=-math.pi / 2, max=math.pi / 2, margin=0.05)
 
 #: Explicitly unconstrained.
 FREE = Interval()

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/domains.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/domains.py
@@ -1,0 +1,242 @@
+"""Per-component coordinate domains for chart strategies.
+
+A chart's ``coord_dimensions`` says what *dimension* each component carries. It
+does not say what values are legal: nothing in ``('length', 'angle', 'angle')``
+records that a spherical radius is positive or that a colatitude stops at pi.
+Generating from dimensions alone therefore produces coordinates that are
+dimensionally well-formed and geometrically nonsense -- measured on 300 draws
+of `Spherical3D`, r <= 0 in 60% and theta outside ``(0, pi)`` in 94%.
+
+Nor can the gap be closed by looking at component *names*:
+
+    Spherical3D      ('r', 'theta', 'phi')   ('length', 'angle', 'angle')
+    MathSpherical3D  ('r', 'theta', 'phi')   ('length', 'angle', 'angle')
+
+Identical names, identical dimensions, opposite meanings -- `Spherical3D` reads
+theta as the colatitude and phi as the azimuth, `MathSpherical3D` the other way
+round. `Polar2D` calls its azimuth ``theta`` as well. A lookup keyed on name or
+dimension cannot distinguish charts that need opposite bounds, so the domains
+are dispatched on the chart *type*.
+"""
+
+__all__ = ("Interval", "component_domains")
+
+import math
+from dataclasses import dataclass
+
+from typing import Any, cast
+
+import plum
+import unxt as u
+
+import coordinax.charts as cxc
+
+
+@dataclass(frozen=True)
+class Interval:
+    """Legal values for one coordinate, in a stated canonical unit.
+
+    An unconstrained component is ``Interval()`` -- no unit, no bounds.
+
+    Parameters
+    ----------
+    unit
+        Unit the bounds are written in. Bounds are converted into whichever
+        unit a strategy actually draws, so that stating ``(0, pi) rad`` still
+        constrains a draw made in ``cycle``.
+    min, max
+        Bounds, or `None` for unbounded on that side.
+    exclude_min, exclude_max
+        Whether the corresponding bound is open.
+    margin
+        How far to stay clear of an *excluded* bound, in ``unit``.
+
+        Strict inequality is not enough to be useful. ``theta = 1e-30 rad``
+        satisfies ``theta > 0`` and is still numerically *at* the pole: the
+        Jacobian there is singular to working precision. The margin is the
+        difference between mathematically legal and numerically usable, and it
+        is why filtering with ``assume`` cannot substitute for this -- the
+        rejection region is not measure-zero.
+
+    """
+
+    unit: str | None = None
+    min: float | None = None
+    max: float | None = None
+    exclude_min: bool = False
+    exclude_max: bool = False
+    margin: float = 0.0
+
+    def bounds_in(self, unit: Any, /) -> tuple[float | None, float | None]:
+        """Return ``(lo, hi)`` expressed in *unit*, margins already applied.
+
+        Conversion is monotonic for every unit pair reachable here (they differ
+        by a positive scale factor), but the result is sorted anyway so that a
+        sign-flipping unit could not silently invert the interval.
+        """
+        if self.unit is None:
+            return self.min, self.max
+
+        lo = (
+            None
+            if self.min is None
+            else self.min + (self.margin if self.exclude_min else 0.0)
+        )
+        hi = (
+            None
+            if self.max is None
+            else self.max - (self.margin if self.exclude_max else 0.0)
+        )
+
+        def to_unit(v: float | None) -> float | None:
+            return None if v is None else float(u.ustrip(unit, u.Q(v, self.unit)))
+
+        lo, hi = to_unit(lo), to_unit(hi)
+        if lo is not None and hi is not None and lo > hi:
+            lo, hi = hi, lo
+        return lo, hi
+
+
+#: Strictly positive radius. Unbounded above; `magnitude` caps it in practice.
+RADIAL = Interval("m", min=0.0, exclude_min=True, margin=1e-3)
+
+#: Polar / colatitude angle, open at both poles where the chart degenerates.
+POLAR = Interval(
+    "rad", min=0.0, max=math.pi, exclude_min=True, exclude_max=True, margin=0.05
+)
+
+#: Azimuth. Closed: no singularity at either end, they are the same ray.
+AZIMUTH = Interval("rad", min=-math.pi, max=math.pi)
+
+#: Latitude, open at the poles for the same reason as `POLAR`.
+LATITUDE = Interval(
+    "rad",
+    min=-math.pi / 2,
+    max=math.pi / 2,
+    exclude_min=True,
+    exclude_max=True,
+    margin=0.05,
+)
+
+#: Explicitly unconstrained.
+FREE = Interval()
+
+
+@plum.dispatch.abstract
+def component_domains(chart: Any, /) -> dict[str, Interval]:
+    """Return the legal interval for each of *chart*'s components.
+
+    Dispatched on the chart type, because names and dimensions do not
+    determine the domain (see the module docstring).
+
+    Examples
+    --------
+    >>> import coordinax.charts as cxc
+    >>> from coordinaxs.hypothesis.charts import component_domains
+
+    `Spherical3D` reads theta as the colatitude:
+
+    >>> component_domains(cxc.sph3d)["theta"].max
+    3.14159...
+
+    `MathSpherical3D` reads it as the azimuth, despite the identical name:
+
+    >>> component_domains(cxc.math_sph3d)["theta"].min
+    -3.14159...
+
+    """
+    raise NotImplementedError  # pragma: no cover
+
+
+@plum.dispatch
+def component_domains(chart: cxc.AbstractChart, /) -> dict[str, Interval]:
+    """Unconstrained by default: a chart is free unless it says otherwise.
+
+    Cartesian-like charts land here and want exactly this.
+    """
+    return dict.fromkeys(chart.components, FREE)
+
+
+# ---------------------------------------------------------------------------
+# Radial
+
+
+@plum.dispatch
+def component_domains(chart: cxc.Radial1D, /) -> dict[str, Interval]:
+    return {"r": RADIAL}
+
+
+@plum.dispatch
+def component_domains(chart: cxc.Polar2D, /) -> dict[str, Interval]:
+    """`Polar2D` names its *azimuth* ``theta``, unlike `Spherical3D`."""
+    return {"r": RADIAL, "theta": AZIMUTH}
+
+
+@plum.dispatch
+def component_domains(chart: cxc.Cylindrical3D, /) -> dict[str, Interval]:
+    return {"rho": RADIAL, "phi": AZIMUTH, "z": FREE}
+
+
+# ---------------------------------------------------------------------------
+# Spherical, in both conventions
+
+
+@plum.dispatch
+def component_domains(chart: cxc.Spherical3D, /) -> dict[str, Interval]:
+    """Physics convention: theta is the colatitude, phi the azimuth."""
+    return {"r": RADIAL, "theta": POLAR, "phi": AZIMUTH}
+
+
+@plum.dispatch
+def component_domains(chart: cxc.MathSpherical3D, /) -> dict[str, Interval]:
+    """Mathematics convention: theta and phi swap roles."""
+    return {"r": RADIAL, "theta": AZIMUTH, "phi": POLAR}
+
+
+@plum.dispatch
+def component_domains(chart: cxc.SphericalTwoSphere, /) -> dict[str, Interval]:
+    return {"theta": POLAR, "phi": AZIMUTH}
+
+
+@plum.dispatch
+def component_domains(chart: cxc.MathSphericalTwoSphere, /) -> dict[str, Interval]:
+    """Swap theta and phi, as in `MathSpherical3D`."""
+    return {"theta": AZIMUTH, "phi": POLAR}
+
+
+# ---------------------------------------------------------------------------
+# Longitude / latitude
+
+
+@plum.dispatch
+def component_domains(chart: cxc.LonLatSpherical3D, /) -> dict[str, Interval]:
+    return {"lon": AZIMUTH, "lat": LATITUDE, "distance": RADIAL}
+
+
+@plum.dispatch
+def component_domains(chart: cxc.LonLatSphericalTwoSphere, /) -> dict[str, Interval]:
+    return {"lon": AZIMUTH, "lat": LATITUDE}
+
+
+@plum.dispatch
+def component_domains(chart: cxc.CircularOneSphere, /) -> dict[str, Interval]:
+    return {"phi": AZIMUTH}
+
+
+# ---------------------------------------------------------------------------
+# Composite charts delegate to what they are built from
+
+
+@plum.dispatch
+def component_domains(chart: cxc.CartesianProductChart, /) -> dict[str, Interval]:
+    """Namespaced union of the factors' domains.
+
+    Keeps a product chart correct for free: constrain the factor once and every
+    product containing it follows.
+    """
+    out: dict[str, Interval] = {}
+    for name, factor in zip(chart.factor_names, chart.factors, strict=True):
+        factor_domains = cast("dict[str, Interval]", component_domains(factor))
+        for comp, interval in factor_domains.items():
+            out[f"{name}.{comp}"] = interval
+    return out

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/main/__init__.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/main/__init__.py
@@ -8,8 +8,10 @@ __all__ = (
     # Charts
     "chart_classes",
     "chart_init_kwargs",
+    "Interval",
     "charts",
     "charts_like",
+    "component_domains",
     "cdicts",
     # Manifolds
     "atlas_classes",
@@ -30,11 +32,13 @@ __all__ = (
 
 from coordinaxs.hypothesis.angles import angles
 from coordinaxs.hypothesis.charts import (
+    Interval,
     cdicts,
     chart_classes,
     chart_init_kwargs,
     charts,
     charts_like,
+    component_domains,
 )
 from coordinaxs.hypothesis.distances import distances
 from coordinaxs.hypothesis.manifolds import (

--- a/packages/coordinaxs.hypothesis/tests/unit/charts/test_domains.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/charts/test_domains.py
@@ -1,0 +1,312 @@
+"""Chart coordinate domains, and that `cdicts` actually respects them.
+
+The domains are the executable form of a claim `coord_dimensions` cannot make:
+which *values* a chart's components may take. These tests are the spec -- if a
+chart's domain is wrong, or `cdicts` stops honouring one, they fail here rather
+than as a mysterious singularity in whatever downstream test drew the point.
+"""
+
+__all__: tuple[str, ...] = ()
+
+import math
+
+import hypothesis.strategies as st
+import pytest
+import unxt as u
+from hypothesis import HealthCheck, given, settings
+from hypothesis.errors import Unsatisfiable
+
+import coordinax.charts as cxc
+
+import coordinaxs.hypothesis.main as cxst
+from coordinaxs.hypothesis.charts import Interval, component_domains
+from coordinaxs.hypothesis.utils import get_all_subclasses
+
+#: Charts with a module-level singleton, which is every chart that needs no
+#: construction arguments.
+CHARTS = [
+    inst
+    for cls in sorted(
+        get_all_subclasses(cxc.AbstractChart, exclude_abstract=True),
+        key=lambda c: c.__name__,
+    )
+    if isinstance(inst := getattr(cxc, cls.__name__.lower(), None), cxc.AbstractChart)
+]
+CHART_IDS = [type(c).__name__ for c in CHARTS]
+
+
+def _in(interval: Interval, q: u.AbstractQuantity) -> bool:
+    """Whether *q* lies inside *interval*, compared in the interval's unit."""
+    if interval.unit is None:
+        return True
+    v = float(u.ustrip(interval.unit, q))
+    lo = interval.min
+    hi = interval.max
+    if lo is not None and (v < lo or (interval.exclude_min and v <= lo)):
+        return False
+    return not (hi is not None and (v > hi or (interval.exclude_max and v >= hi)))
+
+
+class TestDomainsAreWellFormed:
+    """Every chart reports a domain for exactly its own components."""
+
+    @pytest.mark.parametrize("chart", CHARTS, ids=CHART_IDS)
+    def test_keys_match_components(self, chart: cxc.AbstractChart) -> None:
+        assert set(component_domains(chart)) == set(chart.components)
+
+    @pytest.mark.parametrize("chart", CHARTS, ids=CHART_IDS)
+    def test_bounds_are_ordered(self, chart: cxc.AbstractChart) -> None:
+        for name, interval in component_domains(chart).items():
+            if interval.min is not None and interval.max is not None:
+                assert interval.min < interval.max, name
+
+    @pytest.mark.parametrize("chart", CHARTS, ids=CHART_IDS)
+    def test_margin_leaves_room(self, chart: cxc.AbstractChart) -> None:
+        """A margin must not eat the whole interval."""
+        for name, interval in component_domains(chart).items():
+            lo, hi = interval.bounds_in(u.unit(interval.unit or ""))
+            if lo is not None and hi is not None:
+                assert lo < hi, f"{name}: margin closed the interval"
+
+
+class TestConventionsAreDistinguished:
+    """The case that forces dispatch: same names, same dimensions, opposite domains."""
+
+    def test_spherical_pair_is_indistinguishable_by_name_or_dimension(self) -> None:
+        """Establishes *why* a name- or dimension-keyed lookup cannot work."""
+        assert cxc.sph3d.components == cxc.math_sph3d.components
+        assert cxc.sph3d.coord_dimensions == cxc.math_sph3d.coord_dimensions
+
+    def test_physics_convention_theta_is_the_colatitude(self) -> None:
+        theta = component_domains(cxc.sph3d)["theta"]
+        assert theta.min == 0.0
+        assert theta.max == pytest.approx(math.pi)
+
+    def test_maths_convention_theta_is_the_azimuth(self) -> None:
+        theta = component_domains(cxc.math_sph3d)["theta"]
+        assert theta.min == pytest.approx(-math.pi)
+        assert theta.max == pytest.approx(math.pi)
+
+    def test_the_two_conventions_disagree(self) -> None:
+        assert component_domains(cxc.sph3d) != component_domains(cxc.math_sph3d)
+
+    def test_polar2d_theta_is_an_azimuth_not_a_colatitude(self) -> None:
+        """`Polar2D` shares the name `theta` with `Spherical3D`'s colatitude."""
+        assert component_domains(cxc.polar2d)["theta"].min == pytest.approx(-math.pi)
+
+
+class TestBoundsFollowTheUnit:
+    """Bounds are stated in one unit and must hold in whatever unit is drawn."""
+
+    @pytest.mark.parametrize(
+        ("unit_str", "expected_hi"),
+        [("rad", math.pi), ("deg", 180.0), ("cycle", 0.5), ("arcmin", 180 * 60)],
+    )
+    def test_polar_upper_bound_converts(
+        self, unit_str: str, expected_hi: float
+    ) -> None:
+        _, hi = component_domains(cxc.sph3d)["theta"].bounds_in(u.unit(unit_str))
+        # The margin pulls it in slightly; the scale is what matters here.
+        assert hi == pytest.approx(expected_hi, rel=0.05)
+
+    def test_unconstrained_component_has_no_bounds(self) -> None:
+        lo, hi = component_domains(cxc.cart3d)["x"].bounds_in(u.unit("m"))
+        assert lo is None
+        assert hi is None
+
+
+class TestCDictsRespectsDomains:
+    """The payoff: generated points are inside the domain, with no filtering."""
+
+    @pytest.mark.parametrize("chart", CHARTS, ids=CHART_IDS)
+    def test_draws_are_in_domain(self, chart: cxc.AbstractChart) -> None:
+        domains = component_domains(chart)
+
+        @given(point=cxst.cdicts(chart))
+        @settings(
+            max_examples=50, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def check(point: dict) -> None:
+            for name, q in point.items():
+                assert _in(domains[name], q), f"{name}={q!r} outside {domains[name]}"
+
+        check()
+
+    def test_spherical_radius_is_positive(self) -> None:
+        """Was 60% negative before the domains existed."""
+
+        @given(point=cxst.cdicts(cxc.sph3d))
+        @settings(
+            max_examples=200, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def check(point: dict) -> None:
+            assert float(u.ustrip("m", point["r"])) > 0
+
+        check()
+
+    def test_colatitude_is_off_both_poles(self) -> None:
+        """Was 94% outside (0, pi) before the domains existed."""
+
+        @given(point=cxst.cdicts(cxc.sph3d))
+        @settings(
+            max_examples=200, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def check(point: dict) -> None:
+            theta = float(u.ustrip("rad", point["theta"]))
+            assert 0 < theta < math.pi
+
+        check()
+
+    def test_units_still_vary(self) -> None:
+        """Constraining values must not have collapsed unit diversity.
+
+        Drawing a variety of units is the reason `cdicts` is useful for
+        exercising unit handling; the domains convert bounds into the drawn
+        unit rather than pinning it, so this must survive.
+        """
+        seen: set[tuple[str, ...]] = set()
+
+        @given(point=cxst.cdicts(cxc.sph3d))
+        @settings(
+            max_examples=200, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def collect(point: dict) -> None:
+            seen.add(tuple(str(q.unit) for q in point.values()))
+
+        collect()
+        assert len(seen) > 5
+
+
+class TestMagnitude:
+    """The cap that makes draws usable in numerical comparisons."""
+
+    def test_default_bounds_magnitude(self) -> None:
+        @given(point=cxst.cdicts(cxc.cart3d))
+        @settings(
+            max_examples=200, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def check(point: dict) -> None:
+            for q in point.values():
+                assert abs(float(u.ustrip("m", q))) <= 1e3 * (1 + 1e-6)
+
+        check()
+
+    def test_explicit_magnitude_is_honoured(self) -> None:
+        @given(point=cxst.cdicts(cxc.cart3d, magnitude=1.0))
+        @settings(
+            max_examples=100, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def check(point: dict) -> None:
+            for q in point.values():
+                assert abs(float(u.ustrip("m", q))) <= 1.0 * (1 + 1e-6)
+
+        check()
+
+    def test_none_opts_out(self) -> None:
+        """`magnitude=None` restores the unbounded behaviour, for stress tests."""
+        biggest = 0.0
+
+        @given(point=cxst.cdicts(cxc.cart3d, magnitude=None))
+        @settings(
+            max_examples=200, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def collect(point: dict) -> None:
+            nonlocal biggest
+            for q in point.values():
+                biggest = max(biggest, abs(float(u.ustrip("m", q))))
+
+        collect()
+        assert biggest > 1e3
+
+
+class TestMagnitudeFloor:
+    """A `(floor, cap)` range also keeps radial coordinates off the origin.
+
+    The cap alone is not enough for a test that compares derivatives: a
+    Jacobian entry scaling like ``1/r`` is unusable at ``r = 1e-3`` however
+    modest the upper bound. This is what lets `cdicts` replace a hand-rolled
+    per-component strategy.
+    """
+
+    def test_floor_applies_to_a_radius(self) -> None:
+        radii = []
+
+        @given(point=cxst.cdicts(cxc.sph3d, magnitude=(0.5, 8.0)))
+        @settings(
+            max_examples=150, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def collect(point: dict) -> None:
+            radii.append(float(u.ustrip("m", point["r"])))
+
+        collect()
+        assert min(radii) >= 0.5 * (1 - 1e-6)
+        assert max(radii) <= 8.0 * (1 + 1e-6)
+
+    def test_floor_does_not_apply_to_a_free_axis(self) -> None:
+        """``x = 0`` is an ordinary Cartesian value, not a degeneracy.
+
+        Applying the floor everywhere would carve a hole out of the middle of
+        every free axis.
+        """
+        seen_small = False
+
+        @given(point=cxst.cdicts(cxc.cart3d, magnitude=(0.5, 8.0)))
+        @settings(
+            max_examples=200, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def collect(point: dict) -> None:
+            nonlocal seen_small
+            if abs(float(u.ustrip("m", point["x"]))) < 0.5:
+                seen_small = True
+
+        collect()
+        assert seen_small
+
+    def test_scalar_magnitude_still_means_a_cap(self) -> None:
+        """Backwards-compatible: a bare number is the upper bound only."""
+
+        @given(point=cxst.cdicts(cxc.sph3d, magnitude=8.0))
+        @settings(
+            max_examples=100, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def check(point: dict) -> None:
+            assert float(u.ustrip("m", point["r"])) <= 8.0 * (1 + 1e-6)
+
+        check()
+
+
+class TestElementsInteraction:
+    """A caller-supplied `elements` is honoured but still held to the domain."""
+
+    def test_elements_narrows_within_the_domain(self) -> None:
+        @given(
+            point=cxst.cdicts(
+                cxc.sph3d, elements=st.floats(0.5, 2.0, width=32), magnitude=None
+            )
+        )
+        @settings(
+            max_examples=100, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def check(point: dict) -> None:
+            assert float(u.ustrip("m", point["r"])) > 0
+            assert 0 < float(u.ustrip("rad", point["theta"])) < math.pi
+
+        check()
+
+    def test_elements_cannot_reintroduce_invalid_coordinates(self) -> None:
+        """An `elements` range outside the domain fails loudly, not silently.
+
+        Filtering rather than overriding is the deliberate choice here: a
+        caller who asks for negative radii gets `Unsatisfiable`, instead of a
+        `Spherical3D` point with r < 0 that only misbehaves much later.
+        """
+
+        @given(point=cxst.cdicts(cxc.sph3d, elements=st.floats(-10.0, -1.0, width=32)))
+        @settings(
+            max_examples=25, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def check(point: dict) -> None:  # pragma: no cover - never reached
+            pytest.fail("a negative radius should not be reachable")
+
+        with pytest.raises(Unsatisfiable):
+            check()

--- a/packages/coordinaxs.hypothesis/tests/unit/charts/test_domains.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/charts/test_domains.py
@@ -10,6 +10,8 @@ __all__: tuple[str, ...] = ()
 
 import math
 
+from collections.abc import Callable
+
 import hypothesis.strategies as st
 import pytest
 import unxt as u
@@ -17,34 +19,61 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis.errors import Unsatisfiable
 
 import coordinax.charts as cxc
+import coordinax.manifolds as cxm
 
 import coordinaxs.hypothesis.main as cxst
 from coordinaxs.hypothesis.charts import Interval, component_domains
 from coordinaxs.hypothesis.utils import get_all_subclasses
 
-#: Charts with a module-level singleton, which is every chart that needs no
-#: construction arguments.
-CHARTS = [
-    inst
-    for cls in sorted(
-        get_all_subclasses(cxc.AbstractChart, exclude_abstract=True),
-        key=lambda c: c.__name__,
-    )
-    if isinstance(inst := getattr(cxc, cls.__name__.lower(), None), cxc.AbstractChart)
+#: Every concrete chart, one instance each.
+#:
+#: Enumerated from the module's own singletons rather than guessed from class
+#: names: the singleton for `Spherical3D` is `sph3d`, not `spherical3d`, so a
+#: ``getattr(cxc, cls.__name__.lower())`` heuristic silently collects only the
+#: Cartesian-ish half and skips every chart with an interesting domain.
+_SINGLETONS = sorted(
+    {
+        id(obj): obj for obj in vars(cxc).values() if isinstance(obj, cxc.AbstractChart)
+    }.values(),
+    key=lambda c: type(c).__name__,
+)
+
+#: The three that take construction arguments, so have no singleton.
+_CONSTRUCTED = [
+    cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(1.0, "kpc")),
+    cxc.CartesianProductChart(
+        factors=(cxc.cart3d, cxc.polar2d), factor_names=("q", "p")
+    ),
+    cxm.EmbeddedChart(embed_map=cxm.TwoSphereIn3D(radius=u.Q(1.0, "kpc"))),
 ]
+
+CHARTS = [*_SINGLETONS, *_CONSTRUCTED]
 CHART_IDS = [type(c).__name__ for c in CHARTS]
 
 
+def test_every_concrete_chart_is_covered() -> None:
+    """The list above must not drift behind the chart hierarchy.
+
+    Without this, adding a chart silently adds an untested domain -- which is
+    exactly how the original name-guessing version came to skip 13 of 24.
+    """
+    concrete = {
+        c.__name__ for c in get_all_subclasses(cxc.AbstractChart, exclude_abstract=True)
+    }
+    assert concrete - {type(c).__name__ for c in CHARTS} == set()
+
+
 def _in(interval: Interval, q: u.AbstractQuantity) -> bool:
-    """Whether *q* lies inside *interval*, compared in the interval's unit."""
+    """Whether *q* lies inside *interval*, margins included.
+
+    Compares in the interval's own unit, and against the margin-adjusted
+    bounds -- a draw sitting exactly on an open bound is outside.
+    """
     if interval.unit is None:
         return True
+    lo, hi = interval.bounds_in(u.unit(interval.unit))
     v = float(u.ustrip(interval.unit, q))
-    lo = interval.min
-    hi = interval.max
-    if lo is not None and (v < lo or (interval.exclude_min and v <= lo)):
-        return False
-    return not (hi is not None and (v > hi or (interval.exclude_max and v >= hi)))
+    return (lo is None or v >= lo) and (hi is None or v <= hi)
 
 
 class TestDomainsAreWellFormed:
@@ -53,12 +82,6 @@ class TestDomainsAreWellFormed:
     @pytest.mark.parametrize("chart", CHARTS, ids=CHART_IDS)
     def test_keys_match_components(self, chart: cxc.AbstractChart) -> None:
         assert set(component_domains(chart)) == set(chart.components)
-
-    @pytest.mark.parametrize("chart", CHARTS, ids=CHART_IDS)
-    def test_bounds_are_ordered(self, chart: cxc.AbstractChart) -> None:
-        for name, interval in component_domains(chart).items():
-            if interval.min is not None and interval.max is not None:
-                assert interval.min < interval.max, name
 
     @pytest.mark.parametrize("chart", CHARTS, ids=CHART_IDS)
     def test_margin_leaves_room(self, chart: cxc.AbstractChart) -> None:
@@ -115,6 +138,44 @@ class TestBoundsFollowTheUnit:
         assert hi is None
 
 
+#: Physical truths about each coordinate, written out rather than derived from
+#: `component_domains`, so that a wrong constant in that table cannot make the
+#: test agree with it. Covers both spherical conventions, which is the case the
+#: whole dispatch design exists for.
+INVARIANTS = [
+    pytest.param(cxc.sph3d, "r", "m", lambda v: v > 0, id="sph3d-r-positive"),
+    pytest.param(
+        cxc.sph3d, "theta", "rad", lambda v: 0 < v < math.pi, id="sph3d-theta-polar"
+    ),
+    pytest.param(
+        cxc.math_sph3d,
+        "phi",
+        "rad",
+        lambda v: 0 < v < math.pi,
+        id="math_sph3d-phi-polar",
+    ),
+    pytest.param(
+        cxc.math_sph3d,
+        "theta",
+        "rad",
+        lambda v: -math.pi <= v <= math.pi,
+        id="math_sph3d-theta-azimuth",
+    ),
+    pytest.param(cxc.polar2d, "r", "m", lambda v: v > 0, id="polar2d-r-positive"),
+    pytest.param(cxc.cyl3d, "rho", "m", lambda v: v > 0, id="cyl3d-rho-positive"),
+    pytest.param(
+        cxc.lonlat_sph3d,
+        "lat",
+        "rad",
+        lambda v: -math.pi / 2 < v < math.pi / 2,
+        id="lonlat-lat-in-range",
+    ),
+    pytest.param(
+        cxc.sph2, "theta", "rad", lambda v: 0 < v < math.pi, id="sph2-theta-polar"
+    ),
+]
+
+
 class TestCDictsRespectsDomains:
     """The payoff: generated points are inside the domain, with no filtering."""
 
@@ -132,28 +193,31 @@ class TestCDictsRespectsDomains:
 
         check()
 
-    def test_spherical_radius_is_positive(self) -> None:
-        """Was 60% negative before the domains existed."""
+    @pytest.mark.parametrize(
+        ("chart", "component", "unit_str", "predicate"), INVARIANTS
+    )
+    def test_physical_invariant_holds(
+        self,
+        chart: cxc.AbstractChart,
+        component: str,
+        unit_str: str,
+        predicate: Callable[[float], bool],
+    ) -> None:
+        """Draws satisfy the physics, stated *without* consulting the domains.
 
-        @given(point=cxst.cdicts(cxc.sph3d))
+        `test_draws_are_in_domain` above checks draws against
+        `component_domains` -- the same table `cdicts` generated from, so it
+        stays green even if a constant in that table is wrong. It proves the
+        strategy honours the domain, not that the domain is right. These
+        assertions are the independent half: blank out `RADIAL` and they fail.
+        """
+
+        @given(point=cxst.cdicts(chart))
         @settings(
-            max_examples=200, deadline=None, suppress_health_check=list(HealthCheck)
+            max_examples=100, deadline=None, suppress_health_check=list(HealthCheck)
         )
         def check(point: dict) -> None:
-            assert float(u.ustrip("m", point["r"])) > 0
-
-        check()
-
-    def test_colatitude_is_off_both_poles(self) -> None:
-        """Was 94% outside (0, pi) before the domains existed."""
-
-        @given(point=cxst.cdicts(cxc.sph3d))
-        @settings(
-            max_examples=200, deadline=None, suppress_health_check=list(HealthCheck)
-        )
-        def check(point: dict) -> None:
-            theta = float(u.ustrip("rad", point["theta"]))
-            assert 0 < theta < math.pi
+            assert predicate(float(u.ustrip(unit_str, point[component])))
 
         check()
 

--- a/packages/coordinaxs.hypothesis/tests/unit/charts/test_domains.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/charts/test_domains.py
@@ -339,6 +339,81 @@ class TestMagnitudeFloor:
         check()
 
 
+class TestMagnitudeFloorIsRadialOnly:
+    """The floor is a length scale, so it must not reach a bounded angle."""
+
+    def test_floor_does_not_move_a_polar_angle(self) -> None:
+        """`magnitude=(0.5, 8)` must not shove theta 0.5 *radians* off the pole.
+
+        Both `RADIAL` and `POLAR` start at zero, so a predicate keyed on that
+        alone catches the colatitude too and couples an angle to what the
+        caller meant as a length scale. Only `RADIAL` runs to infinity, and
+        that is the discriminator.
+        """
+        thetas = []
+
+        @given(point=cxst.cdicts(cxc.sph3d, magnitude=(0.5, 8.0)))
+        @settings(
+            max_examples=150, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def collect(point: dict) -> None:
+            thetas.append(float(u.ustrip("rad", point["theta"])))
+
+        collect()
+        # Free to sit anywhere above its own margin, well below the 0.5 floor.
+        assert min(thetas) < 0.5
+
+    def test_floor_still_moves_the_radius(self) -> None:
+        """The counterpart: the coordinate the floor is actually for."""
+
+        @given(point=cxst.cdicts(cxc.sph3d, magnitude=(0.5, 8.0)))
+        @settings(
+            max_examples=150, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def check(point: dict) -> None:
+            assert float(u.ustrip("m", point["r"])) >= 0.5 * (1 - 1e-6)
+
+        check()
+
+
+class TestMappingElementsAreSafe:
+    """Kwargs for the element strategy inherit the same safety defaults."""
+
+    def test_no_nan_or_infinity_when_bounds_are_absent(self) -> None:
+        """The hole a caller-supplied mapping used to open.
+
+        The domain bounds hide this whenever they are finite, so it only shows
+        with an unconstrained component *and* `magnitude=None` -- which was 193
+        non-finite draws in 300 before the defaults were applied.
+        """
+        values = []
+
+        @given(point=cxst.cdicts(cxc.cart3d, elements={}, magnitude=None))
+        @settings(
+            max_examples=200, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def collect(point: dict) -> None:
+            values.extend(float(u.ustrip("m", q)) for q in point.values())
+
+        collect()
+        assert all(math.isfinite(v) for v in values)
+
+    def test_caller_keys_still_win(self) -> None:
+        """The defaults fill gaps; they do not override an explicit choice."""
+
+        @given(
+            point=cxst.cdicts(cxc.cart3d, elements={"min_value": 1.0, "max_value": 2.0})
+        )
+        @settings(
+            max_examples=100, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def check(point: dict) -> None:
+            for q in point.values():
+                assert 1.0 <= float(u.ustrip("m", q)) <= 2.0
+
+        check()
+
+
 class TestElementsInteraction:
     """A caller-supplied `elements` is honoured but still held to the domain."""
 

--- a/tests/unit/manifolds/test_metric_matrix_batch_invariant.py
+++ b/tests/unit/manifolds/test_metric_matrix_batch_invariant.py
@@ -42,12 +42,6 @@ CURVILINEAR = [
     (cxm.S2, cxc.sph2),
 ]
 
-# Bounded so squared lengths can't overflow into inf/nan noise; sign is
-# irrelevant (the metric depends on r**2 and sin/cos), so a plain range is fine.
-_coords = st.floats(
-    min_value=-100.0, max_value=100.0, allow_nan=False, allow_infinity=False, width=32
-)
-
 
 @given(data=st.data())
 @settings(deadline=None, max_examples=50)
@@ -55,7 +49,9 @@ def test_curvilinear_metric_batches_like_elementwise(data):
     """Batched diagonal equals the per-element unbatched diagonals."""
     manifold, chart = data.draw(st.sampled_from(CURVILINEAR))
     shape = data.draw(array_shapes(min_dims=1, max_dims=2, min_side=1, max_side=3))
-    point = data.draw(cxst.cdicts(chart, shape=shape, elements=_coords))
+    # No `elements`: the chart's own domain now bounds each coordinate, and
+    # the default magnitude keeps squared lengths clear of inf/nan noise.
+    point = data.draw(cxst.cdicts(chart, shape=shape))
 
     n = len(chart.components)
     gb = cxmapi.metric_matrix(manifold, point, chart).diagonal


### PR DESCRIPTION
`cdicts` generated from `coord_dimensions` alone — which records what *dimension* each component carries and nothing about which *values* are legal. Measured on 300 draws of `Spherical3D`: **r ≤ 0 in 60%**, **θ outside (0, π) in 94%**, magnitudes spanning **1e-5 to 3e38 m**. Dimensionally well-formed, geometrically nonsense, unusable in any test that compares numbers.

`assume` can't repair it: the rejection region is most of the space, so filtering trips `filter_too_much` long before producing a usable sample.

## Why dispatch, and not a lookup table

```
Spherical3D      ('r', 'theta', 'phi')   ('length', 'angle', 'angle')
MathSpherical3D  ('r', 'theta', 'phi')   ('length', 'angle', 'angle')
```

Identical names, identical dimensions, **opposite meanings** — θ is the colatitude in one and the azimuth in the other. `Polar2D` calls its azimuth `theta` too. Any name- or dimension-keyed table is wrong for at least one of them. Only `plum` dispatch on the chart type separates them, which is what `component_domains` does.

## Three design points

**Bounds are converted, not pinned.** The unit is drawn first and the domain expressed in whatever came out, so `(0, π) rad` still constrains a draw made in `cycle`. Unit diversity is *why* `cdicts` is useful for exercising unit handling — pinning units was the easy fix and would have quietly deleted that value. **92 distinct unit combinations survive.**

**`margin` separates legal from usable.** `θ = 1e-30 rad` satisfies θ > 0 and is still numerically *at* the pole. The margin is that gap, and it's the reason `assume` isn't a substitute: the bad region has volume.

**`magnitude` is a range, not just a cap.** A cap alone leaves the *lower* end open, and a Jacobian entry scaling like `1/r` is unusable at `r = 1e-3` however modest the upper bound. `(floor, cap)` closes it. The floor applies only where the coordinate degenerates at zero — a radius, not a Cartesian offset, for which `x = 0` is ordinary.

## `elements` still works

Now *intersected* with the domain rather than overriding it. The kwargs form intersects **exactly** — no filtering, so no rejection and no distorted distribution. An opaque strategy can only be filtered, so an out-of-domain range fails loudly (`Unsatisfiable`) instead of silently yielding coordinates the chart cannot represent.

## Result

| | before | after |
|---|---|---|
| `sph3d` r ≤ 0 | 51–60% | **0%** |
| `sph3d` θ outside (0, π) | 94–97% | **0%** |
| `lonlat` lat outside range | 49% | **0%** |
| max &#124;length&#124; | 3.4e38 m | **1e3 m** |
| `assume` calls needed | — | **none** |

The domains are executable spec: `test_domains.py` asserts every chart's draws land inside its own declared domain, so a wrong domain fails there rather than as a mysterious singularity downstream.

One caller got *simpler*: `test_metric_matrix_batch_invariant` passed its own `elements` to keep squared lengths finite, which the domain and default magnitude now do for it.

## Verified downstream

The #649 jacfwd property — which needed a hand-rolled per-component strategy — passes for **all six chart-pair directions** drawing straight from `cdicts(curv, magnitude=(0.5, 8.0))`. #649 should rebase on this and delete its `_draw_curvilinear_point` helper.

## Not solved

Extreme-scale coverage. Bounding magnitude makes draws usable but doesn't test 1e19 m; that needs a relative-tolerance assertion, not a better strategy.

I also left out the `draw_cdict` escape hatch I floated for coupled components — no chart currently needs it, and `component_domains` being dispatched means adding one later is cheap. Building it now would be scaffolding with zero implementations.

2481 tests pass; ruff and ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
