### PR TITLE
⚡️ perf(vectors): cache the base-point chart conversion across fibres

### DIFF
--- a/src/coordinax/vectors/_src/bundle.py
+++ b/src/coordinax/vectors/_src/bundle.py
@@ -400,14 +400,21 @@ class Coordinate(AbstractVector):
         # 2. Convert each field via tangent pushforward at self.point.
         # Express self.point in each fibre's current chart for the Jacobian;
         # this handles fibres that are in a different chart than self.point.
+        # Fibres sharing a chart (e.g. velocity and acceleration both stored
+        # in the same non-base chart) share the base-point conversion too,
+        # rather than recomputing it once per fibre.
         new_fields: dict[str, Tangent] = {}
+        at_in_chart: dict[cxc.AbstractChart, Point] = {}
         for name, vec in self._data.items():
             target = field_charts.get(name, to_chart)
-            at = (
-                self.point
-                if vec.chart == self.point.chart
-                else cast("Point", cxr.cconvert(self.point, vec.chart))
-            )
+            if vec.chart == self.point.chart:
+                at = self.point
+            elif vec.chart not in at_in_chart:
+                at = at_in_chart[vec.chart] = cast(
+                    "Point", cxr.cconvert(self.point, vec.chart)
+                )
+            else:
+                at = at_in_chart[vec.chart]
             new_fields[name] = cast(
                 "Tangent", cxr.cconvert(vec, target, at=at, usys=usys)
             )

--- a/src/coordinax/vectors/_src/bundle.py
+++ b/src/coordinax/vectors/_src/bundle.py
@@ -403,18 +403,21 @@ class Coordinate(AbstractVector):
         # Fibres sharing a chart (e.g. velocity and acceleration both stored
         # in the same non-base chart) share the base-point conversion too,
         # rather than recomputing it once per fibre.
-        new_fields: dict[str, Tangent] = {}
         at_in_chart: dict[cxc.AbstractChart, Point] = {}
+
+        def point_in_chart(chart: cxc.AbstractChart, /) -> Point:
+            if chart not in at_in_chart:
+                at_in_chart[chart] = cast("Point", cxr.cconvert(self.point, chart))
+            return at_in_chart[chart]
+
+        new_fields: dict[str, Tangent] = {}
         for name, vec in self._data.items():
             target = field_charts.get(name, to_chart)
