### PR TITLE
✅ test: make two duplicated blocks into contracts

### DIFF
--- a/tests/unit/charts/test_jacobian_pt_map.py
+++ b/tests/unit/charts/test_jacobian_pt_map.py
@@ -131,52 +131,37 @@ class TestJacobianPtMapReturnType:
 
 
 class TestJacobianPtMapUnits:
-    """J[j, i].unit = to_chart_dim_j / from_chart_dim_i."""
+    """``J.unit[i, j] == to_chart_unit_i / from_chart_unit_j``, every cell.
 
-    def test_cart3d_to_sph3d_row0_dimensionless(self) -> None:
-        """J[r, *] : m/m → dimensionless (r row, x/y/z columns)."""
-        at = {"x": u.Q(1, "m"), "y": u.Q(0, "m"), "z": u.Q(0, "m")}
-        J = cxc.jac_pt_map(at, cxc.cart3d, cxc.sph3d)
-        # r has units m, x/y/z have units m → m/m = dimensionless
-        for i in range(3):
-            assert J.unit[0, i] == u.unit("") or J.unit[0, i] == u.unit("m/m"), (
-                f"J[r, {i}] unit should be dimensionless, got {J.unit[0, i]}"
-            )
+    The four hand-written checks this replaces each pinned one row or one
+    column of one pair at one hardcoded point -- so ``cart2d <-> polar2d`` had
+    no unit coverage at all, and no reverse direction but one was checked.
 
-    def test_cart3d_to_sph3d_rows1_and_2_are_rad_per_m(self) -> None:
-        """J[θ, *] and J[φ, *] : rad/m (angle output, length input)."""
-        at = {"x": u.Q(1, "m"), "y": u.Q(0, "m"), "z": u.Q(0, "m")}
-        J = cxc.jac_pt_map(at, cxc.cart3d, cxc.sph3d)
-        rad_per_m = u.unit("rad/m")
-        for i in range(3):
-            assert J.unit[1, i] == rad_per_m, (
-                f"J[θ, {i}] unit: expected rad/m, got {J.unit[1, i]}"
-            )
-            assert J.unit[2, i] == rad_per_m, (
-                f"J[φ, {i}] unit: expected rad/m, got {J.unit[2, i]}"
-            )
+    The expected unit is read off `pt_map`'s output rather than written out by
+    hand, so the assertion stays honest without a table of units to maintain:
+    `pt_map` and `jac_pt_map` do their unit bookkeeping independently.
+    """
 
-    def test_cart3d_to_cyl3d_phi_row_is_rad_per_m(self) -> None:
-        """J[φ, *] for Cyl3D : rad/m."""
-        at = {"x": u.Q(1, "m"), "y": u.Q(0, "m"), "z": u.Q(0, "m")}
-        J = cxc.jac_pt_map(at, cxc.cart3d, cxc.cyl3d)
-        # cyl3d components: (rho=m, phi=rad, z=m); cart3d: (x=m, y=m, z=m)
-        # Row 1 (phi): rad output / m input → rad/m
-        for i in range(3):
-            assert J.unit[1, i] == u.unit("rad/m"), (
-                f"J[φ, {i}] should be rad/m, got {J.unit[1, i]}"
-            )
+    @pytest.mark.parametrize(("chart_a", "chart_b"), CHART_PAIRS)
+    @pytest.mark.parametrize("forward", [True, False], ids=["fwd", "rev"])
+    @given(data=st.data())
+    @settings(deadline=None, max_examples=10)
+    def test_every_cell_is_out_over_in(
+        self, chart_a, chart_b, forward, data: st.DataObject
+    ) -> None:
+        curv_pt = data.draw(cxst.cdicts(chart_b, magnitude=WELL_CONDITIONED))
+        from_chart, to_chart = (chart_a, chart_b) if forward else (chart_b, chart_a)
+        at = cxc.pt_map(curv_pt, chart_b, from_chart)
 
