### PR TITLE
✨ fix(hypothesis): let product charts reach the dimensionalities they document

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/charts_product.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/charts_product.py
@@ -5,7 +5,7 @@ __all__: tuple[str, ...] = ("cartesian_product_factors",)
 import functools as ft
 import warnings
 
-from typing import Any
+from typing import Any, Final
 
 import hypothesis.strategies as st
 import plum
@@ -24,9 +24,35 @@ from coordinaxs.hypothesis.utils import (
 ##############################################################################
 # Cartesian Products
 
+#: Concrete flat-key product chart classes.
+#:
+#: Resolved once at import rather than inside the draw: `get_all_subclasses` is
+#: cached, so the `UserWarning` it emits when nothing matches could only ever
+#: fire on the first call, but `warnings.catch_warnings` was being entered on
+#: every draw to suppress it -- and it is not thread-safe.
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", UserWarning)
+    _FLAT_PRODUCT_CLASSES: Final = get_all_subclasses(
+        cxc.AbstractFlatCartesianProductChart, exclude_abstract=True, exclude=()
+    )
+
+
+#: Largest dimensionality a single product factor is drawn at.
+#:
+#: Factors come from `charts(filter=AbstractFixedComponentsChart, ndim=...)`,
+#: which is only densely populated up to 3-D: measured over 60 draws each, ndim
+#: 3 succeeds 60/60 while ndim 4 and 6 have exactly one chart apiece
+#: (``MinkowskiCT``, ``PoincarePolar6D``) and ndim 5 has none. Letting a factor
+#: ask for more than this mostly produces discards.
+FACTOR_NDIM_CAP: Final = 3
+
 
 def _factor_dims(draw: st.DrawFn, /, *, n_factors: int, target_dim: int) -> list[int]:
     """Generate factor dimensions that sum to `target_dim`.
+
+    Each factor gets between 1 and `FACTOR_NDIM_CAP` dimensions. Callers must
+    ensure the request is feasible, i.e.
+    ``n_factors <= target_dim <= FACTOR_NDIM_CAP * n_factors``.
 
     Parameters
     ----------
@@ -43,24 +69,18 @@ def _factor_dims(draw: st.DrawFn, /, *, n_factors: int, target_dim: int) -> list
         A list of factor dimensions that sum to `target_dim`.
 
     """
-    if n_factors == 1:
-        factor_dims = [target_dim]
-    else:
-        # Draw n_factors-1 random splits; the last factor's dim is determined by
-        # what remains, ensuring all factors sum exactly to `target_dim`.
-        remaining = target_dim
-        factor_dims = []
-        for i in range(n_factors - 1):
-            # Reserve at least 1 dimension for each factor still to be assigned
-            # (the current one plus the remaining ones after it), so no factor
-            # ends up with 0 dimensions.
-            max_for_this = remaining - (n_factors - i - 1)
-            # If the budget is already tight (max_for_this < 1), assign 1 to
-            # avoid an invalid range; otherwise draw uniformly.
-            factor_dim = 1 if max_for_this < 1 else draw(st.integers(1, max_for_this))
-            factor_dims.append(factor_dim)
-            remaining -= factor_dim
-        factor_dims.append(remaining)  # Last factor gets the remaining budget
+    factor_dims: list[int] = []
+    remaining = target_dim
+    for i in range(n_factors - 1):
+        factors_left_after = n_factors - i - 1
+        # Leave every later factor at least 1 dimension and at most the cap, so
+        # what remains is always a feasible budget for them.
+        min_this = max(1, remaining - FACTOR_NDIM_CAP * factors_left_after)
+        max_this = min(FACTOR_NDIM_CAP, remaining - factors_left_after)
+        factor_dim = draw(st.integers(min_this, max_this))
+        factor_dims.append(factor_dim)
+        remaining -= factor_dim
+    factor_dims.append(remaining)  # Last factor gets the remaining budget
 
     return factor_dims
 
@@ -107,11 +127,21 @@ def cartesian_product_factors(
         target_dim = ndim
     else:
         min_ndim = 1 if max_factors == 1 else max(2, min_factors)
-        max_ndim = min(6, max_factors)
+        # Each factor carries up to FACTOR_NDIM_CAP dimensions, so the reachable
+        # total is that times the factor count. The old bound was `min(6,
+        # max_factors)`, which capped the *total* by the factor *count* -- with
+        # the default max_factors=3 no product above 3-D was ever generated, so
+        # the 6-D `cart3d x cart3d` case was unreachable by default.
+        max_ndim = min(6, FACTOR_NDIM_CAP * max_factors)
         target_dim = draw(st.integers(min_ndim, max_ndim))
 
-    # Determine number of factors (at least min_factors, at most max_factors)
-    n_factors = draw(st.integers(min_factors, min(target_dim, max_factors)))
+    # Determine the number of factors. Beyond min/max_factors it must be able to
+    # partition target_dim into parts in [1, FACTOR_NDIM_CAP]: at least
+    # ceil(target_dim / cap) parts, and no more than target_dim of them.
+    min_n = max(min_factors, -(-target_dim // FACTOR_NDIM_CAP))
+    max_n = min(target_dim, max_factors)
+    assume(min_n <= max_n)
+    n_factors = draw(st.integers(min_n, max_n))
 
     # Generate factor dimensions that sum to target_dim
     factor_dims = _factor_dims(draw, n_factors=n_factors, target_dim=target_dim)
@@ -340,19 +370,14 @@ def charts(
     """
     # If factor_charts/names are not provided we have a 25% chance to generate a
     # specialized product chart, if any exist.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        flat_product_classes = get_all_subclasses(
-            cxc.AbstractFlatCartesianProductChart, exclude_abstract=True, exclude=()
-        )
     if (
-        flat_product_classes
+        _FLAT_PRODUCT_CLASSES
         and (factor_charts is None and factor_names is None)
-        and draw(st.integers(1, 100)) <= 25
+        and draw(st.integers(0, 3)) == 0
     ):
         # 25% chance to generate a specialized product chart
         # Pick a random specialization
-        flat_cls = draw(st.sampled_from(flat_product_classes))
+        flat_cls = draw(st.sampled_from(_FLAT_PRODUCT_CLASSES))
 
         # Use chart_init_kwargs directly to avoid re-entering the
         # AbstractCartesianProductChart dispatch (flat_cls is a subclass of it,

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/charts_product.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/charts_product.py
@@ -24,12 +24,9 @@ from coordinaxs.hypothesis.utils import (
 ##############################################################################
 # Cartesian Products
 
-#: Concrete flat-key product chart classes.
+#: Concrete flat-key product chart classes, resolved once at import.
 #:
-#: Resolved once at import rather than inside the draw: `get_all_subclasses` is
-#: cached, so the `UserWarning` it emits when nothing matches could only ever
-#: fire on the first call, but `warnings.catch_warnings` was being entered on
-#: every draw to suppress it -- and it is not thread-safe.
+#: `warnings.catch_warnings` is not thread-safe, so it is not entered per draw.
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", UserWarning)
     _FLAT_PRODUCT_CLASSES: Final = get_all_subclasses(
@@ -39,11 +36,9 @@ with warnings.catch_warnings():
 
 #: Largest dimensionality a single product factor is drawn at.
 #:
-#: Factors come from `charts(filter=AbstractFixedComponentsChart, ndim=...)`,
-#: which is only densely populated up to 3-D: measured over 60 draws each, ndim
-#: 3 succeeds 60/60 while ndim 4 and 6 have exactly one chart apiece
-#: (``MinkowskiCT``, ``PoincarePolar6D``) and ndim 5 has none. Letting a factor
-#: ask for more than this mostly produces discards.
+#: `AbstractFixedComponentsChart` is densely populated only up to 3-D; above it
+#: there are at most one or two charts per dimension, so larger factors are
+#: mostly discards.
 FACTOR_NDIM_CAP: Final = 3
 
 
@@ -73,8 +68,8 @@ def _factor_dims(draw: st.DrawFn, /, *, n_factors: int, target_dim: int) -> list
     remaining = target_dim
     for i in range(n_factors - 1):
         factors_left_after = n_factors - i - 1
-        # Leave every later factor at least 1 dimension and at most the cap, so
-        # what remains is always a feasible budget for them.
+        # Bound this factor so what remains still fits the later ones at 1 to
+        # FACTOR_NDIM_CAP dimensions each.
         min_this = max(1, remaining - FACTOR_NDIM_CAP * factors_left_after)
         max_this = min(FACTOR_NDIM_CAP, remaining - factors_left_after)
         factor_dim = draw(st.integers(min_this, max_this))
@@ -127,17 +122,13 @@ def cartesian_product_factors(
         target_dim = ndim
     else:
         min_ndim = 1 if max_factors == 1 else max(2, min_factors)
-        # Each factor carries up to FACTOR_NDIM_CAP dimensions, so the reachable
-        # total is that times the factor count. The old bound was `min(6,
-        # max_factors)`, which capped the *total* by the factor *count* -- with
-        # the default max_factors=3 no product above 3-D was ever generated, so
-        # the 6-D `cart3d x cart3d` case was unreachable by default.
+        # Each factor carries at most FACTOR_NDIM_CAP dimensions, so that times
+        # the factor count is the largest total the factors can sum to.
         max_ndim = min(6, FACTOR_NDIM_CAP * max_factors)
         target_dim = draw(st.integers(min_ndim, max_ndim))
 
-    # Determine the number of factors. Beyond min/max_factors it must be able to
-    # partition target_dim into parts in [1, FACTOR_NDIM_CAP]: at least
-    # ceil(target_dim / cap) parts, and no more than target_dim of them.
+    # Enough factors to cover target_dim at FACTOR_NDIM_CAP each, few enough
+    # that every one can still take at least 1.
     min_n = max(min_factors, -(-target_dim // FACTOR_NDIM_CAP))
     max_n = min(target_dim, max_factors)
     assume(min_n <= max_n)

--- a/packages/coordinaxs.hypothesis/tests/unit/charts/test_product_charts.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/charts/test_product_charts.py
@@ -8,6 +8,7 @@ from hypothesis.errors import Unsatisfiable
 import coordinax.charts as cxc
 
 import coordinaxs.hypothesis.main as cxst
+from coordinaxs.hypothesis.charts._src import charts_product as cxstc
 
 
 class TestProductChartsBasic:
@@ -333,3 +334,36 @@ def test_product_charts_with_fixed_factors_and_ndim(
     # Verify total dimension
     expected_dim = sum(f.ndim for f in factor_charts)
     assert chart.ndim == expected_dim
+
+
+class TestProductChartDimensionality:
+    """The reachable total dimensionality, and the per-factor cap it implies."""
+
+    @pytest.mark.parametrize("ndim", [2, 3, 4, 5, 6])
+    def test_requested_ndim_is_reachable_and_exact(self, ndim: int) -> None:
+        """Every total in 2-6 is generated, with factor dims summing to it.
+
+        The total used to be bounded by `min(6, max_factors)` -- the factor
+        *count* -- so with the default ``max_factors=3`` nothing above 3-D was
+        ever produced and the 6-D ``cart3d x cart3d`` product was unreachable.
+        """
+
+        @given(chart=cxst.charts(cxc.AbstractCartesianProductChart, ndim=ndim))
+        @settings(max_examples=15, deadline=None)
+        def check(chart: cxc.AbstractCartesianProductChart) -> None:
+            assert chart.ndim == ndim
+            assert sum(f.ndim for f in chart.factors) == ndim
+
+        check()
+
+    @given(factors=cxstc.cartesian_product_factors())
+    def test_factor_dims_respect_the_cap(
+        self, factors: tuple[cxc.AbstractChart, ...]
+    ) -> None:
+        """No factor is asked for a dimensionality charts are sparse at.
+
+        Fixed-component charts are only densely populated up to 3-D, so drawing
+        a 5-D factor is nearly all discards.
+        """
+        assert factors
+        assert all(1 <= f.ndim <= cxstc.FACTOR_NDIM_CAP for f in factors)

--- a/packages/coordinaxs.hypothesis/tests/unit/charts/test_product_charts.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/charts/test_product_charts.py
@@ -339,13 +339,45 @@ def test_product_charts_with_fixed_factors_and_ndim(
 class TestProductChartDimensionality:
     """The reachable total dimensionality, and the per-factor cap it implies."""
 
-    @pytest.mark.parametrize("ndim", [2, 3, 4, 5, 6])
-    def test_requested_ndim_is_reachable_and_exact(self, ndim: int) -> None:
-        """Every total in 2-6 is generated, with factor dims summing to it.
+    @pytest.mark.parametrize("max_factors", [2, 3])
+    def test_default_total_is_bounded_by_capacity_not_factor_count(
+        self, max_factors: int
+    ) -> None:
+        """Without ``ndim``, totals scale with what the factors can carry.
 
-        The total used to be bounded by `min(6, max_factors)` -- the factor
-        *count* -- so with the default ``max_factors=3`` nothing above 3-D was
-        ever produced and the 6-D ``cart3d x cart3d`` product was unreachable.
+        The bound was ``min(6, max_factors)``, which limited the total by the
+        *number* of factors instead of their capacity, so ``max_factors=3``
+        never produced a product above 3-D. Asserting on the default draw is
+        what makes this a regression test: passing ``ndim=`` explicitly bypasses
+        the bound entirely and so exercises none of it.
+        """
+        totals: set[int] = set()
+
+        @given(factors=cxstc.cartesian_product_factors(max_factors=max_factors))
+        @settings(max_examples=100, deadline=None)
+        def collect(factors: tuple[cxc.AbstractChart, ...]) -> None:
+            totals.add(sum(f.ndim for f in factors))
+
+        collect()
+        ceiling = min(6, cxstc.FACTOR_NDIM_CAP * max_factors)
+        assert max(totals) > max_factors, f"capped at the factor count: {totals}"
+        assert max(totals) == ceiling, f"never reached {ceiling}: {totals}"
+
+    @given(factors=cxstc.cartesian_product_factors())
+    def test_factor_dims_respect_the_cap(
+        self, factors: tuple[cxc.AbstractChart, ...]
+    ) -> None:
+        """No factor is asked for a dimensionality charts are sparse at."""
+        assert factors
+        assert all(1 <= f.ndim <= cxstc.FACTOR_NDIM_CAP for f in factors)
+
+    @pytest.mark.parametrize("ndim", [2, 3, 4, 5, 6])
+    def test_explicit_ndim_stays_satisfiable(self, ndim: int) -> None:
+        """The feasibility `assume` does not reject requests it can satisfy.
+
+        Guards this change rather than the original bug: constraining the factor
+        count to those that can partition ``target_dim`` could have made valid
+        ``ndim=`` requests unsatisfiable.
         """
 
         @given(chart=cxst.charts(cxc.AbstractCartesianProductChart, ndim=ndim))
@@ -355,15 +387,3 @@ class TestProductChartDimensionality:
             assert sum(f.ndim for f in chart.factors) == ndim
 
         check()
-
-    @given(factors=cxstc.cartesian_product_factors())
-    def test_factor_dims_respect_the_cap(
-        self, factors: tuple[cxc.AbstractChart, ...]
-    ) -> None:
-        """No factor is asked for a dimensionality charts are sparse at.
-
-        Fixed-component charts are only densely populated up to 3-D, so drawing
-        a 5-D factor is nearly all discards.
-        """
-        assert factors
-        assert all(1 <= f.ndim <= cxstc.FACTOR_NDIM_CAP for f in factors)


### PR DESCRIPTION
The total dimensionality of a randomly-drawn product chart was bounded by

```python
max_ndim = min(6, max_factors)
```

which caps the **total** by the factor **count**. With the default `max_factors=3`, no product above 3-D was ever generated. Measured over 300 draws of `charts(AbstractCartesianProductChart)`: **93% came out 2-D or 3-D**, and the 6-D `cart3d × cart3d` phase-space product — the case this module's own docstring uses as its worked example — was unreachable by default.

## Why raising the bound isn't enough on its own

`_factor_dims` had no per-factor cap, so a bigger total would just hand some factor `ndim=5` — and `charts(filter=AbstractFixedComponentsChart, ndim=5)` matches nothing. Measured, 60 draws each:

| factor ndim | charts found |
|---|---|
| 1 | sparse (4/60 survive) |
| 2 | sparse (5/60) |
| **3** | **60/60** |
| 4 | one (`MinkowskiCT`) |
| 5 | **none** |
| 6 | one (`PoincarePolar6D`) |

So the fix is both halves: `FACTOR_NDIM_CAP = 3` per factor, `min(6, 3 * max_factors)` on the total, and a feasibility `assume` on the factor count so an impossible request (`ndim=10, max_factors=3`) is discarded rather than silently mis-dimensioned.

## Result

`JAX_ENABLE_X64=1` (the suite's setting):

| | before | after |
|---|---|---|
| default draws at ndim ≥ 4 | 21/300 | **194/300** |
| default draws at ndim 2–3 | 279/300 | **101/300** |
| `ndim=6` discards | 29/80 | **10/80** |
| `ndim=3` discards | 14/80 | **3/80** |

Cost rises 3.11 → 3.59 ms/draw, which is the higher-dimensional charts actually being built rather than skipped.

## Two smaller things in the same file

- **`warnings.catch_warnings()` on every draw**, to suppress a warning that — since `get_all_subclasses` is cached — can only fire on the very first call. It is also not thread-safe. Hoisted to a module-level constant computed once at import.
- **`draw(st.integers(1, 100)) <= 25`** for a 25% branch → `draw(st.integers(0, 3)) == 0`. Same probability, less entropy consumed per draw, and it shrinks toward the branch rather than wandering across 100 values.

641 package tests pass, plus 454 in `tests/unit/charts`; ruff and ty clean. No files shared with #651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
