### PR TITLE
🐛 fix(hypothesis): `magnitude` must not clamp bounded coordinates

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
@@ -113,26 +113,17 @@ def _component_quantities(
         if canon is not None:
             floor = float(u.ustrip(unit, u.Q(floor, canon)))
             cap = float(u.ustrip(unit, u.Q(cap, canon)))
-        # The cap says how large an *unbounded* coordinate may get; its whole
-        # rationale is float32 resolution at huge values. A coordinate its own
-        # domain already bounds has no use for it -- a colatitude stops at pi
-        # either way -- and clamping one couples an angle to what the caller
-        # meant as a length scale. Worse, a cap below such a domain's lower
-        # bound empties it: `magnitude=(1e-3, 1e-2)` used to leave POLAR
-        # needing `0.05 <= theta <= 0.01` and `cdicts` raised `InvalidArgument`
-        # for every chart carrying a colatitude.
+        # Only where the domain is open: a bounded coordinate has no use for a
+        # magnitude, and a cap under its lower bound empties it outright --
+        # `magnitude=(1e-3, 1e-2)` left POLAR needing `0.05 <= theta <= 0.01`.
         if lo is None:
             lo = -cap
         if hi is None:
             hi = cap
 
-        # The floor is for coordinates that run from the origin to infinity --
-        # radii. `min == 0 and max is None` is exactly that half-line, and
-        # `lo` is then just RADIAL's stand-off margin. An explicit floor is the
-        # caller stating the scale of the problem, so it *replaces* that
-        # default rather than being clamped by it: the margin is an absolute
-        # 1e-3 m, so `max(lo, floor)` would silently make every radius below a
-        # millimetre undrawable no matter what magnitude was asked for.
+        # `min == 0 and max is None` is a radial half-line, where `lo` is only
+        # RADIAL's absolute 1e-3 m margin. An explicit floor states the scale
+        # of the problem, so it replaces that default; clamping barred sub-mm.
         if floor > 0 and interval.min == 0.0 and interval.max is None:
             lo = floor
 

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
@@ -113,19 +113,28 @@ def _component_quantities(
         if canon is not None:
             floor = float(u.ustrip(unit, u.Q(floor, canon)))
             cap = float(u.ustrip(unit, u.Q(cap, canon)))
-        lo = -cap if lo is None else max(lo, -cap)
-        hi = cap if hi is None else min(hi, cap)
+        # The cap says how large an *unbounded* coordinate may get; its whole
+        # rationale is float32 resolution at huge values. A coordinate its own
+        # domain already bounds has no use for it -- a colatitude stops at pi
+        # either way -- and clamping one couples an angle to what the caller
+        # meant as a length scale. Worse, a cap below such a domain's lower
+        # bound empties it: `magnitude=(1e-3, 1e-2)` used to leave POLAR
+        # needing `0.05 <= theta <= 0.01` and `cdicts` raised `InvalidArgument`
+        # for every chart carrying a colatitude.
+        if lo is None:
+            lo = -cap
+        if hi is None:
+            hi = cap
 
         # The floor is for coordinates that run from the origin to infinity --
-        # radii. `min == 0 and max is None` is exactly that half-line.
-        #
-        # Testing `margin > 0` instead would also catch POLAR, whose colatitude
-        # starts at zero but stops at pi: `magnitude=(0.5, 8)` would then shove
-        # theta 0.5 *radians* off the pole, coupling an angle to what the
-        # caller meant as a length scale. A bounded coordinate has no use for a
-        # magnitude floor.
+        # radii. `min == 0 and max is None` is exactly that half-line, and
+        # `lo` is then just RADIAL's stand-off margin. An explicit floor is the
+        # caller stating the scale of the problem, so it *replaces* that
+        # default rather than being clamped by it: the margin is an absolute
+        # 1e-3 m, so `max(lo, floor)` would silently make every radius below a
+        # millimetre undrawable no matter what magnitude was asked for.
         if floor > 0 and interval.min == 0.0 and interval.max is None:
-            lo = floor if lo is None else max(lo, floor)
+            lo = floor
 
     width = 32 if dtype is jnp.float32 else 64
     lo = _snap_inward(lo, width, up=True)

--- a/packages/coordinaxs.hypothesis/tests/unit/charts/test_cdicts.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/charts/test_cdicts.py
@@ -1,7 +1,10 @@
 """Tests for coordinaxs-hypothesis strategies."""
 
+import math
+
+import pytest
 import unxt as u
-from hypothesis import given, strategies as st
+from hypothesis import given, settings, strategies as st
 
 import coordinax.charts as cxc
 
@@ -127,3 +130,60 @@ def test_cdicts_with_no_argument_draws_a_chart(
     assert isinstance(p, dict)
     assert p
     assert all(isinstance(v, u.AbstractQuantity) for v in p.values())
+
+
+class TestMagnitudeLeavesBoundedComponentsAlone:
+    """`magnitude` scales the *unbounded* coordinates and nothing else.
+
+    Its whole rationale is float32 resolution at large values, so a coordinate
+    its own domain already bounds -- a colatitude stops at pi either way -- has
+    no use for it. Clamping one couples an angle to what the caller meant as a
+    length scale.
+    """
+
+    #: Small enough that clamping an angle by it empties the angle's domain.
+    #: `POLAR` needs ``theta >= 0.05 rad``, so a cap of 0.01 leaves nothing.
+    TINY = (1e-3, 1e-2)
+
+    @pytest.mark.parametrize(
+        "chart",
+        [
+            pytest.param(cxc.sph3d, id="sph3d"),
+            pytest.param(cxc.math_sph3d, id="math_sph3d"),
+            pytest.param(cxc.lonlat_sph3d, id="lonlat_sph3d"),
+            pytest.param(cxc.cyl3d, id="cyl3d"),
+            pytest.param(cxc.polar2d, id="polar2d"),
+        ],
+    )
+    def test_a_tiny_magnitude_is_drawable(self, chart) -> None:
+        """Regression: a cap under 0.05 used to empty every angular domain.
+
+        `cdicts` raised `InvalidArgument` outright -- not a filtered draw, an
+        unsatisfiable one -- for any chart carrying a bounded angle.
+        """
+
+        @given(p=cxst.cdicts(chart, magnitude=self.TINY))
+        @settings(max_examples=5, deadline=None)
+        def check(p) -> None:
+            assert set(p) == set(chart.components)
+
+        check()
+
+    @given(p=cxst.cdicts(cxc.sph3d, magnitude=(1e-12, 1e-11)))
+    @settings(max_examples=20, deadline=None)
+    def test_radius_reaches_the_requested_scale(self, p) -> None:
+        """An explicit floor replaces RADIAL's stand-off margin.
+
+        The margin is an absolute ``1e-3 m``. Clamping the floor by it made
+        every radius below a millimetre undrawable however small a magnitude
+        was asked for.
+        """
+        r = float(u.ustrip("m", p["r"]))
+        assert 1e-12 <= r <= 1e-11
+
+    @given(p=cxst.cdicts(cxc.sph3d, magnitude=(1e-12, 1e-11)))
+    @settings(max_examples=20, deadline=None)
+    def test_angles_keep_their_own_domain(self, p) -> None:
+        """Theta stays a colatitude even when the length scale is 1e-12 m."""
+        theta = float(u.ustrip("rad", p["theta"]))
+        assert 0.0 < theta < math.pi

--- a/packages/coordinaxs.hypothesis/tests/unit/charts/test_cdicts.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/charts/test_cdicts.py
@@ -133,16 +133,9 @@ def test_cdicts_with_no_argument_draws_a_chart(
 
 
 class TestMagnitudeLeavesBoundedComponentsAlone:
-    """`magnitude` scales the *unbounded* coordinates and nothing else.
+    """`magnitude` scales the *unbounded* coordinates and nothing else."""
 
-    Its whole rationale is float32 resolution at large values, so a coordinate
-    its own domain already bounds -- a colatitude stops at pi either way -- has
-    no use for it. Clamping one couples an angle to what the caller meant as a
-    length scale.
-    """
-
-    #: Small enough that clamping an angle by it empties the angle's domain.
-    #: `POLAR` needs ``theta >= 0.05 rad``, so a cap of 0.01 leaves nothing.
+    #: Under `POLAR`'s 0.05 rad lower bound, so a cap of 0.01 leaves nothing.
     TINY = (1e-3, 1e-2)
 
     @pytest.mark.parametrize(
@@ -156,11 +149,7 @@ class TestMagnitudeLeavesBoundedComponentsAlone:
         ],
     )
     def test_a_tiny_magnitude_is_drawable(self, chart) -> None:
-        """Regression: a cap under 0.05 used to empty every angular domain.
-
-        `cdicts` raised `InvalidArgument` outright -- not a filtered draw, an
-        unsatisfiable one -- for any chart carrying a bounded angle.
-        """
+        """Regression: this used to raise `InvalidArgument`, not just filter."""
 
         @given(p=cxst.cdicts(chart, magnitude=self.TINY))
         @settings(max_examples=5, deadline=None)
@@ -172,12 +161,7 @@ class TestMagnitudeLeavesBoundedComponentsAlone:
     @given(p=cxst.cdicts(cxc.sph3d, magnitude=(1e-12, 1e-11)))
     @settings(max_examples=20, deadline=None)
     def test_radius_reaches_the_requested_scale(self, p) -> None:
-        """An explicit floor replaces RADIAL's stand-off margin.
-
-        The margin is an absolute ``1e-3 m``. Clamping the floor by it made
-        every radius below a millimetre undrawable however small a magnitude
-        was asked for.
-        """
+        """An explicit floor replaces RADIAL's absolute 1e-3 m margin."""
         r = float(u.ustrip("m", p["r"]))
         assert 1e-12 <= r <= 1e-11
 


### PR DESCRIPTION
Found while adding extreme-scale `jac_pt_map` coverage — `cdicts` cannot produce the draws that test needs.

## The bug

#651 gave `cdicts` a magnitude window and correctly excluded bounded coordinates from its **floor**, for the reason [its comment spells out](https://github.com/GalacticDynamics/coordinax/blob/main/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py): a colatitude stops at π either way, so shoving it 0.5 rad off the pole because the caller asked for a *length* scale of 0.5 m couples an angle to a length.

The same argument applies to the **cap**, and I left that half in during review. It bites harder, because a cap can empty a bounded domain outright rather than merely distort it:

```python
>>> cxst.cdicts(cxc.sph3d, magnitude=(1e-3, 1e-2)).example()
InvalidArgument: There are no 32-bit floating-point values between
min_value=0.05000000074505806 and max_value=0.009999999776482582
```

POLAR needs `theta >= 0.05 rad`; the cap set `hi = 0.01`. Every chart carrying a colatitude — `sph3d`, `math_sph3d`, `lonlat_sph3d` — was unsatisfiable for any magnitude under 0.05. Not a filtered draw; an outright raise.

The radial floor had a quieter version of the same fault. `RADIAL` is bounded below only by its stand-off margin, an absolute `1e-3 m`, and the floor was clamped by it (`max(lo, floor)`). So **every radius below a millimetre was undrawable regardless of the magnitude requested**, with no error saying so — `magnitude=(1e-12, 1e-11)` silently could not be honoured.

## The fix

Clamp a coordinate by the magnitude only on the sides its own domain leaves open, and let an explicit floor *replace* `RADIAL`'s default stand-off rather than be clamped by it.

```python
>>> [float(u.ustrip("m", cxst.cdicts(cxc.sph3d, magnitude=(1e-12, 1e-11)).example()["r"]))]
[3.2e-12]   # and theta stays in (0, pi)
```

Verified across 1e-30 … 1e+19: `r` lands in the requested window, `theta` keeps its own domain.

## No behaviour change for existing callers

`magnitude=1e3` (the default) and `magnitude=(0.5, 8)` are unaffected — for those the old and new forms agree on every domain in the table, since `min(hi, cap)` and `max(lo, -cap)` were already no-ops there. Confirmed by the suites below.

## Verification

- `packages/coordinaxs.hypothesis` + `tests/unit/charts`: 1219 passed, 4 skipped. (The one failure in that run is `test_product_manifold_factor_dims_sum_to_ndim[5]`, a pre-existing seed-dependent `filter_too_much` flake on `main`, unrelated to this change and being fixed separately.)
- Mutation-tested both halves: restoring the old cap clamp fails 4 of the new tests; restoring the old floor clamp fails 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)