### PR TITLE
✨ feat(hypothesis): draw NoAtlas, MinkowskiAtlas, NoManifold, MinkowskiManifold

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
@@ -128,6 +128,9 @@ def atlases(
     - **``CartesianProductAtlas``**: returns a ``CartesianProductAtlas``
       built from two factor atlases whose dimensionalities sum to ``ndim``
       (at least 2). ``CartesianProductAtlas`` is excluded from the factors.
+    - **``NoAtlas``**: returns ``NoAtlas()`` (always 0-D). By name only.
+    - **``MinkowskiAtlas``**: returns ``MinkowskiAtlas()`` (always 4-D). By
+      name only.
 
     Parameters
     ----------
@@ -142,7 +145,8 @@ def atlases(
           subtree.
         - A **concrete** subclass of ``AbstractAtlas``: draw an instance of
           exactly that class (``EuclideanAtlas``, ``HyperSphericalAtlas``,
-          ``CustomAtlas``, ``CartesianProductAtlas``).
+          ``CustomAtlas``, ``CartesianProductAtlas``, ``NoAtlas``,
+          ``MinkowskiAtlas``).
 
     filter
         Restrict the pool of atlas classes to those that are subclasses of
@@ -228,6 +232,8 @@ def atlases(
     >>> custom = cxmst.atlases(cxm.CustomAtlas)
     >>> product = cxmst.atlases(cxm.CartesianProductAtlas)
     >>> product_4d = cxmst.atlases(cxm.CartesianProductAtlas, ndim=4)
+    >>> none = cxmst.atlases(cxm.NoAtlas)
+    >>> minkowski = cxmst.atlases(cxm.MinkowskiAtlas)
 
     Require specific chart classes in a ``CustomAtlas``:
 
@@ -270,17 +276,14 @@ _NDIM_SUPPORT: Final[
     (cxm.HyperSphericalAtlas, lambda ndim: ndim == 2),
     # A product needs at least one factor, each contributing >= 1 dimension.
     (cxm.CartesianProductAtlas, lambda ndim: ndim >= 1),
-    # A CustomAtlas is assembled from zero-argument charts of the target
-    # dimensionality, so it exists at exactly the dimensionalities those charts
-    # do -- there are none at ndim 5 or 7. Mirrors the `CustomManifold` entry.
+    # A CustomAtlas exists only at dims where zero-arg charts do.
     (cxm.CustomAtlas, lambda ndim: bool(matching_chart_classes_for_ndim(ndim))),
     # EuclideanAtlas is currently generated only for dimensions 0-3.
     (cxm.EuclideanAtlas, lambda ndim: 0 <= ndim <= 3),
 )
 
-#: Concrete atlas types with no registered strategy; never offered as
-#: candidates. Separate from `_NDIM_SUPPORT`: these work at no ndim at all.
-_NO_STRATEGY: Final[tuple[type[cxm.AbstractAtlas], ...]] = (
+#: Drawable by name only -- degenerate (no charts) or physics-pinned (ndim=4).
+_EXCLUDED_FROM_GENERIC_POOL: Final[tuple[type[cxm.AbstractAtlas], ...]] = (
     cxm.NoAtlas,
     cxm.MinkowskiAtlas,
 )
@@ -346,7 +349,7 @@ def atlases(
     classes = tuple(
         cls
         for cls in all_classes
-        if not issubclass(cls, _NO_STRATEGY)
+        if not issubclass(cls, _EXCLUDED_FROM_GENERIC_POOL)
         and (target_ndim is None or _atlas_class_supports_ndim(cls, target_ndim))
         and (not required_chart_classes or issubclass(cls, cxm.CustomAtlas))
     )
@@ -663,3 +666,55 @@ def atlases(
     )
     factor_names = tuple(f"f{i}" for i in range(n_factors))
     return cxm.CartesianProductAtlas(factors=factors, factor_names=factor_names)
+
+
+@plum.dispatch
+@strip_return_annotation
+@st.composite
+def atlases(
+    draw: st.DrawFn,
+    atlas_cls: type[cxm.NoAtlas],
+    /,
+    *,
+    filter: type | tuple[type, ...] | st.SearchStrategy = (),
+    exclude: tuple[type, ...] = (),
+    ndim: int | st.SearchStrategy | None = None,
+) -> Any:
+    """Draw ``NoAtlas()`` (always 0-D); any other ``ndim`` is assumed away.
+
+    >>> import coordinax.manifolds as cxm
+    >>> import coordinaxs.hypothesis.manifolds as cxmst
+
+    >>> none = cxmst.atlases(cxm.NoAtlas)
+
+    """
+    target_ndim = draw_if_strategy(draw, ndim)
+    if target_ndim is not None and target_ndim != 0:
+        assume(False)
+    return cxm.NoAtlas()
+
+
+@plum.dispatch
+@strip_return_annotation
+@st.composite
+def atlases(
+    draw: st.DrawFn,
+    atlas_cls: type[cxm.MinkowskiAtlas],
+    /,
+    *,
+    filter: type | tuple[type, ...] | st.SearchStrategy = (),
+    exclude: tuple[type, ...] = (),
+    ndim: int | st.SearchStrategy | None = None,
+) -> Any:
+    """Draw ``MinkowskiAtlas()`` (always 4-D); any other ``ndim`` is assumed away.
+
+    >>> import coordinax.manifolds as cxm
+    >>> import coordinaxs.hypothesis.manifolds as cxmst
+
+    >>> minkowski = cxmst.atlases(cxm.MinkowskiAtlas)
+
+    """
+    target_ndim = draw_if_strategy(draw, ndim)
+    if target_ndim is not None and target_ndim != 4:
+        assume(False)
+    return cxm.MinkowskiAtlas()

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
@@ -2,6 +2,8 @@
 
 __all__ = ("manifold_classes", "manifolds")
 
+import inspect
+
 from collections.abc import Callable
 from typing import Any, Final, cast
 
@@ -71,9 +73,8 @@ _NDIM_SUPPORT: Final[
     (cxm.EuclideanManifold, lambda _: True),
 )
 
-#: Concrete manifold types with no registered strategy; never offered as
-#: candidates. Separate from `_NDIM_SUPPORT`: these work at no ndim at all.
-_NO_STRATEGY: Final[tuple[type[cxm.AbstractManifold], ...]] = (
+#: Drawable by name only -- degenerate (no charts) or physics-pinned (ndim=4).
+_EXCLUDED_FROM_GENERIC_POOL: Final[tuple[type[cxm.AbstractManifold], ...]] = (
     cxm.NoManifold,
     cxm.MinkowskiManifold,
 )
@@ -170,7 +171,7 @@ def manifolds(
             exclude_abstract=True,
             exclude=exclude,
         )
-        if not issubclass(cls, _NO_STRATEGY)
+        if not issubclass(cls, _EXCLUDED_FROM_GENERIC_POOL)
         and (target_ndim is None or _manifold_class_supports_ndim(cls, target_ndim))
     )
     if not classes:
@@ -243,8 +244,9 @@ def manifolds(
             "When manifold_cls is provided, filter and exclude must be empty."
         )
 
-    if issubclass(manifold_cls, _NO_STRATEGY):
-        # Filtering on the class would select it right back and land here again.
+    if not inspect.isabstract(manifold_cls):
+        # Reachable only when no more specific overload matched, so
+        # redispatching here would re-select this method and recurse.
         msg = f"No manifold strategy is registered for {manifold_cls.__name__}."
         raise NotImplementedError(msg)
 
@@ -471,3 +473,57 @@ def manifolds(
     )
     factor_names = tuple(f"f{i}" for i in range(n_factors))
     return cxm.CartesianProductManifold(factors=factors, factor_names=factor_names)
+
+
+@plum.dispatch
+@strip_return_annotation
+@st.composite
+def manifolds(
+    draw: st.DrawFn,
+    M_cls: type[cxm.NoManifold],
+    /,
+    *,
+    filter: type | tuple[type, ...] | st.SearchStrategy = (),
+    exclude: tuple[type, ...] = (),
+    ndim: int | st.SearchStrategy | None = None,
+) -> Any:
+    """Draw ``NoManifold()`` (always 0-D); any other ``ndim`` is assumed away.
+
+    >>> import coordinax.manifolds as cxm
+    >>> import coordinaxs.hypothesis.manifolds as cxmst
+
+    >>> none = cxmst.manifolds(cxm.NoManifold)
+
+    """
+    del M_cls
+    target_ndim = draw_if_strategy(draw, ndim)
+    if target_ndim is not None and target_ndim != 0:
+        assume(False)
+    return cxm.NoManifold()
+
+
+@plum.dispatch
+@strip_return_annotation
+@st.composite
+def manifolds(
+    draw: st.DrawFn,
+    M_cls: type[cxm.MinkowskiManifold],
+    /,
+    *,
+    filter: type | tuple[type, ...] | st.SearchStrategy = (),
+    exclude: tuple[type, ...] = (),
+    ndim: int | st.SearchStrategy | None = None,
+) -> Any:
+    """Draw ``MinkowskiManifold()`` (always 4-D); other ``ndim`` is assumed away.
+
+    >>> import coordinax.manifolds as cxm
+    >>> import coordinaxs.hypothesis.manifolds as cxmst
+
+    >>> minkowski = cxmst.manifolds(cxm.MinkowskiManifold)
+
+    """
+    del M_cls
+    target_ndim = draw_if_strategy(draw, ndim)
+    if target_ndim is not None and target_ndim != 4:
+        assume(False)
+    return cxm.MinkowskiManifold()

--- a/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
@@ -185,36 +185,68 @@ class TestNdimIsHonoured:
         check()
 
 
-class TestOnlyDrawableCandidatesAreSelected:
-    """Classes with no registered strategy are never offered as candidates."""
+class TestExcludedFromGenericPoolAreStillExplicitlyDrawable:
+    """`NoAtlas`, `MinkowskiAtlas`, `NoManifold`, `MinkowskiManifold`.
+
+    These are excluded from the generic no-argument pool (they are
+    degenerate/fixed rather than "just another atlas/manifold"), but each has
+    its own strategy and is drawable by requesting it explicitly.
+    """
 
     @pytest.mark.parametrize(
-        ("cls", "strategy"),
+        ("cls", "strategy", "expected_ndim"),
         [
-            (cxm.NoAtlas, cxst.atlases),
-            (cxm.MinkowskiAtlas, cxst.atlases),
-            (cxm.NoManifold, cxst.manifolds),
-            (cxm.MinkowskiManifold, cxst.manifolds),
+            (cxm.NoAtlas, cxst.atlases, 0),
+            (cxm.MinkowskiAtlas, cxst.atlases, 4),
+            (cxm.NoManifold, cxst.manifolds, 0),
+            (cxm.MinkowskiManifold, cxst.manifolds, 4),
         ],
     )
     @given(data=st.data())
-    def test_requesting_one_directly_says_so(
+    def test_requesting_one_directly_succeeds(
         self,
         cls: type,
         strategy: Callable[..., st.SearchStrategy[object]],
+        expected_ndim: int,
         data: st.DataObject,
     ) -> None:
-        """Asking for one by name raises, naming the class."""
-        with pytest.raises(NotImplementedError, match=cls.__name__):
-            data.draw(strategy(cls))
+        """Asking for one by name draws an instance of exactly that class."""
+        obj = data.draw(strategy(cls))
+        assert isinstance(obj, cls)
+        assert obj.ndim == expected_ndim
+
+    @pytest.mark.parametrize(
+        ("cls", "strategy", "bad_ndim"),
+        [
+            (cxm.NoAtlas, cxst.atlases, 1),
+            (cxm.MinkowskiAtlas, cxst.atlases, 3),
+            (cxm.NoManifold, cxst.manifolds, 1),
+            (cxm.MinkowskiManifold, cxst.manifolds, 3),
+        ],
+    )
+    def test_requesting_one_with_wrong_ndim_is_unsatisfiable(
+        self,
+        cls: type,
+        strategy: Callable[..., st.SearchStrategy[object]],
+        bad_ndim: int,
+    ) -> None:
+        """A ``ndim`` other than the type's fixed dimensionality is discarded."""
+
+        @given(obj=strategy(cls, ndim=bad_ndim))
+        @settings(max_examples=10, deadline=None)
+        def check(obj: object) -> None:
+            pytest.fail(f"ndim={bad_ndim} should be unsatisfiable, got {obj!r}")
+
+        with pytest.raises(Unsatisfiable):
+            check()
 
     @given(atlas=cxst.atlases())
-    def test_drawn_atlases_all_have_strategies(self, atlas: object) -> None:
-        """No draw yields a type the module has no strategy for."""
+    def test_drawn_atlases_never_include_excluded_types(self, atlas: object) -> None:
+        """The generic no-argument pool never yields these sentinel/fixed types."""
         assert not isinstance(atlas, (cxm.NoAtlas, cxm.MinkowskiAtlas))
 
     @given(M=cxst.manifolds())
-    def test_drawn_manifolds_all_have_strategies(self, M: object) -> None:
+    def test_drawn_manifolds_never_include_excluded_types(self, M: object) -> None:
         """Same for manifolds."""
         assert not isinstance(M, (cxm.NoManifold, cxm.MinkowskiManifold))
 
@@ -244,8 +276,7 @@ class TestOnlyDrawableCandidatesAreSelected:
     ) -> None:
         """A type with no `_NDIM_SUPPORT` entry is treated as unrestricted.
 
-        Which is why `_NO_STRATEGY` has to be a separate gate: this predicate
-        answers "at which ndim", not "can it be drawn at all", and would wave
-        these two through at every ndim.
+        Which is why `_EXCLUDED_FROM_GENERIC_POOL` is a separate gate: this
+        predicate answers "at which ndim", not "belongs in the generic pool".
         """
         assert supports_ndim(cls, 3) is True


### PR DESCRIPTION
Stacked on #663 — this diff includes #663's commit until that one merges, at which point it will shrink to just the commit below.

## The gap #663 left open

#663 stopped `NoAtlas`, `MinkowskiAtlas`, `NoManifold`, and `MinkowskiManifold` from being offered by the generic no-argument pool (selecting one there recursed until hypothesis exhausted its draw buffer). But it also made them undrawable *even when requested by name* — `atlases(cxm.NoAtlas)` raised `NotImplementedError`, which is what this PR fixes.

## What's added

Each of the four now has its own strategy, dispatched exactly like `EuclideanAtlas` or `HyperSphericalAtlas`:

```python
>>> cxst.atlases(cxm.NoAtlas)        # NoAtlas(), ndim=0
>>> cxst.atlases(cxm.MinkowskiAtlas) # MinkowskiAtlas(), ndim=4
>>> cxst.manifolds(cxm.NoManifold)        # NoManifold(), ndim=0
>>> cxst.manifolds(cxm.MinkowskiManifold) # MinkowskiManifold(), ndim=4
```

`ndim=` other than each type's fixed dimensionality is discarded via `hypothesis.assume`, matching how `HyperSphericalAtlas` already handles its fixed `ndim=2`.

## Why they still don't join the generic pool

`NoAtlas`/`NoManifold` are degenerate sentinels — `default_chart()` raises and `has_chart()` is always `False`. `MinkowskiAtlas`/`MinkowskiManifold` are pinned to a specific physical spacetime (ndim=4), not a generic testable shape. If plain `atlases()`/`manifolds()` started handing these back intermittently, every property test that assumes `default_chart()` succeeds on "any" drawn atlas/manifold (there are several, e.g. `test_atlases_generates_valid_atlas_instances`) would break — the exact kind of instability #663 was fighting, just relocated. So `_NO_STRATEGY` — renamed here to `_EXCLUDED_FROM_GENERIC_POOL` since "no strategy" is no longer accurate — keeps doing what it did before: excluding these four from the untargeted pool, while the new per-class dispatches make them reachable on request.

## Verification

`coordinaxs.hypothesis` unit tests (424), plus `tests/unit/manifolds` and `tests/unit/charts` at the repo root (894), all pass. Doctests for both modified modules pass. ruff and ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)