### PR TITLE
⚡️ fix(hypothesis): honour `ndim` in manifold strategies, drop dispatch overhead

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/_common.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/_common.py
@@ -15,17 +15,6 @@ import coordinax.charts as cxc
 from coordinaxs.hypothesis.utils import get_all_subclasses
 
 
-def _is_zero_arg_constructible(
-    chart_cls: type[cxc.AbstractChart[Any, Any, Any]], /
-) -> bool:
-    """Return True if chart_cls can be instantiated with no arguments."""
-    try:
-        chart_cls()
-    except TypeError:
-        return False
-    return True
-
-
 @ft.cache
 def matching_chart_classes_for_ndim(
     ndim: int, /
@@ -39,8 +28,12 @@ def matching_chart_classes_for_ndim(
     classes: list[type[cxc.AbstractChart[Any, Any, Any]]] = []
     for cls in get_all_subclasses(cxc.AbstractChart, exclude_abstract=True):
         cls = cast("type[cxc.AbstractChart[Any, Any, Any]]", cls)
-        if not _is_zero_arg_constructible(cls):
+        # One construction serves both questions: a `TypeError` means the class
+        # needs arguments, and otherwise the instance carries the ndim to check.
+        try:
+            chart = cls()
+        except TypeError:
             continue
-        if cls().ndim == ndim:
+        if chart.ndim == ndim:
             classes.append(cls)
     return tuple(classes)

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/_common.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/_common.py
@@ -1,0 +1,46 @@
+"""Shared helpers for the atlas and manifold strategies.
+
+Lives here rather than in either module because ``manifold`` imports ``atlas``,
+so the helper cannot sit in ``manifold`` without a cycle.
+"""
+
+__all__: tuple[str, ...] = ()
+
+import functools as ft
+
+from typing import Any, cast
+
+import coordinax.charts as cxc
+
+from coordinaxs.hypothesis.utils import get_all_subclasses
+
+
+def _is_zero_arg_constructible(
+    chart_cls: type[cxc.AbstractChart[Any, Any, Any]], /
+) -> bool:
+    """Return True if chart_cls can be instantiated with no arguments."""
+    try:
+        chart_cls()
+    except TypeError:
+        return False
+    return True
+
+
+@ft.cache
+def matching_chart_classes_for_ndim(
+    ndim: int, /
+) -> tuple[type[cxc.AbstractChart[Any, Any, Any]], ...]:
+    """Return zero-arg chart classes whose default instance has ``ndim``.
+
+    Cached: this instantiates every concrete chart class, and both the
+    ``CustomAtlas`` strategy and the ``CustomManifold`` ndim predicate call it
+    on every draw.
+    """
+    classes: list[type[cxc.AbstractChart[Any, Any, Any]]] = []
+    for cls in get_all_subclasses(cxc.AbstractChart, exclude_abstract=True):
+        cls = cast("type[cxc.AbstractChart[Any, Any, Any]]", cls)
+        if not _is_zero_arg_constructible(cls):
+            continue
+        if cls().ndim == ndim:
+            classes.append(cls)
+    return tuple(classes)

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
@@ -117,7 +117,8 @@ def atlases(
     - **An abstract** ``AbstractAtlas`` **subclass**: treats the class as a
       filter and redispatches without a class argument.
     - **``EuclideanAtlas``**: returns a ``EuclideanAtlas(dim)`` with ``dim``
-      in ``[0, 3]``, constrained by ``ndim`` when given.
+      in ``[0, 3]``, pinned by ``ndim`` when given; hypothesis discards the
+      example if ``ndim`` falls outside that range.
     - **``HyperSphericalAtlas``**: returns a ``HyperSphericalAtlas()``. Only compatible
       with ``ndim=2``; hypothesis discards the example otherwise.
     - **``CustomAtlas``**: returns a ``CustomAtlas`` whose charts are drawn
@@ -459,8 +460,11 @@ def atlases(
 ) -> Any:
     """Draw a ``EuclideanAtlas`` with dimensionality in ``[0, 3]``.
 
-    If ``ndim`` is given, the atlas is constructed with that exact dimension
-    (clamped to ``[0, 3]``). Otherwise, the dimension is drawn uniformly.
+    If ``ndim`` is given, the atlas is constructed with exactly that dimension.
+    Values outside ``[0, 3]`` are discarded via `hypothesis.assume` rather than
+    clamped into range, so a request this strategy cannot satisfy shows up as an
+    unsatisfiable example instead of an atlas of the wrong dimensionality.
+    Otherwise, the dimension is drawn uniformly.
 
     >>> import coordinax.manifolds as cxm
     >>> import coordinaxs.hypothesis.manifolds as cxmst

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
@@ -4,7 +4,8 @@ __all__ = ("atlas_classes", "atlases")
 
 import inspect
 
-from typing import Any, cast
+from collections.abc import Callable
+from typing import Any, Final, cast
 
 import hypothesis.strategies as st
 import plum
@@ -13,6 +14,7 @@ from hypothesis import assume
 import coordinax.charts as cxc
 import coordinax.manifolds as cxm
 
+from ._common import matching_chart_classes_for_ndim
 from coordinaxs.hypothesis.utils import (
     draw_if_strategy,
     get_all_subclasses,
@@ -249,58 +251,39 @@ def atlases(
 
 
 # ---------------------------------------------------------------------------
-# ndim-compatibility helper — extend by adding a new dispatch for each new
-# concrete atlas type.
+# ndim-compatibility helper — extend by adding an entry for each new concrete
+# atlas type.
 # ---------------------------------------------------------------------------
 
-
-@plum.dispatch
-def _atlas_class_supports_ndim(
-    cls: type[cxm.EuclideanAtlas],
-    ndim: int,
-    /,
-) -> bool:
-    """EuclideanAtlas supports dimensions 0-3."""
-    return ndim <= 3
-
-
-@plum.dispatch
-def _atlas_class_supports_ndim(
-    cls: type[cxm.HyperSphericalAtlas],
-    ndim: int,
-    /,
-) -> bool:
-    """HyperSphericalAtlas is always 2-D."""
-    return ndim == 2
-
-
-@plum.dispatch
-def _atlas_class_supports_ndim(
-    cls: type[cxm.CartesianProductAtlas],
-    ndim: int,
-    /,
-) -> bool:
-    """CartesianProductAtlas supports any positive dimensionality (≥1 factor)."""
-    return ndim >= 1
+#: Which dimensionalities each concrete atlas type can be drawn at.
+#:
+#: A plain table rather than `plum.dispatch`, for the same reason as
+#: `_NDIM_SUPPORT` in ``manifold.py``: ``type[X]`` signatures are unfaithful, so
+#: plum's method cache was disabled and every call ran a full resolution -- on a
+#: predicate consulted once per candidate class per draw. The listed types are
+#: mutually disjoint, so order is not load-bearing.
+_NDIM_SUPPORT: Final[
+    tuple[tuple[type[cxm.AbstractAtlas], Callable[[int], bool]], ...]
+] = (
+    # HyperSphericalAtlas is always 2-D.
+    (cxm.HyperSphericalAtlas, lambda ndim: ndim == 2),
+    # A product needs at least one factor, each contributing >= 1 dimension.
+    (cxm.CartesianProductAtlas, lambda ndim: ndim >= 1),
+    (cxm.CustomAtlas, lambda ndim: ndim >= 1),
+    # EuclideanAtlas is currently generated only for dimensions 0-3.
+    (cxm.EuclideanAtlas, lambda ndim: 0 <= ndim <= 3),
+)
 
 
-@plum.dispatch
-def _atlas_class_supports_ndim(
-    cls: type[cxm.CustomAtlas],
-    ndim: int,
-    /,
-) -> bool:
-    """CustomAtlas supports any positive dimensionality."""
-    return ndim >= 1
+def _atlas_class_supports_ndim(cls: type[cxm.AbstractAtlas], ndim: int, /) -> bool:
+    """Whether *cls* can be drawn at *ndim*.
 
-
-@plum.dispatch
-def _atlas_class_supports_ndim(
-    cls: type[cxm.AbstractAtlas],
-    ndim: int,
-    /,
-) -> bool:
-    """Fallback: unknown atlas types are assumed to support any ndim."""
+    Types absent from `_NDIM_SUPPORT` (``NoAtlas``, ``MinkowskiAtlas``) fall
+    through to `True`, matching the previous ``AbstractAtlas`` catch-all.
+    """
+    for base, supports in _NDIM_SUPPORT:
+        if issubclass(cls, base):
+            return supports(ndim)
     return True
 
 
@@ -496,7 +479,11 @@ def atlases(
     if target_ndim is None:
         dim = draw(st.integers(min_value=0, max_value=3))
     else:
-        dim = max(0, min(target_ndim, 3))
+        # Discard rather than clamp: `max(0, min(target_ndim, 3))` silently
+        # handed back a 3-D atlas for `ndim=5` (and a 0-D one for `ndim=-1`),
+        # breaking the documented promise that `ndim` pins the dimensionality.
+        assume(_atlas_class_supports_ndim(cxm.EuclideanAtlas, target_ndim))
+        dim = target_ndim
 
     # Construct
     return cxm.EuclideanAtlas(dim)
@@ -587,22 +574,13 @@ def atlases(
                 f"expected ndim={custom_ndim}."
             )
 
-    filtered_classes: list[type[cxc.AbstractChart[Any, Any, Any]]] = []
-    for cls in get_all_subclasses(cxc.AbstractChart, exclude_abstract=True):
-        cls = cast("type[cxc.AbstractChart[Any, Any, Any]]", cls)
-        try:
-            chart = cls()
-        except TypeError:
-            continue
-        if chart.ndim == custom_ndim:
-            filtered_classes.append(cls)
-
+    filtered_classes = matching_chart_classes_for_ndim(custom_ndim)
     if not filtered_classes:
         assume(False)
 
     sampled_classes = draw(
         st.lists(
-            st.sampled_from(tuple(filtered_classes)),
+            st.sampled_from(filtered_classes),
             min_size=1,
             max_size=4,
             unique=True,
@@ -664,7 +642,10 @@ def atlases(
             dims.append(dim_i)
             remaining -= dim_i
 
-        assume(remaining == 0)
+        # No `assume(remaining == 0)`: on the last factor `factors_left_after`
+        # is 0, so min_this == max_this == remaining and the loop always lands
+        # exactly on the target. The feasibility `assume` above is what does the
+        # work.
 
     factors = tuple(
         draw(cast("Any", atlases)(exclude=(cxm.CartesianProductAtlas,), ndim=d))

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
@@ -2,7 +2,8 @@
 
 __all__ = ("manifold_classes", "manifolds")
 
-from typing import Any, cast
+from collections.abc import Callable
+from typing import Any, Final, cast
 
 import hypothesis.strategies as st
 import plum
@@ -12,36 +13,12 @@ import coordinax.charts as cxc
 import coordinax.manifolds as cxm
 
 from . import atlas as atlas_strategies
+from ._common import matching_chart_classes_for_ndim
 from coordinaxs.hypothesis.utils import (
     draw_if_strategy,
     get_all_subclasses,
     strip_return_annotation,
 )
-
-
-def _is_zero_arg_constructible(
-    chart_cls: type[cxc.AbstractChart[Any, Any, Any]], /
-) -> bool:
-    """Return True if chart_cls can be instantiated with no arguments."""
-    try:
-        chart_cls()
-    except TypeError:
-        return False
-    return True
-
-
-def _matching_chart_classes_for_ndim(
-    ndim: int, /
-) -> tuple[type[cxc.AbstractChart[Any, Any, Any]], ...]:
-    """Return zero-arg chart classes with default instance ndim == target ndim."""
-    classes: list[type[cxc.AbstractChart[Any, Any, Any]]] = []
-    for cls in get_all_subclasses(cxc.AbstractChart, exclude_abstract=True):
-        cls = cast("type[cxc.AbstractChart[Any, Any, Any]]", cls)
-        if not _is_zero_arg_constructible(cls):
-            continue
-        if cls().ndim == ndim:
-            classes.append(cls)
-    return tuple(classes)
 
 
 @st.composite
@@ -66,54 +43,46 @@ def manifold_classes(
 
 
 # ---------------------------------------------------------------------------
-# ndim-compatibility helper — extend by adding a new dispatch for each new
-# concrete manifold type.
+# ndim-compatibility helper — extend by adding an entry for each new concrete
+# manifold type.
 # ---------------------------------------------------------------------------
 
-
-@plum.dispatch
-def _manifold_class_supports_ndim(
-    cls: type[cxm.EuclideanManifold], ndim: int, /
-) -> bool:
-    """EuclideanManifold supports any dimensionality."""
-    return True
-
-
-@plum.dispatch
-def _manifold_class_supports_ndim(
-    cls: type[cxm.HyperSphericalManifold], ndim: int, /
-) -> bool:
-    """HyperSphericalManifold is always 2-D."""
-    return ndim == 2
-
-
-@plum.dispatch
-def _manifold_class_supports_ndim(
-    cls: type[cxm.EmbeddedManifold], ndim: int, /
-) -> bool:
-    """EmbeddedManifold: only the 2-D embedded two-sphere is currently generated."""
-    return ndim == 2
-
-
-@plum.dispatch
-def _manifold_class_supports_ndim(
-    cls: type[cxm.CartesianProductManifold], ndim: int, /
-) -> bool:
-    """CartesianProductManifold requires at least 1 dimension."""
-    return ndim >= 1
+#: Which dimensionalities each concrete manifold type can be drawn at.
+#:
+#: A plain table rather than `plum.dispatch`: these signatures are all
+#: ``type[X]``, which plum cannot treat as faithful, so its method cache was
+#: disabled and every call ran a full resolution -- 5555 of them per 200
+#: examples, because the no-argument dispatch tests the predicate against every
+#: candidate class on every draw and product manifolds recurse. Dispatch bought
+#: nothing here: the types are closed and local, and `issubclass` gives the same
+#: subtype fallthrough. The listed types are mutually disjoint, so order is not
+#: load-bearing; keep the most specific first anyway for anything added later.
+_NDIM_SUPPORT: Final[
+    tuple[tuple[type[cxm.AbstractManifold], Callable[[int], bool]], ...]
+] = (
+    # HyperSphericalManifold and EmbeddedManifold are always 2-D.
+    (cxm.HyperSphericalManifold, lambda ndim: ndim == 2),
+    (cxm.EmbeddedManifold, lambda ndim: ndim == 2),
+    # A product needs at least one factor, each contributing >= 1 dimension.
+    (cxm.CartesianProductManifold, lambda ndim: ndim >= 1),
+    # CustomManifold works only where matching zero-arg charts exist.
+    (cxm.CustomManifold, lambda ndim: bool(matching_chart_classes_for_ndim(ndim))),
+    # EuclideanManifold supports any dimensionality.
+    (cxm.EuclideanManifold, lambda _: True),
+)
 
 
-@plum.dispatch
-def _manifold_class_supports_ndim(cls: type[cxm.CustomManifold], ndim: int, /) -> bool:
-    """CustomManifold supports ndim when matching zero-arg charts exist."""
-    return len(_matching_chart_classes_for_ndim(ndim)) > 0
-
-
-@plum.dispatch
 def _manifold_class_supports_ndim(
     cls: type[cxm.AbstractManifold], ndim: int, /
 ) -> bool:
-    """Fallback: unknown manifold types are assumed to support any ndim."""
+    """Whether *cls* can be drawn at *ndim*.
+
+    Types absent from `_NDIM_SUPPORT` (``NoManifold``, ``MinkowskiManifold``)
+    fall through to `True`, matching the previous ``AbstractManifold`` catch-all.
+    """
+    for base, supports in _NDIM_SUPPORT:
+        if issubclass(cls, base):
+            return supports(ndim)
     return True
 
 
@@ -194,8 +163,7 @@ def manifolds(
             exclude_abstract=True,
             exclude=exclude,
         )
-        if target_ndim is None
-        or cast("Any", _manifold_class_supports_ndim)(cls, target_ndim)
+        if target_ndim is None or _manifold_class_supports_ndim(cls, target_ndim)
     )
     if not classes:
         assume(False)
@@ -468,23 +436,21 @@ def manifolds(
     else:
         total_ndim = draw(st.integers(min_value=n_factors, max_value=n_factors + 4))
 
-    # Partition total_ndim into n_factors positive integers via n_factors-1 cuts.
-    cuts = (
-        sorted(
-            draw(
-                st.lists(
-                    st.integers(1, total_ndim - 1),
-                    min_size=n_factors - 1,
-                    max_size=n_factors - 1,
-                    unique=True,
-                )
-            )
-        )
-        if n_factors > 1
-        else []
-    )
-    boundaries = [0, *cuts, total_ndim]
-    dims = [boundaries[i + 1] - boundaries[i] for i in range(n_factors)]
+    # Partition total_ndim into n_factors positive integers, drawing each factor
+    # from the range that still leaves >= 1 dimension for every factor after it.
+    # The previous form drew n_factors-1 *unique* cuts from `integers(1,
+    # total_ndim - 1)`; when total_ndim == n_factors that range holds exactly as
+    # many values as the list needs, so hypothesis had to rejection-sample its
+    # way to the single valid answer -- and total_ndim == n_factors is the
+    # common case whenever `ndim=` is pinned.
+    dims: list[int] = []
+    remaining = total_ndim
+    for i in range(n_factors - 1):
+        # Reserve >= 1 dimension for each factor still to be assigned after i.
+        dim_i = draw(st.integers(1, remaining - (n_factors - i - 1)))
+        dims.append(dim_i)
+        remaining -= dim_i
+    dims.append(remaining)  # last factor takes the rest, which is >= 1
 
     factors = tuple(
         draw(cast("Any", manifolds)(exclude=(cxm.CartesianProductManifold,), ndim=d))

--- a/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
@@ -1,7 +1,9 @@
 """Tests for manifold strategies."""
 
 import hypothesis.strategies as st
-from hypothesis import given
+import pytest
+from hypothesis import given, settings
+from hypothesis.errors import Unsatisfiable
 
 import coordinax.charts as cxc
 import coordinax.manifolds as cxm
@@ -121,3 +123,59 @@ def test_custom_manifold_from_type_registration(M: cxm.CustomManifold) -> None:
     """st.from_type(CustomManifold) resolves to the registered strategy."""
     assert isinstance(M, cxm.CustomManifold)
     assert M.has_chart(M.default_chart())
+
+
+class TestNdimIsHonoured:
+    """``ndim=`` pins the dimensionality; it is never silently clamped."""
+
+    @pytest.mark.parametrize("ndim", [0, 1, 2, 3])
+    def test_euclidean_atlas_matches_requested_ndim(self, ndim: int) -> None:
+        """A supported ``ndim`` yields an atlas of exactly that dimensionality."""
+
+        @given(atlas=cxst.atlases(cxm.EuclideanAtlas, ndim=ndim))
+        @settings(max_examples=10, deadline=None)
+        def check(atlas: cxm.EuclideanAtlas) -> None:
+            assert atlas.ndim == ndim
+
+        check()
+
+    @pytest.mark.parametrize("ndim", [-1, 4, 5])
+    def test_euclidean_atlas_discards_unsupported_ndim(self, ndim: int) -> None:
+        """An unsupported ``ndim`` is discarded, not clamped into range.
+
+        ``max(0, min(target_ndim, 3))`` used to hand back a 3-D atlas for
+        ``ndim=5`` and a 0-D one for ``ndim=-1``, quietly violating the
+        documented contract.
+        """
+
+        @given(atlas=cxst.atlases(cxm.EuclideanAtlas, ndim=ndim))
+        @settings(max_examples=10, deadline=None)
+        def check(atlas: cxm.EuclideanAtlas) -> None:
+            pytest.fail(f"ndim={ndim} should be unsatisfiable, got {atlas!r}")
+
+        with pytest.raises(Unsatisfiable):
+            check()
+
+    @pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5, 6])
+    def test_product_manifold_factor_dims_sum_to_ndim(self, ndim: int) -> None:
+        """Factor dimensionalities partition the requested total exactly."""
+
+        @given(M=cxst.manifolds(cxm.CartesianProductManifold, ndim=ndim))
+        @settings(max_examples=20, deadline=None)
+        def check(M: cxm.CartesianProductManifold) -> None:
+            assert sum(f.ndim for f in M.factors) == ndim
+            assert all(f.ndim >= 1 for f in M.factors)
+            assert M.ndim == ndim
+
+        check()
+
+    @pytest.mark.parametrize("ndim", [1, 2, 3, 4])
+    def test_product_atlas_factor_dims_sum_to_ndim(self, ndim: int) -> None:
+        """Same contract for the atlas-level product partition."""
+
+        @given(atlas=cxst.atlases(cxm.CartesianProductAtlas, ndim=ndim))
+        @settings(max_examples=20, deadline=None)
+        def check(atlas: cxm.CartesianProductAtlas) -> None:
+            assert sum(f.ndim for f in atlas.factors) == ndim
+
+        check()


### PR DESCRIPTION
Two `ndim` contract bugs in the manifold/atlas strategies, and the cost of the predicate that enforces it.

## `ndim` was clamped, not honoured

```python
dim = max(0, min(target_ndim, 3))
```

`atlases(EuclideanAtlas, ndim=5)` returned a **3-D** atlas; `ndim=-1` returned a 0-D one. Both silently contradict the documented promise that `ndim` pins the dimensionality — a test asking for 5 got 3 and passed whatever it was asserting about "a 5-D atlas".

Now discarded via `assume`, with the supported range stated once in the support table rather than twice in two different forms. `test_euclidean_atlas_discards_unsupported_ndim` asserts unsupported values are unsatisfiable instead of quietly wrong.

## The product partition rejection-sampled

`CartesianProductManifold` partitioned `total_ndim` by drawing `n_factors - 1` **unique** cuts from `integers(1, total_ndim - 1)`. When `total_ndim == n_factors` that range holds exactly as many values as the list needs, so hypothesis had to rejection-sample its way to the one valid answer — and `total_ndim == n_factors` is the common case whenever `ndim=` is pinned.

Replaced with the sequential draw `atlas.py` already used, so the two partition sites now agree. The set of reachable partitions is unchanged; the distribution over them shifts, which is fine for a search strategy and is now pinned by a test asserting the factor dims sum to the requested total.

## The predicate was a plum dispatch on `type[X]`

plum cannot treat `type[X]` signatures as faithful, so its method cache was disabled and every call ran a full resolution through beartype. Instrumented: **5555 resolutions per 200 examples** of `manifolds(ndim=3)` — the no-argument dispatch tests the predicate against every candidate class on every draw, and product manifolds recurse.

This is the same trap `custom_types.py` already documents for `dict[...]`:

> A parametric `dict[...]` annotation makes every plum signature using CDict "unfaithful", disabling plum's method cache (a full ~200x slower resolution per call).

Dispatch bought nothing here. The types are closed, local, and **mutually disjoint** (verified — no pair is a subclass of another), so the ordered table is not even order-dependent, and `issubclass` gives the same subtype fallthrough. `NoManifold`/`NoAtlas`/`MinkowskiManifold`/`MinkowskiAtlas` still fall through to `True`, exactly as the old `Abstract*` catch-all dispatch did.

Also caches `matching_chart_classes_for_ndim` — it instantiates every concrete chart class and was called once per candidate class per draw — and moves it to `_common.py`, deleting a verbatim copy of the same scan in `atlas.py`. (`_common.py` rather than either module because `manifold` imports `atlas`; this matches the existing `representations/_src/_common.py`.)

## Result

250 draws, `JAX_ENABLE_X64=1` (the suite's setting):

| | before | after |
|---|---|---|
| `manifolds(ndim=3)` | 7.20 ms/ex | **4.54 ms/ex** (−37%) |
| `atlases()` | 9.14 ms/ex | **6.94 ms/ex** (−24%) |

Net −11 lines despite the added tests and comments.

## Found in passing, not fixed here

`manifolds(CartesianProductManifold, ndim=7)` trips `filter_too_much` under `@given`. **Pre-existing** — confirmed by running the new test against unmodified `main`. The new test covers ndim 1–6; the ndim ≥ 7 path wants its own look.

652 package tests pass, plus 1220 in `tests/unit/{manifolds,charts,representations}`; ruff and ty clean. No files shared with #651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
