### PR TITLE
🐛 fix(hypothesis): resolve kind candidates per draw, not at import

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/_common.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/_common.py
@@ -24,6 +24,12 @@ def draw_subclass(
     kinds): candidates default to ``all_classes`` unless ``include`` is given,
     then ``exclude`` is removed and one is sampled. Raises `ValueError` (naming
     ``kind``) if nothing remains.
+
+    Callers pass ``all_classes`` freshly from `get_all_subclasses` rather than
+    from a module-level constant. A constant is resolved at *import* time, which
+    is before any module imported later can register its subclasses -- and,
+    unlike `get_all_subclasses`, it cannot be refreshed, so
+    ``get_all_subclasses.cache_clear()`` had no effect on these three strategies.
     """
     candidates = all_classes if include is None else include
     exclude_set = set(exclude)

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/bases.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/bases.py
@@ -2,16 +2,12 @@
 
 __all__ = ("basis_classes", "bases")
 
-from typing import Final
-
 import hypothesis.strategies as st
 
 import coordinax.representations as cxr
 
 from ._common import draw_subclass
 from coordinaxs.hypothesis.utils import get_all_subclasses
-
-BASES: Final = get_all_subclasses(cxr.AbstractBasis, exclude_abstract=True)
 
 
 @st.composite
@@ -53,7 +49,13 @@ def basis_classes(
     ...     assert issubclass(basis_cls, cxr.NoBasis)
 
     """
-    return draw_subclass(draw, BASES, include=include, exclude=exclude, kind="basis")  # ty: ignore[invalid-return-type]
+    return draw_subclass(
+        draw,
+        get_all_subclasses(cxr.AbstractBasis, exclude_abstract=True),
+        include=include,
+        exclude=exclude,
+        kind="basis",
+    )  # ty: ignore[invalid-return-type]
 
 
 @st.composite

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/geoms.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/geoms.py
@@ -2,16 +2,12 @@
 
 __all__ = ("geometry_classes", "geometries")
 
-from typing import Final
-
 import hypothesis.strategies as st
 
 import coordinax.representations as cxr
 
 from ._common import draw_subclass
 from coordinaxs.hypothesis.utils import get_all_subclasses
-
-GEOMETRIES: Final = get_all_subclasses(cxr.AbstractGeometry, exclude_abstract=True)
 
 
 @st.composite