-    def test_sph3d_to_cart3d_theta_col_is_m_per_rad(self) -> None:
-        """J[*, θ] for Sph3D → Cart3D : m/rad (length output / angle input)."""
-        at = {"r": u.Q(1, "m"), "theta": u.Q(jnp.pi / 2, "rad"), "phi": u.Q(0, "rad")}
-        J = cxc.jac_pt_map(at, cxc.sph3d, cxc.cart3d)
-        # cart3d: (x=m, y=m, z=m); sph3d: (r=m, theta=rad, phi=rad)
-        # Column 1 (theta): m output / rad input → m/rad
-        for j in range(3):
-            assert J.unit[j, 1] == u.unit("m/rad"), (
-                f"J[{j}, θ] should be m/rad, got {J.unit[j, 1]}"
-            )
+        J = cxc.jac_pt_map(at, from_chart, to_chart)
+        out = cxc.pt_map(at, from_chart, to_chart)
+
+        for i, out_comp in enumerate(to_chart.components):
+            for j, in_comp in enumerate(from_chart.components):
+                expected = out[out_comp].unit / at[in_comp].unit
+                assert J.unit[i, j] == expected, (
+                    f"J[{out_comp}, {in_comp}]: expected {expected}, got {J.unit[i, j]}"
+                )
 
 
 # ===========================================================================

--- a/tests/unit/frames/test_bob_frame.py
+++ b/tests/unit/frames/test_bob_frame.py
@@ -190,55 +190,52 @@ class TestBobVelocityTransform:
         assert result == v
 
 
-class TestBobDisplacementInvariance:
-    """Displacements are invariant under the Alice ↔ Bob transform.
+class TestBobInvariance:
+    """Displacements and accelerations are unchanged by the Alice <-> Bob maps.
 
     Per spec (software-spec-bob):
-      Displacement: unchanged (both Translate and Boost are identity on displacements).
-    """
-
-    def test_alice_to_bob_displacement_invariant(self):
-        alice_to_bob = cxf.frame_transition(cxf.alice, cxf.bob)
-        d = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
-        result = cxfm.act(alice_to_bob, None, d, cxc.cart3d, cxr.coord_disp)
-        assert result == d
-
-    def test_bob_to_alice_displacement_invariant(self):
-        bob_to_alice = cxf.frame_transition(cxf.bob, cxf.alice)
-        d = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
-        result = cxfm.act(bob_to_alice, None, d, cxc.cart3d, cxr.coord_disp)
-        assert result == d
-
-    def test_translate_alone_displacement_invariant(self):
-        """The Translate component alone is identity on displacements."""
-        shift = cxfm.Translate.from_([100_000, 10_000, 0], "km")
-        d = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
-        result = cxfm.act(shift, None, d, cxc.cart3d, cxr.coord_disp)
-        assert result == d
-
-    def test_boost_alone_displacement_invariant(self):
-        """The Boost component alone is identity on displacements."""
-        boost = cxfm.Boost.from_([269_813_212.2, 0, 0], "m/s")
-        d = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
-        result = cxfm.act(boost, None, d, cxc.cart3d, cxr.coord_disp)
-        assert result == d
-
-
-class TestBobAccelerationInvariance:
-    """Accelerations are invariant under the Alice ↔ Bob transform.
-
-    Per spec (software-spec-bob):
+      Displacement: unchanged (both Translate and Boost are identity on
+      displacements).
       Acceleration: unchanged (Boost is identity on accelerations).