-            if vec.chart == self.point.chart:
-                at = self.point
-            elif vec.chart not in at_in_chart:
-                at = at_in_chart[vec.chart] = cast(
-                    "Point", cxr.cconvert(self.point, vec.chart)
-                )
-            else:
-                at = at_in_chart[vec.chart]
+            at = (
+                self.point
+                if vec.chart == self.point.chart
+                else point_in_chart(vec.chart)
+            )
             new_fields[name] = cast(
                 "Tangent", cxr.cconvert(vec, target, at=at, usys=usys)
             )

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -665,9 +665,12 @@ def act(
     # so as not to violate Tangent's at-chart requirement.
     kw_base = dict(kw)
     new_fields: dict[str, Any] = {}
+    point_data_cache: dict[Any, CDict] = {}
     for name, fibre in x._data.items():
         if "at" not in kw_base:
-            fibre_kw = {**kw_base, "at": _point_data_in(x.point, fibre.chart)}
+            if fibre.chart not in point_data_cache:
+                point_data_cache[fibre.chart] = _point_data_in(x.point, fibre.chart)
+            fibre_kw = {**kw_base, "at": point_data_cache[fibre.chart]}
         else:
             fibre_kw = kw_base
         new_fields[name] = cxfm.act(op, tau, fibre, **fibre_kw)
@@ -717,6 +720,16 @@ def _act_coordinate_jet(
     """
     point_chart = x.point.chart
 
+    # Point data expressed in a given fibre chart, memoized: several fibres
+    # (e.g. velocity and acceleration) commonly share a chart, so this avoids
+    # recomputing the same base-point conversion once per fibre.
+    point_data_cache: dict[Any, CDict] = {}
+
+    def point_data_in(chart: Any, /) -> CDict:
+        if chart not in point_data_cache:
+            point_data_cache[chart] = _point_data_in(x.point, chart)
+        return point_data_cache[chart]
+
     # Assemble the jet in the point's chart. Fibres in other charts are
     # converted in (and back out) via the Jacobian pushforward.
     jet: dict[int, CDict] = {0: x.point.data}
@@ -730,7 +743,7 @@ def _act_coordinate_jet(
         orig_chart = fibre.chart
         f = fibre
         if orig_chart != point_chart:
-            at_f = _point_data_in(x.point, orig_chart)
+            at_f = point_data_in(orig_chart)
             f = cast("Tangent", cxrapi.cconvert(f, point_chart, at=at_f, usys=usys))
         if order in jet:
             msg = (
@@ -765,7 +778,7 @@ def _act_coordinate_jet(
             fibre.data,
             fibre.chart,
             fibre.rep,
-            at=_point_data_in(x.point, fibre.chart),
+            at=point_data_in(fibre.chart),
             usys=usys,
         )
         new_fields[name] = replace(fibre, data=data)

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -4,6 +4,7 @@ __all__: tuple[str, ...] = ()
 
 from dataclasses import replace
 
+from collections.abc import Callable
 from typing import Any, cast
 
 import jax.tree as jtu
@@ -665,12 +666,10 @@ def act(
     # so as not to violate Tangent's at-chart requirement.
     kw_base = dict(kw)
     new_fields: dict[str, Any] = {}
-    point_data_cache: dict[Any, CDict] = {}
+    point_data_in = _cached_point_data_in(x.point)
     for name, fibre in x._data.items():
         if "at" not in kw_base:
-            if fibre.chart not in point_data_cache:
-                point_data_cache[fibre.chart] = _point_data_in(x.point, fibre.chart)
-            fibre_kw = {**kw_base, "at": point_data_cache[fibre.chart]}
+            fibre_kw = {**kw_base, "at": point_data_in(fibre.chart)}
         else:
             fibre_kw = kw_base
         new_fields[name] = cxfm.act(op, tau, fibre, **fibre_kw)
@@ -702,6 +701,22 @@ def _point_data_in(point: Point, chart: Any, /) -> CDict:
     return cast("Point", cxr.cconvert(point, chart)).data
 
 
+def _cached_point_data_in(point: Point, /) -> Callable[[Any], CDict]:
+    """Return a memoized `_point_data_in(point, chart)`, keyed by chart.
+
+    Several fibres (e.g. velocity and acceleration) commonly share a chart,
+    so this avoids recomputing the same base-point conversion once per fibre.
+    """
+    cache: dict[Any, CDict] = {}
+
+    def point_data_in(chart: Any, /) -> CDict:
+        if chart not in cache:
+            cache[chart] = _point_data_in(point, chart)
+        return cache[chart]
+
+    return point_data_in
+
+
 def _act_coordinate_jet(
     op: cxfm.AbstractTransform,
     tau: Any,
@@ -719,16 +734,7 @@ def _act_coordinate_jet(
     transform by the frozen-tau pushforward at the base point.
     """
     point_chart = x.point.chart
-
-    # Point data expressed in a given fibre chart, memoized: several fibres
-    # (e.g. velocity and acceleration) commonly share a chart, so this avoids
-    # recomputing the same base-point conversion once per fibre.
-    point_data_cache: dict[Any, CDict] = {}
-
-    def point_data_in(chart: Any, /) -> CDict:
-        if chart not in point_data_cache:
-            point_data_cache[chart] = _point_data_in(x.point, chart)
-        return point_data_cache[chart]
+    point_data_in = _cached_point_data_in(x.point)
 
     # Assemble the jet in the point's chart. Fibres in other charts are
     # converted in (and back out) via the Jacobian pushforward.

--- a/tests/unit/vectors/test_coordinate.py
+++ b/tests/unit/vectors/test_coordinate.py
@@ -210,6 +210,46 @@ class TestChartAlignment:
         assert pv["velocity"].chart == cxc.sph3d
         assert pv["acceleration"].chart == cxc.sph3d
 
+    def test_cconvert_with_fields_sharing_a_non_base_chart(self) -> None:
+        """``cconvert`` is correct when multiple fibres share one non-base chart.
+
+        Regression test for a base-point-conversion cache keyed by fibre
+        chart: velocity and acceleration both sit in sph3d here (the base
+        point is cart3d), so cconvert must anchor *both* fibres' Jacobian
+        pushforward at the same correctly-converted point -- not silently
+        reuse a stale or wrong-chart conversion for the second fibre.
+        """
+        base = cxv.Point.from_([1, 0, 0], "m")  # cart3d
+        vel_sph = _make_sph_vel(1, 0, 0)
+        acc_sph = cx.Tangent.from_(
+            {
+                "r": u.Q(0.1, "m/s^2"),
+                "theta": u.Q(0, "rad/s^2"),
+                "phi": u.Q(0, "rad/s^2"),
+            },
+            cxc.sph3d,
+            cxr.coord_acc,
+        )
+        pv = Coordinate(point=base, velocity=vel_sph, acceleration=acc_sph)
+        pv_cart = pv.cconvert(cxc.cart3d)
+
+        # Each fibre converted alone (single-fibre Coordinate) must agree with
+        # the shared-cache multi-fibre conversion above.
+        vel_alone = Coordinate(point=base, velocity=vel_sph).cconvert(cxc.cart3d)
+        acc_alone = Coordinate(point=base, acceleration=acc_sph).cconvert(cxc.cart3d)
+
+        for comp in ("x", "y", "z"):
+            assert jnp.allclose(
+                pv_cart["velocity"][comp].value,
+                vel_alone["velocity"][comp].value,
+                atol=1e-10,
+            )
+            assert jnp.allclose(
+                pv_cart["acceleration"][comp].value,
+                acc_alone["acceleration"][comp].value,
+                atol=1e-10,
+            )
+
 
 # ---------------------------------------------------------------------------
 # TestMappingAPI


### PR DESCRIPTION
Fourth (and lowest-severity) item from a `coordinax.vectors` performance audit — narrow, mechanical caching, no logic change.

## The redundancy

`Coordinate.cconvert` (`bundle.py`), `act(Coordinate, ...)`, and `_act_coordinate_jet` (joint jet prolongation under time-dependent transforms, both `register_cx.py`) each need the base point expressed in a fibre's chart, to anchor that fibre's Jacobian pushforward. Each recomputes this conversion independently *per fibre*, even when multiple fibres share a chart — e.g. `velocity` and `acceleration` both stored in `sph3d` while the base `point` is `cart3d` pays the full point-to-`sph3d` conversion twice instead of once.

## Fix

A local dict keyed by chart, memoizing the conversion within each of the three loops. Charts are already required to be hashable — they're `eqx.field(static=True)` on `Point`/`Tangent`, which JAX's own pytree aux-data caching depends on — so this is safe (verified: `hash(cxc.cart3d)` works, charts usable as dict keys).

Measured (best-of-9, 100 iterations, 2 fibres sharing a non-base chart, `Coordinate.cconvert`):

| | time |
|---|---|
| before | ~45.5ms |
| after | **~37.0ms** (~19% faster) |

Scales with how many fibres share a chart — a bundle with 3+ same-chart fibres saves proportionally more.

## Tests

`test_cconvert_with_fields_sharing_a_non_base_chart` (new, `test_coordinate.py`): constructs a 2-fibre bundle sharing `sph3d`, converts it, and compares each fibre's result against converting that fibre *alone* in a single-fibre bundle — this is the check that would catch a memoization bug reusing the wrong chart's point for one fibre, not just "does it still run."

The `act(Coordinate)` and jet-prolongation (`_act_coordinate_jet`) paths don't have an existing test class in this file to extend cleanly, so I hand-verified both (time-independent `Rotate` and time-dependent `Translate`, 2 shared-chart fibres) against single-fibre results — they agree. The existing doctests in `register_cx.py` continue to exercise both code paths (single-fibre) as part of the normal test run.

Full suite: `7951 passed`, two failures — both pre-existing Hypothesis flakes unrelated to this change (`tests/unit/angles/test_angle.py::test_wrap_array_angle`, seen on multiple unrelated branches this session; `coordinaxs.hypothesis/tests/unit/vectors/test_vectors.py::test_vectors_propagate_shape`, a `Point`-only shape test that exercises neither `Coordinate.cconvert` nor `act` — confirmed green on 4/4 standalone reruns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)