### PR TITLE
✅ test(charts): check `jac_pt_map` far from unit scale

### DIFF
--- a/tests/unit/charts/test_jacobian_pt_map.py
+++ b/tests/unit/charts/test_jacobian_pt_map.py
@@ -798,26 +798,15 @@ class TestJacobianPtMapCDictArrayBranch:
 # ===========================================================================
 
 
-#: Magnitudes the scale-free properties are checked at, spanning 34 decades.
+#: Magnitudes for the scale-free properties, spanning 34 decades.
 #:
-#: `WELL_CONDITIONED` deliberately stays near 1 so an *absolute* tolerance on
-#: Jacobian entries means something, which leaves the arithmetic untested at
-#: the magnitudes real data arrives in -- parsecs, or metres between atoms.
-#:
-#: The range is bounded by float32, not by the charts, and the binding limit is
-#: *underflow at the top*: entries of ``J_{cart->sph}`` scale like ``1/r**2``,
-#: and ``1/r**2`` reaches float32's smallest normal at
-#: ``r = sqrt(1/tiny) = 9.2e18`` -- measured to fail there, well before
-#: ``r**2`` would overflow at ``sqrt(max) = 1.8e19``. At the bottom ``r**2``
-#: underflows below ``sqrt(tiny) = 1.1e-19``, and near-pole colatitudes shrink
-#: ``x`` and ``y`` further, so the floor sits above that at 1e-16.
-#:
-#: Each entry is drawn over ``[mag, 10*mag]``, so the tops and bottoms of those
-#: windows are what must stay inside [1e-16, 1e18]. Measured worst case across
-#: the whole angular domain is 2.6e-5, against ``atol=1e-4``.
-#:
-#: Not asserted as a boundary test: the limits move if JAX x64 is enabled, so
-#: pinning them would encode the dtype of the environment rather than the maths.
+#: Bounded by float32, not by the charts. `J_{cart->sph}` entries scale like
+#: ``1/r**2``, which underflows at ``sqrt(1/tiny) = 9.2e18`` -- *before*
+#: ``r**2`` overflows at ``sqrt(max) = 1.8e19``. The floor is 1e-16 rather than
+#: ``sqrt(tiny) = 1.1e-19`` because near-pole colatitudes shrink ``x`` and
+#: ``y``. Each entry draws over ``[mag, 10*mag]``, so those windows must stay
+#: inside [1e-16, 1e18]; worst measured error there is 2.6e-5 vs ``atol=1e-4``.
+#: Not asserted as a boundary test -- the limits move under JAX x64.
 EXTREME_MAGNITUDES = [
     pytest.param(1e-16, id="1e-16"),
     pytest.param(1e-11, id="1e-11"),
@@ -829,17 +818,10 @@ EXTREME_MAGNITUDES = [
 
 
 class TestJacobianPtMapAtExtremeScales:
-    r"""The scale-free properties, checked far from unit scale.
+    """Scale-free properties, checked far from unit scale.
 
-    Every other Jacobian test here pins points near 1 because it compares
-    entries against an absolute tolerance, and entries of these Jacobians
-    scale like ``r`` and ``1/r``. That leaves the arithmetic untested at the
-    magnitudes real data arrives in -- parsecs, or metres between atoms.
-
-    Both properties below are *dimensionless*, so they sidestep that: the
-    identity matrix is the identity matrix at any scale, and a relative error
-    is scale-free by construction. One flat tolerance therefore works across
-    all 36 decades, with no rtol/atol tradeoff to tune.
+    Every other Jacobian test here pins points near 1 to keep an absolute
+    tolerance meaningful. These two are dimensionless, so they need not.
     """
 
     @pytest.mark.parametrize("magnitude", EXTREME_MAGNITUDES)
@@ -853,12 +835,7 @@ class TestJacobianPtMapAtExtremeScales:
         magnitude: float,
         data: st.DataObject,
     ) -> None:
-        """``J_{curv->cart} @ J_{cart->curv} = I``, at any magnitude.
-
-        The chain rule does not care how big the coordinates are, so this is
-        the same assertion `TestJacobianPtMapCompositionProperty` makes -- run
-        where the numbers are extreme rather than convenient.
-        """
+        """``J_{curv->cart} @ J_{cart->curv} = I``, at any magnitude."""
         p_curv = data.draw(cxst.cdicts(curv, magnitude=(magnitude, magnitude * 10.0)))
         p_cart = cxc.pt_map(p_curv, curv, cart)
 
@@ -871,14 +848,11 @@ class TestJacobianPtMapAtExtremeScales:
     def test_analytic_dispatch_agrees_with_jacfwd(self, magnitude: float) -> None:
         """The closed-form `Cart2D -> Polar2D` Jacobian matches autodiff.
 
-        This is the only pair with a hand-written Jacobian, and it is reached
-        only on *packed* input -- a cdict resolves to the generic branch, which
-        is ``jax.jacfwd(pt_map)`` itself and so cannot disagree with it. Passing
-        an array is what makes this an independent check rather than a
-        tautology.
+        Packed input on purpose: a cdict resolves to the generic branch, which
+        *is* ``jax.jacfwd(pt_map)`` and so cannot disagree with it. Only
+        array/Quantity reaches the hand-written Jacobian.
 
-        Compared relatively: entries here scale like ``1/r``, so an absolute
-        tolerance would be vacuous at 1e18 and unmeetable at 1e-18.
+        Compared relatively -- entries scale like ``1/r``.
         """
         theta = 0.7
         at = jnp.asarray(

--- a/tests/unit/charts/test_jacobian_pt_map.py
+++ b/tests/unit/charts/test_jacobian_pt_map.py
@@ -852,7 +852,10 @@ class TestJacobianPtMapAtExtremeScales:
         *is* ``jax.jacfwd(pt_map)`` and so cannot disagree with it. Only
         array/Quantity reaches the hand-written Jacobian.
 
-        Compared relatively -- entries scale like ``1/r``.
+        Compared relatively, with no ``atol`` -- entries scale like ``1/r``, so
+        any absolute floor is vacuous at 1e18 and unmeetable at 1e-18. At
+        ``theta = 0.7`` no entry is ever exactly zero, so a relative
+        comparison of the full matrix is well defined.
         """
         theta = 0.7
         at = jnp.asarray(
@@ -866,5 +869,4 @@ class TestJacobianPtMapAtExtremeScales:
         )
 
         assert np.all(np.isfinite(got))
-        nonzero = expected != 0
-        assert_allclose(got[nonzero], expected[nonzero], rtol=1e-5)
+        assert_allclose(got, expected, rtol=1e-5)

--- a/tests/unit/charts/test_jacobian_pt_map.py
+++ b/tests/unit/charts/test_jacobian_pt_map.py
@@ -3,11 +3,13 @@
 __all__: tuple[str, ...] = ()
 
 import itertools
+import math
 
 import jaxtyping
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 from hypothesis import given, settings, strategies as st
 from numpy.testing import assert_allclose
@@ -789,3 +791,106 @@ class TestJacobianPtMapCDictArrayBranch:
         at = {"x": jnp.array(1), "y": jnp.array(0), "z": jnp.array(0)}
         with pytest.raises((jaxtyping.TypeCheckError, ValueError), match="usys"):
             cxc.jac_pt_map(at, cxc.cart3d, cxc.sph3d)
+
+
+# ===========================================================================
+# Extreme scales
+# ===========================================================================
+
+
+#: Magnitudes the scale-free properties are checked at, spanning 34 decades.
+#:
+#: `WELL_CONDITIONED` deliberately stays near 1 so an *absolute* tolerance on
+#: Jacobian entries means something, which leaves the arithmetic untested at
+#: the magnitudes real data arrives in -- parsecs, or metres between atoms.
+#:
+#: The range is bounded by float32, not by the charts, and the binding limit is
+#: *underflow at the top*: entries of ``J_{cart->sph}`` scale like ``1/r**2``,
+#: and ``1/r**2`` reaches float32's smallest normal at
+#: ``r = sqrt(1/tiny) = 9.2e18`` -- measured to fail there, well before
+#: ``r**2`` would overflow at ``sqrt(max) = 1.8e19``. At the bottom ``r**2``
+#: underflows below ``sqrt(tiny) = 1.1e-19``, and near-pole colatitudes shrink
+#: ``x`` and ``y`` further, so the floor sits above that at 1e-16.
+#:
+#: Each entry is drawn over ``[mag, 10*mag]``, so the tops and bottoms of those
+#: windows are what must stay inside [1e-16, 1e18]. Measured worst case across
+#: the whole angular domain is 2.6e-5, against ``atol=1e-4``.
+#:
+#: Not asserted as a boundary test: the limits move if JAX x64 is enabled, so
+#: pinning them would encode the dtype of the environment rather than the maths.
+EXTREME_MAGNITUDES = [
+    pytest.param(1e-16, id="1e-16"),
+    pytest.param(1e-11, id="1e-11"),
+    pytest.param(1e-6, id="1e-6"),
+    pytest.param(1e6, id="1e6"),
+    pytest.param(1e11, id="1e11"),
+    pytest.param(1e17, id="1e17"),
+]
+
+
+class TestJacobianPtMapAtExtremeScales:
+    r"""The scale-free properties, checked far from unit scale.
+
+    Every other Jacobian test here pins points near 1 because it compares
+    entries against an absolute tolerance, and entries of these Jacobians
+    scale like ``r`` and ``1/r``. That leaves the arithmetic untested at the
+    magnitudes real data arrives in -- parsecs, or metres between atoms.
+
+    Both properties below are *dimensionless*, so they sidestep that: the
+    identity matrix is the identity matrix at any scale, and a relative error
+    is scale-free by construction. One flat tolerance therefore works across
+    all 36 decades, with no rtol/atol tradeoff to tune.
+    """
+
+    @pytest.mark.parametrize("magnitude", EXTREME_MAGNITUDES)
+    @pytest.mark.parametrize(("cart", "curv"), CHART_PAIRS)
+    @given(data=st.data())
+    @settings(deadline=None, max_examples=5)
+    def test_composition_is_the_identity(
+        self,
+        cart: cxc.AbstractChart,
+        curv: cxc.AbstractChart,
+        magnitude: float,
+        data: st.DataObject,
+    ) -> None:
+        """``J_{curv->cart} @ J_{cart->curv} = I``, at any magnitude.
+
+        The chain rule does not care how big the coordinates are, so this is
+        the same assertion `TestJacobianPtMapCompositionProperty` makes -- run
+        where the numbers are extreme rather than convenient.
+        """
+        p_curv = data.draw(cxst.cdicts(curv, magnitude=(magnitude, magnitude * 10.0)))
+        p_cart = cxc.pt_map(p_curv, curv, cart)
+
+        j_fwd = cxc.jac_pt_map(p_cart, cart, curv)
+        j_inv = cxc.jac_pt_map(p_curv, curv, cart)
+
+        assert_allclose(qnp.matmul(j_inv, j_fwd).value, jnp.eye(curv.ndim), atol=1e-4)
+
+    @pytest.mark.parametrize("magnitude", EXTREME_MAGNITUDES)
+    def test_analytic_dispatch_agrees_with_jacfwd(self, magnitude: float) -> None:
+        """The closed-form `Cart2D -> Polar2D` Jacobian matches autodiff.
+
+        This is the only pair with a hand-written Jacobian, and it is reached
+        only on *packed* input -- a cdict resolves to the generic branch, which
+        is ``jax.jacfwd(pt_map)`` itself and so cannot disagree with it. Passing
+        an array is what makes this an independent check rather than a
+        tautology.
+
+        Compared relatively: entries here scale like ``1/r``, so an absolute
+        tolerance would be vacuous at 1e18 and unmeetable at 1e-18.
+        """
+        theta = 0.7
+        at = jnp.asarray(
+            [magnitude * math.cos(theta), magnitude * math.sin(theta)],
+            dtype=jnp.float32,
+        )
+
+        got = np.asarray(cxc.jac_pt_map(at, cxc.cart2d, cxc.polar2d, usys=usys_si))
+        expected = np.asarray(
+            jax.jacfwd(cxc.pt_map(None, cxc.cart2d, cxc.polar2d, usys=usys_si))(at)
+        )
+
+        assert np.all(np.isfinite(got))
+        nonzero = expected != 0
+        assert_allclose(got[nonzero], expected[nonzero], rtol=1e-5)


### PR DESCRIPTION
The last of the four audit follow-ups. #667 was its prerequisite — `cdicts` could not draw these magnitudes until that landed.

## The gap

Every Jacobian test in this file pins points near 1, via `WELL_CONDITIONED = (0.5, 8.0)`. That is correct for those tests — they compare entries against an *absolute* tolerance, and entries scale like `r` and `1/r`. But it means the arithmetic is untested at the magnitudes real data arrives in: parsecs, or metres between atoms.

## Two properties that don't have that problem

Both are dimensionless, so one flat tolerance works at every scale and there's no rtol/atol tradeoff to tune:

1. **Composition identity** `J_inv @ J_fwd = I` over `CHART_PAIRS`, at six magnitudes from 1e-16 to 1e17.
2. **Closed-form `Cart2D → Polar2D` vs `jax.jacfwd`**, compared relatively.

The second is given **packed array input on purpose**. This is the part worth reviewing:

```python
cdict     -> jacobian.py:193   # generic branch
array     -> jacobian.py:289   # analytic closed form
quantity  -> jacobian.py:316   # analytic closed form
```

The generic branch *is* `jax.jacfwd(pt_map)`. Comparing it against `jacfwd` is a tautology that cannot fail — the existing `test_agrees_with_jacfwd` passes cdicts, so on values it only exercises packing and units. Only array/Quantity input reaches the hand-written Jacobian, which is the one implementation here autodiff can genuinely check.

## Where the limit actually is

Bounded by float32, not by the charts — and not where I first assumed. I initially wrote that `r**2` overflow set the ceiling. Measuring showed the binding limit is **underflow at the top**: `J_{cart→sph}` entries scale like `1/r**2`, which reaches float32's smallest normal at `sqrt(1/tiny) = 9.2e18` — it fails there, well before `r**2` would overflow at `sqrt(max) = 1.8e19`.

| | limit | mechanism |
|---|---|---|
| top | 9.2e18 | `1/r**2` underflows (`sqrt(1/tiny)`) |
| bottom | 1e-16 | `r**2` underflows at `sqrt(tiny)=1.1e-19`; near-pole colatitudes shrink `x`,`y` further, raising the floor |

Worst case measured across the whole angular domain is **2.6e-5** against `atol=1e-4`. Near-pole angles matter — at benign angles the error is ~1.2e-7, so a probe that skipped them would have picked a tolerance 200× too tight.

The boundary is **documented, not asserted**: it moves if JAX x64 is enabled (see #660), so pinning it would encode the environment's dtype rather than the maths.

## Verification

- 76 pass in the file; **4569 passed, 7 skipped, 1 xfailed** across `tests` + `packages`.
- Stable over five different hypothesis seeds.
- Mutation-tested both, above the tolerance: a 1e-3 perturbation to the closed form fails all 6 analytic cases; one to the generic Jacobian fails 18 composition cases. (My first attempt used 1e-7, below `rtol=1e-5`, and correctly passed — worth noting so the check isn't mistaken for a weak one.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)