### PR TITLE
⚡️ perf(hypothesis): draw only representations `Point` can accept

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/vectors/_src/vec.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/vectors/_src/vec.py
@@ -40,6 +40,17 @@ import coordinaxs.hypothesis.charts as cxcst
 import coordinaxs.hypothesis.representations as cxrst
 from coordinaxs.hypothesis.utils import draw_if_strategy, strip_return_annotation
 
+#: Charts the default ``vectors()`` draw skips, on top of what ``charts()``
+#: already excludes. Spelled as an extension rather than a bare ``exclude=``
+#: argument: that *replaces* the ``charts()`` default, which silently readmitted
+#: the 0-D and two-sphere charts it is meant to keep out.
+_VECTOR_CHART_EXCLUDE = (
+    cxc.Abstract0D,
+    cxc.SphericalTwoSphere,
+    cxc.Time1D,
+    cxm.EmbeddedChart,
+)
+
 
 @plum.dispatch.abstract
 def vectors(*args: Any, **kwargs: Any) -> cxv.Point:
@@ -77,7 +88,7 @@ st.register_type_strategy(cxv.Point, lambda _: vectors())  # ty: ignore[missing-
 @st.composite
 def vectors(
     draw: st.DrawFn,
-    chart: st.SearchStrategy = cxcst.charts(exclude=(cxc.Time1D, cxm.EmbeddedChart)),  # ty: ignore[missing-argument],
+    chart: st.SearchStrategy = cxcst.charts(exclude=_VECTOR_CHART_EXCLUDE),  # ty: ignore[missing-argument],
     /,
     **kw: Any,
 ) -> cxv.Point:
@@ -174,7 +185,11 @@ def vectors(draw: st.DrawFn, chart: cxc.AbstractChart, /, **kw: Any) -> cxv.Poin
     ... def test_cart3d(vec): ...
 
     """
-    rep = draw(cxrst.representations(check_valid=True))
+    # `Point.from_` accepts only `cxr.point`, so a tangent-geometry draw can
+    # never yield a point -- drawing across all geometries discarded ~60% of
+    # examples. Constrain to point geometry, whose valid basis and semantic
+    # kinds are both singletons, so this draws exactly the reps that can work.
+    rep = draw(cxrst.representations(geom_kind=cxr.PointGeometry()))
     try:
         return draw(vectors(chart, rep, **kw))  # ty: ignore[too-many-positional-arguments]
     except (TypeError, ValueError, plum.NotFoundLookupError):

--- a/packages/coordinaxs.hypothesis/tests/unit/vectors/test_vectors.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/vectors/test_vectors.py
@@ -130,3 +130,32 @@ class TestPointValueControl:
         """elements= with explicit bounds keeps all component magnitudes in range."""
         assert -10 <= vec.data["x"].ustrip("m") <= 10
         assert -10 <= vec.data["y"].ustrip("m") <= 10
+
+
+class TestDefaultDraw:
+    """Guards on what the no-argument ``vectors()`` draw generates."""
+
+    @given(rep=cxrst.representations(geom_kind=cxr.PointGeometry()))
+    def test_point_geometry_reps_are_exactly_the_accepted_rep(
+        self, rep: cxr.Representation
+    ) -> None:
+        """Every point-geometry rep is the one ``Point.from_`` accepts.
+
+        ``vectors(chart)`` relies on this: it draws under point geometry rather
+        than across all geometries, which is only lossless while the valid basis
+        and semantic kinds for point geometry stay singletons. If coordinax ever
+        adds a second of either, this fails and ``vectors`` needs revisiting.
+        """
+        assert rep == cxr.point
+
+    @given(vec=vector_strategy())
+    def test_default_draw_skips_excluded_charts(self, vec: cxv.Point) -> None:
+        """The default draw excludes 0-D, two-sphere, time and embedded charts.
+
+        ``exclude=`` replaces rather than extends the ``charts()`` default, so
+        naming only the extra classes silently readmitted the 0-D charts.
+        """
+        assert not isinstance(
+            vec.chart,
+            (cxc.Abstract0D, cxc.SphericalTwoSphere, cxc.Time1D, cxm.EmbeddedChart),
+        )


### PR DESCRIPTION
`vectors(chart)` drew from `representations(check_valid=True)` — across *every* geometry — and handed the result to `Point.from_`, which accepts only `cxr.point`:

```python
if rep != cxr.point:
    raise ValueError(f"Point construction needs point rep, got {rep}.")
```

So every tangent-geometry draw was dead on arrival. Measured on 250 draws: **152 discarded**, and invisibly, because the failure lands in a blanket `assume(False)`. `Point.from_` was the sole source — instrumenting it accounted for 58 of 59 raised errors with "needs point rep".

## Lossless, not a narrowing

Constraining to point geometry does not drop reps that could have worked. For `PointGeometry` the valid basis and semantic kinds are both singletons (`NoBasis`, `Location`), so `representations(geom_kind=PointGeometry())` yields **exactly** `cxr.point` — verified over 100 draws.

That equivalence is the load-bearing assumption, so it is now a test rather than a comment. If coordinax ever adds a second point-geometry basis or semantic kind, `test_point_geometry_reps_are_exactly_the_accepted_rep` fails and says this strategy needs revisiting — instead of quietly generating reps `Point` rejects again.

## Second bug, same function

`exclude=` **replaces** the `charts()` default `(Abstract0D, SphericalTwoSphere)` rather than extending it. Passing `exclude=(Time1D, EmbeddedChart)` therefore silently readmitted the 0-D and two-sphere charts that default exists to keep out — `Cart0D` was observed in the draws. Now spelled as an explicit extension with a comment naming the trap.

## Result

250 draws, `JAX_ENABLE_X64=1` (the suite's setting):

| | before | after |
|---|---|---|
| valid examples | 98/250 | **206/250** |
| cost per *useful* example | 21.9 ms | **12.9 ms** |
| 0-D charts drawn | yes | **none** |

Wall-clock per draw is flat — the win is that draws now produce points instead of being thrown away.

## Relationship to #651

Disjoint and complementary. No shared files. The 44 discards that remain do not come from this path: they trace to `charts/_src/cdict.py` drawing out-of-domain component values, which is precisely what #651 fixes. Merging both should leave close to zero discards on this strategy.

637 tests pass; ruff and ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
