### PR TITLE
🐛 fix(manifolds): reject indefinite metrics in `norm` instead of returning `nan`

### DIFF
--- a/src/coordinax/_src/manifolds/_utils.py
+++ b/src/coordinax/_src/manifolds/_utils.py
@@ -7,7 +7,59 @@ from jaxtyping import Array
 import unxt as u
 import unxts.linalg as ul
 
+from coordinax._src.base import AbstractMetricField
+
 DMLS = u.unit("")
+
+
+def require_positive_definite(metric: AbstractMetricField, fname: str, /) -> None:
+    r"""Raise `NotImplementedError` unless *metric* is positive-definite.
+
+    A Riemannian magnitude $\sqrt{v^\top G v}$ is real-valued only when $G$ is
+    positive-definite.  Under an indefinite (pseudo-Riemannian) metric such as
+    `~coordinax.manifolds.MinkowskiMetric`, $v^\top G v$ is *negative* for
+    timelike vectors, so the square root evaluates to ``nan`` -- a wrong answer
+    wearing the costume of a real one.  Callers get a loud failure instead.
+
+    Parameters
+    ----------
+    metric
+        The metric field to check, via its ``signature``.
+    fname
+        Name of the calling function, used in the error message.
+
+    Examples
+    --------
+    >>> import coordinax.manifolds as cxm
+    >>> from coordinax._src.manifolds._utils import require_positive_definite
+
+    A Riemannian metric passes silently:
+
+    >>> require_positive_definite(cxm.FlatMetric(3), "norm") is None
+    True
+
+    An indefinite one does not:
+
+    >>> try:
+    ...     require_positive_definite(cxm.MinkowskiMetric(), "norm")
+    ... except NotImplementedError as e:
+    ...     print(e)
+    norm() supports only positive-definite metrics, but MinkowskiMetric has
+    signature (-1, 1, 1, 1), which is pseudo-Riemannian (indefinite). Under such
+    a metric `sqrt(v^T G v)` is `nan` for timelike vectors rather than a
+    meaningful magnitude.
+
+    """
+    if all(s > 0 for s in metric.signature):
+        return
+    msg = (
+        f"{fname}() supports only positive-definite metrics, but "
+        f"{type(metric).__name__} has signature {tuple(metric.signature)}, which "
+        "is pseudo-Riemannian (indefinite). Under such a metric "
+        "`sqrt(v^T G v)` is `nan` for timelike vectors rather than a "
+        "meaningful magnitude."
+    )
+    raise NotImplementedError(msg)
 
 
 def as_quantity_matrix(x: ul.QM | Array, /) -> ul.QM:

--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -12,7 +12,7 @@ import unxt as u
 import coordinax.angles as cxa
 import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
-from ._utils import as_quantity_matrix
+from ._utils import as_quantity_matrix, require_positive_definite
 from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.custom_types import CDict, OptUSys
 from coordinax._src.metric.matrix import DenseMetric
