### PR TITLE
🐛 fix(vectors): batch indexing crashes on broadcastable-but-unequal shapes

### DIFF
--- a/src/coordinax/vectors/_src/base.py
+++ b/src/coordinax/vectors/_src/base.py
@@ -29,8 +29,8 @@ import coordinax.frames as cxf
 import coordinax.manifolds as cxm
 import coordinax.representations as cxr
 import coordinax.transforms as cxfm
-from .custom_types import HasShape
-from coordinax.internal import pos_named_objs
+from .custom_types import HasShape, Shape
+from coordinax.internal import CDict, pos_named_objs
 
 if TYPE_CHECKING:
     from typing import Self
@@ -635,6 +635,27 @@ class AbstractVector(
         # Otherwise, apply the transformation and return a new point
         new = cxfm.act(op, t, self)
         return dataclassish.replace(new, frame=toframe)  # ty: ignore[invalid-return-type]
+
+
+# ===================================================================
+# Broadcast-aware batch indexing
+#
+# Shared by `Point.__getitem__`, `Tangent.__getitem__`, and
+# `Coordinate.__getitem__`. Component leaves are only required to be
+# *broadcast-compatible*, not identically shaped (that is the whole point of
+# `.shape` being `broadcast_shapes(*(v.shape for v in data.values()))`) — so a
+# leaf narrower than the target shape must be broadcast to it before an
+# integer/slice index is applied, or indexing raises on any leaf that doesn't
+# already carry the full batch shape (e.g. a scalar component alongside a
+# batched one).
+
+
+def broadcast_and_index_data(data: CDict, shape: Shape, key: Any, /) -> CDict:
+    """Broadcast every leaf in ``data`` to ``shape``, then apply ``key``."""
+    return {
+        k: (v if v.shape == shape else jnp.broadcast_to(v, shape))[key]
+        for k, v in data.items()
+    }
 
 
 # ===================================================================

--- a/src/coordinax/vectors/_src/base.py
+++ b/src/coordinax/vectors/_src/base.py
@@ -637,19 +637,7 @@ class AbstractVector(
         return dataclassish.replace(new, frame=toframe)  # ty: ignore[invalid-return-type]
 
 
-# ===================================================================
-# Broadcast-aware batch indexing
-#
-# Shared by `Point.__getitem__`, `Tangent.__getitem__`, and
-# `Coordinate.__getitem__`. Component leaves are only required to be
-# *broadcast-compatible*, not identically shaped (that is the whole point of
-# `.shape` being `broadcast_shapes(*(v.shape for v in data.values()))`) — so a
-# leaf narrower than the target shape must be broadcast to it before an
-# integer/slice index is applied, or indexing raises on any leaf that doesn't
-# already carry the full batch shape (e.g. a scalar component alongside a
-# batched one).
-
-
+# Shared by Point/Tangent/Coordinate __getitem__.
 def broadcast_and_index_data(data: CDict, shape: Shape, key: Any, /) -> CDict:
     """Broadcast every leaf in ``data`` to ``shape``, then apply ``key``."""
     return {

--- a/src/coordinax/vectors/_src/bundle.py
+++ b/src/coordinax/vectors/_src/bundle.py
@@ -27,6 +27,7 @@ import coordinax.representations as cxr
 import coordinax.transforms as cxfm
 from .base import (
     AbstractVector,
+    broadcast_and_index_data,
     vector_comps_unit_docs,
     vector_values_str,
     vectorform_pdoc as _vec_vectorform_pdoc,
@@ -292,10 +293,22 @@ class Coordinate(AbstractVector):
         if isinstance(key, str):
             return self._data[key]
 
-        # Batch-indexing: delegate to Point/Tangent indexing so invalid
-        # indices raise consistently instead of silently skipping.
-        new_point = self.point[key]
-        new_fields = {k: v[key] for k, v in self._data.items()}
+        # Batch-indexing: broadcast every component (base point + all fields)
+        # to the *bundle's* shape before indexing -- fields need only be
+        # broadcast-compatible with the point (and each other), not
+        # identically shaped, e.g. a scalar `point` with a batched `velocity`
+        # fibre. Indexing each vector's own (narrower) data directly would
+        # raise on the unbatched leaves instead of indexing consistently.
+        shape = self.shape
+        new_point = dataclassish.replace(
+            self.point, data=broadcast_and_index_data(self.point.data, shape, key)
+        )
+        new_fields = {
+            name: dataclassish.replace(
+                vec, data=broadcast_and_index_data(vec.data, shape, key)
+            )
+            for name, vec in self._data.items()
+        }
         return Coordinate._create_unchecked(new_point, new_fields)
 
     def keys(self) -> KeysView[str]:

--- a/src/coordinax/vectors/_src/bundle.py
+++ b/src/coordinax/vectors/_src/bundle.py
@@ -293,12 +293,8 @@ class Coordinate(AbstractVector):
         if isinstance(key, str):
             return self._data[key]
 
-        # Batch-indexing: broadcast every component (base point + all fields)
-        # to the *bundle's* shape before indexing -- fields need only be
-        # broadcast-compatible with the point (and each other), not
-        # identically shaped, e.g. a scalar `point` with a batched `velocity`
-        # fibre. Indexing each vector's own (narrower) data directly would
-        # raise on the unbatched leaves instead of indexing consistently.
+        # Broadcast point + fields to the bundle shape (not each vector's
+        # own) before indexing.
         shape = self.shape
         new_point = dataclassish.replace(
             self.point, data=broadcast_and_index_data(self.point.data, shape, key)

--- a/src/coordinax/vectors/_src/point.py
+++ b/src/coordinax/vectors/_src/point.py
@@ -151,10 +151,6 @@ class Point(
     def __getitem__(self, key: Any) -> "V | Point":  # ty: ignore[invalid-method-override]
         if isinstance(key, str):
             return self.data[key]
-        # Components need only be broadcast-*compatible* (that's what `.shape`
-        # promises), not identically shaped, so broadcast to `.shape` before
-        # indexing -- otherwise a batch index fails on any narrower leaf (e.g.
-        # a scalar component alongside a batched one).
         data = broadcast_and_index_data(self.data, self.shape, key)
         return replace(self, data=data)  # ty: ignore[invalid-return-type]
 

--- a/src/coordinax/vectors/_src/point.py
+++ b/src/coordinax/vectors/_src/point.py
@@ -17,7 +17,7 @@ import unxt as u
 import coordinax.charts as cxc
 import coordinax.frames as cxf
 import coordinax.representations as cxr
-from .base import AbstractVector
+from .base import AbstractVector, broadcast_and_index_data
 from .custom_types import CKey, HasShape
 from .mixins import AstropyRepresentationAPIMixin
 
@@ -151,7 +151,12 @@ class Point(
     def __getitem__(self, key: Any) -> "V | Point":  # ty: ignore[invalid-method-override]
         if isinstance(key, str):
             return self.data[key]
-        return replace(self, data={k: v[key] for k, v in self.data.items()})  # ty: ignore[invalid-return-type]
+        # Components need only be broadcast-*compatible* (that's what `.shape`
+        # promises), not identically shaped, so broadcast to `.shape` before
+        # indexing -- otherwise a batch index fails on any narrower leaf (e.g.
+        # a scalar component alongside a batched one).
+        data = broadcast_and_index_data(self.data, self.shape, key)
+        return replace(self, data=data)  # ty: ignore[invalid-return-type]
 
 
 # ===================================================================

--- a/src/coordinax/vectors/_src/tangent.py
+++ b/src/coordinax/vectors/_src/tangent.py
@@ -17,7 +17,7 @@ import unxt as u
 import coordinax.charts as cxc
 import coordinax.frames as cxf
 import coordinax.representations as cxr
-from .base import AbstractVector
+from .base import AbstractVector, broadcast_and_index_data
 from .custom_types import CKey, HasShape
 from .mixins import AstropyRepresentationAPIMixin
 from .point import _frame_converter
@@ -141,7 +141,12 @@ class Tangent(
     def __getitem__(self, key: Any) -> "V | Tangent":  # ty: ignore[invalid-method-override]
         if isinstance(key, str):
             return self.data[key]
-        return replace(self, data={k: v[key] for k, v in self.data.items()})  # ty: ignore[invalid-return-type,not-subscriptable]
+        # Components need only be broadcast-*compatible* (that's what `.shape`
+        # promises), not identically shaped, so broadcast to `.shape` before
+        # indexing -- otherwise a batch index fails on any narrower leaf (e.g.
+        # a scalar component alongside a batched one).
+        data = broadcast_and_index_data(self.data, self.shape, key)
+        return replace(self, data=data)  # ty: ignore[invalid-return-type,not-subscriptable]
 
 
 # ===================================================================

--- a/src/coordinax/vectors/_src/tangent.py
+++ b/src/coordinax/vectors/_src/tangent.py
@@ -141,10 +141,6 @@ class Tangent(
     def __getitem__(self, key: Any) -> "V | Tangent":  # ty: ignore[invalid-method-override]
         if isinstance(key, str):
             return self.data[key]
-        # Components need only be broadcast-*compatible* (that's what `.shape`
-        # promises), not identically shaped, so broadcast to `.shape` before
-        # indexing -- otherwise a batch index fails on any narrower leaf (e.g.
-        # a scalar component alongside a batched one).
         data = broadcast_and_index_data(self.data, self.shape, key)
         return replace(self, data=data)  # ty: ignore[invalid-return-type,not-subscriptable]
 

--- a/tests/unit/vectors/test_coordinate.py
+++ b/tests/unit/vectors/test_coordinate.py
@@ -450,6 +450,30 @@ class TestJAXCompat:
         assert isinstance(pv0, Coordinate)
         assert pv0.shape == ()
 
+    def test_batch_indexing_with_scalar_point_and_batched_fibre(self) -> None:
+        """pv[0] works when the point and a fibre have different shapes.
+
+        Regression test: `Coordinate.shape` broadcasts the point's shape
+        against every fibre's shape, so a single (unbatched) point paired with
+        a batched fibre is a supported case -- indexing must broadcast every
+        component to the *bundle's* shape, not the base point's own narrower
+        shape, before applying the index.
+        """
+        base = cxv.Point.from_([1.0, 2.0, 3.0], "m")  # unbatched: shape ()
+        vel_data = {
+            "x": u.Q(jnp.array([1.0, 2.0, 3.0]), "m/s"),
+            "y": u.Q(0.0, "m/s"),
+            "z": u.Q(0.0, "m/s"),
+        }
+        vel = cxv.Tangent.from_(vel_data, cxc.cart3d, cxr.coord_vel)
+        pv = Coordinate(point=base, velocity=vel)
+        assert pv.shape == (3,)
+
+        pv0 = pv[0]
+        assert pv0.shape == ()
+        assert pv0.point["x"] == u.Q(1.0, "m")
+        assert pv0["velocity"]["x"] == u.Q(1.0, "m/s")
+
     def test_vmap_cconvert(self) -> None:
         """Vmap over a Coordinate converts correctly."""
         base = cxv.Point.from_(jnp.ones((2, 3)), "m")

--- a/tests/unit/vectors/test_coordinate.py
+++ b/tests/unit/vectors/test_coordinate.py
@@ -451,14 +451,7 @@ class TestJAXCompat:
         assert pv0.shape == ()
 
     def test_batch_indexing_with_scalar_point_and_batched_fibre(self) -> None:
-        """pv[0] works when the point and a fibre have different shapes.
-
-        Regression test: `Coordinate.shape` broadcasts the point's shape
-        against every fibre's shape, so a single (unbatched) point paired with
-        a batched fibre is a supported case -- indexing must broadcast every
-        component to the *bundle's* shape, not the base point's own narrower
-        shape, before applying the index.
-        """
+        """pv[0] broadcasts point and fibre to the bundle shape first (regression)."""
         base = cxv.Point.from_([1.0, 2.0, 3.0], "m")  # unbatched: shape ()
         vel_data = {
             "x": u.Q(jnp.array([1.0, 2.0, 3.0]), "m/s"),

--- a/tests/unit/vectors/test_point.py
+++ b/tests/unit/vectors/test_point.py
@@ -92,6 +92,38 @@ def test_point_from_with_frame(args):
     assert p["z"] == u.Q(3.0, "km")
 
 
+class TestPointIndexing:
+    """Batch indexing (``p[i]``) respects the broadcast ``.shape`` contract."""
+
+    def test_index_with_scalar_and_batched_components(self):
+        """Indexing works when components have different (broadcastable) shapes.
+
+        Regression test: `.shape` is `broadcast_shapes(*(v.shape for v in
+        data.values()))`, so a scalar component alongside a batched one is a
+        supported, documented case -- indexing must broadcast each leaf to
+        `.shape` first, not index the raw (narrower) leaves directly.
+        """
+        p = cx.Point.from_(
+            {"x": u.Q([1.0, 2.0, 3.0], "m"), "y": u.Q(5.0, "m"), "z": u.Q(0.0, "m")},
+            cxc.cart3d,
+        )
+        assert p.shape == (3,)
+        p0 = p[0]
+        assert p0["x"] == u.Q(1.0, "m")
+        assert p0["y"] == u.Q(5.0, "m")
+        assert p0["z"] == u.Q(0.0, "m")
+
+    def test_index_preserves_chart_and_frame(self):
+        p = cx.Point.from_(
+            {"x": u.Q([1.0, 2.0], "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")},
+            cxc.cart3d,
+            cxf.alice,
+        )
+        p0 = p[0]
+        assert p0.chart == cxc.cart3d
+        assert p0.frame == cxf.alice
+
+
 class TestPointEquality:
     """``==`` accounts for the chart and frame, and never raises."""
 

--- a/tests/unit/vectors/test_point.py
+++ b/tests/unit/vectors/test_point.py
@@ -96,13 +96,7 @@ class TestPointIndexing:
     """Batch indexing (``p[i]``) respects the broadcast ``.shape`` contract."""
 
     def test_index_with_scalar_and_batched_components(self):
-        """Indexing works when components have different (broadcastable) shapes.
-
-        Regression test: `.shape` is `broadcast_shapes(*(v.shape for v in
-        data.values()))`, so a scalar component alongside a batched one is a
-        supported, documented case -- indexing must broadcast each leaf to
-        `.shape` first, not index the raw (narrower) leaves directly.
-        """
+        """Scalar component broadcasts before indexing, doesn't crash (regression)."""
         p = cx.Point.from_(
             {"x": u.Q([1.0, 2.0, 3.0], "m"), "y": u.Q(5.0, "m"), "z": u.Q(0.0, "m")},
             cxc.cart3d,

--- a/tests/unit/vectors/test_tangent.py
+++ b/tests/unit/vectors/test_tangent.py
@@ -546,13 +546,7 @@ class TestVectorShape:
         assert v[1]["y"].value == jnp.array(4)
 
     def test_index_with_scalar_and_batched_components(self):
-        """Indexing works when components have different (broadcastable) shapes.
-
-        Regression test: `.shape` is `broadcast_shapes(*(v.shape for v in
-        data.values()))`, so a scalar component alongside a batched one is a
-        supported, documented case -- indexing must broadcast each leaf to
-        `.shape` first, not index the raw (narrower) leaves directly.
-        """
+        """Scalar component broadcasts before indexing, doesn't crash (regression)."""
         data = {
             "x": u.Q([1.0, 2.0, 3.0], "m/s"),
             "y": u.Q(5.0, "m/s"),  # scalar: broadcasts against x

--- a/tests/unit/vectors/test_tangent.py
+++ b/tests/unit/vectors/test_tangent.py
@@ -545,6 +545,28 @@ class TestVectorShape:
         assert v[1]["x"].value == jnp.array(2)
         assert v[1]["y"].value == jnp.array(4)
 
+    def test_index_with_scalar_and_batched_components(self):
+        """Indexing works when components have different (broadcastable) shapes.
+
+        Regression test: `.shape` is `broadcast_shapes(*(v.shape for v in
+        data.values()))`, so a scalar component alongside a batched one is a
+        supported, documented case -- indexing must broadcast each leaf to
+        `.shape` first, not index the raw (narrower) leaves directly.
+        """
+        data = {
+            "x": u.Q([1.0, 2.0, 3.0], "m/s"),
+            "y": u.Q(5.0, "m/s"),  # scalar: broadcasts against x
+            "z": u.Q(0.0, "m/s"),  # scalar: broadcasts against x
+        }
+        v = cx.Tangent(
+            data=data, chart=cxc.cart3d, basis=cxr.coord_basis, semantic=cxr.vel
+        )
+        assert v.shape == (3,)
+        v0 = v[0]
+        assert v0["x"] == u.Q(1.0, "m/s")
+        assert v0["y"] == u.Q(5.0, "m/s")
+        assert v0["z"] == u.Q(0.0, "m/s")
+
 
 # ======================================================================
 # JAX compatibility


### PR DESCRIPTION
Second correctness bug from the same audit — lower severity than #652 (crashes loudly instead of corrupting silently), but a real contract violation.

## The bug

`Point`, `Tangent`, and `Coordinate` all document and implement `.shape` as `broadcast_shapes(*(v.shape for v in data.values()))` — components need only be broadcast-*compatible*, not identically shaped. `Point`'s own docstring gives this as the intended use case ("Batching is represented by broadcasting the component leaves"). But `__getitem__`'s non-string branch applied the index to each **raw, unbroadcast** leaf:

```python
p = cx.Point.from_({"x": Q([1.,2.,3.],"m"), "y": Q(5.,"m"), "z": Q(0.,"m")}, cart3d)
p.shape   # (3,)  -- correct, matches the documented contract
p[0]      # IndexError: Too many indices: array is 0-dimensional, but 1 were indexed
```

Same crash for `Tangent[0]` and `Coordinate[0]` — identical `__getitem__` shape in all three, verified empirically for each.

## Fix

Adds `broadcast_and_index_data(data, shape, key)` in `base.py`, shared by all three `__getitem__` implementations (alongside the existing `vector_comps_unit_docs`/`vector_values_str` shared-helper pattern already in that file). It broadcasts each leaf to the target shape before indexing, skipping the broadcast op entirely when the leaf is already at that shape (so the common homogeneous-shape case pays no extra cost).

`Coordinate` needed its own care: it broadcasts the point and every fibre to the **bundle's** shape (`self.shape`, which broadcasts across point + all fibres), not each vector's own shape — a `Coordinate` with an unbatched point and a batched fibre needs the point broadcast up to the fibre's batch size before indexing, which delegating to `self.point[key]` (broadcasting only to the point's own, narrower shape) wouldn't do.

String-key access (`p["x"]`) is unaffected — still returns the raw, unbroadcast leaf, matching existing behavior and existing tests.

## Tests

- `TestPointIndexing` (new, `test_point.py`): scalar + batched component, indexed.
- `test_index_with_scalar_and_batched_components` (new, `test_tangent.py`), alongside the existing indexing tests in `TestVectorShape`.
- `test_batch_indexing_with_scalar_point_and_batched_fibre` (new, `test_coordinate.py`), alongside the existing `test_batch_indexing`.

Full suite green (`7955 passed`; one pre-existing Hypothesis flake in an unrelated `angles` test, confirmed unaffected by this diff — same flake I've hit on other unrelated branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)