### PR TITLE
✨ feat(astro): gate `unxts.parametric` registrations on it being installed

### DIFF
--- a/packages/coordinaxs.astro/pyproject.toml
+++ b/packages/coordinaxs.astro/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-dependencies = ["coordinax>=0.24"]
+dependencies = ["coordinax>=0.24", "optional-dependencies>=0.3.2"]
 description = "Astronomy-specific reference frames for coordinax"
 dynamic = ["version"]
 license = "MIT"
@@ -38,6 +38,10 @@ hypothesis = [
   "hypothesis>=6.148.7",
   "unxts.hypothesis>=2.0",
 ]
+# Promotion rules between astro's distances and `unxts.parametric`'s
+# `ParametricQuantity`. Registered on import when installed, skipped otherwise:
+#   pip install "coordinaxs.astro[parametric]"
+parametric = ["unxts.parametric>=2.0"]
 
 [project.entry-points."coordinaxs.frames"]
 astro = "coordinaxs.astro._setup_package:coordinaxs_frames_exports"

--- a/packages/coordinaxs.astro/pyproject.toml
+++ b/packages/coordinaxs.astro/pyproject.toml
@@ -18,10 +18,8 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-# optional-dependencies >=0.5.0: earlier versions keyed enum members on the
-# installed version, silently aliasing any two members that shared one. (The
-# same fix ships in 0.4.1, but that is the 0.4.x maintenance line; 0.5.0 is
-# mainline.)
+# optional-dependencies >=0.5.0: earlier versions silently aliased enum members
+# that shared a version.
 dependencies    = ["coordinax>=0.24", "optional-dependencies>=0.5.0"]
 description     = "Astronomy-specific reference frames for coordinax"
 dynamic         = ["version"]
@@ -42,9 +40,7 @@ hypothesis = [
   "hypothesis>=6.148.7",
   "unxts.hypothesis>=2.0",
 ]
-# Promotion rules between astro's distances and `unxts.parametric`'s
-# `ParametricQuantity`. Registered on import when installed, skipped otherwise:
-#   pip install "coordinaxs.astro[parametric]"
+# Promotion rules between astro's distances and `ParametricQuantity`.
 parametric = ["unxts.parametric>=2.0"]
 
 [project.entry-points."coordinaxs.frames"]

--- a/packages/coordinaxs.astro/pyproject.toml
+++ b/packages/coordinaxs.astro/pyproject.toml
@@ -18,12 +18,14 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-dependencies = ["coordinax>=0.24", "optional-dependencies>=0.3.2"]
-description = "Astronomy-specific reference frames for coordinax"
-dynamic = ["version"]
-license = "MIT"
-name = "coordinaxs.astro"
-readme = "README.md"
+# optional-dependencies >=0.4.1: earlier versions keyed enum members on the
+# installed version, silently aliasing any two members that shared one.
+dependencies    = ["coordinax>=0.24", "optional-dependencies>=0.4.1"]
+description     = "Astronomy-specific reference frames for coordinax"
+dynamic         = ["version"]
+license         = "MIT"
+name            = "coordinaxs.astro"
+readme          = "README.md"
 requires-python = ">=3.12"
 
 [project.optional-dependencies]

