### PR TITLE
⚡️ fix(hypothesis): only offer atlas/manifold types that can actually be drawn

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
@@ -270,17 +270,29 @@ _NDIM_SUPPORT: Final[
     (cxm.HyperSphericalAtlas, lambda ndim: ndim == 2),
     # A product needs at least one factor, each contributing >= 1 dimension.
     (cxm.CartesianProductAtlas, lambda ndim: ndim >= 1),
-    (cxm.CustomAtlas, lambda ndim: ndim >= 1),
+    # A CustomAtlas is assembled from zero-argument charts of the target
+    # dimensionality, so it exists at exactly the dimensionalities those charts
+    # do -- there are none at ndim 5 or 7. Mirrors the `CustomManifold` entry.
+    (cxm.CustomAtlas, lambda ndim: bool(matching_chart_classes_for_ndim(ndim))),
     # EuclideanAtlas is currently generated only for dimensions 0-3.
     (cxm.EuclideanAtlas, lambda ndim: 0 <= ndim <= 3),
+)
+
+#: Concrete atlas types this module has no strategy for.
+#:
+#: Kept separate from `_NDIM_SUPPORT` because it is not a question of
+#: dimensionality: these cannot be drawn at *any* ndim.
+_NO_STRATEGY: Final[tuple[type[cxm.AbstractAtlas], ...]] = (
+    cxm.NoAtlas,
+    cxm.MinkowskiAtlas,
 )
 
 
 def _atlas_class_supports_ndim(cls: type[cxm.AbstractAtlas], ndim: int, /) -> bool:
     """Whether *cls* can be drawn at *ndim*.
 
-    Types absent from `_NDIM_SUPPORT` (``NoAtlas``, ``MinkowskiAtlas``) fall
-    through to `True`, matching the previous ``AbstractAtlas`` catch-all.
+    Types absent from `_NDIM_SUPPORT` fall through to `True`; add an entry when
+    adding a concrete atlas type whose dimensionality is restricted.
     """
     for base, supports in _NDIM_SUPPORT:
         if issubclass(cls, base):
