### PR TITLE
🐛 fix(hypothesis): draw only manifolds that have a strategy

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
@@ -258,6 +258,10 @@ def atlases(
 
 #: Which dimensionalities each concrete atlas type can be drawn at.
 #:
+#: Membership is also the record of which types are drawable at all: a type
+#: listed here has an `atlases` dispatch below, and a type absent from it does
+#: not, so every draw of one is discarded.
+#:
 #: A plain table rather than `plum.dispatch`, for the same reason as
 #: `_NDIM_SUPPORT` in ``manifold.py``: ``type[X]`` signatures are unfaithful, so
 #: plum's method cache was disabled and every call ran a full resolution -- on a
@@ -276,16 +280,21 @@ _NDIM_SUPPORT: Final[
 )
 
 
-def _atlas_class_supports_ndim(cls: type[cxm.AbstractAtlas], ndim: int, /) -> bool:
-    """Whether *cls* can be drawn at *ndim*.
+def _atlas_class_supports_ndim(
+    cls: type[cxm.AbstractAtlas], ndim: int | None, /
+) -> bool:
+    """Whether *cls* can be drawn, at *ndim* when one is requested.
 
-    Types absent from `_NDIM_SUPPORT` (``NoAtlas``, ``MinkowskiAtlas``) fall
-    through to `True`, matching the previous ``AbstractAtlas`` catch-all.
+    Types absent from `_NDIM_SUPPORT` (``NoAtlas``, ``MinkowskiAtlas``) are not
+    drawable at any dimensionality: no `atlases` dispatch is registered for
+    them, so selecting one only leads to the redispatch finding an empty
+    candidate pool and discarding the example. The catch-all used to answer
+    `True`, which kept them in the pool on every draw.
     """
     for base, supports in _NDIM_SUPPORT:
         if issubclass(cls, base):
-            return supports(ndim)
-    return True
+            return ndim is None or supports(ndim)
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -336,7 +345,7 @@ def atlases(
     classes = tuple(
         cls
         for cls in all_classes
-        if (target_ndim is None or _atlas_class_supports_ndim(cls, target_ndim))
+        if _atlas_class_supports_ndim(cls, target_ndim)
         and (not required_chart_classes or issubclass(cls, cxm.CustomAtlas))
     )
     if not classes:
@@ -612,8 +621,9 @@ def atlases(
     The number of factors is drawn uniformly from 1 to 5. Each factor atlas is
     drawn as a non-product atlas with ndim in ``[1, 3]``, and the total
     dimensionality of the product equals the sum of those factor dimensionalities.
-    When ``ndim`` is given, examples are constrained so a valid partition into
-    ``n_factors`` values in ``[1, 3]`` exists.
+    When ``ndim`` is given, the factor count is drawn from the range that admits
+    a partition into values in ``[1, 3]``; an ``ndim`` no factor count can reach
+    (below 1, or above 15) is discarded via ``hypothesis.assume``.
 
     >>> import coordinax.manifolds as cxm
     >>> import coordinaxs.hypothesis.manifolds as cxmst
@@ -627,15 +637,21 @@ def atlases(
     """
     target_ndim = draw_if_strategy(draw, ndim)
 
-    # Draw the number of factors: 1–5
-    n_factors = draw(st.integers(min_value=1, max_value=5))
-
     dims: list[int] = []
     if target_ndim is None:
+        # Draw the number of factors: 1–5
+        n_factors = draw(st.integers(min_value=1, max_value=5))
         dims = [draw(st.integers(min_value=1, max_value=3)) for _ in range(n_factors)]
     else:
-        # Feasibility for partition of target_ndim into n_factors entries in [1, 3].
-        assume(n_factors <= target_ndim <= 3 * n_factors)
+        # A partition of target_ndim into n_factors entries in [1, 3] exists iff
+        # n_factors <= target_ndim <= 3 * n_factors. Solve that for n_factors and
+        # draw from the feasible range, rather than drawing 1-5 and rejecting:
+        # at `ndim=1` only one of the five counts worked.
+        lo = max(1, -(-target_ndim // 3))
+        hi = min(5, target_ndim)
+        if lo > hi:  # no factor count reaches this target
+            assume(False)
+        n_factors = draw(st.integers(min_value=lo, max_value=hi))
 
         remaining = target_ndim
         for i in range(n_factors):
@@ -648,8 +664,8 @@ def atlases(
 
         # No `assume(remaining == 0)`: on the last factor `factors_left_after`
         # is 0, so min_this == max_this == remaining and the loop always lands
-        # exactly on the target. The feasibility `assume` above is what does the
-        # work.
+        # exactly on the target. The `n_factors` range above is what makes every
+        # iteration's range non-empty.
 
     factors = tuple(
         draw(cast("Any", atlases)(exclude=(cxm.CartesianProductAtlas,), ndim=d))

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
@@ -3,6 +3,7 @@
 __all__ = ("atlas_classes", "atlases")
 
 import inspect
+import math
 
 from collections.abc import Callable
 from typing import Any, Final, cast
@@ -285,7 +286,9 @@ def _atlas_class_supports_ndim(
 ) -> bool:
     """Whether *cls* can be drawn, at *ndim* when one is requested.
 
-    Types absent from `_NDIM_SUPPORT` (``NoAtlas``, ``MinkowskiAtlas``) are not
+    Matching is by `issubclass`, so a subclass of a listed base inherits that
+    base's entry rather than needing one of its own. Types matching no entry
+    (``NoAtlas``, ``MinkowskiAtlas``) are not
     drawable at any dimensionality: no `atlases` dispatch is registered for
     them, so selecting one only leads to the redispatch finding an empty
     candidate pool and discarding the example. The catch-all used to answer
@@ -647,7 +650,7 @@ def atlases(
         # n_factors <= target_ndim <= 3 * n_factors. Solve that for n_factors and
         # draw from the feasible range, rather than drawing 1-5 and rejecting:
         # at `ndim=1` only one of the five counts worked.
-        lo = max(1, -(-target_ndim // 3))
+        lo = max(1, math.ceil(target_ndim / 3))
         hi = min(5, target_ndim)
         if lo > hi:  # no factor count reaches this target
             assume(False)

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
@@ -43,15 +43,18 @@ def manifold_classes(
 
 
 # ---------------------------------------------------------------------------
-# ndim-compatibility helper — extend by adding an entry for each new concrete
-# manifold type.
+# ndim-compatibility helper — a new manifold type needs an entry only when no
+# existing entry's base already covers it.
 # ---------------------------------------------------------------------------
 
 #: Which dimensionalities each concrete manifold type can be drawn at.
 #:
-#: Membership is also the record of which types are drawable at all: a type
-#: listed here has a `manifolds` dispatch below, and a type absent from it does
-#: not, so every draw of one is discarded.
+#: This table is also the record of which types are drawable at all. Matching is
+#: by `issubclass`, so a type is drawable when it is a subclass of some entry's
+#: base -- it need not be listed in its own right, and a new subclass of a listed
+#: base inherits that entry (and must therefore be served by the same dispatch).
+#: A type matching no entry has no `manifolds` dispatch, so every draw of one is
+#: discarded.
 #:
 #: A plain table rather than `plum.dispatch`: these signatures are all
 #: ``type[X]``, which plum cannot treat as faithful, so its method cache was
@@ -81,7 +84,7 @@ def _manifold_class_supports_ndim(
 ) -> bool:
     """Whether *cls* can be drawn, at *ndim* when one is requested.
 
-    Types absent from `_NDIM_SUPPORT` (``NoManifold``, ``MinkowskiManifold``)
+    Types matching no `_NDIM_SUPPORT` base (``NoManifold``, ``MinkowskiManifold``)
     are not drawable at any dimensionality: no `manifolds` dispatch is
     registered for them, so selecting one only leads to the redispatch finding
     an empty candidate pool and discarding the example. The catch-all used to

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
@@ -49,6 +49,10 @@ def manifold_classes(
 
 #: Which dimensionalities each concrete manifold type can be drawn at.
 #:
+#: Membership is also the record of which types are drawable at all: a type
+#: listed here has a `manifolds` dispatch below, and a type absent from it does
+#: not, so every draw of one is discarded.
+#:
 #: A plain table rather than `plum.dispatch`: these signatures are all
 #: ``type[X]``, which plum cannot treat as faithful, so its method cache was
 #: disabled and every call ran a full resolution -- 5555 of them per 200
@@ -73,17 +77,23 @@ _NDIM_SUPPORT: Final[
 
 
 def _manifold_class_supports_ndim(
-    cls: type[cxm.AbstractManifold], ndim: int, /
+    cls: type[cxm.AbstractManifold], ndim: int | None, /
 ) -> bool:
-    """Whether *cls* can be drawn at *ndim*.
+    """Whether *cls* can be drawn, at *ndim* when one is requested.
 
     Types absent from `_NDIM_SUPPORT` (``NoManifold``, ``MinkowskiManifold``)
-    fall through to `True`, matching the previous ``AbstractManifold`` catch-all.
+    are not drawable at any dimensionality: no `manifolds` dispatch is
+    registered for them, so selecting one only leads to the redispatch finding
+    an empty candidate pool and discarding the example. The catch-all used to
+    answer `True`, which put them in the pool on every draw and threw the
+    resulting examples away -- for ``ndim=5``, where they are two of the three
+    candidates, that was enough filtering to trip the ``filter_too_much``
+    health check.
     """
     for base, supports in _NDIM_SUPPORT:
         if issubclass(cls, base):
-            return supports(ndim)
-    return True
+            return ndim is None or supports(ndim)
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -163,7 +173,7 @@ def manifolds(
             exclude_abstract=True,
             exclude=exclude,
         )
-        if target_ndim is None or _manifold_class_supports_ndim(cls, target_ndim)
+        if _manifold_class_supports_ndim(cls, target_ndim)
     )
     if not classes:
         assume(False)
@@ -410,9 +420,9 @@ def manifolds(
 
     The number of factors is drawn uniformly from 1 to 5. The total
     dimensionality of the product equals the sum of the factor dimensionalities.
-    When ``ndim`` is given it must be at least the number of factors (each
-    factor contributes at least 1 dimension); examples that cannot satisfy this
-    are discarded via ``hypothesis.assume``.
+    When ``ndim`` is given, each factor contributes at least 1 dimension, so the
+    factor count is drawn from ``[1, min(5, ndim)]``; ``ndim < 1`` admits no
+    product at all and is discarded via ``hypothesis.assume``.
 
     >>> import coordinax.manifolds as cxm
     >>> import coordinaxs.hypothesis.manifolds as cxmst
@@ -426,15 +436,17 @@ def manifolds(
     """
     target_ndim = draw_if_strategy(draw, ndim)
 
-    # Draw the number of factors: 1–5
-    n_factors = draw(st.integers(min_value=1, max_value=5))
-
-    # Each factor needs at least 1 dimension, so total_ndim >= n_factors.
-    if target_ndim is not None:
-        assume(target_ndim >= n_factors)
-        total_ndim = target_ndim
-    else:
+    # Each factor needs at least 1 dimension, so bound the factor count by the
+    # target up front rather than drawing 1-5 and rejecting the infeasible ones:
+    # at `ndim=1` that rejected four draws in five.
+    if target_ndim is None:
+        n_factors = draw(st.integers(min_value=1, max_value=5))
         total_ndim = draw(st.integers(min_value=n_factors, max_value=n_factors + 4))
+    else:
+        # No factor count works below 1 dimension; that request is unsatisfiable.
+        assume(target_ndim >= 1)
+        n_factors = draw(st.integers(min_value=1, max_value=min(5, target_ndim)))
+        total_ndim = target_ndim
 
     # Partition total_ndim into n_factors positive integers, drawing each factor
     # from the range that still leaves >= 1 dimension for every factor after it.

--- a/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
@@ -9,6 +9,9 @@ import coordinax.charts as cxc
 import coordinax.manifolds as cxm
 
 import coordinaxs.hypothesis.main as cxst
+from coordinaxs.hypothesis.manifolds._src.atlas import _atlas_class_supports_ndim
+from coordinaxs.hypothesis.manifolds._src.manifold import _manifold_class_supports_ndim
+from coordinaxs.hypothesis.utils import get_all_subclasses
 
 
 @given(atlas_cls=cxst.atlas_classes())
@@ -179,3 +182,43 @@ class TestNdimIsHonoured:
             assert sum(f.ndim for f in atlas.factors) == ndim
 
         check()
+
+
+def _assert_drawable(strategy: st.SearchStrategy, cls: type) -> None:
+    """Draw a few examples from *strategy*, expecting instances of *cls*.
+
+    A separate function rather than an inline closure: `given` rejects default
+    arguments, and closing over a loop variable trips ``ruff``'s B023.
+    """
+
+    @given(obj=strategy)
+    @settings(max_examples=3, deadline=None)
+    def check(obj: object) -> None:
+        assert isinstance(obj, cls)
+
+    check()  # raises Unsatisfiable if `cls` has no registered strategy
+
+
+class TestOnlyDrawableClassesAreOffered:
+    """The candidate pool never offers a class the redispatch cannot draw.
+
+    ``NoManifold``/``MinkowskiManifold`` (and ``NoAtlas``/``MinkowskiAtlas``)
+    have no strategy registered, so every example that selected one was thrown
+    away. At ``ndim=5``, where two of the three manifold candidates were such
+    types, that was enough filtering to trip the ``filter_too_much`` health
+    check on unlucky seeds.
+    """
+
+    @pytest.mark.parametrize("ndim", [None, 0, 1, 2, 3, 4, 5, 6])
+    def test_every_manifold_candidate_is_drawable(self, ndim: int | None) -> None:
+        """Each class the pool can select yields an instance, not a discard."""
+        for cls in get_all_subclasses(cxm.AbstractManifold, exclude_abstract=True):
+            if _manifold_class_supports_ndim(cls, ndim):
+                _assert_drawable(cxst.manifolds(cls, ndim=ndim), cls)
+
+    @pytest.mark.parametrize("ndim", [None, 0, 1, 2, 3])
+    def test_every_atlas_candidate_is_drawable(self, ndim: int | None) -> None:
+        """Same invariant one level down, for the atlas pool."""
+        for cls in get_all_subclasses(cxm.AbstractAtlas, exclude_abstract=True):
+            if _atlas_class_supports_ndim(cls, ndim):
+                _assert_drawable(cxst.atlases(cls, ndim=ndim), cls)

--- a/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
@@ -184,21 +184,6 @@ class TestNdimIsHonoured:
         check()
 
 
-def _assert_drawable(strategy: st.SearchStrategy, cls: type) -> None:
-    """Draw a few examples from *strategy*, expecting instances of *cls*.
-
-    A separate function rather than an inline closure: `given` rejects default
-    arguments, and closing over a loop variable trips ``ruff``'s B023.
-    """
-
-    @given(obj=strategy)
-    @settings(max_examples=3, deadline=None)
-    def check(obj: object) -> None:
-        assert isinstance(obj, cls)
-
-    check()  # raises Unsatisfiable if `cls` has no registered strategy
-
-
 class TestOnlyDrawableClassesAreOffered:
     """The candidate pool never offers a class the redispatch cannot draw.
 
@@ -210,15 +195,30 @@ class TestOnlyDrawableClassesAreOffered:
     """
 
     @pytest.mark.parametrize("ndim", [None, 0, 1, 2, 3, 4, 5, 6])
-    def test_every_manifold_candidate_is_drawable(self, ndim: int | None) -> None:
-        """Each class the pool can select yields an instance, not a discard."""
+    @given(data=st.data())
+    @settings(max_examples=1, deadline=None)
+    def test_every_manifold_candidate_is_drawable(
+        self, ndim: int | None, data: st.DataObject
+    ) -> None:
+        """Each class the pool can select yields an instance, not a discard.
+
+        One `given` per ``ndim`` drawing every candidate once, rather than a
+        nested `given` per class: proving each class satisfiable needs a single
+        successful draw, and this way the count of hypothesis runs does not grow
+        with the class hierarchy. A class with no registered strategy filters
+        every draw, which surfaces as `Unsatisfiable`.
+        """
         for cls in get_all_subclasses(cxm.AbstractManifold, exclude_abstract=True):
             if _manifold_class_supports_ndim(cls, ndim):
-                _assert_drawable(cxst.manifolds(cls, ndim=ndim), cls)
+                assert isinstance(data.draw(cxst.manifolds(cls, ndim=ndim)), cls)
 
     @pytest.mark.parametrize("ndim", [None, 0, 1, 2, 3])
-    def test_every_atlas_candidate_is_drawable(self, ndim: int | None) -> None:
+    @given(data=st.data())
+    @settings(max_examples=1, deadline=None)
+    def test_every_atlas_candidate_is_drawable(
+        self, ndim: int | None, data: st.DataObject
+    ) -> None:
         """Same invariant one level down, for the atlas pool."""
         for cls in get_all_subclasses(cxm.AbstractAtlas, exclude_abstract=True):
             if _atlas_class_supports_ndim(cls, ndim):
-                _assert_drawable(cxst.atlases(cls, ndim=ndim), cls)
+                assert isinstance(data.draw(cxst.atlases(cls, ndim=ndim)), cls)


### PR DESCRIPTION
`manifolds(CartesianProductManifold, ndim=5)` tripped hypothesis'
`filter_too_much` health check on unlucky seeds: 7 examples generated, 50
filtered out. Two constructive-ordering mistakes, both rejecting after the
draw rather than narrowing before it.

The dominant one is the candidate pool. `_NDIM_SUPPORT` lists the manifold
types that have a `manifolds` dispatch, and the lookup fell through to `True`
for everything else -- so `NoManifold` and `MinkowskiManifold`, which have no
strategy at all, entered the pool on every draw and were discarded 100% of the
time when the redispatch found an empty pool of its own. At `ndim=5` they were
two of the three candidates, which is enough filtering to fail the health
check. Absence from the table now means undrawable, and the pool is filtered
by that whether or not an `ndim` was requested. `atlas.py` had the identical
defect for `NoAtlas`/`MinkowskiAtlas`.

The second is the factor count. Both product strategies drew `n_factors` from
1-5 and then `assume`d feasibility against the target; at `ndim=1` that threw
away four draws in five. Each now draws from the range that admits a
partition -- `[1, min(5, ndim)]` for manifolds, and for atlases the range
solving `n_factors <= ndim <= 3 * n_factors`, whose factor dims are capped at
3. The remaining `assume`s fire only for an `ndim` no factor count can reach,
where discarding is the documented contract rather than filtering.

No health check is suppressed: the distribution is now uniform over
partitions instead of biased by rejection.


## Verification

Original failing seed:

```
uv run --no-sync pytest "packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py::TestNdimIsHonoured" -q -p no:randomly --hypothesis-seed=177413034573078205584757766006941302796
```

`1 failed, 16 passed in 3.58s` → `17 passed in 0.70s`.

- 25 random-seed sweep over `tests/unit/manifolds/`: clean.
- `packages/coordinaxs.hypothesis`: 774 passed, 1 skipped.
- Downstream consumers `tests/unit/{manifolds,charts}`: 894 passed.
- The 13 new tests in `TestOnlyDrawableClassesAreOffered` all fail with the fix reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