--- a/packages/coordinaxs.astro/pyproject.toml
+++ b/packages/coordinaxs.astro/pyproject.toml
@@ -18,9 +18,11 @@ classifiers = [
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
-# optional-dependencies >=0.4.1: earlier versions keyed enum members on the
-# installed version, silently aliasing any two members that shared one.
-dependencies    = ["coordinax>=0.24", "optional-dependencies>=0.4.1"]
+# optional-dependencies >=0.5.0: earlier versions keyed enum members on the
+# installed version, silently aliasing any two members that shared one. (The
+# same fix ships in 0.4.1, but that is the 0.4.x maintenance line; 0.5.0 is
+# mainline.)
+dependencies    = ["coordinax>=0.24", "optional-dependencies>=0.5.0"]
 description     = "Astronomy-specific reference frames for coordinax"
 dynamic         = ["version"]
 license         = "MIT"

--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/__init__.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/__init__.py
@@ -7,6 +7,10 @@ from .frame_transforms import *
 from .galactic import *
 from .galactocentric import *
 from .icrs import *
+from .optional_deps import OptDeps
 from .parallax import *
 from .register_constructors import *
 from .register_converters import *
+
+if OptDeps.UNXTS_PARAMETRIC.installed:
+    from .register_parametric import *

--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/optional_deps.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/optional_deps.py
@@ -11,15 +11,13 @@ class OptDeps(OptionalDependencyEnum):  # type: ignore[misc]  # pylint: disable=
     Member names are canonicalized to distribution names, so
     ``UNXTS_PARAMETRIC`` resolves ``unxts.parametric``.
 
-    Keep at most one ``unxts.*`` member here. :class:`OptionalDependencyEnum`
-    keys each member on its installed *version*, and equal values make an
-    `enum.Enum` collapse the later member into an alias of the earlier one --
-    silently, with no error. The ``unxts.*`` sub-packages are released together
-    and so usually share a version (``unxts.api``, ``unxts.hypothesis`` and
-    ``unxts.parametric`` are all 2.0.0 as of writing), which makes version an
-    unsafe key for telling them apart. A second one belongs behind an
-    import-spec lookup instead -- `optional_dependencies.utils.is_installed`
-    resolves by module name, independent of version.
+    Add further members freely, including other ``unxts.*`` sub-packages. Up to
+    ``optional-dependencies`` 0.4.0 that was unsafe: members were keyed on the
+    installed *version*, so any two sharing one -- every pair of uninstalled
+    dependencies, and the co-released ``unxts.*`` packages, which usually share
+    a version -- silently collapsed into a single `enum.Enum` member reporting
+    the wrong package's state. 0.4.1 keys members so they stay distinct, hence
+    the floor in ``pyproject.toml``.
     """
 
     UNXTS_PARAMETRIC = auto()

--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/optional_deps.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/optional_deps.py
@@ -1,0 +1,25 @@
+"""Optional dependencies. Internal use only."""
+
+__all__ = ("OptDeps",)
+
+from optional_dependencies import OptionalDependencyEnum, auto
+
+
+class OptDeps(OptionalDependencyEnum):  # type: ignore[misc]  # pylint: disable=invalid-enum-extension
+    """Optional dependencies for ``coordinaxs.astro``.
+
+    Member names are canonicalized to distribution names, so
+    ``UNXTS_PARAMETRIC`` resolves ``unxts.parametric``.
+
+    Keep at most one ``unxts.*`` member here. :class:`OptionalDependencyEnum`
+    keys each member on its installed *version*, and equal values make an
+    `enum.Enum` collapse the later member into an alias of the earlier one --
+    silently, with no error. The ``unxts.*`` sub-packages are released together
+    and so usually share a version (``unxts.api``, ``unxts.hypothesis`` and
+    ``unxts.parametric`` are all 2.0.0 as of writing), which makes version an
+    unsafe key for telling them apart. A second one belongs behind an
+    import-spec lookup instead -- `optional_dependencies.utils.is_installed`
+    resolves by module name, independent of version.
+    """
+
+    UNXTS_PARAMETRIC = auto()

--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/optional_deps.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/optional_deps.py
@@ -16,7 +16,7 @@ class OptDeps(OptionalDependencyEnum):  # type: ignore[misc]  # pylint: disable=
     installed *version*, so any two sharing one -- every pair of uninstalled
     dependencies, and the co-released ``unxts.*`` packages, which usually share
     a version -- silently collapsed into a single `enum.Enum` member reporting
-    the wrong package's state. 0.4.1 keys members so they stay distinct, hence
+    the wrong package's state. 0.5.0 keys members so they stay distinct, hence
     the floor in ``pyproject.toml``.
     """
 

--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/optional_deps.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/optional_deps.py
@@ -5,19 +5,12 @@ __all__ = ("OptDeps",)
 from optional_dependencies import OptionalDependencyEnum, auto
 
 
-class OptDeps(OptionalDependencyEnum):  # type: ignore[misc]  # pylint: disable=invalid-enum-extension
+class OptDeps(OptionalDependencyEnum):  # pylint: disable=invalid-enum-extension
     """Optional dependencies for ``coordinaxs.astro``.
 
     Member names are canonicalized to distribution names, so
-    ``UNXTS_PARAMETRIC`` resolves ``unxts.parametric``.
-
-    Add further members freely, including other ``unxts.*`` sub-packages. Up to
-    ``optional-dependencies`` 0.4.0 that was unsafe: members were keyed on the
-    installed *version*, so any two sharing one -- every pair of uninstalled
-    dependencies, and the co-released ``unxts.*`` packages, which usually share
-    a version -- silently collapsed into a single `enum.Enum` member reporting
-    the wrong package's state. 0.5.0 keys members so they stay distinct, hence
-    the floor in ``pyproject.toml``.
+    ``UNXTS_PARAMETRIC`` resolves ``unxts.parametric``. Add members freely:
+    they stay distinct even when they share a version.
     """
 
     UNXTS_PARAMETRIC = auto()

--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/register_parametric.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/register_parametric.py
@@ -1,10 +1,4 @@
-"""Registrations that apply only when `unxts.parametric` is installed.
-
-Imported from `coordinaxs.astro._src` behind
-``OptDeps.UNXTS_PARAMETRIC.installed``, so nothing here may be imported
-unconditionally: `unxts.parametric` is an optional extra
-(``pip install "coordinaxs.astro[parametric]"``).
-"""
+"""Promotion rules for `unxts.parametric`; imported only when it is installed."""
 
 __all__: tuple[str, ...] = ()
 
@@ -15,15 +9,8 @@ from unxts.parametric import ParametricQuantity
 from .distance_modulus import DistanceModulus
 from .parallax import Parallax
 
-# When a distance interacts with a `ParametricQuantity`, degrade to the
-# parametric quantity -- the same reasoning as the `AbstractDistance`/`Q` rules
-# in `coordinax.distances`: the result of e.g. dividing a parallax by a
-# non-dimensionless quantity has units that are not a parallax's.
-#
-# `ParametricQuantity` is not a `unxt.Q` subclass, so the core rules do not
-# reach it. Without these, `Parallax(1, "mas") * PQ(1.0, "rad")` dispatched to
-# the `Parallax`-returning multiply and raised ``Parallax must have angular
-# dimensions``, while the mirrored `PQ * Parallax` returned a `PQ` -- the
-# operand order decided whether the expression worked.
+# Degrade to the parametric quantity, as the `AbstractDistance`/`Q` rules in
+# `coordinax.distances` do. `ParametricQuantity` is not a `unxt.Q` subclass, so
+# those rules never reach it.
 add_promotion_rule(Parallax, ParametricQuantity, ParametricQuantity)
 add_promotion_rule(DistanceModulus, ParametricQuantity, ParametricQuantity)

--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/register_parametric.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/register_parametric.py
@@ -1,0 +1,29 @@
+"""Registrations that apply only when `unxts.parametric` is installed.
+
+Imported from `coordinaxs.astro._src` behind
+``OptDeps.UNXTS_PARAMETRIC.installed``, so nothing here may be imported
+unconditionally: `unxts.parametric` is an optional extra
+(``pip install "coordinaxs.astro[parametric]"``).
+"""
+
+__all__: tuple[str, ...] = ()
+
+from plum import add_promotion_rule
+
+from unxts.parametric import ParametricQuantity
+
+from .distance_modulus import DistanceModulus
+from .parallax import Parallax
+
+# When a distance interacts with a `ParametricQuantity`, degrade to the
+# parametric quantity -- the same reasoning as the `AbstractDistance`/`Q` rules
+# in `coordinax.distances`: the result of e.g. dividing a parallax by a
+# non-dimensionless quantity has units that are not a parallax's.
+#
+# `ParametricQuantity` is not a `unxt.Q` subclass, so the core rules do not
+# reach it. Without these, `Parallax(1, "mas") * PQ(1.0, "rad")` dispatched to
+# the `Parallax`-returning multiply and raised ``Parallax must have angular
+# dimensions``, while the mirrored `PQ * Parallax` returned a `PQ` -- the
+# operand order decided whether the expression worked.
+add_promotion_rule(Parallax, ParametricQuantity, ParametricQuantity)
+add_promotion_rule(DistanceModulus, ParametricQuantity, ParametricQuantity)

--- a/packages/coordinaxs.astro/tests/unit/distances/test_parametric_promotion.py
+++ b/packages/coordinaxs.astro/tests/unit/distances/test_parametric_promotion.py
@@ -38,13 +38,7 @@ def test_promotes_to_parametric_quantity(distance: u.AbstractQuantity) -> None:
 
 @DISTANCES
 def test_arithmetic_is_order_independent(distance: u.AbstractQuantity) -> None:
-    """Both operand orders give a `ParametricQuantity`.
-
-    Without the promotion rule, ``distance * pq`` dispatched to the
-    distance-returning multiply and raised on the dimension check, while
-    ``pq * distance`` succeeded -- the operand order decided whether the
-    expression worked at all.
-    """
+    """Both operand orders give a `ParametricQuantity`."""
     pq = PQ(1.0, "rad")
     assert isinstance(distance * pq, ParametricQuantity)
     assert isinstance(pq * distance, ParametricQuantity)

--- a/packages/coordinaxs.astro/tests/unit/distances/test_parametric_promotion.py
+++ b/packages/coordinaxs.astro/tests/unit/distances/test_parametric_promotion.py
@@ -1,0 +1,56 @@
+"""Tests for the optional `unxts.parametric` registrations."""
+
+import sys
+
+import plum
+import pytest
+
+import unxt as u
+
+import coordinaxs.astro as cxastro
+from coordinaxs.astro._src.optional_deps import OptDeps
+
+if not OptDeps.UNXTS_PARAMETRIC.installed:
+    # Module-level: the imports below would fail at collection time, so this
+    # has to skip before them rather than as a `pytestmark` on each test.
+    pytest.skip("unxts.parametric is not installed", allow_module_level=True)
+
+from unxts.parametric import PQ, ParametricQuantity
+
+DISTANCES = pytest.mark.parametrize(
+    "distance",
+    [cxastro.Parallax(1, "mas"), cxastro.DistanceModulus(1, "mag")],
+    ids=["Parallax", "DistanceModulus"],
+)
+
+
+def test_registrations_ran() -> None:
+    """The gated import in ``_src/__init__`` fired for this install."""
+    assert "coordinaxs.astro._src.register_parametric" in sys.modules
+
+
+@DISTANCES
+def test_promotes_to_parametric_quantity(distance: u.AbstractQuantity) -> None:
+    """A distance and a `ParametricQuantity` promote to the latter."""
+    promoted = plum.promote(distance, PQ(1.0, "rad"))
+    assert all(isinstance(x, ParametricQuantity) for x in promoted)
+
+
+@DISTANCES
+def test_arithmetic_is_order_independent(distance: u.AbstractQuantity) -> None:
+    """Both operand orders give a `ParametricQuantity`.
+
+    Without the promotion rule, ``distance * pq`` dispatched to the
+    distance-returning multiply and raised on the dimension check, while
+    ``pq * distance`` succeeded -- the operand order decided whether the
+    expression worked at all.
+    """
+    pq = PQ(1.0, "rad")
+    assert isinstance(distance * pq, ParametricQuantity)
+    assert isinstance(pq * distance, ParametricQuantity)
+
+
+@DISTANCES
+def test_quantity_promotion_is_unchanged(distance: u.AbstractQuantity) -> None:
+    """The pre-existing degrade-to-`Q` behaviour still holds."""
+    assert isinstance(distance * u.Q(2.0, ""), u.Q)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,9 @@ test = [
   "pytest-env>=1.1.5",
   "pytest-github-actions-annotate-failures>=0.3.0",
   "sybil[pytest]>=8.0.0",
-  # the hypothesis annotation-strategy tests use ParametricQuantity["length"].
+  # the hypothesis annotation-strategy tests use ParametricQuantity["length"],
+  # and it is what makes `coordinaxs.astro`'s `[parametric]` extra -- and the
+  # registrations gated on it -- exercised rather than skipped.
   "unxts.parametric>=2.0",
 ]
 test-all = [{ include-group = "test" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,9 +117,7 @@ test = [
   "pytest-env>=1.1.5",
   "pytest-github-actions-annotate-failures>=0.3.0",
   "sybil[pytest]>=8.0.0",
-  # the hypothesis annotation-strategy tests use ParametricQuantity["length"],
-  # and it is what makes `coordinaxs.astro`'s `[parametric]` extra -- and the
-  # registrations gated on it -- exercised rather than skipped.
+  # the hypothesis annotation-strategy tests use ParametricQuantity["length"].
   "unxts.parametric>=2.0",
 ]
 test-all = [{ include-group = "test" }]

--- a/uv.lock
+++ b/uv.lock
@@ -751,6 +751,7 @@ name = "coordinaxs-astro"
 source = { editable = "packages/coordinaxs.astro" }
 dependencies = [
     { name = "coordinax" },
+    { name = "optional-dependencies" },
 ]
 
 [package.optional-dependencies]
@@ -762,6 +763,9 @@ hypothesis = [
     { name = "hypothesis" },
     { name = "unxts-hypothesis" },
 ]
+parametric = [
+    { name = "unxts-parametric" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -769,9 +773,11 @@ requires-dist = [
     { name = "coordinax", editable = "." },
     { name = "coordinaxs-hypothesis", marker = "extra == 'hypothesis'", editable = "packages/coordinaxs.hypothesis" },
     { name = "hypothesis", marker = "extra == 'hypothesis'", specifier = ">=6.148.7" },
+    { name = "optional-dependencies", specifier = ">=0.3.2" },
     { name = "unxts-hypothesis", marker = "extra == 'hypothesis'", specifier = ">=2.0" },
+    { name = "unxts-parametric", marker = "extra == 'parametric'", specifier = ">=2.0" },
 ]
-provides-extras = ["astropy", "hypothesis"]
+provides-extras = ["astropy", "hypothesis", "parametric"]
 
 [[package]]
 name = "coordinaxs-curveframes"

--- a/uv.lock
+++ b/uv.lock
@@ -773,7 +773,7 @@ requires-dist = [
     { name = "coordinax", editable = "." },
     { name = "coordinaxs-hypothesis", marker = "extra == 'hypothesis'", editable = "packages/coordinaxs.hypothesis" },
     { name = "hypothesis", marker = "extra == 'hypothesis'", specifier = ">=6.148.7" },
-    { name = "optional-dependencies", specifier = ">=0.4.1" },
+    { name = "optional-dependencies", specifier = ">=0.5.0" },
     { name = "unxts-hypothesis", marker = "extra == 'hypothesis'", specifier = ">=2.0" },
     { name = "unxts-parametric", marker = "extra == 'parametric'", specifier = ">=2.0" },
 ]
@@ -1989,14 +1989,14 @@ wheels = [
 
 [[package]]
 name = "optional-dependencies"
-version = "0.4.1"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/42/8344ac009b7ba239b5bd82387aa5ab459dd7f706b80d73692ca6e31a2c95/optional_dependencies-0.4.1.tar.gz", hash = "sha256:8f71acbef015b08945e78fa531630290375d089d06de1d475567634991cb8160", size = 85720, upload-time = "2026-08-07T00:31:45.722Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/89/67e3cbc57a0869231b589b39f8606c98bba81b91f3b72bd56be99040aa78/optional_dependencies-0.5.0.tar.gz", hash = "sha256:05edd224eaf1b7531a6e2ead85de2698dbc2f5edba445533dd7722f160602251", size = 80533, upload-time = "2026-08-07T00:40:23.063Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/a3/7810502242eba30a288c0e79c5a395c1ec6ed41a4eab6e5b3c8e3cf4ee20/optional_dependencies-0.4.1-py3-none-any.whl", hash = "sha256:f1ceb198a9154f6bdbf6295df663b4b91edebe5dc3d8678c03df3fbb985c1545", size = 10132, upload-time = "2026-08-07T00:31:44.53Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/81/aea272ab6faa04addb1045d54dece562a56e13200dd200d0cf71b034f7c9/optional_dependencies-0.5.0-py3-none-any.whl", hash = "sha256:320eb33710e5a38efc536141277c3d0da48a093aecfb15e3a7dc9491669c0821", size = 10102, upload-time = "2026-08-07T00:40:21.689Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -773,7 +773,7 @@ requires-dist = [
     { name = "coordinax", editable = "." },
     { name = "coordinaxs-hypothesis", marker = "extra == 'hypothesis'", editable = "packages/coordinaxs.hypothesis" },
     { name = "hypothesis", marker = "extra == 'hypothesis'", specifier = ">=6.148.7" },
-    { name = "optional-dependencies", specifier = ">=0.3.2" },
+    { name = "optional-dependencies", specifier = ">=0.4.1" },
     { name = "unxts-hypothesis", marker = "extra == 'hypothesis'", specifier = ">=2.0" },
     { name = "unxts-parametric", marker = "extra == 'parametric'", specifier = ">=2.0" },
 ]
@@ -1989,14 +1989,14 @@ wheels = [
 
 [[package]]
 name = "optional-dependencies"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/9a/01c2aaee8ec00abe3dd51368c8a8c341b4352c1b23859d862edd62bd7ae5/optional_dependencies-0.4.0.tar.gz", hash = "sha256:8c2a764021ec47466a9c0375608d6976aa7f0d87f9a611e511ae70861edbd921", size = 68226, upload-time = "2025-09-03T03:32:23.117Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/42/8344ac009b7ba239b5bd82387aa5ab459dd7f706b80d73692ca6e31a2c95/optional_dependencies-0.4.1.tar.gz", hash = "sha256:8f71acbef015b08945e78fa531630290375d089d06de1d475567634991cb8160", size = 85720, upload-time = "2026-08-07T00:31:45.722Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/1c/c03aa5a23a3320f8b2875e1ddf6db679412533d95da2ebee15bfe611c1e3/optional_dependencies-0.4.0-py3-none-any.whl", hash = "sha256:aa5e4c2939681cf6b5f38de9ed7cdd60647526076452c29fbe170335fe34bf4a", size = 8551, upload-time = "2025-09-03T03:32:22.124Z" },
+    { url = "https://files.pythonhosted.org/packages/65/a3/7810502242eba30a288c0e79c5a395c1ec6ed41a4eab6e5b3c8e3cf4ee20/optional_dependencies-0.4.1-py3-none-any.whl", hash = "sha256:f1ceb198a9154f6bdbf6295df663b4b91edebe5dc3d8678c03df3fbb985c1545", size = 10132, upload-time = "2026-08-07T00:31:44.53Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`unxts.parametric` is not a `coordinaxs.astro` dependency, but its `ParametricQuantity` is not a `unxt.Q` subclass either, so the `AbstractDistance`/`Q` promotion rules in `coordinax.distances` never reached it. The result depended on operand order:

```python
Parallax(1, "mas") * PQ(1.0, "rad")   # ValueError: Parallax must have angular dimensions
PQ(1.0, "rad") * Parallax(1, "mas")   # PQ['solid angle'](..., unit='mas rad')
```

Same for `DistanceModulus`.

## What this does

Adds the two missing promotion rules, in their own `_src/register_parametric.py` so the optional import is confined to one file, imported from `_src/__init__` behind `OptDeps.UNXTS_PARAMETRIC.installed`.

`OptDeps` follows the `optional-dependencies` idiom `unxt` itself uses. It requires **>=0.4.1**: earlier versions keyed enum members on the installed *version*, so any two members sharing one silently collapsed into a single member reporting the wrong package's state — which caught every pair of uninstalled dependencies, and the co-released `unxts.*` packages (`unxts.api`, `unxts.hypothesis` and `unxts.parametric` are all 2.0.0). That is fixed in 0.4.1 (GalacticDynamics/optional_dependencies#57), so members can be added freely here.

`unxts.parametric` is declared as a `[parametric]` extra; the tests skip at module level on the same `OptDeps` check, so they run where the extra is installed and skip — not fail — where it is not.

## Verification

- Both paths exercised: with the distribution hidden from `importlib.metadata`, `coordinaxs.astro` imports without pulling in `unxts.parametric` at all.
- Multi-member safety confirmed against the real packages: three `unxts.*` members at 2.0.0 plus two uninstalled ones all stay distinct.
- `packages/coordinaxs.astro`: 398 passed, 2 skipped. pre-commit clean.

## Note

`coordinax.distances.Distance` has the identical gap (`Distance * PQ` raises the same way). A single `add_promotion_rule(AbstractDistance, ParametricQuantity, ...)` in core would close it for all three types, but core cannot import an optional package that only astro declares — it would need the same `OptDeps` treatment there. Left out of scope; happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