+
+    The two spec lines are one contract -- ``act`` is the identity on these
+    representations -- so they are one table. Written out per-transform, the
+    acceleration half had covered only the two composite transitions; the
+    cross product adds ``Translate`` and ``Boost`` alone, which is where the
+    spec's claim about `Boost` actually bites.
     """
 
-    def test_alice_to_bob_acceleration_invariant(self):
-        alice_to_bob = cxf.frame_transition(cxf.alice, cxf.bob)
-        a = {"x": u.Q(1.0, "m/s^2"), "y": u.Q(2.0, "m/s^2"), "z": u.Q(3.0, "m/s^2")}
-        result = cxfm.act(alice_to_bob, None, a, cxc.cart3d, cxr.coord_acc)
-        assert result == a
-
-    def test_bob_to_alice_acceleration_invariant(self):
-        bob_to_alice = cxf.frame_transition(cxf.bob, cxf.alice)
-        a = {"x": u.Q(1.0, "m/s^2"), "y": u.Q(2.0, "m/s^2"), "z": u.Q(3.0, "m/s^2")}
-        result = cxfm.act(bob_to_alice, None, a, cxc.cart3d, cxr.coord_acc)
-        assert result == a
+    @pytest.mark.parametrize(
+        "transform",
+        [
+            pytest.param(cxf.frame_transition(cxf.alice, cxf.bob), id="alice-to-bob"),
+            pytest.param(cxf.frame_transition(cxf.bob, cxf.alice), id="bob-to-alice"),
+            pytest.param(
+                cxfm.Translate.from_([100_000, 10_000, 0], "km"), id="translate-alone"
+            ),
+            pytest.param(
+                cxfm.Boost.from_([269_813_212.2, 0, 0], "m/s"), id="boost-alone"
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("rep", "value"),
+        [
+            pytest.param(
+                cxr.coord_disp,
+                {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")},
+                id="displacement",
+            ),
+            pytest.param(
+                cxr.coord_acc,
+                {
+                    "x": u.Q(1.0, "m/s^2"),
+                    "y": u.Q(2.0, "m/s^2"),
+                    "z": u.Q(3.0, "m/s^2"),
+                },
+                id="acceleration",
+            ),
+        ],
+    )
+    def test_act_is_the_identity(self, transform, rep, value) -> None:
+        assert cxfm.act(transform, None, value, cxc.cart3d, rep) == value


### PR DESCRIPTION
Follow-up to the audit item *"19 cdict literals repeated ≥3× within one file → fixtures"*. **Most of that item should not be done, and this PR does the two parts that should.**

## What I found instead

I re-measured after #649/#651/#661 landed and looked at how each repeated literal is actually used. They split cleanly in two:

**Load-bearing anchors — leave alone.** `{"x": 3, "y": 4, "z": 0} m` appears 5× in `test_norm.py`, and every use asserts `== 5 m`. It is a 3-4-5 triangle; the literal *is* the explanation of the expected value. `{0,0,0} km` appears 6× in `test_act_usage.py` as the input to `act(shift, origin) == shift`. Hiding either behind a fixture name costs the reader locality and buys nothing — a fixture is not a free abstraction. Same for `test_change_basis.py`, `test_metrics.py`, `test_prolongation.py`, `test_tangent.py`.

**Duplication symptoms — fix the cause.** Where the same literal appeared in several near-identical *test bodies*, the repeat was a side effect of several tests asserting one contract. Those are the two blocks in this PR. The literal stops repeating as a consequence, not as the goal.

## The two changes

**`TestJacobianPtMapUnits`** — four tests, each pinning one row or one column of one pair at one hardcoded point:

| covered | not covered |
|---|---|
| `cart3d→sph3d` rows 0, 1, 2 | `cart2d↔polar2d` — *no unit coverage at all* |
| `cart3d→cyl3d` row 1 | `cart3d→cyl3d` rows 0, 2 |
| `sph3d→cart3d` column 1 | `polar2d→cart2d`, `cyl3d→cart3d` |

Replaced by one property over `CHART_PAIRS` in both directions asserting **every** cell: `J.unit[i,j] == out[to.components[i]].unit / at[from.components[j]].unit`.

The expected unit is read off `pt_map`'s output rather than written out by hand, so there is no unit table to maintain. Not tautological — `pt_map` and `jac_pt_map` do their unit bookkeeping independently. Note the old row-0 test asserted `== u.unit("") or == u.unit("m/m")`; the property pins the exact value.

Mutation-tested: inverting the ratio in `_repack_q_from_jac` (`uj / ui` → `ui / uj`) fails all 6 cases.

**`TestBobDisplacementInvariance` + `TestBobAccelerationInvariance`** — six tests of one statement, *"`act` is the identity on this representation"*. Merged into one table over transform × representation. The acceleration half had only covered the two composite transitions, so the cross product adds `Translate` and `Boost` alone — and the spec line it tests is specifically *"Boost is identity on accelerations"*, which was the untested case. Verified all 8 combinations hold before writing the table.

## Verification

- 2161 passed, 5 skipped across `tests/`.
- Collected tests over the two touched files: **75 → 79** (+2 bob cases, +2 jacobian directions). Checked the inventory, not just the count — that caught a stray duplicate my first edit left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)