### PR TITLE
🐛 fix(vectors): Tangent add/subtract silently corrupts across charts

### DIFF
--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -425,13 +425,38 @@ def subtract(lhs: Point, rhs: Point, /) -> Point:
     return replace(lhs, data=result_data)
 
 
+def _check_same_tangent_space(lhs: Tangent, rhs: Tangent, op_name: str, /) -> None:
+    """Check that two Tangents share a chart and representation.
+
+    Component-wise addition is only meaningful within a single tangent space:
+    same manifold *and* same chart (the coordinate basis vector fields differ
+    chart to chart, even when two charts happen to name their components the
+    same way -- e.g. Galilean and Minkowski spacetime charts both use ``(ct,
+    x, y, z)``), and same basis/semantic (``rep``).
+    """
+    if lhs.chart != rhs.chart:
+        msg = (
+            f"Cannot {op_name} Tangent vectors with different charts: "
+            f"{lhs.chart!r} vs {rhs.chart!r}."
+        )
+        raise ValueError(msg)
+    if lhs.rep != rhs.rep:
+        msg = (
+            f"Cannot {op_name} Tangent vectors with different representations: "
+            f"{lhs.rep!r} vs {rhs.rep!r}."
+        )
+        raise ValueError(msg)
+
+
 @plum.dispatch
 def add(lhs: Tangent, rhs: Tangent, /) -> Tangent:
     """Add two tangent vectors component-wise.
 
     Tangent spaces are genuine vector spaces: addition is component-wise in any
     chart basis (no Cartesian round-trip is needed or correct).  Both operands
-    must share the same representation (chart + basis + semantic).
+    must share the same chart and representation (basis + semantic) -- adding
+    components from two different charts is meaningless even when the charts
+    happen to name their components the same way.
 
     >>> import unxt as u
     >>> import coordinax as cx
@@ -451,13 +476,7 @@ def add(lhs: Tangent, rhs: Tangent, /) -> Tangent:
     Q(5., 'm / s')
 
     """
-    if lhs.rep != rhs.rep:
-        msg = (
-            f"Cannot add Tangent vectors with different representations: "
-            f"{lhs.rep!r} vs {rhs.rep!r}."
-        )
-        raise ValueError(msg)
-
+    _check_same_tangent_space(lhs, rhs, "add")
     data = jtu.map(jnp.add, lhs.data, rhs.data, is_leaf=uq.is_any_quantity)
     return replace(lhs, data=data)
 
@@ -468,7 +487,9 @@ def subtract(lhs: Tangent, rhs: Tangent, /) -> Tangent:
 
     Tangent spaces are genuine vector spaces: subtraction is component-wise in
     any chart basis (no Cartesian round-trip is needed or correct).  Both
-    operands must share the same representation (chart + basis + semantic).
+    operands must share the same chart and representation (basis + semantic)
+    -- subtracting components from two different charts is meaningless even
+    when the charts happen to name their components the same way.
 
     >>> import unxt as u
     >>> import coordinax as cx