@@ -336,7 +348,8 @@ def atlases(
     classes = tuple(
         cls
         for cls in all_classes
-        if (target_ndim is None or _atlas_class_supports_ndim(cls, target_ndim))
+        if not issubclass(cls, _NO_STRATEGY)
+        and (target_ndim is None or _atlas_class_supports_ndim(cls, target_ndim))
         and (not required_chart_classes or issubclass(cls, cxm.CustomAtlas))
     )
     if not classes:
@@ -430,10 +443,12 @@ def atlases(
         raise ValueError(msg)
 
     if not inspect.isabstract(atlas_cls):
-        kwargs: dict[str, Any] = {"ndim": ndim}
-        if issubclass(atlas_cls, cxm.CustomAtlas):
-            kwargs["required_chart_classes"] = required_chart_classes
-        return draw(cast("Any", atlases)(atlas_cls, **kwargs))
+        # Only reachable when no more specific overload matched, since plum
+        # picks the most specific one -- so redispatching here selected this
+        # same method again and recursed until hypothesis ran out of buffer and
+        # reported `Unsatisfiable`, with nothing pointing at the real cause.
+        msg = f"No atlas strategy is registered for {atlas_cls.__name__}."
+        raise NotImplementedError(msg)
 
     # Draw and redispatch
     return draw(

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
@@ -278,10 +278,8 @@ _NDIM_SUPPORT: Final[
     (cxm.EuclideanAtlas, lambda ndim: 0 <= ndim <= 3),
 )
 
-#: Concrete atlas types this module has no strategy for.
-#:
-#: Kept separate from `_NDIM_SUPPORT` because it is not a question of
-#: dimensionality: these cannot be drawn at *any* ndim.
+#: Concrete atlas types with no registered strategy; never offered as
+#: candidates. Separate from `_NDIM_SUPPORT`: these work at no ndim at all.
 _NO_STRATEGY: Final[tuple[type[cxm.AbstractAtlas], ...]] = (
     cxm.NoAtlas,
     cxm.MinkowskiAtlas,
@@ -443,10 +441,8 @@ def atlases(
         raise ValueError(msg)
 
     if not inspect.isabstract(atlas_cls):
-        # Only reachable when no more specific overload matched, since plum
-        # picks the most specific one -- so redispatching here selected this
-        # same method again and recursed until hypothesis ran out of buffer and
-        # reported `Unsatisfiable`, with nothing pointing at the real cause.
+        # Reachable only when no more specific overload matched, so
+        # redispatching here would re-select this method and recurse.
         msg = f"No atlas strategy is registered for {atlas_cls.__name__}."
         raise NotImplementedError(msg)
 

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
@@ -71,14 +71,23 @@ _NDIM_SUPPORT: Final[
     (cxm.EuclideanManifold, lambda _: True),
 )
 
+#: Concrete manifold types this module has no strategy for.
+#:
+#: Kept separate from `_NDIM_SUPPORT` because it is not a question of
+#: dimensionality: these cannot be drawn at *any* ndim.
+_NO_STRATEGY: Final[tuple[type[cxm.AbstractManifold], ...]] = (
+    cxm.NoManifold,
+    cxm.MinkowskiManifold,
+)
+
 
 def _manifold_class_supports_ndim(
     cls: type[cxm.AbstractManifold], ndim: int, /
 ) -> bool:
     """Whether *cls* can be drawn at *ndim*.
 
-    Types absent from `_NDIM_SUPPORT` (``NoManifold``, ``MinkowskiManifold``)
-    fall through to `True`, matching the previous ``AbstractManifold`` catch-all.
+    Types absent from `_NDIM_SUPPORT` fall through to `True`; add an entry when
+    adding a concrete manifold type whose dimensionality is restricted.
     """
     for base, supports in _NDIM_SUPPORT:
         if issubclass(cls, base):
@@ -163,7 +172,8 @@ def manifolds(
             exclude_abstract=True,
             exclude=exclude,
         )
-        if target_ndim is None or _manifold_class_supports_ndim(cls, target_ndim)
+        if not issubclass(cls, _NO_STRATEGY)
+        and (target_ndim is None or _manifold_class_supports_ndim(cls, target_ndim))
     )
     if not classes:
         assume(False)
@@ -234,6 +244,13 @@ def manifolds(
         raise ValueError(
             "When manifold_cls is provided, filter and exclude must be empty."
         )
+
+    if issubclass(manifold_cls, _NO_STRATEGY):
+        # Using the class as a filter would select it right back, land here
+        # again and recurse until hypothesis ran out of buffer and reported
+        # `Unsatisfiable`, with nothing pointing at the real cause.
+        msg = f"No manifold strategy is registered for {manifold_cls.__name__}."
+        raise NotImplementedError(msg)
 
     return draw(
         cast("Any", manifolds)(

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
@@ -71,10 +71,8 @@ _NDIM_SUPPORT: Final[
     (cxm.EuclideanManifold, lambda _: True),
 )
 
-#: Concrete manifold types this module has no strategy for.
-#:
-#: Kept separate from `_NDIM_SUPPORT` because it is not a question of
-#: dimensionality: these cannot be drawn at *any* ndim.
+#: Concrete manifold types with no registered strategy; never offered as
+#: candidates. Separate from `_NDIM_SUPPORT`: these work at no ndim at all.
 _NO_STRATEGY: Final[tuple[type[cxm.AbstractManifold], ...]] = (
     cxm.NoManifold,
     cxm.MinkowskiManifold,
@@ -246,9 +244,7 @@ def manifolds(
         )
 
     if issubclass(manifold_cls, _NO_STRATEGY):
-        # Using the class as a filter would select it right back, land here
-        # again and recurse until hypothesis ran out of buffer and reported
-        # `Unsatisfiable`, with nothing pointing at the real cause.
+        # Filtering on the class would select it right back and land here again.
         msg = f"No manifold strategy is registered for {manifold_cls.__name__}."
         raise NotImplementedError(msg)
 

--- a/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
@@ -12,6 +12,7 @@ import coordinax.manifolds as cxm
 
 import coordinaxs.hypothesis.main as cxst
 from coordinaxs.hypothesis.manifolds._src.atlas import _atlas_class_supports_ndim
+from coordinaxs.hypothesis.manifolds._src.manifold import _manifold_class_supports_ndim
 
 
 @given(atlas_cls=cxst.atlas_classes())
@@ -230,3 +231,21 @@ class TestOnlyDrawableCandidatesAreSelected:
         that is what the predicate calls, so it would assert itself.
         """
         assert _atlas_class_supports_ndim(cxm.CustomAtlas, ndim) is supported
+
+    @pytest.mark.parametrize(
+        ("supports_ndim", "cls"),
+        [
+            (_atlas_class_supports_ndim, cxm.MinkowskiAtlas),
+            (_manifold_class_supports_ndim, cxm.MinkowskiManifold),
+        ],
+    )
+    def test_types_absent_from_the_table_default_to_supported(
+        self, supports_ndim: Callable[[type, int], bool], cls: type
+    ) -> None:
+        """A type with no `_NDIM_SUPPORT` entry is treated as unrestricted.
+
+        Which is why `_NO_STRATEGY` has to be a separate gate: this predicate
+        answers "at which ndim", not "can it be drawn at all", and would wave
+        these two through at every ndim.
+        """
+        assert supports_ndim(cls, 3) is True

--- a/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
@@ -11,9 +11,7 @@ import coordinax.charts as cxc
 import coordinax.manifolds as cxm
 
 import coordinaxs.hypothesis.main as cxst
-from coordinaxs.hypothesis.manifolds._src.atlas import (
-    _atlas_class_supports_ndim,
-)
+from coordinaxs.hypothesis.manifolds._src.atlas import _atlas_class_supports_ndim
 
 
 @given(atlas_cls=cxst.atlas_classes())
@@ -205,22 +203,17 @@ class TestOnlyDrawableCandidatesAreSelected:
         strategy: Callable[..., st.SearchStrategy[object]],
         data: st.DataObject,
     ) -> None:
-        """Asking for one by name raises, naming the class.
-
-        It used to redispatch to the overload it was already in and recurse
-        until hypothesis ran out of buffer, surfacing as `Unsatisfiable` with
-        nothing pointing at the cause.
-        """
+        """Asking for one by name raises, naming the class."""
         with pytest.raises(NotImplementedError, match=cls.__name__):
             data.draw(strategy(cls))
 
     @given(atlas=cxst.atlases())
-    def test_drawn_atlases_are_never_strategy_less(self, atlas: object) -> None:
+    def test_drawn_atlases_all_have_strategies(self, atlas: object) -> None:
         """No draw yields a type the module has no strategy for."""
         assert not isinstance(atlas, (cxm.NoAtlas, cxm.MinkowskiAtlas))
 
     @given(M=cxst.manifolds())
-    def test_drawn_manifolds_are_never_strategy_less(self, M: object) -> None:
+    def test_drawn_manifolds_all_have_strategies(self, M: object) -> None:
         """Same for manifolds."""
         assert not isinstance(M, (cxm.NoManifold, cxm.MinkowskiManifold))
 
@@ -233,8 +226,7 @@ class TestOnlyDrawableCandidatesAreSelected:
     ) -> None:
         """``CustomAtlas`` supports only dimensionalities with zero-arg charts.
 
-        The expectations are spelled out rather than recomputed from
-        `matching_chart_classes_for_ndim`, which is what the predicate itself
-        calls -- otherwise this would assert the implementation against itself.
+        Spelled out, not recomputed from `matching_chart_classes_for_ndim` --
+        that is what the predicate calls, so it would assert itself.
         """
         assert _atlas_class_supports_ndim(cxm.CustomAtlas, ndim) is supported

--- a/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
@@ -1,5 +1,7 @@
 """Tests for manifold strategies."""
 
+from collections.abc import Callable
+
 import hypothesis.strategies as st
 import pytest
 from hypothesis import given, settings
@@ -9,6 +11,9 @@ import coordinax.charts as cxc
 import coordinax.manifolds as cxm
 
 import coordinaxs.hypothesis.main as cxst
+from coordinaxs.hypothesis.manifolds._src.atlas import (
+    _atlas_class_supports_ndim,
+)
 
 
 @given(atlas_cls=cxst.atlas_classes())
@@ -156,7 +161,7 @@ class TestNdimIsHonoured:
         with pytest.raises(Unsatisfiable):
             check()
 
-    @pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5, 6])
+    @pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5, 6, 7])
     def test_product_manifold_factor_dims_sum_to_ndim(self, ndim: int) -> None:
         """Factor dimensionalities partition the requested total exactly."""
 
@@ -179,3 +184,57 @@ class TestNdimIsHonoured:
             assert sum(f.ndim for f in atlas.factors) == ndim
 
         check()
+
+
+class TestOnlyDrawableCandidatesAreSelected:
+    """Classes with no registered strategy are never offered as candidates."""
+
+    @pytest.mark.parametrize(
+        ("cls", "strategy"),
+        [
+            (cxm.NoAtlas, cxst.atlases),
+            (cxm.MinkowskiAtlas, cxst.atlases),
+            (cxm.NoManifold, cxst.manifolds),
+            (cxm.MinkowskiManifold, cxst.manifolds),
+        ],
+    )
+    @given(data=st.data())
+    def test_requesting_one_directly_says_so(
+        self,
+        cls: type,
+        strategy: Callable[..., st.SearchStrategy[object]],
+        data: st.DataObject,
+    ) -> None:
+        """Asking for one by name raises, naming the class.
+
+        It used to redispatch to the overload it was already in and recurse
+        until hypothesis ran out of buffer, surfacing as `Unsatisfiable` with
+        nothing pointing at the cause.
+        """
+        with pytest.raises(NotImplementedError, match=cls.__name__):
+            data.draw(strategy(cls))
+
+    @given(atlas=cxst.atlases())
+    def test_drawn_atlases_are_never_strategy_less(self, atlas: object) -> None:
+        """No draw yields a type the module has no strategy for."""
+        assert not isinstance(atlas, (cxm.NoAtlas, cxm.MinkowskiAtlas))
+
+    @given(M=cxst.manifolds())
+    def test_drawn_manifolds_are_never_strategy_less(self, M: object) -> None:
+        """Same for manifolds."""
+        assert not isinstance(M, (cxm.NoManifold, cxm.MinkowskiManifold))
+
+    @pytest.mark.parametrize(
+        ("ndim", "supported"),
+        [(1, True), (2, True), (3, True), (4, True), (5, False), (7, False)],
+    )
+    def test_custom_atlas_support_tracks_available_charts(
+        self, ndim: int, supported: bool
+    ) -> None:
+        """``CustomAtlas`` supports only dimensionalities with zero-arg charts.
+
+        The expectations are spelled out rather than recomputed from
+        `matching_chart_classes_for_ndim`, which is what the predicate itself
+        calls -- otherwise this would assert the implementation against itself.
+        """
+        assert _atlas_class_supports_ndim(cxm.CustomAtlas, ndim) is supported


### PR DESCRIPTION
Follow-up to the review comment on #657, which flagged that `_NDIM_SUPPORT` marks `CustomAtlas` as supporting any `ndim >= 1` while the strategy discards when no zero-arg charts exist at that dimensionality. I [measured that suggestion and declined it there](https://github.com/GalacticDynamics/coordinax/pull/657#issuecomment-5206267458) — the benefit was ~0.7% and it destabilised a test. Chasing *why* it destabilised anything turned up a much larger version of the same problem, which is what this fixes.

## Four types that can never be drawn

`NoAtlas`, `MinkowskiAtlas`, `NoManifold` and `MinkowskiManifold` are concrete, so `get_all_subclasses` returns them and class selection offers them at **every** `ndim`. None has a registered strategy:

```
atlases(NoAtlas)          -> Unsatisfiable
atlases(MinkowskiAtlas)   -> Unsatisfiable
manifolds(NoManifold)     -> Unsatisfiable
manifolds(MinkowskiManifold) -> Unsatisfiable
```

Selecting one lands in the generic `type[Abstract*]` overload, which redispatches on the concrete class — and plum resolves that straight back to the same overload. It recursed until hypothesis exhausted its draw buffer (`StopTest`) and surfaced as `Unsatisfiable`, with nothing in the traceback pointing at the cause.

That branch is unreachable-by-design: plum picks the most specific method, so the generic overload only ever receives a class that has no specific one. It could never have succeeded. It now raises `NotImplementedError` naming the class — which is what the abstract docstring already documented under `Raises`.

## The cost was time, not discards

This is why the earlier measurement looked so flat. Hypothesis prunes a branch that keeps failing, so discard *counts* barely move — but every attempt still burned a deep recursion first. 250 draws, `JAX_ENABLE_X64=1`:

| | before | after | |
|---|---|---|---|
| `atlases()` | 9.01 ms/ex | **3.37** | 2.7× |
| `atlases(ndim=5)` | 18.10 ms/ex | **3.38** | 5.4× |
| `atlases(ndim=6)` | 16.52 ms/ex | **3.93** | 4.2× |
| `atlases(ndim=7)` | 23.93 ms/ex | **3.35** | 7.1× |
| `manifolds(ndim=5)` | 22.67 ms/ex | **3.63** | 6.2× |
| `manifolds(ndim=6)` | 22.76 ms/ex | **3.01** | 7.6× |
| `manifolds(ndim=7)` | 25.57 ms/ex | **3.43** | 7.5× |
| `manifolds(Product, ndim=5)` | 17.17 ms/ex | **4.57** | 3.8× |
| `manifolds(Product, ndim=7)` | 20.86 ms/ex | **3.81** | 5.5× |

## The original comment, now safe to take

With the phantoms gone, `CustomAtlas` takes the honest predicate — `bool(matching_chart_classes_for_ndim(ndim))`, matching `CustomManifold` — and this time nothing destabilises, because the filtering that made the product path marginal *was* the phantoms. The `ndim=7` case I had to drop from `test_product_manifold_factor_dims_sum_to_ndim` in #657 is **restored and passing**.

## Design note

`_NO_STRATEGY` is deliberately separate from `_NDIM_SUPPORT`: these types are not restricted to *some* dimensionalities, they cannot be drawn at *any*. Folding them in as `lambda _: False` would have read like a dimensionality claim. A new concrete type with neither an entry nor a strategy now fails loudly on first use instead of silently recursing.

## Verification

Six of the new tests fail against `main` as of 35bfdb8f1 (the squashed #657); the two "never drawn" guards pass there too, since hypothesis's pruning already made those outcomes rare — they are regression guards, not proofs.

2752 passed, 5 skipped with the package and `tests/unit` in **one** session, fresh `.hypothesis`, fixed order. ruff and ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
