### PR TITLE
⚡️ perf(hypothesis): draw a feasible product factor count, don't reject one

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
@@ -126,8 +126,8 @@ def atlases(
       dimensionality. The ``required_chart_classes`` argument pins specific
       chart types into the atlas.
     - **``CartesianProductAtlas``**: returns a ``CartesianProductAtlas``
-      built from two factor atlases whose dimensionalities sum to ``ndim``
-      (at least 2). ``CartesianProductAtlas`` is excluded from the factors.
+      built from 1-5 factor atlases whose dimensionalities sum to ``ndim``.
+      ``CartesianProductAtlas`` is excluded from the factors.
     - **``NoAtlas``**: returns ``NoAtlas()`` (always 0-D). By name only.
     - **``MinkowskiAtlas``**: returns ``MinkowskiAtlas()`` (always 4-D). By
       name only.
@@ -618,11 +618,11 @@ def atlases(
 ) -> Any:
     """Draw a ``CartesianProductAtlas`` with 1-5 non-product factor atlases.
 
-    The number of factors is drawn uniformly from 1 to 5. Each factor atlas is
-    drawn as a non-product atlas with ndim in ``[1, 3]``, and the total
-    dimensionality of the product equals the sum of those factor dimensionalities.
-    When ``ndim`` is given, the factor count is drawn from the range that admits
-    a partition into values in ``[1, 3]``; an ``ndim`` no factor count can reach
+    Each factor atlas is drawn as a non-product atlas with ndim in ``[1, 3]``,
+    and the total dimensionality of the product equals the sum of those factor
+    dimensionalities. Without ``ndim`` the factor count is drawn uniformly from
+    1 to 5. With ``ndim`` given it is drawn uniformly from the counts that admit
+    a partition into values in ``[1, 3]``; an ``ndim`` no count can reach
     (below 1, or above 15) is discarded via ``hypothesis.assume``.
 
     >>> import coordinax.manifolds as cxm

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/atlas.py
@@ -621,8 +621,9 @@ def atlases(
     The number of factors is drawn uniformly from 1 to 5. Each factor atlas is
     drawn as a non-product atlas with ndim in ``[1, 3]``, and the total
     dimensionality of the product equals the sum of those factor dimensionalities.
-    When ``ndim`` is given, examples are constrained so a valid partition into
-    ``n_factors`` values in ``[1, 3]`` exists.
+    When ``ndim`` is given, the factor count is drawn from the range that admits
+    a partition into values in ``[1, 3]``; an ``ndim`` no factor count can reach
+    (below 1, or above 15) is discarded via ``hypothesis.assume``.
 
     >>> import coordinax.manifolds as cxm
     >>> import coordinaxs.hypothesis.manifolds as cxmst
@@ -636,15 +637,20 @@ def atlases(
     """
     target_ndim = draw_if_strategy(draw, ndim)
 
-    # Draw the number of factors: 1–5
-    n_factors = draw(st.integers(min_value=1, max_value=5))
-
     dims: list[int] = []
     if target_ndim is None:
+        n_factors = draw(st.integers(min_value=1, max_value=5))
         dims = [draw(st.integers(min_value=1, max_value=3)) for _ in range(n_factors)]
     else:
-        # Feasibility for partition of target_ndim into n_factors entries in [1, 3].
-        assume(n_factors <= target_ndim <= 3 * n_factors)
+        # A partition of target_ndim into n_factors entries in [1, 3] exists iff
+        # n_factors <= target_ndim <= 3 * n_factors. Solve that for n_factors and
+        # draw from the feasible range, rather than drawing 1-5 and rejecting:
+        # at ndim=1 only one of the five counts worked.
+        lo = max(1, -(-target_ndim // 3))
+        hi = min(5, target_ndim)
+        if lo > hi:  # no factor count reaches this target
+            assume(False)
+        n_factors = draw(st.integers(min_value=lo, max_value=hi))
 
         remaining = target_ndim
         for i in range(n_factors):
@@ -657,8 +663,8 @@ def atlases(
 
         # No `assume(remaining == 0)`: on the last factor `factors_left_after`
         # is 0, so min_this == max_this == remaining and the loop always lands
-        # exactly on the target. The feasibility `assume` above is what does the
-        # work.
+        # exactly on the target. The `n_factors` range above is what makes every
+        # iteration's range non-empty.
 
     factors = tuple(
         draw(cast("Any", atlases)(exclude=(cxm.CartesianProductAtlas,), ndim=d))

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
@@ -423,11 +423,12 @@ def manifolds(
 ) -> Any:
     """Draw a ``CartesianProductManifold`` with 1-5 non-product factor manifolds.
 
-    The number of factors is drawn uniformly from 1 to 5. The total
-    dimensionality of the product equals the sum of the factor dimensionalities.
-    When ``ndim`` is given, each factor contributes at least 1 dimension, so the
-    factor count is drawn from ``[1, min(5, ndim)]``; ``ndim < 1`` admits no
-    product at all and is discarded via ``hypothesis.assume``.
+    The total dimensionality of the product equals the sum of the factor
+    dimensionalities. Without ``ndim`` the factor count is drawn uniformly from
+    1 to 5. With ``ndim`` given, each factor contributes at least 1 dimension,
+    so the count is drawn uniformly from ``[1, min(5, ndim)]``, every value of
+    which admits a partition; ``ndim < 1`` admits no product at all and is
+    discarded via ``hypothesis.assume``.
 
     >>> import coordinax.manifolds as cxm
     >>> import coordinaxs.hypothesis.manifolds as cxmst

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/manifolds/_src/manifold.py
@@ -425,9 +425,9 @@ def manifolds(
 
     The number of factors is drawn uniformly from 1 to 5. The total
     dimensionality of the product equals the sum of the factor dimensionalities.
-    When ``ndim`` is given it must be at least the number of factors (each
-    factor contributes at least 1 dimension); examples that cannot satisfy this
-    are discarded via ``hypothesis.assume``.
+    When ``ndim`` is given, each factor contributes at least 1 dimension, so the
+    factor count is drawn from ``[1, min(5, ndim)]``; ``ndim < 1`` admits no
+    product at all and is discarded via ``hypothesis.assume``.
 
     >>> import coordinax.manifolds as cxm
     >>> import coordinaxs.hypothesis.manifolds as cxmst
@@ -441,15 +441,17 @@ def manifolds(
     """
     target_ndim = draw_if_strategy(draw, ndim)
 
-    # Draw the number of factors: 1–5
-    n_factors = draw(st.integers(min_value=1, max_value=5))
-
-    # Each factor needs at least 1 dimension, so total_ndim >= n_factors.
-    if target_ndim is not None:
-        assume(target_ndim >= n_factors)
-        total_ndim = target_ndim
-    else:
+    # Each factor needs at least 1 dimension, so bound the factor count by the
+    # target up front rather than drawing 1-5 and rejecting the infeasible
+    # counts: at ndim=1 that threw away four draws in five.
+    if target_ndim is None:
+        n_factors = draw(st.integers(min_value=1, max_value=5))
         total_ndim = draw(st.integers(min_value=n_factors, max_value=n_factors + 4))
+    else:
+        # Below 1 dimension no factor count works at all.
+        assume(target_ndim >= 1)
+        n_factors = draw(st.integers(min_value=1, max_value=min(5, target_ndim)))
+        total_ndim = target_ndim
 
     # Partition total_ndim into n_factors positive integers, drawing each factor
     # from the range that still leaves >= 1 dimension for every factor after it.

--- a/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/manifolds/test_manifolds.py
@@ -280,3 +280,37 @@ class TestExcludedFromGenericPoolAreStillExplicitlyDrawable:
         predicate answers "at which ndim", not "belongs in the generic pool".
         """
         assert supports_ndim(cls, 3) is True
+
+
+class TestProductFactorCountIsDrawnFeasible:
+    """The factor count is narrowed to the target, not drawn then rejected."""
+
+    @pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
+    def test_product_manifold_low_ndim_does_not_filter(self, ndim: int) -> None:
+        """Low ``ndim`` products generate without tripping ``filter_too_much``.
+
+        Drawing the count from 1-5 and `assume`-ing feasibility rejected most
+        counts at small targets -- at ``ndim=1`` only one of the five worked --
+        which is what made this strategy fragile under the health check.
+        """
+
+        @given(M=cxst.manifolds(cxm.CartesianProductManifold, ndim=ndim))
+        @settings(max_examples=25, deadline=None)
+        def check(M: cxm.CartesianProductManifold) -> None:
+            assert 1 <= len(M.factors) <= min(5, ndim)
+            assert sum(f.ndim for f in M.factors) == ndim
+
+        check()
+
+    @pytest.mark.parametrize("ndim", [1, 2, 3, 4, 5])
+    def test_product_atlas_low_ndim_does_not_filter(self, ndim: int) -> None:
+        """Same for atlases, whose factors are additionally capped at 3-D."""
+
+        @given(atlas=cxst.atlases(cxm.CartesianProductAtlas, ndim=ndim))
+        @settings(max_examples=25, deadline=None)
+        def check(atlas: cxm.CartesianProductAtlas) -> None:
+            n = len(atlas.factors)
+            assert n <= ndim <= 3 * n
+            assert sum(f.ndim for f in atlas.factors) == ndim
+
+        check()


### PR DESCRIPTION
Rebase of #670 onto `main`, reduced to the half that has not already landed.

## What's left of #670

#670 diagnosed two things. The dominant one — undrawable types (`NoManifold`, `MinkowskiManifold`, and the atlas twins) entering the candidate pool and being discarded 100% of the time — landed as #663. `main` already has it.

The second has not landed: both product strategies draw `n_factors` from 1–5 and *then* `assume` it against the target. At `ndim=1` only one of the five counts can work. They now draw from the range that admits a partition — `[1, min(5, ndim)]` for manifolds, and for atlases the range solving `n_factors <= ndim <= 3 * n_factors`, since its factor dims are capped at 3. The remaining `assume`s fire only for an `ndim` no factor count reaches, where discarding is the documented contract.

## Result

200 draws each, `JAX_ENABLE_X64=1`. Discards go to zero:

| ndim | manifolds before | after | atlases before | after |
|---|---|---|---|---|
| 1 | 4 | **0** | 4 | **0** |
| 2 | 3 | **0** | 3 | **0** |
| 3 | 2 | **0** | 2 | **0** |
| 5 | 0 | **0** | 1 | **0** |

Wall-clock is unchanged within noise. Hypothesis prunes a branch that keeps failing, so the rejected counts were already cheap — the same effect that made #663's discard counts look flat while its real cost was elsewhere. The value here is that the generator no longer *depends* on that pruning, and the distribution over factor counts is uniform rather than shaped by rejection.

## What this does not claim

It does not fix the `filter_too_much` failure #670 was opened for. **#663 did.** The seed #670 cites,

```
--hypothesis-seed=177413034573078205584757766006941302796
```

now passes on plain `main`: `18 passed`. I checked before writing this up, rather than inheriting the original motivation.

Likewise the new tests **pass against `main`'s source too**, and I am not presenting them as a reproduction. The old code was wasteful, not wrong, so no assertion separates the two — nothing observable changes except the discard count, which is seed-dependent. The tests pin the invariant instead: factor count inside the feasible range, dims summing to the target.

## Not included

#670's other half also reshaped the drawability check — folding "has a strategy" into `_NDIM_SUPPORT` so that absence means undrawable, replacing #663's separate `_NO_STRATEGY`. That is a design question about already-merged code, not a rebase, so it is left out of this PR and raised separately.

2814 passed, 5 skipped with the package and `tests/unit` in one session; ruff and ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)