### PR TITLE
♻️ refactor(transforms)!: move the group markers to `coordinax.transforms.groups`

### DIFF
--- a/docs/api/frames.md
+++ b/docs/api/frames.md
@@ -62,7 +62,7 @@ Transform operations and transform classes are in [`coordinax.transforms`](trans
 
 ### Transformation Group Classes (Markers)
 
-Transformation-group marker classes are in [`coordinax.transforms`](transforms.md).
+Transformation-group marker classes are in [`coordinax.transforms.groups`](transforms.md#transformation-group-classes-markers), reached as `cxfm.groups.<Name>`.
 
 ## Design & Integration
 

--- a/docs/api/transforms.md
+++ b/docs/api/transforms.md
@@ -50,18 +50,18 @@ out = cxfm.act(frame_op, None, v)
 
 ## Transformation Group Classes (Markers)
 
-Used for classification and dispatch; not instantiated directly:
+These live in the `coordinax.transforms.groups` sub-namespace, reached as `cxfm.groups.<Name>`. They are used for classification and dispatch, and are never instantiated:
 
-- `AbstractTransformGroup`
-- `IdentityGroup`
-- `DiffeomorphismGroup`
-- `AffineGroup`
-- `EuclideanGroup`
-- `OrthogonalGroup`
-- `SpecialOrthogonalGroup`
-- `LorentzGroup`
-- `ProperOrthochronousLorentzGroup`
-- `PoincareGroup`
+- `groups.AbstractTransformGroup`
+- `groups.IdentityGroup`
+- `groups.DiffeomorphismGroup`
+- `groups.AffineGroup`
+- `groups.EuclideanGroup`
+- `groups.OrthogonalGroup`
+- `groups.SpecialOrthogonalGroup`
+- `groups.LorentzGroup`
+- `groups.ProperOrthochronousLorentzGroup`
+- `groups.PoincareGroup`
 
 ```{eval-rst}
 
@@ -69,5 +69,9 @@ Used for classification and dispatch; not instantiated directly:
 
 .. automodule:: coordinax.transforms
     :exclude-members: aval, default, materialise, enable_materialise
+
+.. currentmodule:: coordinax.transforms.groups
+
+.. automodule:: coordinax.transforms.groups
 
 ```

--- a/docs/guides/frames.md
+++ b/docs/guides/frames.md
@@ -43,7 +43,7 @@ In `coordinax`, this is an **active** transformation: applying the operator move
 
 ## Transformation Groups: Mathematical Classification
 
-Transformations are classified by the **geometric structures they preserve**. This classification lives in **transformation groups**.
+Transformations are classified by the **geometric structures they preserve**. This classification lives in **transformation groups**: marker classes in the `coordinax.transforms.groups` sub-namespace, reached as `cxfm.groups.<Name>` and returned by each transform's `groups()` classmethod.
 
 ### Group Hierarchy (ASCII Tree)
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -988,7 +988,8 @@ A non-exhaustive table of exported objects are:
 | `coordinax.representations` | `cconvert`, `change_basis`, `tangent_map`, </br> `Representation`, `point`, `coord_disp`, `coord_vel`, `coord_acc`, `phys_disp`, `phys_vel`, `phys_acc`, </br> `PointGeometry`, `point_geom`, `TangentGeometry`, `tangent_geom`, </br> `NoBasis`, `no_basis`, `CoordinateBasis`, `coord_basis`, `PhysicalBasis`, `phys_basis`, </br> `Location`, `loc`, `Displacement`, `dpl`, `Velocity`, `vel`, `Acceleration`, `acc`, </br> `guess_geometry_kind`, `guess_semantic_kind`, `guess_rep` |
 | `coordinax.vectors` | `Point`, `Tangent`, `Coordinate`, `ToUnitsOptions` |
 | `coordinax.manifolds` | `guess_manifold`, `scale_factors`, `angle_between`, </br> `EuclideanManifold`, `Rn`, `FlatMetric`, `R3`, </br> `EmbeddedManifold`, `EmbeddedChart` </br> `S2`, `embedded_twosphere`, </br> `CustomManifold`,`CustomAtlas`, </br> `CartesianProductManifold`, `galilean_spacetime` |
-| `coordinax.transforms` | `act`, `pushforward`, `act_jet`, `simplify`, `compose`, `materialize_transform`, `is_time_dependent`, `tau_derivative`, </br> `AbstractTransform`, `Identity`, `Composed`, `Translate`, `Rotate`, `Reflect`, `Scale`, `Shear`, `Boost`, `identity`, </br> `AbstractTransformGroup`, `IdentityGroup`, `DiffeomorphismGroup`, `AffineGroup`, `EuclideanGroup`, `OrthogonalGroup`, `SpecialOrthogonalGroup`, `PoincareGroup`, `LorentzGroup`, `ProperOrthochronousLorentzGroup` |
+| `coordinax.transforms` | `act`, `pushforward`, `act_jet`, `simplify`, `compose`, `materialize_transform`, `is_time_dependent`, `tau_derivative`, </br> `AbstractTransform`, `AbstractCompositeTransform`, `Identity`, `Composed`, `Translate`, `Rotate`, `Reflect`, `Scale`, `Shear`, `Boost`, `identity`, </br> `groups` |
+| `coordinax.transforms.groups` | `AbstractTransformGroup`, `IdentityGroup`, `DiffeomorphismGroup`, `AffineGroup`, `EuclideanGroup`, `OrthogonalGroup`, `SpecialOrthogonalGroup`, `PoincareGroup`, `LorentzGroup`, `ProperOrthochronousLorentzGroup` |
 | `coordinax.frames` | `frame_transition`, </br> `AbstractReferenceFrame`, `FrameTransformError`, </br> `NoFrame`, `Alice`, `Alex`, `Bob`, `bob`, `TransformedReferenceFrame` |
 
 </br>
@@ -4459,7 +4460,7 @@ Frame objects in `coordinax.frames` depend on `coordinax.transforms` for operato
 
 ### Transformation Groups
 
-Transformation groups classify families of coordinate transformations that preserve particular geometric structures. In _coordinax_, these are represented by subclasses of `AbstractTransformGroup`.
+Transformation groups classify families of coordinate transformations that preserve particular geometric structures. In _coordinax_, these are represented by subclasses of `AbstractTransformGroup`, which live in the `coordinax.transforms.groups` sub-namespace and are reached as `cxfm.groups.<Name>`.
 
 A transformation-group class identifies the **structural category** of a transformation (for example affine, orthogonal, or Lorentz). These classes do **not** represent concrete group elements. Instead they are used to
 

--- a/src/coordinax/transforms/__init__.py
+++ b/src/coordinax/transforms/__init__.py
@@ -29,17 +29,6 @@ __all__: tuple[str, ...] = (
     "materialize_transform",
     "is_time_dependent",
     "tau_derivative",
-    # Groups
-    "AbstractTransformGroup",
-    "IdentityGroup",
-    "DiffeomorphismGroup",
-    "AffineGroup",
-    "EuclideanGroup",
-    "OrthogonalGroup",
-    "SpecialOrthogonalGroup",
-    "PoincareGroup",
-    "LorentzGroup",
-    "ProperOrthochronousLorentzGroup",
     # Transformations
     "AbstractTransform",
     "AbstractCompositeTransform",
@@ -52,9 +41,12 @@ __all__: tuple[str, ...] = (
     "Scale",
     "Shear",
     "identity",
+    # Sub-namespaces
+    "groups",
 )
 
 with install_import_hook("coordinax.transforms"):
+    from . import groups
     from ._src.actions import (
         AbstractCompositeTransform,
         AbstractTransform,
@@ -70,18 +62,6 @@ with install_import_hook("coordinax.transforms"):
         is_time_dependent,
         materialize_transform,
         tau_derivative,
-    )
-    from ._src.groups import (
-        AbstractTransformGroup,
-        AffineGroup,
-        DiffeomorphismGroup,
-        EuclideanGroup,
-        IdentityGroup,
-        LorentzGroup,
-        OrthogonalGroup,
-        PoincareGroup,
-        ProperOrthochronousLorentzGroup,
-        SpecialOrthogonalGroup,
     )
     from coordinaxs.api.transforms import act, act_jet, compose, pushforward, simplify
 

--- a/src/coordinax/transforms/groups.py
+++ b/src/coordinax/transforms/groups.py
@@ -1,0 +1,46 @@
+"""Transformation-group markers.
+
+This namespace holds the marker classes that classify *what structure a
+transform preserves* — `EuclideanGroup` for rigid motions, `AffineGroup` for
+affine maps, and so on. They are types, never instances: they are returned by
+`AbstractTransform.groups` and used for classification and dispatch, so they
+live apart from the transforms themselves.
+
+Examples
+--------
+>>> import unxt as u
+>>> import coordinax.transforms as cxfm
+
+>>> op = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+>>> op.groups() == frozenset(
+...     (cxfm.groups.SpecialOrthogonalGroup, cxfm.groups.DiffeomorphismGroup)
+... )
+True
+
+"""
+
+__all__ = (
+    "AbstractTransformGroup",
+    "IdentityGroup",
+    "DiffeomorphismGroup",
+    "AffineGroup",
+    "EuclideanGroup",
+    "OrthogonalGroup",
+    "SpecialOrthogonalGroup",
+    "PoincareGroup",
+    "LorentzGroup",
+    "ProperOrthochronousLorentzGroup",
+)
+
+from ._src.groups import (
+    AbstractTransformGroup,
+    AffineGroup,
+    DiffeomorphismGroup,
+    EuclideanGroup,
+    IdentityGroup,
+    LorentzGroup,
+    OrthogonalGroup,
+    PoincareGroup,
+    ProperOrthochronousLorentzGroup,
+    SpecialOrthogonalGroup,
+)

--- a/tests/unit/transforms/test_boost.py
+++ b/tests/unit/transforms/test_boost.py
@@ -59,13 +59,17 @@ class TestBoostConstruction:
 
     def test_groups_is_affine(self, boost):
         # A Galilean boost is an affine (time-parameterized translation) map.
-        assert boost.groups() == frozenset((cxfm.AffineGroup, cxfm.DiffeomorphismGroup))
+        assert boost.groups() == frozenset(
+            (cxfm.groups.AffineGroup, cxfm.groups.DiffeomorphismGroup)
+        )
 
     def test_composed_groups_with_translate(self, boost):
         shift = cxfm.Translate.from_([1, 2, 3], "m")
         op = cxfm.Composed((shift, boost))
         # Least common supergroup of Euclidean (Translate) and Affine (Boost).
-        assert op.groups() == frozenset((cxfm.AffineGroup, cxfm.DiffeomorphismGroup))
+        assert op.groups() == frozenset(
+            (cxfm.groups.AffineGroup, cxfm.groups.DiffeomorphismGroup)
+        )
 
 
 # ============================================================================

--- a/tests/unit/transforms/test_groups.py
+++ b/tests/unit/transforms/test_groups.py
@@ -10,22 +10,22 @@ import coordinax.transforms as cxfm
 def test_concrete_transform_groups_match_spec() -> None:
     """Concrete transforms expose their primary transformation groups."""
     assert cxfm.Identity.groups() == frozenset(
-        (cxfm.IdentityGroup, cxfm.DiffeomorphismGroup)
+        (cxfm.groups.IdentityGroup, cxfm.groups.DiffeomorphismGroup)
     )
     assert cxfm.Translate.groups() == frozenset(
-        (cxfm.EuclideanGroup, cxfm.DiffeomorphismGroup)
+        (cxfm.groups.EuclideanGroup, cxfm.groups.DiffeomorphismGroup)
     )
     assert cxfm.Rotate.groups() == frozenset(
-        (cxfm.SpecialOrthogonalGroup, cxfm.DiffeomorphismGroup)
+        (cxfm.groups.SpecialOrthogonalGroup, cxfm.groups.DiffeomorphismGroup)
     )
     assert cxfm.Reflect.groups() == frozenset(
-        (cxfm.OrthogonalGroup, cxfm.DiffeomorphismGroup)
+        (cxfm.groups.OrthogonalGroup, cxfm.groups.DiffeomorphismGroup)
     )
     assert cxfm.Scale.groups() == frozenset(
-        (cxfm.AffineGroup, cxfm.DiffeomorphismGroup)
+        (cxfm.groups.AffineGroup, cxfm.groups.DiffeomorphismGroup)
     )
     assert cxfm.Shear.groups() == frozenset(
-        (cxfm.AffineGroup, cxfm.DiffeomorphismGroup)
+        (cxfm.groups.AffineGroup, cxfm.groups.DiffeomorphismGroup)
     )
 
 
@@ -34,13 +34,17 @@ def test_composed_rotate_and_translate_promotes_to_euclidean_group() -> None:
     op = cxfm.Rotate.from_euler("z", u.Q(0, "deg")) | cxfm.Translate.from_(
         [1, 0, 0], "m"
     )
-    assert op.groups() == frozenset((cxfm.EuclideanGroup, cxfm.DiffeomorphismGroup))
+    assert op.groups() == frozenset(
+        (cxfm.groups.EuclideanGroup, cxfm.groups.DiffeomorphismGroup)
+    )
 
 
 def test_composed_rotate_and_scale_promotes_to_affine_group() -> None:
     """Adding a scale lifts a rigid motion into the affine group."""
     op = cxfm.Rotate.from_euler("z", u.Q(0, "deg")) | cxfm.Scale.from_factors([2, 1, 1])
-    assert op.groups() == frozenset((cxfm.AffineGroup, cxfm.DiffeomorphismGroup))
+    assert op.groups() == frozenset(
+        (cxfm.groups.AffineGroup, cxfm.groups.DiffeomorphismGroup)
+    )
 
 
 def test_composed_reflect_and_rotate_promotes_to_orthogonal_group() -> None:
@@ -48,12 +52,14 @@ def test_composed_reflect_and_rotate_promotes_to_orthogonal_group() -> None:
     op = cxfm.Reflect.from_normal([1, 0, 0]) | cxfm.Rotate.from_euler(
         "z", u.Q(0, "deg")
     )
-    assert op.groups() == frozenset((cxfm.OrthogonalGroup, cxfm.DiffeomorphismGroup))
+    assert op.groups() == frozenset(
+        (cxfm.groups.OrthogonalGroup, cxfm.groups.DiffeomorphismGroup)
+    )
 
 
 def test_composed_identity_is_neutral_for_group_inference() -> None:
     """Identity should not widen the inferred group of a composition."""
     op = cxfm.Identity() | cxfm.Rotate.from_euler("z", u.Q(0, "deg"))
     assert op.groups() == frozenset(
-        (cxfm.SpecialOrthogonalGroup, cxfm.DiffeomorphismGroup)
+        (cxfm.groups.SpecialOrthogonalGroup, cxfm.groups.DiffeomorphismGroup)
     )


### PR DESCRIPTION
## Summary

Moves the ten transform-group marker types out of the flat `coordinax.transforms`
namespace into a new **`coordinax.transforms.groups`** sub-namespace:

```python
import coordinax.transforms as cxfm

cxfm.groups.SpecialOrthogonalGroup     # was cxfm.SpecialOrthogonalGroup
cxfm.groups.LorentzGroup
```

`AbstractTransformGroup`, `IdentityGroup`, `DiffeomorphismGroup`, `AffineGroup`,
`EuclideanGroup`, `OrthogonalGroup`, `SpecialOrthogonalGroup`, `PoincareGroup`,
`LorentzGroup`, `ProperOrthochronousLorentzGroup`.

## Why

The flat namespace carried 30+ names. The group markers are a coherent family
and a different *kind* of thing from everything around them: you never construct
one or apply it — an operator is *classified by* them, via its `groups()`
classmethod. They read better one level down, and the flat namespace drops to 20.

The private implementation path (`coordinax.transforms._src.groups`) is
unchanged; this is purely about the public surface.

## Breaking change — no shims

Intentionally no aliases and no flat re-exports: `cxfm.SpecialOrthogonalGroup`
simply stops existing. Verified — all ten are absent from the flat namespace and
present in `cxfm.groups`.

## Notes

- `docs/api/transforms.md` gained an explicit `automodule:: coordinax.transforms.groups`
  block. Without it the ten classes would have silently dropped out of the
  rendered API reference, since `automodule:: coordinax.transforms` no longer
  reaches them. Confirmed they render as `coordinax.transforms.groups.<Name>` in
  a clean HTML build.
- The `docs/spec.md` export table gained a `coordinax.transforms.groups` row, and
  picked up `AbstractCompositeTransform`, which the old flat row was missing.
- `docs/api/frames.md` also pointed group markers at `coordinax.transforms`; redirected.

## Verification

- full suite — 9020 passed, 7 skipped, 1 xfailed
- `pytest docs -q` — 869 passed
- `nox -s docs` — clean build (`docs/_build` wiped first), succeeded
- `prek run --all-files` — clean

The one failure in the suite run was a seed-dependent hypothesis
`filter_too_much` health check in `coordinaxs.hypothesis`'s product-manifold
strategy, unrelated to transforms; it passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**#642 is stacked on this PR.** It targets this branch rather than `main`, so
merging this one first keeps that diff clean. Nothing in here depends on #642.
