### PR TITLE
🐛 fix(hypothesis): `Radial1D` is not a radius

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/domains.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/domains.py
@@ -133,14 +133,6 @@ def component_domains(chart: cxc.AbstractChart, /) -> dict[str, Interval]:
 # Radial
 
 
-# `Radial1D` deliberately has no overload. Its docstring calls it "semantically
-# equivalent to Cart1D but uses `r` instead of `x`", and `pt_map` bears that
-# out: cart1d -> radial1d carries the sign through, so x = -5 m gives r = -5 m
-# and round-trips. Constraining it to r > 0 on the strength of the *name* would
-# silently halve the chart's domain -- the same trap as reading `theta` off a
-# name, in the other direction. It falls through to the unconstrained default.
-
-
 @plum.dispatch
 def component_domains(chart: cxc.Polar2D, /) -> dict[str, Interval]:
     """`Polar2D` names its *azimuth* ``theta``, unlike `Spherical3D`."""

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/domains.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/domains.py
@@ -133,9 +133,12 @@ def component_domains(chart: cxc.AbstractChart, /) -> dict[str, Interval]:
 # Radial
 
 
-@plum.dispatch
-def component_domains(chart: cxc.Radial1D, /) -> dict[str, Interval]:
-    return {"r": RADIAL}
+# `Radial1D` deliberately has no overload. Its docstring calls it "semantically
+# equivalent to Cart1D but uses `r` instead of `x`", and `pt_map` bears that
+# out: cart1d -> radial1d carries the sign through, so x = -5 m gives r = -5 m
+# and round-trips. Constraining it to r > 0 on the strength of the *name* would
+# silently halve the chart's domain -- the same trap as reading `theta` off a
+# name, in the other direction. It falls through to the unconstrained default.
 
 
 @plum.dispatch

--- a/packages/coordinaxs.hypothesis/tests/unit/charts/test_domains.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/charts/test_domains.py
@@ -118,6 +118,44 @@ class TestConventionsAreDistinguished:
         assert component_domains(cxc.polar2d)["theta"].min == pytest.approx(-math.pi)
 
 
+class TestRadial1DIsNotRadial:
+    """`Radial1D` names its coordinate `r` but is a relabelled `Cart1D`.
+
+    Its own docstring says "semantically equivalent to Cart1D but uses `r`
+    instead of `x`", and `pt_map` agrees: the sign carries through. Reading a
+    domain off the *name* would halve it -- the mirror image of the
+    `Spherical3D` / `MathSpherical3D` case, where the name is the same but the
+    meaning differs.
+    """
+
+    def test_domain_matches_cart1d(self) -> None:
+        assert (
+            component_domains(cxc.radial1d)["r"] == component_domains(cxc.cart1d)["x"]
+        )
+
+    def test_negative_r_round_trips(self) -> None:
+        """The behaviour that makes a positive-only domain wrong."""
+        there = cxc.pt_map({"x": u.Q(-5.0, "m")}, cxc.cart1d, cxc.radial1d)
+        back = cxc.pt_map(there, cxc.radial1d, cxc.cart1d)
+        assert float(u.ustrip("m", there["r"])) == pytest.approx(-5.0)
+        assert float(u.ustrip("m", back["x"])) == pytest.approx(-5.0)
+
+    def test_draws_reach_negative_values(self) -> None:
+        seen_negative = False
+
+        @given(point=cxst.cdicts(cxc.radial1d))
+        @settings(
+            max_examples=100, deadline=None, suppress_health_check=list(HealthCheck)
+        )
+        def collect(point: dict) -> None:
+            nonlocal seen_negative
+            if float(u.ustrip("m", point["r"])) < 0:
+                seen_negative = True
+
+        collect()
+        assert seen_negative
+
+
 class TestBoundsFollowTheUnit:
     """Bounds are stated in one unit and must hold in whatever unit is drawn."""
 


### PR DESCRIPTION
A bug I introduced in #651.

`component_domains(Radial1D)` returned `{"r": RADIAL}`, forcing `r > 0`. That reads the constraint off the component *name* — the exact mistake [the module docstring](https://github.com/GalacticDynamics/coordinax/blob/main/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/domains.py) warns about, just in the other direction.

`Radial1D`'s own docstring says it is *"semantically equivalent to `coordinax.charts.Cart1D` but uses `r` instead of `x`"*, and `pt_map` agrees:

```python
>>> cxc.pt_map({"x": u.Q(-5.0, "m")}, cxc.cart1d, cxc.radial1d)
{'r': Quantity(-5., unit='m')}
```

The sign carries through and round-trips. So the overload silently halved the chart's domain: no draw from `cdicts(radial1d)` ever exercised negative `r`.

Drop the overload — it falls through to the unconstrained default. `TestRadial1DIsNotRadial` pins all three legs of the argument: the domain matches `cart1d`'s, negative `r` round-trips, and draws actually reach negative values.

**Verification:** 183 passed in `packages/coordinaxs.hypothesis/tests/unit/charts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)