@@ -81,12 +81,7 @@ def angle_between(
     Angle(1.57079633, 'rad')
 
     """
-    if not all(s > 0 for s in metric.signature):
-        msg = (
-            "angle_between currently supports only positive-definite metrics; "
-            "pseudo-Riemannian or indefinite metrics are unsupported."
-        )
-        raise NotImplementedError(msg)
+    require_positive_definite(metric, "angle_between")
 
     chart.check_data(at, keys=True, values=False)
     chart.check_data(uvec, keys=True, values=False)

--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -81,7 +81,10 @@ def angle_between(
     Angle(1.57079633, 'rad')
 
     """
-    require_positive_definite(metric, "angle_between")
+    # Guards `chart.M.metric` rather than the `metric` argument: the matrix below
+    # comes from `chart.M`, so checking the argument would validate one metric
+    # while computing with another.
+    require_positive_definite(chart.M.metric, "angle_between")
 
     chart.check_data(at, keys=True, values=False)
     chart.check_data(uvec, keys=True, values=False)

--- a/src/coordinax/_src/manifolds/norm.py
+++ b/src/coordinax/_src/manifolds/norm.py
@@ -229,8 +229,6 @@ def norm(
     norm() supports only positive-definite metrics, but
 
     """
-    require_positive_definite(metric, "norm")
-
     keys = chart.components
     qty_flags = [is_any_quantity(val) for val in v.values()]
     if any(qty_flags) and not all(qty_flags):
@@ -242,6 +240,11 @@ def norm(
 
     if metric != chart.M.metric:
         raise ValueError("Metric-level dispatch: metric must match chart's metric")
+
+    # After the match check, so a mismatched *indefinite* metric still reports the
+    # mismatch rather than the definiteness. Guards `chart.M.metric` because that
+    # is what `metric_matrix` below actually uses.
+    require_positive_definite(chart.M.metric, "norm")
 
     if not is_qty and usys is None:
         raise TypeError(
@@ -366,7 +369,11 @@ def norm(
             "(no unit information). "
             "Example: pass `usys=unxt.unitsystems.si`."
         )
-    require_positive_definite(metric, "norm")
+    # Guards `chart.M.metric`, not the `metric` argument: this overload builds
+    # the matrix from `chart.M` and has no match check, so checking the argument
+    # would let `norm(v, FlatMetric(4), minkowskict, ...)` past the guard and
+    # straight back to the `nan` this guard exists to prevent.
+    require_positive_definite(chart.M.metric, "norm")
     mm = cxmapi.metric_matrix(chart.M, at, chart)
     return array_norm(mm.to_dense().matrix, v)  # ty: ignore[unresolved-attribute]
 

--- a/src/coordinax/_src/manifolds/norm.py
+++ b/src/coordinax/_src/manifolds/norm.py
@@ -14,6 +14,7 @@ from unxt.quantity import is_any_quantity
 
 import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
+from ._utils import require_positive_definite
 from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.charts import Cart0D, Cart1D, Cart2D, Cart3D, CartND
 from coordinax._src.custom_types import CDict, OptUSys
@@ -215,7 +216,21 @@ def norm(
     >>> cxm.norm(v, metric, cxc.sph2, at=at)
     Q(0.61237244, 'rad / s')
 
+    An indefinite metric has no real-valued norm and is rejected rather than
+    silently returning ``nan``:
+
+    >>> v4 = {"ct": u.Q(5.0, "m"), "x": u.Q(1.0, "m"),
+    ...       "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> at4 = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> try:
+    ...     cxm.norm(v4, cxm.MinkowskiMetric(), cxc.minkowskict, at=at4)
+    ... except NotImplementedError as e:
+    ...     print(str(e)[:52])
+    norm() supports only positive-definite metrics, but
+
     """
+    require_positive_definite(metric, "norm")
+
     keys = chart.components
     qty_flags = [is_any_quantity(val) for val in v.values()]
     if any(qty_flags) and not all(qty_flags):
@@ -351,6 +366,7 @@ def norm(
             "(no unit information). "
             "Example: pass `usys=unxt.unitsystems.si`."
         )
+    require_positive_definite(metric, "norm")
     mm = cxmapi.metric_matrix(chart.M, at, chart)
     return array_norm(mm.to_dense().matrix, v)  # ty: ignore[unresolved-attribute]
 

--- a/tests/unit/manifolds/test_angle_between_dispatch.py
+++ b/tests/unit/manifolds/test_angle_between_dispatch.py
@@ -62,6 +62,29 @@ class TestAngleBetweenFailureModes:
         with pytest.raises(NotImplementedError, match=r"pseudo.*indefinite"):
             cxm.angle_between(metric, cxc.minkowskict, uvec, vvec, at=at)
 
+    def test_guard_follows_the_metric_actually_used(self):
+        """A positive-definite argument cannot bypass an indefinite chart metric.
+
+        The matrix comes from ``chart.M``, so the guard must check that rather
+        than the ``metric`` argument, else the two disagree.
+        """
+        at = {k: jnp.array(0) for k in ("ct", "x", "y", "z")}
+        uvec = {
+            "ct": jnp.array(1),
+            "x": jnp.array(0),
+            "y": jnp.array(0),
+            "z": jnp.array(0),
+        }
+        vvec = {
+            "ct": jnp.array(0),
+            "x": jnp.array(1),
+            "y": jnp.array(0),
+            "z": jnp.array(0),
+        }
+
+        with pytest.raises(NotImplementedError, match=r"pseudo.*indefinite"):
+            cxm.angle_between(cxm.FlatMetric(4), cxc.minkowskict, uvec, vvec, at=at)
+
 
 class TestAngleBetweenJAX:
     """Tests for JAX compatibility of angle_between."""

--- a/tests/unit/manifolds/test_norm.py
+++ b/tests/unit/manifolds/test_norm.py
@@ -669,6 +669,35 @@ class TestIndefiniteMetricsAreRejected:
         assert "MinkowskiMetric" in str(exc.value)
         assert "(-1, 1, 1, 1)" in str(exc.value)
 
+    def test_mismatched_metric_reports_the_mismatch_not_the_signature(self):
+        """Ordering: an invalid call is diagnosed as invalid, not as indefinite.
+
+        The definiteness guard runs *after* the metric/chart match check, so
+        passing an indefinite metric that also does not belong to the chart
+        reports the mismatch — the actual defect in the call.
+        """
+        v = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+        at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+        with pytest.raises(ValueError, match="must match chart"):
+            cxm.norm(v, cxm.MinkowskiMetric(), cxc.cart3d, at=at)
+
+    def test_guard_follows_the_metric_actually_used(self):
+        """A positive-definite *argument* cannot smuggle an indefinite chart past.
+
+        The packed-array overload builds its matrix from ``chart.M`` and has no
+        match check, so guarding the ``metric`` argument would let this call
+        through to the very ``nan`` the guard exists to prevent.
+        """
+        at = {k: jnp.array(0.0) for k in ("ct", "x", "y", "z")}
+        with pytest.raises(NotImplementedError, match=r"pseudo.*indefinite"):
+            cxm.norm(
+                jnp.array([5.0, 1.0, 0.0, 0.0]),
+                cxm.FlatMetric(4),
+                cxc.minkowskict,
+                at=at,
+                usys=u.unitsystems.si,
+            )
+
     def test_positive_definite_metrics_still_work(self):
         """Positive control: the guard does not disturb Riemannian metrics."""
         v = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}

--- a/tests/unit/manifolds/test_norm.py
+++ b/tests/unit/manifolds/test_norm.py
@@ -3,6 +3,8 @@
 Coverage includes Euclidean and spherical metric behavior, plus JIT/vmap usage.
 """
 
+from typing import ClassVar
+
 import jax
 import jax.numpy as jnp
 import pytest
@@ -609,3 +611,67 @@ class TestProductMetricInterBlockUnits:
         gm, _ = self._metric((cxm.R1, cxm.R1), ("line0", "line1"), at)
         assert gm.unit[0, 1] == u.unit("")
         assert gm.unit[1, 0] == u.unit("")
+
+
+class TestIndefiniteMetricsAreRejected:
+    """`norm` has no real value under an indefinite metric, so it refuses.
+
+    ``sqrt(vᵀ G v)`` is real-valued only for a positive-definite ``G``. Under
+    the Minkowski signature ``(-1, 1, 1, 1)`` the quadratic form is negative
+    for timelike vectors, and the square root used to return ``nan`` — a wrong
+    answer indistinguishable from a real one at the call site.
+    """
+
+    AT: ClassVar = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+
+    @staticmethod
+    def _fourvec(ct, x):
+        return {
+            "ct": u.Q(ct, "m"),
+            "x": u.Q(x, "m"),
+            "y": u.Q(0.0, "m"),
+            "z": u.Q(0.0, "m"),
+        }
+
+    @pytest.mark.parametrize(
+        ("kind", "ct", "x"),
+        [("timelike", 5.0, 1.0), ("spacelike", 1.0, 5.0), ("null", 3.0, 3.0)],
+    )
+    def test_cdict_norm_raises(self, kind, ct, x):
+        """Every causal type is rejected, not just the one that gave ``nan``."""
+        del kind
+        with pytest.raises(NotImplementedError, match=r"pseudo.*indefinite"):
+            cxm.norm(
+                self._fourvec(ct, x), cxm.MinkowskiMetric(), cxc.minkowskict, at=self.AT
+            )
+
+    def test_packed_array_norm_raises(self):
+        """The bare-array overload is guarded too, not only the CDict one."""
+        at = {k: jnp.array(0.0) for k in ("ct", "x", "y", "z")}
+        with pytest.raises(NotImplementedError, match=r"pseudo.*indefinite"):
+            cxm.norm(
+                jnp.array([5.0, 1.0, 0.0, 0.0]),
+                cxm.MinkowskiMetric(),
+                cxc.minkowskict,
+                at=at,
+                usys=u.unitsystems.si,
+            )
+
+    def test_error_names_the_metric_and_signature(self):
+        """The message says which metric and signature, not just 'unsupported'."""
+        with pytest.raises(NotImplementedError) as exc:
+            cxm.norm(
+                self._fourvec(5.0, 1.0),
+                cxm.MinkowskiMetric(),
+                cxc.minkowskict,
+                at=self.AT,
+            )
+        assert "MinkowskiMetric" in str(exc.value)
+        assert "(-1, 1, 1, 1)" in str(exc.value)
+
+    def test_positive_definite_metrics_still_work(self):
+        """Positive control: the guard does not disturb Riemannian metrics."""
+        v = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+        at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+        got = cxm.norm(v, cxm.FlatMetric(3), cxc.cart3d, at=at)
+        assert bool(qnp.isclose(got.ustrip("m"), 5.0))

--- a/tests/unit/manifolds/test_separation_dispatch.py
+++ b/tests/unit/manifolds/test_separation_dispatch.py
@@ -1,6 +1,7 @@
 """Tests for the separation() manifold API dispatches."""
 
 import jax.numpy as jnp
+import pytest
 
 import quaxed.numpy as qnp
 import unxt as u
@@ -58,3 +59,37 @@ class TestSeparationDispatches:
         d = cxm.separation(cxc.cart3d, a, b).ustrip("m")
         assert bool(qnp.isclose(d[0], 5.0))
         assert bool(qnp.isclose(d[1], qnp.sqrt(2.0)))
+
+
+class TestIndefiniteMetricSeparation:
+    """`separation` inherits `norm`'s guard instead of returning ``nan``.
+
+    Regression: a timelike pair used to yield ``Distance(nan, 'm')`` while a
+    spacelike pair yielded a plausible number, so the failure was invisible
+    unless you happened to probe a timelike interval.
+    """
+
+    @staticmethod
+    def _event(ct, x):
+        return {
+            "ct": u.Q(ct, "m"),
+            "x": u.Q(x, "m"),
+            "y": u.Q(0.0, "m"),
+            "z": u.Q(0.0, "m"),
+        }
+
+    @pytest.mark.parametrize(
+        ("kind", "ct", "x"),
+        [("timelike", 5.0, 1.0), ("spacelike", 1.0, 5.0), ("null", 3.0, 3.0)],
+    )
+    def test_raises_rather_than_returning_nan(self, kind, ct, x):
+        del kind
+        origin = self._event(0.0, 0.0)
+        with pytest.raises(NotImplementedError, match=r"pseudo.*indefinite"):
+            cxm.separation(cxc.minkowskict, origin, self._event(ct, x))
+
+    def test_euclidean_separation_is_unaffected(self):
+        """Positive control: the common Riemannian path is untouched."""
+        a = {"x": u.Q(3.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+        b = {"x": u.Q(0.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+        assert bool(qnp.isclose(cxm.separation(cxc.cart3d, a, b).ustrip("m"), 5.0))


### PR DESCRIPTION
> ### 📍 Merge order: **1 of 4** — Minkowski/special-relativity series
> | # | PR | Depends on |
> |---|----|-----------|
> | **1** | **this PR** — stop `norm`/`separation` returning `nan` | — (merge first) |
> | 2 | `LorentzBoost` operator | #1 |
> | 3 | `interval` / proper time / causality | #1, #2 |
> | 4 | docs + special-relativity tutorial | #1, #2, #3 |
>
> **This PR is standalone** — it branches off `main` and can merge on its own.

## The bug

`norm` computes $\sqrt{v^\top G v}$, real-valued only when $G$ is positive-definite. Under the Minkowski signature $(-1,1,1,1)$ the quadratic form is *negative* for timelike vectors, so the square root silently produced `nan`:

```python
a = {"ct": u.Q(0.0, "m"), "x": u.Q(0.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
b = {"ct": u.Q(5.0, "m"), "x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}

cxm.separation(cxc.minkowskict, a, b)   # timelike
# -> Distance(nan, unit='m')
```

The three causal cases behaved differently on `main`, which is what made this hard to spot:

| pair | `main` | why it's bad |
|---|---|---|
| timelike `(ct=5, x=1)` | `Distance(nan, 'm')` | silent wrong answer |
| spacelike `(ct=1, x=5)` | `Distance(4.899, 'm')` | plausible → masks the problem |
| null `(ct=3, x=3)` | `Distance(0., 'm')` | plausible → masks the problem |

Unless you happened to probe a *timelike* interval, everything looked fine.

## The fix

`angle_between` already refused indefinite metrics ([angle_between.py:84](https://github.com/GalacticDynamics/coordinax/blob/main/src/coordinax/_src/manifolds/angle_between.py#L84)). That check becomes the shared `require_positive_definite` helper in `_src/manifolds/_utils.py`, called from `angle_between` and from **both** metric-level `norm` overloads (the `CDict` one and the packed-array one).

`separation` inherits the guard for free — it is defined as the norm of a coordinate difference, so fixing the shared function fixes every caller rather than patching each entry point. The error names the metric and its signature instead of just saying "unsupported":

```
norm() supports only positive-definite metrics, but MinkowskiMetric has
signature (-1, 1, 1, 1), which is pseudo-Riemannian (indefinite). Under such a
metric `sqrt(v^T G v)` is `nan` for timelike vectors rather than a meaningful
magnitude.
```

## Deliberate behaviour change

This also rejects **spacelike** pairs, which previously returned a *correct* magnitude. That is intentional: `norm` cannot promise a real magnitude under a metric where the answer's very existence depends on the causal character of its argument, and returning a number for one causal type while returning `nan` for another is precisely what hid this. The Minkowski-correct API — invariant interval with timelike/spacelike/null classification, plus proper time — lands in PR 3 of this series; this PR only stops the silent `nan`.

## Verification

- New `TestIndefiniteMetricsAreRejected` (test_norm.py) and `TestIndefiniteMetricSeparation` (test_separation_dispatch.py): all three causal types raise; the message names metric + signature; both the `CDict` and packed-array overloads are covered; positive controls confirm Riemannian metrics are untouched.
- The pre-existing `test_indefinite_metric_is_not_supported` for `angle_between` passes **unchanged** after the dedup, confirming no behavioural regression there.
- Full `tests/unit`: **1987 passed, 5 skipped**. ruff, ruff-format and ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)