@@ -488,13 +509,7 @@ def subtract(lhs: Tangent, rhs: Tangent, /) -> Tangent:
     Q(3., 'm / s')
 
     """
-    if lhs.rep != rhs.rep:
-        msg = (
-            f"Cannot subtract Tangent vectors with different representations: "
-            f"{lhs.rep!r} vs {rhs.rep!r}."
-        )
-        raise ValueError(msg)
-
+    _check_same_tangent_space(lhs, rhs, "subtract")
     data = jtu.map(jnp.subtract, lhs.data, rhs.data, is_leaf=uq.is_any_quantity)
     return replace(lhs, data=data)
 

--- a/tests/unit/vectors/test_arithmetic.py
+++ b/tests/unit/vectors/test_arithmetic.py
@@ -440,6 +440,61 @@ class TestTangentMismatchedRep:
 
 
 # ===================================================================
+# Tangent mismatched chart → error
+# ===================================================================
+
+
+class TestTangentMismatchedChart:
+    """Adding/subtracting Tangents from different charts raises ValueError.
+
+    Regression test: `rep` (basis + semantic) does not include the chart, so a
+    guard that only checks `rep` lets through two Tangents from *different*
+    manifolds whenever their charts happen to name components the same way --
+    e.g. `GalileanCT` and `MinkowskiCT` both use ``(ct, x, y, z)``. Adding
+    their coordinate-basis components would silently produce a value with no
+    physical meaning instead of raising.
+    """
+
+    def _galilean_minkowski_vel(self) -> tuple:
+        data = {
+            "ct": u.Q(1.0, "m/s"),
+            "x": u.Q(2.0, "m/s"),
+            "y": u.Q(3.0, "m/s"),
+            "z": u.Q(4.0, "m/s"),
+        }
+        gal = cx.Tangent.from_(data, cxc.galileanct, cxr.coord_vel)
+        mink = cx.Tangent.from_(data, cxc.minkowskict, cxr.coord_vel)
+        return gal, mink
+
+    def test_same_rep_different_chart_same_keys(self) -> None:
+        """Sanity check: the two charts really do collide on component names."""
+        gal, mink = self._galilean_minkowski_vel()
+        assert gal.rep == mink.rep
+        assert gal.chart != mink.chart
+        assert set(gal.data) == set(mink.data)
+
+    def test_add_different_chart_raises(self) -> None:
+        gal, mink = self._galilean_minkowski_vel()
+        with pytest.raises(ValueError, match="Cannot add Tangent vectors"):
+            _ = gal + mink
+
+    def test_sub_different_chart_raises(self) -> None:
+        gal, mink = self._galilean_minkowski_vel()
+        with pytest.raises(ValueError, match="Cannot subtract Tangent vectors"):
+            _ = gal - mink
+
+    def test_cx_add_different_chart_raises(self) -> None:
+        gal, mink = self._galilean_minkowski_vel()
+        with pytest.raises(ValueError, match="Cannot add Tangent vectors"):
+            cxr.add(gal, mink)
+
+    def test_cx_subtract_different_chart_raises(self) -> None:
+        gal, mink = self._galilean_minkowski_vel()
+        with pytest.raises(ValueError, match="Cannot subtract Tangent vectors"):
+            cxr.subtract(gal, mink)
+
+
+# ===================================================================
 # Coordinate broadcast / convert (required for JAX JIT / vmap)
 # ===================================================================
 


### PR DESCRIPTION
Correctness bug found during a `coordinax.vectors` audit, highest severity of the batch.

## The bug

`Tangent.add`/`subtract` (`register_cx.py`) only guard `lhs.rep != rhs.rep`. `Tangent.rep` is `Representation(tangent_geom, basis, semantic)` — it **does not include the chart**. Two `Tangent`s from genuinely different manifolds add without error whenever their charts happen to name components the same way:

```python
gal  = cxc.GalileanCT()    # ('ct','x','y','z'), all "length"
mink = cxc.MinkowskiCT()   # ('ct','x','y','z'), all "length" -- different manifold, different metric

v_gal  = cx.Tangent.from_({'ct':Q(1,'m/s'),'x':Q(2,'m/s'),'y':Q(3,'m/s'),'z':Q(4,'m/s')}, gal, coord_vel)
v_mink = cx.Tangent.from_({'ct':Q(10,'m/s'),'x':Q(20,'m/s'),'y':Q(30,'m/s'),'z':Q(40,'m/s')}, mink, coord_vel)

v_gal + v_mink
# → <Tangent: chart=GalileanCT (ct, x, y, z) [m/s] [11. 22. 33. 44.]>
# no error, no warning -- and the result is physically meaningless
```

Galilean and Minkowski spacetime are different manifolds with different metrics; adding their coordinate-basis tangent vectors component-wise doesn't mean anything. This is reachable through plain `v1 + v2` — no obscure internal path, it goes straight through `quax.register(jax.lax.add_p)`.

## Why only Tangent

Every other chart-sensitive vector operation in this module already guards on chart:

- `Point + Point` across the same two charts correctly **raises** (`_binop_via_cartesian` round-trips through `pt_map`, and there's no registered transform between the manifolds → `NotImplementedError`).
- `AbstractVector.__eq__` checks `self.chart != other_vec.chart` before comparing — its own comment names this exact hazard ("avoids the component-key mismatch that comparing different-chart data dicts would otherwise raise").
- `equivalent`, `separation`, and `change_basis` all check chart.

`Tangent.add`/`subtract` is the one place the guard was dropped — the `rep`-only check reads like it was meant to also imply chart equality (they usually go together), but doesn't actually enforce it.

## Fix

Adds the missing chart check alongside the existing rep check, factored into a shared `_check_same_tangent_space(lhs, rhs, op_name)` helper used by both `add` and `subtract`.

## Tests

New `TestTangentMismatchedChart` in `tests/unit/vectors/test_arithmetic.py`, using the exact `GalileanCT`/`MinkowskiCT` collision above: a sanity check that the two charts really do collide on component names, then asserts `add`/`subtract` raise via both `+`/`-` and `cxr.add`/`cxr.subtract`.

Full suite green (`8004 passed`; two pre-existing Hypothesis flakes in an unrelated `charts` test unaffected by this diff, confirmed to pass standalone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)