@@ -54,7 +50,11 @@ def geometry_classes(
 
     """
     return draw_subclass(
-        draw, GEOMETRIES, include=include, exclude=exclude, kind="geometry"
+        draw,
+        get_all_subclasses(cxr.AbstractGeometry, exclude_abstract=True),
+        include=include,
+        exclude=exclude,
+        kind="geometry",
     )  # ty: ignore[invalid-return-type]
 
 

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/semantics.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/semantics.py
@@ -2,16 +2,12 @@
 
 __all__ = ("semantic_classes", "semantics")
 
-from typing import Final
-
 import hypothesis.strategies as st
 
 import coordinax.representations as cxr
 
 from ._common import draw_subclass
 from coordinaxs.hypothesis.utils import get_all_subclasses
-
-SEMANTICS: Final = get_all_subclasses(cxr.AbstractSemanticKind, exclude_abstract=True)
 
 
 @st.composite
@@ -54,7 +50,11 @@ def semantic_classes(
 
     """
     return draw_subclass(
-        draw, SEMANTICS, include=include, exclude=exclude, kind="semantic"
+        draw,
+        get_all_subclasses(cxr.AbstractSemanticKind, exclude_abstract=True),
+        include=include,
+        exclude=exclude,
+        kind="semantic",
     )  # ty: ignore[invalid-return-type]
 
 

--- a/packages/coordinaxs.hypothesis/tests/unit/representations/test_kind_strategies.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/representations/test_kind_strategies.py
@@ -10,11 +10,14 @@ concrete class, and the "no candidates left" error message.
 
 __all__: tuple[str, ...] = ()
 
+import importlib
+
+from collections.abc import Callable
 from types import SimpleNamespace
 
 import hypothesis.strategies as st
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 
 import coordinax.representations as cxr
 
@@ -118,3 +121,39 @@ class TestInstanceStrategies:
         assert isinstance(
             data.draw(kind.instances(include=(kind.sample,))), kind.sample
         )
+
+
+@pytest.mark.parametrize(
+    ("module_name", "strategy", "base", "keep"),
+    [
+        ("bases", cxrst.basis_classes, cxr.AbstractBasis, cxr.NoBasis),
+        ("geoms", cxrst.geometry_classes, cxr.AbstractGeometry, cxr.PointGeometry),
+        ("semantics", cxrst.semantic_classes, cxr.AbstractSemanticKind, cxr.Location),
+    ],
+)
+def test_candidates_are_resolved_per_draw_not_at_import(
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+    strategy: Callable[[], st.SearchStrategy[type]],
+    base: type,
+    keep: type,
+) -> None:
+    """The candidate set is read at draw time, not frozen at import.
+
+    These strategies used to sample from a module-level constant resolved when
+    the module was first imported, so any subclass registered by a later import
+    was invisible forever -- and `get_all_subclasses.cache_clear()`, which the
+    rest of the package relies on, could not bring it back. Narrowing what
+    `get_all_subclasses` returns must therefore change what is drawn.
+    """
+    module = importlib.import_module(
+        f"coordinaxs.hypothesis.representations._src.{module_name}"
+    )
+    monkeypatch.setattr(module, "get_all_subclasses", lambda *a, **kw: (keep,))
+
+    @given(cls=strategy())
+    @settings(max_examples=25, deadline=None, database=None)
+    def check(cls: type) -> None:
+        assert cls is keep
+
+    check()


### PR DESCRIPTION
`bases`, `geoms` and `semantics` each sampled from a module-level constant:

```python
BASES: Final = get_all_subclasses(cxr.AbstractBasis, exclude_abstract=True)
```

resolved when the module is **first imported**. Any concrete kind registered by a module imported later is invisible to these strategies — and permanently so, because unlike `get_all_subclasses` a constant cannot be refreshed.

That matters because the rest of the package treats `get_all_subclasses.cache_clear()` as the way to pick up a changed class tree — its own docstring examples call it before each assertion. For these three strategies it silently did nothing. Demonstrated:

```
at import: BASES 3
after defining a new concrete basis:
  module constant BASES     : 3   <- stale, and unfixable
  get_all_subclasses (cached): 3
  after cache_clear         : 4   <- recovers
```

## Fix

Call through to `get_all_subclasses` at draw time. It is still cached, so the cost is one dict lookup per draw, and the staleness window shrinks from *forever* to *until the next `cache_clear`*.

## On the test

The test narrows what `get_all_subclasses` returns and asserts the drawn class follows. It **fails on unmodified `main`** for all three kinds, which is the point — otherwise it would prove nothing.

An earlier version defined a real `AbstractLinearBasis` subclass at runtime and asserted it got drawn. Dropped: hypothesis' internal caches keep the class reachable, so it stays in `__subclasses__()` past the test and broke `test_valid_basis_classes_for_tangent_geometry` downstream. Testing that path properly needs subprocess isolation, which is more machinery than this fix is worth.

## Not addressed here

`get_all_subclasses` itself is `@ft.cache`d over mutable `__subclasses__()` state, so a subclass registered after the first call is still invisible until the cache is cleared. Removing that cache is a hot-path change — the walk is ~33 µs uncached vs ~0.07 µs cached — and my attempt to measure the end-to-end effect gave inconsistent results (one strategy appeared *faster* uncached, which means the monkeypatch was not reaching every call site). I would rather leave it than land a perf change on a number I do not trust. Worth its own look.

638 package tests pass, plus 318 in `tests/unit/representations`; ruff and ty clean. No files shared with #651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
