### PR TITLE
🎨 style: set `skip-magic-trailing-comma` and reformat

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -329,10 +329,7 @@ _SHORT_NAME_URLS: dict[str, str] = {
 
 
 def _resolve_short_names(
-    app: Sphinx,
-    env: BuildEnvironment,
-    node: Element,
-    contnode: Element,
+    app: Sphinx, env: BuildEnvironment, node: Element, contnode: Element
 ) -> Node | None:
     """Resolve known bare short names to external documentation links."""
     if node.get("refdomain") != "py":
@@ -366,10 +363,7 @@ def _py_suffix_index(
 
 
 def _resolve_internal_short_names(
-    app: Sphinx,
-    env: BuildEnvironment,
-    node: Element,
-    contnode: Element,
+    app: Sphinx, env: BuildEnvironment, node: Element, contnode: Element
 ) -> Node | None:
     """Resolve a bare short name to a coordinax object of the same name.
 
@@ -433,12 +427,7 @@ def _display_math_repl(match: "re.Match[str]") -> str:
 
 
 def _convert_dollar_math(
-    app: Sphinx,
-    what: str,
-    name: str,
-    obj: object,
-    options: object,
-    lines: list[str],
+    app: Sphinx, what: str, name: str, obj: object, options: object, lines: list[str]
 ) -> None:
     """Rewrite ``$...$`` / ``$$...$$`` maths in docstrings to RST math."""
     # Restrict to this project's own docstrings: ``$`` reliably means math only
@@ -477,12 +466,7 @@ _QUAX_VALUE_SOURCES = ("quax", "unxt")
 
 
 def _clean_quax_value_docstrings(
-    app: Sphinx,
-    what: str,
-    name: str,
-    obj: object,
-    options: object,
-    lines: list[str],
+    app: Sphinx, what: str, name: str, obj: object, options: object, lines: list[str]
 ) -> None:
     """Replace the quax-materialisation members' MkDocs docstrings with clean RST.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -142,10 +142,7 @@ def test(s: nox.Session, /) -> None:
     # This session installs the `workspace` extra (interop included), so the
     # interop order-independence tests must run, not silently skip.
     s.run(
-        "pytest",
-        *ignore_args,
-        *posargs,
-        env={"COORDINAX_REQUIRE_INTEROP_TESTS": "1"},
+        "pytest", *ignore_args, *posargs, env={"COORDINAX_REQUIRE_INTEROP_TESTS": "1"}
     )
     # s.notify("pytest_benchmark", posargs=s.posargs)
 

--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/distance_modulus.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/distance_modulus.py
@@ -195,12 +195,7 @@ def from_(
 
 
 @cxd.Distance.from_.dispatch  # ty: ignore[unresolved-attribute]
-def from_(
-    cls: type[cxd.Distance],
-    dm: DistanceModulus,
-    /,
-    **kw: Any,
-) -> cxd.Distance:
+def from_(cls: type[cxd.Distance], dm: DistanceModulus, /, **kw: Any) -> cxd.Distance:
     """Compute distance from distance modulus.
 
     >>> import coordinax.distances as cxd

--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/galactocentric.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/galactocentric.py
@@ -72,8 +72,7 @@ class Galactocentric(AbstractSpaceFrame):
     #: https://ui.adsabs.harvard.edu/abs/2018A%26A...615L..15G
     #: https://ui.adsabs.harvard.edu/abs/2004ApJ...616..872R
     galcen_v_sun: cxv.Tangent = eqx.field(  # ty: ignore[invalid-assignment]
-        converter=Unless(cxv.Tangent, cxv.Tangent.from_),
-        default=GALCEN_V_SUN_DEFAULT,
+        converter=Unless(cxv.Tangent, cxv.Tangent.from_), default=GALCEN_V_SUN_DEFAULT
     )
 
     # --------

--- a/packages/coordinaxs.astro/tests/unit/test_frame_transforms.py
+++ b/packages/coordinaxs.astro/tests/unit/test_frame_transforms.py
@@ -209,9 +209,7 @@ class TestFrameTransformProperties:
 
 
 def _astropy_icrs_to_gcf_phase_space(
-    xyz_pc: Iterable[float],
-    vxyz_kms: Iterable[float],
-    frame: cxastro.Galactocentric,
+    xyz_pc: Iterable[float], vxyz_kms: Iterable[float], frame: cxastro.Galactocentric
 ):
     x, y, z = xyz_pc
     vx, vy, vz = vxyz_kms
@@ -490,10 +488,7 @@ def test_galactocentric_spherical_velocity_fibre():
     # reference: same input with a Cartesian velocity fibre
     vel_cart = cx.cconvert(vel_sph, cx.cart3d, at=pt.data, usys=usys)
     out_ref = cx.act(
-        op,
-        None,
-        cxv.Coordinate(cx.cconvert(pt, cx.cart3d), vel=vel_cart),
-        usys=usys,
+        op, None, cxv.Coordinate(cx.cconvert(pt, cx.cart3d), vel=vel_cart), usys=usys
     )
     out_v = cx.cconvert(
         out._data["vel"],

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -10,10 +10,7 @@ This module defines the two abstract base classes on which the entire
 
 """
 
-__all__ = (
-    "AbstractParallelTransportFrame",
-    "AbstractParallelTransportTransform",
-)
+__all__ = ("AbstractParallelTransportFrame", "AbstractParallelTransportTransform")
 
 import abc
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/register_frames.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/register_frames.py
@@ -33,8 +33,7 @@ from .base import AbstractParallelTransportFrame
 
 @plum.dispatch
 def frame_transition(
-    from_frame: cxf.AbstractReferenceFrame,
-    to_frame: AbstractParallelTransportFrame,
+    from_frame: cxf.AbstractReferenceFrame, to_frame: AbstractParallelTransportFrame
 ) -> AbstractTransform:
     r"""Return the composite transform operator *to* a curve frame.
 
@@ -85,8 +84,7 @@ def frame_transition(
 
 @plum.dispatch
 def frame_transition(
-    from_frame: AbstractParallelTransportFrame,
-    to_frame: cxf.AbstractReferenceFrame,
+    from_frame: AbstractParallelTransportFrame, to_frame: cxf.AbstractReferenceFrame
 ) -> AbstractTransform:
     r"""Return the composite transform operator *from* a curve frame.
 
@@ -123,8 +121,7 @@ def frame_transition(
 
 @plum.dispatch(precedence=1)  # ty: ignore[no-matching-overload]
 def frame_transition(
-    from_frame: AbstractParallelTransportFrame,
-    to_frame: AbstractParallelTransportFrame,
+    from_frame: AbstractParallelTransportFrame, to_frame: AbstractParallelTransportFrame
 ) -> AbstractTransform:
     r"""Return the composite transform operator between two curve frames.
 

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/__init__.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/__init__.py
@@ -19,8 +19,7 @@ from coordinaxs.hypothesis.utils import get_all_subclasses
 # Note: Pass the callable, not an invoked strategy
 st.register_type_strategy(cxc.AbstractChart, lambda _: charts())  # ty: ignore[missing-argument]
 st.register_type_strategy(
-    cxc.CartesianProductChart,
-    lambda _: charts(cxc.CartesianProductChart),
+    cxc.CartesianProductChart, lambda _: charts(cxc.CartesianProductChart)
 )
 
 for flag_cls in get_all_subclasses(cxc.AbstractDimensionalFlag, exclude_abstract=False):

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
@@ -137,12 +137,7 @@ def _component_quantities(
 
 
 def _bounded_elements(
-    elements: Elements,
-    /,
-    *,
-    lo: float | None,
-    hi: float | None,
-    width: int,
+    elements: Elements, /, *, lo: float | None, hi: float | None, width: int
 ) -> Elements:
     """Confine *elements* to ``[lo, hi]``, however it was supplied.
 

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/chart_kwargs.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/chart_kwargs.py
@@ -22,11 +22,7 @@ from coordinaxs.hypothesis.utils import (
 
 @plum.dispatch.abstract
 def chart_init_kwargs(
-    draw: st.DrawFn,
-    chart_class: Any,
-    /,
-    *,
-    ndim: int | None | st.SearchStrategy = None,
+    draw: st.DrawFn, chart_class: Any, /, *, ndim: int | None | st.SearchStrategy = None
 ) -> dict[str, Any]:
     """Strategy to draw initialization kwargs for a chart class.
 

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/charts.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/charts.py
@@ -199,10 +199,7 @@ def charts(
 
 @plum.dispatch
 def strategy_for_annotation(
-    ann: type[cxc.AbstractChart],
-    /,
-    *,
-    meta: annotations.Metadata,
+    ann: type[cxc.AbstractChart], /, *, meta: annotations.Metadata
 ) -> st.SearchStrategy:
     """Strategy for chart-typed annotations.
 

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/__init__.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/__init__.py
@@ -1,15 +1,5 @@
 """Hypothesis strategies for coordinax manifolds."""
 
-__all__ = (
-    "atlas_classes",
-    "atlases",
-    "manifold_classes",
-    "manifolds",
-)
+__all__ = ("atlas_classes", "atlases", "manifold_classes", "manifolds")
 
-from ._src import (
-    atlas_classes,
-    atlases,
-    manifold_classes,
-    manifolds,
-)
+from ._src import atlas_classes, atlases, manifold_classes, manifolds

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
@@ -583,12 +583,7 @@ def atlases(
         assume(False)
 
     sampled_classes = draw(
-        st.lists(
-            st.sampled_from(filtered_classes),
-            min_size=1,
-            max_size=4,
-            unique=True,
-        )
+        st.lists(st.sampled_from(filtered_classes), min_size=1, max_size=4, unique=True)
     )
     classes = tuple(dict.fromkeys((*sampled_classes, *required_chart_classes)))
     default_cls = draw(st.sampled_from(classes))

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/cdict.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/cdict.py
@@ -65,11 +65,7 @@ def cdicts(
 @strip_return_annotation
 @st.composite
 def cdicts(
-    draw: st.DrawFn,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
-    **kwargs: Any,
+    draw: st.DrawFn, chart: cxc.AbstractChart, rep: cxr.Representation, /, **kwargs: Any
 ) -> CDict:
     """Generate a CDict for a chart and full ``Representation`` descriptor.
 

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/annotations/annotated_utils.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/annotations/annotated_utils.py
@@ -37,10 +37,7 @@ RECOGNIZE_NONINTROSPECTABLE.append((isannotated, AnnotatedNotIntrospectable))
 
 @plum.dispatch
 def strategy_for_annotation(
-    ann: AnnotatedNotIntrospectable,
-    /,
-    *,
-    meta: Metadata,
+    ann: AnnotatedNotIntrospectable, /, *, meta: Metadata
 ) -> st.SearchStrategy:
     """Unwrap and parse."""
     # Unpack Annotated type

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/annotations/jaxtyping_utils.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/annotations/jaxtyping_utils.py
@@ -49,10 +49,7 @@ RECOGNIZE_NONINTROSPECTABLE.append(
 
 @plum.dispatch
 def strategy_for_annotation(
-    ann: JaxtypingNotIntrospectable,
-    /,
-    *,
-    meta: Metadata,
+    ann: JaxtypingNotIntrospectable, /, *, meta: Metadata
 ) -> st.SearchStrategy:
     """Unwrap and parse."""
     if not (

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/custom_types.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/custom_types.py
@@ -1,10 +1,6 @@
 """Internal custom types."""
 
-__all__ = (
-    "Shape",
-    "CKey",
-    "CDict",
-)
+__all__ = ("Shape", "CKey", "CDict")
 
 from typing import TYPE_CHECKING, Any, TypeAlias
 

--- a/packages/coordinaxs.hypothesis/tests/unit/charts/test_charts_like.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/charts/test_charts_like.py
@@ -25,10 +25,7 @@ TEMPLATES = [
 @pytest.mark.parametrize(("template", "ndim", "bases"), TEMPLATES)
 @given(data=st.data())
 def test_charts_like_matches_template(
-    template: cxc.AbstractChart,
-    ndim: int,
-    bases: tuple[type, ...],
-    data: st.DataObject,
+    template: cxc.AbstractChart, ndim: int, bases: tuple[type, ...], data: st.DataObject
 ) -> None:
     """Every draw shares the template's dimensionality and base classes."""
     chart = data.draw(cxst.charts_like(template))

--- a/packages/coordinaxs.hypothesis/tests/unit/utils/annotations/test_beartype_validators.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/utils/annotations/test_beartype_validators.py
@@ -51,9 +51,7 @@ def test_multiple_validators(data):
     """Test that multiple Beartype validators can be combined."""
     # Define an annotated type with multiple validators
     BoundedLength = Annotated[
-        PQ["length"],
-        Is[lambda x: x.value > 0],
-        Is[lambda x: x.value < 100],
+        PQ["length"], Is[lambda x: x.value > 0], Is[lambda x: x.value < 100]
     ]
 
     # Build a strategy for this type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -370,6 +370,11 @@ namespace-packages = [
   "packages/coordinaxs.interop.astropy/src/coordinaxs/interop",
 ]
 
+[tool.ruff.format]
+# Collapse a call or signature onto one line whenever it fits, instead of
+# leaving it exploded because it happens to end in a trailing comma.
+skip-magic-trailing-comma = true
+
 [tool.ruff.lint]
 extend-select = ["ALL"]
 ignore = [

--- a/src/coordinax/_src/charts/d1.py
+++ b/src/coordinax/_src/charts/d1.py
@@ -6,15 +6,7 @@
 
 """
 
-__all__ = (
-    "Abstract1D",
-    "Cart1D",
-    "cart1d",
-    "Radial1D",
-    "radial1d",
-    "Time1D",
-    "time1d",
-)
+__all__ = ("Abstract1D", "Cart1D", "cart1d", "Radial1D", "radial1d", "Time1D", "time1d")
 
 import dataclasses
 

--- a/src/coordinax/_src/charts/d3.py
+++ b/src/coordinax/_src/charts/d3.py
@@ -277,7 +277,7 @@ LonLatSpherical3DDims = tuple[Ang, Ang, Len]
 @jtu.register_static
 @chart_dataclass_decorator
 class LonLatSpherical3D(
-    AbstractSpherical3D[MT, LonLatSphericalKeys, LonLatSpherical3DDims],
+    AbstractSpherical3D[MT, LonLatSphericalKeys, LonLatSpherical3DDims]
 ):
     r"""Longitude-latitude spherical coordinates.
 

--- a/src/coordinax/_src/charts/d4.py
+++ b/src/coordinax/_src/charts/d4.py
@@ -4,9 +4,7 @@ __all__ = ("Abstract4D",)
 
 from typing import Any, Literal as L, override  # noqa: N817
 
-from coordinax._src.base import (
-    AbstractDimensionalFlag,
-)
+from coordinax._src.base import AbstractDimensionalFlag
 
 
 class Abstract4D(AbstractDimensionalFlag, n=4):

--- a/src/coordinax/_src/charts/register_guess.py
+++ b/src/coordinax/_src/charts/register_guess.py
@@ -99,8 +99,7 @@ def guess_chart(obj: CDict, /) -> AbstractChart:
 
 @plum.dispatch
 def guess_chart(
-    _: Shaped[ArrayLike, "*batch 1"] | Shaped[u.AbstractQuantity, "*batch 1"],
-    /,
+    _: Shaped[ArrayLike, "*batch 1"] | Shaped[u.AbstractQuantity, "*batch 1"], /
 ) -> AbstractChart:
     """Infer a 1D Cartesian chart from last dimension of a value / quantity.
 
@@ -116,8 +115,7 @@ def guess_chart(
 
 @plum.dispatch
 def guess_chart(
-    _: Shaped[ArrayLike, "*batch 2"] | Shaped[u.AbstractQuantity, "*batch 2"],
-    /,
+    _: Shaped[ArrayLike, "*batch 2"] | Shaped[u.AbstractQuantity, "*batch 2"], /
 ) -> AbstractChart:
     """Infer a 2D Cartesian chart from last dimension of a value / quantity.
 
@@ -133,8 +131,7 @@ def guess_chart(
 
 @plum.dispatch
 def guess_chart(
-    _: Shaped[ArrayLike, "*batch 3"] | Shaped[u.AbstractQuantity, "*batch 3"],
-    /,
+    _: Shaped[ArrayLike, "*batch 3"] | Shaped[u.AbstractQuantity, "*batch 3"], /
 ) -> AbstractChart:
     """Infer a 3D Cartesian chart from last dimension of a value / quantity.
 
@@ -150,8 +147,7 @@ def guess_chart(
 
 @plum.dispatch(precedence=-1)  # ty: ignore[no-matching-overload]
 def guess_chart(
-    _: Shaped[ArrayLike, "*batch N"] | Shaped[u.AbstractQuantity, "*batch N"],
-    /,
+    _: Shaped[ArrayLike, "*batch N"] | Shaped[u.AbstractQuantity, "*batch N"], /
 ) -> AbstractChart:
     """Infer a N-dimensional Cartesian chart from last dimension of a value / quantity.
 

--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -1576,7 +1576,7 @@ def pt_map(
     *(
         (u.AbstractQuantity, EuclideanManifold, typ, EuclideanManifold, typ)
         for typ in (Cart0D, Cart1D, Radial1D, Time1D, Cart2D, Cart3D, CartND)
-    ),
+    )
 )
 def pt_map(
     q: u.AbstractQuantity,

--- a/src/coordinax/_src/euclidean/manifold.py
+++ b/src/coordinax/_src/euclidean/manifold.py
@@ -1,14 +1,6 @@
 """Euclidean manifolds."""
 
-__all__ = (
-    "EuclideanManifold",
-    "Rn",
-    "R0",
-    "R1",
-    "R2",
-    "R3",
-    "RN",
-)
+__all__ = ("EuclideanManifold", "Rn", "R0", "R1", "R2", "R3", "RN")
 
 import dataclasses
 

--- a/src/coordinax/_src/euclidean/scale_factors.py
+++ b/src/coordinax/_src/euclidean/scale_factors.py
@@ -21,12 +21,7 @@ DMLS = u.unit("")
 
 @plum.dispatch
 def scale_factors(
-    metric: FlatMetric,
-    chart: AbstractChart,
-    /,
-    *,
-    at: CDict,
-    usys: OptUSys = None,
+    metric: FlatMetric, chart: AbstractChart, /, *, at: CDict, usys: OptUSys = None
 ) -> ul.QM:
     """Compute only the Euclidean metric diagonal instead of forming ``J.T @ J``.
 

--- a/src/coordinax/_src/manifolds/guess.py
+++ b/src/coordinax/_src/manifolds/guess.py
@@ -18,13 +18,7 @@ from coordinax._src.charts.d3 import (
     ProlateSpheroidal3D,
 )
 from coordinax._src.custom_types import CDict
-from coordinax._src.euclidean import (
-    R0,
-    R1,
-    R2,
-    R3,
-    EuclideanManifold,
-)
+from coordinax._src.euclidean import R0, R1, R2, R3, EuclideanManifold
 from coordinax._src.null import no_manifold
 
 # ===================================================================

--- a/src/coordinax/_src/manifolds/norm.py
+++ b/src/coordinax/_src/manifolds/norm.py
@@ -18,9 +18,7 @@ from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.charts import Cart0D, Cart1D, Cart2D, Cart3D, CartND
 from coordinax._src.custom_types import CDict, OptUSys
 from coordinax._src.euclidean import FlatMetric
-from coordinax._src.internal import (
-    pack_uniform_unit,
-)
+from coordinax._src.internal import pack_uniform_unit
 
 # ===================================================================
 # Metric Matrix

--- a/src/coordinax/_src/manifolds/scale_factors.py
+++ b/src/coordinax/_src/manifolds/scale_factors.py
@@ -76,12 +76,7 @@ def scale_factors(
 
 @plum.dispatch
 def scale_factors(
-    metric: PullbackMetric,
-    chart: AbstractChart,
-    /,
-    *,
-    at: CDict,
-    usys: OptUSys = None,
+    metric: PullbackMetric, chart: AbstractChart, /, *, at: CDict, usys: OptUSys = None
 ) -> ul.QM:
     """Return scale factors for a pullback (induced) metric.
 
@@ -140,9 +135,7 @@ def scale_factors(
         )
         raise NotImplementedError(msg)
     M = EmbeddedManifold(
-        intrinsic=embed_map.intrinsic.M,
-        ambient=ambient,
-        embed_map=embed_map,
+        intrinsic=embed_map.intrinsic.M, ambient=ambient, embed_map=embed_map
     )
     mm = cxmapi.metric_matrix(M, at, chart)
     return as_quantity_matrix(mm.matrix).diag()  # ty: ignore[unresolved-attribute]

--- a/src/coordinax/_src/minkowski/charts.py
+++ b/src/coordinax/_src/minkowski/charts.py
@@ -11,10 +11,7 @@ import plum
 
 from .atlas import MinkowskiAtlas
 from .manifold import MinkowskiManifold
-from coordinax._src.base import (
-    AbstractFixedComponentsChart,
-    chart_dataclass_decorator,
-)
+from coordinax._src.base import AbstractFixedComponentsChart, chart_dataclass_decorator
 from coordinax._src.charts.d4 import Abstract4D
 from coordinax._src.custom_types import Len
 

--- a/src/coordinax/_src/minkowski/manifold.py
+++ b/src/coordinax/_src/minkowski/manifold.py
@@ -1,9 +1,6 @@
 """Minkowski spacetime manifold."""
 
-__all__ = (
-    "MinkowskiManifold",
-    "minkowski4d",
-)
+__all__ = ("MinkowskiManifold", "minkowski4d")
 
 import dataclasses
 

--- a/src/coordinax/_src/product/galilean_ct.py
+++ b/src/coordinax/_src/product/galilean_ct.py
@@ -26,8 +26,7 @@ from coordinax._src.custom_types import CDict, Ds, Ks
 from coordinax._src.euclidean.manifold import R1, R3
 
 galilean_spacetime: Final = CartesianProductManifold(
-    factors=(R1, R3),
-    factor_names=("ct", "space"),
+    factors=(R1, R3), factor_names=("ct", "space")
 )
 r"""The 4-dimensional Galilean spacetime manifold, $\mathbb{R} \times \mathbb{R}^3$."""
 

--- a/src/coordinax/_src/spherical/chart.py
+++ b/src/coordinax/_src/spherical/chart.py
@@ -203,7 +203,7 @@ SphericalTwoSphereDims = tuple[Ang, Ang]
 @jtu.register_static
 @chart_dataclass_decorator
 class SphericalTwoSphere(
-    AbstractSphericalTwoSphere[MT, SphericalTwoSphereKeys, SphericalTwoSphereDims],
+    AbstractSphericalTwoSphere[MT, SphericalTwoSphereKeys, SphericalTwoSphereDims]
 ):
     r"""Intrinsic chart on the unit two-sphere with components ``(theta, phi)``.
 

--- a/src/coordinax/frames/__init__.py
+++ b/src/coordinax/frames/__init__.py
@@ -156,7 +156,4 @@ _load_optional_frame_exports()
 
 
 # clean up namespace
-del (
-    install_import_hook,
-    Final,
-)
+del (install_import_hook, Final)

--- a/src/coordinax/frames/_src/example.py
+++ b/src/coordinax/frames/_src/example.py
@@ -175,9 +175,7 @@ bob = Bob()
 
 @plum.dispatch.multi((Alice, Alice), (Alex, Alex), (Bob, Bob))
 def frame_transition(
-    from_frame: AbstractReferenceFrame,
-    to_frame: AbstractReferenceFrame,
-    /,
+    from_frame: AbstractReferenceFrame, to_frame: AbstractReferenceFrame, /
 ) -> cxfm.Identity:
     """Return an identity operator for frames that are the same.
 

--- a/src/coordinax/frames/_src/xfm.py
+++ b/src/coordinax/frames/_src/xfm.py
@@ -1,9 +1,6 @@
 """Transformations on Frames."""
 
-__all__ = (
-    "AbstractTransformedReferenceFrame",
-    "TransformedReferenceFrame",
-)
+__all__ = ("AbstractTransformedReferenceFrame", "TransformedReferenceFrame")
 
 from typing import Generic, final
 from typing_extensions import TypeVar

--- a/src/coordinax/representations/_src/guess.py
+++ b/src/coordinax/representations/_src/guess.py
@@ -231,11 +231,7 @@ def guess_basis_kind(obj: AbstractBasis, /) -> AbstractBasis:
 # Mapping from dimension to basis kind
 DIM_TO_BASIS_MAP: dict[
     u.AbstractDimension | tuple[u.AbstractDimension, ...], AbstractBasis
-] = {
-    LENGTH: no_basis,
-    ANGLE: no_basis,
-    (ANGLE, LENGTH): no_basis,
-}
+] = {LENGTH: no_basis, ANGLE: no_basis, (ANGLE, LENGTH): no_basis}
 
 
 @plum.dispatch

--- a/src/coordinax/transforms/__init__.py
+++ b/src/coordinax/transforms/__init__.py
@@ -126,9 +126,7 @@ def _load_optional_transform_exports() -> None:
             )
         eps = sorted(current + legacy, key=lambda ep: ep.name)
         exported = load_exports(
-            eps,
-            group=_TRANSFORM_EXPORTS_ENTRYPOINT_GROUP,
-            noun="transform export",
+            eps, group=_TRANSFORM_EXPORTS_ENTRYPOINT_GROUP, noun="transform export"
         )
         globals().update(exported)
     finally:
@@ -137,7 +135,4 @@ def _load_optional_transform_exports() -> None:
 
 _load_optional_transform_exports()
 
-del (
-    install_import_hook,
-    Final,
-)
+del (install_import_hook, Final)

--- a/src/coordinax/transforms/_src/actions/base.py
+++ b/src/coordinax/transforms/_src/actions/base.py
@@ -1,10 +1,6 @@
 """Base classes for operators on coordinates."""
 
-__all__ = (
-    "AbstractTransform",
-    "is_time_dependent",
-    "materialize_transform",
-)
+__all__ = ("AbstractTransform", "is_time_dependent", "materialize_transform")
 
 import abc
 import dataclasses

--- a/src/coordinax/transforms/_src/actions/boost.py
+++ b/src/coordinax/transforms/_src/actions/boost.py
@@ -166,8 +166,7 @@ def act(
         # (delta(tau) = dv*tau) implements the ladder rule, the flat-chart
         # gating, and the generic fallback with anchors (at=, at_vel=).
         return cast(
-            "CDict",
-            cxfmapi.act(_as_translate(op), tau, x, chart, rep, usys=usys, **kw),
+            "CDict", cxfmapi.act(_as_translate(op), tau, x, chart, rep, usys=usys, **kw)
         )
 
     # --- Point input: x + dv * tau, via the Translate ladder machinery.

--- a/src/coordinax/transforms/_src/actions/composed.py
+++ b/src/coordinax/transforms/_src/actions/composed.py
@@ -370,12 +370,7 @@ def act(
 
 @plum.dispatch
 def act_jet(
-    op: Composed,
-    tau: Any,
-    jet: dict,
-    chart: cxc.AbstractChart,
-    /,
-    **kw: object,
+    op: Composed, tau: Any, jet: dict, chart: cxc.AbstractChart, /, **kw: object
 ) -> dict:
     """Prolong a Composed transform: fold the prolongations left-to-right.
 

--- a/src/coordinax/transforms/_src/actions/constants.py
+++ b/src/coordinax/transforms/_src/actions/constants.py
@@ -1,9 +1,6 @@
 """Internal custom types for coordinax."""
 
-__all__ = (
-    "LENGTH",
-    "SPEED",
-)
+__all__ = ("LENGTH", "SPEED")
 
 import unxt as u
 

--- a/src/coordinax/vectors/_src/bundle.py
+++ b/src/coordinax/vectors/_src/bundle.py
@@ -589,11 +589,7 @@ def from_(cls: type[Coordinate], p: Point, /) -> Coordinate:
 
 @Coordinate.from_.dispatch  # ty: ignore[unresolved-attribute]
 def from_(
-    cls: type[Coordinate],
-    data: Mapping[str, Any],
-    /,
-    *,
-    point: Point | None = None,
+    cls: type[Coordinate], data: Mapping[str, Any], /, *, point: Point | None = None
 ) -> Coordinate:
     """Create a ``Coordinate`` from a mapping of named objects.
 

--- a/src/coordinax/vectors/_src/point.py
+++ b/src/coordinax/vectors/_src/point.py
@@ -178,11 +178,7 @@ def from_(cls: type[Point], obj: Point, /) -> Point:
 
 @Point.from_.dispatch  # ty: ignore[unresolved-attribute]
 def from_(
-    cls: type[Point],
-    obj: Any,
-    chart: cxc.AbstractChart,
-    rep: cxr.Representation,
-    /,
+    cls: type[Point], obj: Any, chart: cxc.AbstractChart, rep: cxr.Representation, /
 ) -> Point:
     """Construct a vector from an object, and chart and rep info.
 

--- a/src/coordinax/vectors/_src/register_compare.py
+++ b/src/coordinax/vectors/_src/register_compare.py
@@ -32,12 +32,7 @@ from .base import AbstractVector
 
 @plum.dispatch
 def equivalent(
-    a: AbstractVector,
-    b: AbstractVector,
-    /,
-    *,
-    rtol: float = 1e-5,
-    atol: float = 1e-8,
+    a: AbstractVector, b: AbstractVector, /, *, rtol: float = 1e-5, atol: float = 1e-8
 ) -> Any:
     """Whether two vectors denote the same geometric point.
 

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -718,12 +718,7 @@ def _cached_point_data_in(point: Point, /) -> Callable[[Any], CDict]:
 
 
 def _act_coordinate_jet(
-    op: cxfm.AbstractTransform,
-    tau: Any,
-    x: Coordinate,
-    /,
-    *,
-    usys: OptUSys = None,
+    op: cxfm.AbstractTransform, tau: Any, x: Coordinate, /, *, usys: OptUSys = None
 ) -> Coordinate:
     """Act a time-dependent transform on a Coordinate via joint prolongation.
 

--- a/tests/benchmark/test_act_act_jet.py
+++ b/tests/benchmark/test_act_act_jet.py
@@ -65,11 +65,7 @@ def test_static_rotate_vel(benchmark, jet):
 
 def _moving_translate():
     return cxfm.Translate(
-        lambda t: {
-            "x": u.Q(3.0, "km/s") * t,
-            "y": u.Q(0.0, "km"),
-            "z": u.Q(0.0, "km"),
-        },
+        lambda t: {"x": u.Q(3.0, "km/s") * t, "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")},
         chart=cxc.cart3d,
     )
 
@@ -101,10 +97,7 @@ def test_td_rotate_jet_generic(benchmark):
         return jnp.array([[ct, -st, 0.0], [st, ct, 0.0], [0.0, 0.0, 1.0]])
 
     op = cxfm.Rotate.from_(rot_z)
-    jet2 = {
-        0: q3(1.0, 2.0, 3.0, "m"),
-        1: q3(0.5, -0.5, 0.0, "m/s"),
-    }
+    jet2 = {0: q3(1.0, 2.0, 3.0, "m"), 1: q3(0.5, -0.5, 0.0, "m/s")}
     _bench_jitted(
         benchmark,
         lambda tau, jet_: cxfm.act_jet(op, tau, jet_, cxc.cart3d),

--- a/tests/unit/charts/test_jacobian_pt_map.py
+++ b/tests/unit/charts/test_jacobian_pt_map.py
@@ -523,10 +523,7 @@ class TestJacobianPtMapCompositionProperty:
     @given(data=st.data())
     @settings(deadline=None)
     def test_composition_is_the_identity(
-        self,
-        cart: cxc.AbstractChart,
-        curv: cxc.AbstractChart,
-        data: st.DataObject,
+        self, cart: cxc.AbstractChart, curv: cxc.AbstractChart, data: st.DataObject
     ) -> None:
         """J_{curv->cart} @ J_{cart->curv} = I at an arbitrary point.
 

--- a/tests/unit/charts/test_predef_charts.py
+++ b/tests/unit/charts/test_predef_charts.py
@@ -203,9 +203,7 @@ def _strict_dimension_component(chart: cxc.AbstractChart) -> str:
 
 
 @pytest.mark.parametrize(
-    ("chart", "cls"),
-    [(p[1], p[2]) for p in _CHART_PARAMS],
-    ids=_CHART_IDS,
+    ("chart", "cls"), [(p[1], p[2]) for p in _CHART_PARAMS], ids=_CHART_IDS
 )
 def test_predef_chart_type(chart, cls) -> None:
     """Each predefined chart is an instance of its declared class."""
@@ -224,9 +222,7 @@ def test_predef_chart_is_abstract_chart(chart) -> None:
 
 
 @pytest.mark.parametrize(
-    ("chart", "expected"),
-    [(p[1], p[3]) for p in _CHART_PARAMS],
-    ids=_CHART_IDS,
+    ("chart", "expected"), [(p[1], p[3]) for p in _CHART_PARAMS], ids=_CHART_IDS
 )
 def test_predef_chart_components(chart, expected) -> None:
     """Components matches the expected tuple."""
@@ -234,9 +230,7 @@ def test_predef_chart_components(chart, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    ("chart", "expected"),
-    [(p[1], p[4]) for p in _CHART_PARAMS],
-    ids=_CHART_IDS,
+    ("chart", "expected"), [(p[1], p[4]) for p in _CHART_PARAMS], ids=_CHART_IDS
 )
 def test_predef_chart_coord_dimensions(chart, expected) -> None:
     """coord_dimensions matches the expected tuple."""
@@ -244,9 +238,7 @@ def test_predef_chart_coord_dimensions(chart, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    ("chart", "expected_ndim"),
-    [(p[1], p[5]) for p in _CHART_PARAMS],
-    ids=_CHART_IDS,
+    ("chart", "expected_ndim"), [(p[1], p[5]) for p in _CHART_PARAMS], ids=_CHART_IDS
 )
 def test_predef_chart_ndim(chart, expected_ndim) -> None:
     """Ndim matches the expected value and is consistent with components."""
@@ -261,9 +253,7 @@ def test_predef_chart_ndim(chart, expected_ndim) -> None:
 
 
 @pytest.mark.parametrize(
-    ("chart", "cls"),
-    [(p[1], p[2]) for p in _CHART_PARAMS],
-    ids=_CHART_IDS,
+    ("chart", "cls"), [(p[1], p[2]) for p in _CHART_PARAMS], ids=_CHART_IDS
 )
 def test_predef_chart_equals_fresh_instance(chart, cls) -> None:
     """The predefined instance equals a freshly constructed instance."""
@@ -276,9 +266,7 @@ def test_predef_chart_equals_fresh_instance(chart, cls) -> None:
 
 
 @pytest.mark.parametrize(
-    ("chart", "cls"),
-    [(p[1], p[2]) for p in _CHART_PARAMS],
-    ids=_CHART_IDS,
+    ("chart", "cls"), [(p[1], p[2]) for p in _CHART_PARAMS], ids=_CHART_IDS
 )
 def test_predef_chart_repr_contains_class_name(chart, cls) -> None:
     """Repr includes the class name."""

--- a/tests/unit/manifolds/test_metric_field.py
+++ b/tests/unit/manifolds/test_metric_field.py
@@ -17,9 +17,7 @@ import pytest
 import unxt as u
 
 import coordinax.manifolds as cxm
-from coordinax._src.metric.field import (
-    RoundMetric as DynamicRoundMetric,
-)
+from coordinax._src.metric.field import RoundMetric as DynamicRoundMetric
 
 # ---------------------------------------------------------------------------
 # Fixtures: every concrete AbstractMetricField subtype from the public API

--- a/tests/unit/manifolds/test_metric_pullback_consistency.py
+++ b/tests/unit/manifolds/test_metric_pullback_consistency.py
@@ -265,10 +265,7 @@ class TestNonCanonicalTwoSphereMetric:
 
     @pytest.mark.parametrize(
         ("chart", "keys"),
-        [
-            (cxc.lonlat_sph2, ("lon", "lat")),
-            (cxc.math_sph2, ("theta", "phi")),
-        ],
+        [(cxc.lonlat_sph2, ("lon", "lat")), (cxc.math_sph2, ("theta", "phi"))],
     )
     def test_scale_factors_match_metric_diagonal(self, chart, keys):
         """They must agree with the diagonal of the full metric."""

--- a/tests/unit/manifolds/test_norm.py
+++ b/tests/unit/manifolds/test_norm.py
@@ -537,10 +537,7 @@ class TestNormJAXCompatSphere:
         metric = cxm.RoundMetric(ndim=2)
         at = {"theta": u.Angle(jnp.pi / 2, "rad"), "phi": u.Angle(0, "rad")}
         magnitudes = jnp.array([1, 2, 3])
-        v_batch = {
-            "theta": u.Q(magnitudes, "rad/s"),
-            "phi": u.Q(jnp.zeros(3), "rad/s"),
-        }
+        v_batch = {"theta": u.Q(magnitudes, "rad/s"), "phi": u.Q(jnp.zeros(3), "rad/s")}
         results = jax.vmap(lambda v: cxm.norm(v, metric, cxc.sph2, at=at))(v_batch)
         assert qnp.allclose(results, u.Q(magnitudes, "rad/s"), atol=u.Q(1e-5, "rad/s"))
 

--- a/tests/unit/representations/test_guess_semantic_kind.py
+++ b/tests/unit/representations/test_guess_semantic_kind.py
@@ -224,10 +224,7 @@ class TestWithChart:
 
     @pytest.mark.parametrize(
         ("guess", "expected"),
-        [
-            (cxr.guess_geometry_kind, cxr.point_geom),
-            (cxr.guess_rep, cxr.point),
-        ],
+        [(cxr.guess_geometry_kind, cxr.point_geom), (cxr.guess_rep, cxr.point)],
         ids=["geometry_kind", "rep"],
     )
     def test_matching_keys(self, guess, expected) -> None:

--- a/tests/unit/test_entrypoint_backcompat.py
+++ b/tests/unit/test_entrypoint_backcompat.py
@@ -178,9 +178,7 @@ def test_frames_provider_not_callable_raises(monkeypatch: Any) -> None:
     """An entry point that loads to a non-callable is rejected."""
     ep = _FakeEntryPoint("bad", provider=42)  # load() returns a non-callable
     monkeypatch.setattr(
-        cxf,
-        "entry_points",
-        _fake_groups(**{cxf._FRAME_EXPORTS_ENTRYPOINT_GROUP: [ep]}),
+        cxf, "entry_points", _fake_groups(**{cxf._FRAME_EXPORTS_ENTRYPOINT_GROUP: [ep]})
     )
     with pytest.raises(TypeError, match="is not callable"):
         cxf._load_optional_frame_exports()
@@ -191,9 +189,7 @@ def test_frames_exports_not_mapping_raises(monkeypatch: Any) -> None:
     """A provider that returns a non-mapping is rejected."""
     ep = _FakeEntryPoint("bad", provider=lambda: [1, 2, 3])
     monkeypatch.setattr(
-        cxf,
-        "entry_points",
-        _fake_groups(**{cxf._FRAME_EXPORTS_ENTRYPOINT_GROUP: [ep]}),
+        cxf, "entry_points", _fake_groups(**{cxf._FRAME_EXPORTS_ENTRYPOINT_GROUP: [ep]})
     )
     with pytest.raises(TypeError, match="must return a mapping"):
         cxf._load_optional_frame_exports()
@@ -204,9 +200,7 @@ def test_frames_non_string_export_name_raises(monkeypatch: Any) -> None:
     """A non-string export name is rejected."""
     ep = _FakeEntryPoint("bad", exports={123: object()})
     monkeypatch.setattr(
-        cxf,
-        "entry_points",
-        _fake_groups(**{cxf._FRAME_EXPORTS_ENTRYPOINT_GROUP: [ep]}),
+        cxf, "entry_points", _fake_groups(**{cxf._FRAME_EXPORTS_ENTRYPOINT_GROUP: [ep]})
     )
     with pytest.raises(TypeError, match="non-string export name"):
         cxf._load_optional_frame_exports()
@@ -256,9 +250,7 @@ def test_frames_exports_land_in_module_globals(monkeypatch: Any) -> None:
     sentinel = object()
     ep = _FakeEntryPoint("plugin", exports={"_InjectedFrame": sentinel})
     monkeypatch.setattr(
-        cxf,
-        "entry_points",
-        _fake_groups(**{cxf._FRAME_EXPORTS_ENTRYPOINT_GROUP: [ep]}),
+        cxf, "entry_points", _fake_groups(**{cxf._FRAME_EXPORTS_ENTRYPOINT_GROUP: [ep]})
     )
     cxf._load_optional_frame_exports()
     assert cxf._InjectedFrame is sentinel  # cleaned up by the fixture

--- a/tests/unit/test_validate_tag.py
+++ b/tests/unit/test_validate_tag.py
@@ -89,12 +89,7 @@ def test_parse_version_tag(validate_tag, tag: str, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    ("stdout", "exists"),
-    [
-        ("v1.0.0\n", True),
-        ("\n", False),
-    ],
-    ids=["found", "absent"],
+    ("stdout", "exists"), [("v1.0.0\n", True), ("\n", False)], ids=["found", "absent"]
 )
 def test_check_coordinator_tag_exists(validate_tag, fake_git, stdout, exists) -> None:
     with fake_git(stdout):

--- a/tests/usage/charts/test_jacobian.py
+++ b/tests/usage/charts/test_jacobian.py
@@ -183,10 +183,7 @@ class TestChainRuleViaCurriedForm:
     @given(data=st.data())
     @settings(deadline=None)
     def test_composition_is_the_identity(
-        self,
-        cart: cxc.AbstractChart,
-        curv: cxc.AbstractChart,
-        data: st.DataObject,
+        self, cart: cxc.AbstractChart, curv: cxc.AbstractChart, data: st.DataObject
     ) -> None:
         """J_{cart->curv} @ J_{curv->cart} = I at an arbitrary point.
 


### PR DESCRIPTION
Follow-up to a ponytail review of the open test PRs, which asked whether trailing commas were costing lines. They are — a magic trailing comma pins a call or signature open even when it fits on one line, so a four-argument signature costs six lines.

```diff
 def _resolve_short_names(
-    app: Sphinx,
-    env: BuildEnvironment,
-    node: Element,
-    contnode: Element,
+    app: Sphinx, env: BuildEnvironment, node: Element, contnode: Element
 ) -> Node | None:
```

**56 files, -229 lines.** `COM812` (missing-trailing-comma) is already ignored "for ruff.format", so this finishes a decision the config had half-made.

## This is mechanical, and I checked rather than assumed

Every one of the 56 changed files parses to a **byte-identical AST** against `main`:

```python
ast.dump(ast.parse(old)) == ast.dump(ast.parse(new))   # 56/56
```

I ran that per file rather than eyeballing a 388-line diff — it's the only check that actually proves a reformat changed nothing. Also:

- `ruff format` is idempotent (second pass is a no-op).
- `ruff check` clean; full `prek run --all-files` clean.
- Suite: **4524 passed, 7 skipped, 1 xfailed**.

The single failure is `test_product_manifold_factor_dims_sum_to_ndim[6]` — the pre-existing seed-dependent `filter_too_much` flake, which I reproduced on a clean `main` checkout earlier (it hit `[5]` there). Unrelated to formatting; being fixed separately.

## The tradeoff

An exploded signature makes the *next* diff one line instead of four — that's the standard argument for the magic trailing comma, and it's a genuine cost. My read is that -229 lines of standing noise is worth more than a slightly tidier future diff, but it's a style call and easy to revert: drop the three-line config block and re-run `ruff format`.

Where this touches the branches it came from, they'll pick it up on their next rebase; no conflicts expected since the change is whitespace-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)