### PR TITLE
✨ feat(manifolds): add `interval`, `causal_character`, `proper_time`, `proper_distance`

### DIFF
--- a/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
+++ b/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
@@ -11,6 +11,10 @@ __all__ = (
     "pt_map",
     "norm",
     "separation",
+    "interval",
+    "causal_character",
+    "proper_time",
+    "proper_distance",
 )
 
 from typing import TYPE_CHECKING, Any
@@ -610,4 +614,40 @@ def metric_representation(M: Any, chart: Any, /) -> Any:
 
     """
     del M, chart
+    raise NotImplementedError  # pragma: no cover
+
+
+@plum.dispatch.abstract
+def interval(*args: Any, **kwargs: Any) -> Any:
+    """Signed squared interval between two points.
+
+    ``interval`` is the metric quadratic form of the coordinate difference,
+    *without* the square root that `norm` and `separation` take.  It is
+    therefore defined for every metric, including indefinite ones where
+    `separation` has no real value: for a Riemannian metric it is the squared
+    separation, and for a Lorentzian one its sign is the pair's causal
+    character.
+    """
+    raise NotImplementedError  # pragma: no cover
+
+
+@plum.dispatch.abstract
+def causal_character(*args: Any, **kwargs: Any) -> Any:
+    """Classify a pair of events as timelike, null, or spacelike.
+
+    Defined for Lorentzian metrics; the classification is the sign of
+    `interval`.
+    """
+    raise NotImplementedError  # pragma: no cover
+
+
+@plum.dispatch.abstract
+def proper_time(*args: Any, **kwargs: Any) -> Any:
+    """Proper time between two timelike-separated events."""
+    raise NotImplementedError  # pragma: no cover
+
+
+@plum.dispatch.abstract
+def proper_distance(*args: Any, **kwargs: Any) -> Any:
+    """Proper distance between two spacelike-separated events."""
     raise NotImplementedError  # pragma: no cover

--- a/src/coordinax/_src/manifolds/__init__.py
+++ b/src/coordinax/_src/manifolds/__init__.py
@@ -4,6 +4,7 @@ __all__: tuple[str, ...] = ()
 
 from .angle_between import *
 from .guess import *
+from .interval import *
 from .norm import *
 from .scale_factors import *
 from .separation import *

--- a/src/coordinax/_src/manifolds/_utils.py
+++ b/src/coordinax/_src/manifolds/_utils.py
@@ -47,7 +47,9 @@ def require_positive_definite(metric: AbstractMetricField, fname: str, /) -> Non
     norm() supports only positive-definite metrics, but MinkowskiMetric has
     signature (-1, 1, 1, 1), which is pseudo-Riemannian (indefinite). Under such
     a metric `sqrt(v^T G v)` is `nan` for timelike vectors rather than a
-    meaningful magnitude.
+    meaningful magnitude. Use `interval` for the signed square, or
+    `proper_time` / `proper_distance` for the magnitude of a timelike /
+    spacelike pair.
 
     """
     if all(s > 0 for s in metric.signature):
@@ -57,7 +59,9 @@ def require_positive_definite(metric: AbstractMetricField, fname: str, /) -> Non
         f"{type(metric).__name__} has signature {tuple(metric.signature)}, which "
         "is pseudo-Riemannian (indefinite). Under such a metric "
         "`sqrt(v^T G v)` is `nan` for timelike vectors rather than a "
-        "meaningful magnitude."
+        "meaningful magnitude. Use `interval` for the signed square, or "
+        "`proper_time` / `proper_distance` for the magnitude of a timelike / "
+        "spacelike pair."
     )
     raise NotImplementedError(msg)
 

--- a/src/coordinax/_src/manifolds/interval.py
+++ b/src/coordinax/_src/manifolds/interval.py
@@ -1,0 +1,324 @@
+r"""Dispatch implementations for the interval / causality API.
+
+`norm` refuses indefinite metrics, because $\sqrt{v^\top G v}$ has no real value
+when the quadratic form can go negative.  The quantity that *is* well defined
+there is the form itself, unrooted:
+
+$$ \Delta s^2 = \Delta x^\top G\, \Delta x, $$
+
+which is what this module exposes as `interval`.  For a Riemannian metric it is
+simply the squared `separation`; for a Lorentzian one its **sign** is the causal
+character of the pair, and its magnitude gives proper time (timelike) or proper
+distance (spacelike).
+"""
+
+__all__: tuple[str, ...] = ()
+
+from typing import Any, Literal, cast
+
+import plum
+
+import quaxed.numpy as jnp
+import unxt as u
+
+import coordinaxs.api.charts as cxcapi
+import coordinaxs.api.manifolds as cxmapi
+from .quadratic_form import quadratic_form
+from coordinax._src.base import AbstractChart, AbstractMetricField
+from coordinax._src.custom_types import CDict, OptUSys
+
+#: Speed of light in vacuum, for converting a length-valued proper interval
+#: into a duration.  `MinkowskiCT` measures time as ``ct`` in length units, so
+#: this is needed only at the boundary where a caller wants seconds.
+C_LIGHT = u.Q(299792458.0, "m/s")
+
+CausalCharacter = Literal["timelike", "null", "spacelike"]
+
+_MSG_NOT_LORENTZIAN = (
+    "{fname}() requires a Lorentzian metric (exactly one negative signature "
+    "entry, as in Minkowski's (-1, 1, 1, 1)); {name} has signature {sig}. "
+    "Causal character is not defined for this metric."
+)
+
+_MSG_NOT_TIMELIKE = (
+    "proper_time() is defined only for timelike-separated events; this pair is "
+    "{kind} (interval^2 = {ds2}). Use `interval` for the signed square, or "
+    "`proper_distance` for a spacelike pair."
+)
+
+_MSG_NOT_SPACELIKE = (
+    "proper_distance() is defined only for spacelike-separated events; this "
+    "pair is {kind} (interval^2 = {ds2}). Use `interval` for the signed "
+    "square, or `proper_time` for a timelike pair."
+)
+
+
+def _require_lorentzian(metric: AbstractMetricField, fname: str, /) -> None:
+    """Raise unless *metric* has exactly one timelike direction."""
+    sig = tuple(metric.signature)
+    if sum(1 for s in sig if s < 0) != 1:
+        msg = _MSG_NOT_LORENTZIAN.format(
+            fname=fname, name=type(metric).__name__, sig=sig
+        )
+        raise ValueError(msg)
+
+
+# ===================================================================
+# interval
+
+
+@plum.dispatch
+def interval(
+    chart: AbstractChart, a: CDict, b: CDict, /, *, usys: OptUSys = None
+) -> Any:
+    r"""Signed squared interval between two points, in the chart's metric.
+
+    Unlike `separation`, this is defined for *every* metric, because it never
+    takes a square root.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    For a Riemannian metric it is the squared separation:
+
+    >>> a = {"x": u.Q(3.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> b = {"x": u.Q(0.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+    >>> cxm.interval(cxc.cart3d, a, b).round(2)
+    Q(25., 'm2')
+
+    For Minkowski it is negative for a timelike pair -- the case that used to
+    make `separation` return ``nan``:
+
+    >>> o = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> ev = {"ct": u.Q(5.0, "m"), "x": u.Q(1.0, "m"),
+    ...       "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> cxm.interval(cxc.minkowskict, o, ev).round(2)
+    Q(-24., 'm2')
+
+    """
+    return cxmapi.interval(chart.M.metric, chart, a, b, usys=usys)
+
+
+@plum.dispatch
+def interval(
+    metric: AbstractMetricField,
+    chart: AbstractChart,
+    a: CDict,
+    b: CDict,
+    /,
+    *,
+    usys: OptUSys = None,
+) -> Any:
+    r"""Signed squared interval with respect to an explicit metric.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> o = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> ev = {"ct": u.Q(1.0, "m"), "x": u.Q(5.0, "m"),
+    ...       "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> cxm.interval(cxm.MinkowskiMetric(), cxc.minkowskict, o, ev).round(2)
+    Q(24., 'm2')
+
+    """
+    chart.check_data(a, keys=True, values=False)
+    chart.check_data(b, keys=True, values=False)
+
+    diff = {k: b[k] - a[k] for k in chart.components}
+
+    # The same contraction `norm` takes the square root of, evaluated at `a`.
+    # Sharing it is what gives `interval` the unit handling it would otherwise
+    # have to restate -- and makes `separation**2 == interval` hold by
+    # construction rather than by the test that asserts it.
+    return quadratic_form(diff, chart, at=a, usys=usys, fname="interval")
+
+
+@plum.dispatch
+def interval(
+    chart: AbstractChart,
+    a: u.AbstractQuantity,
+    b: u.AbstractQuantity,
+    /,
+    *,
+    usys: OptUSys = None,
+) -> Any:
+    """Signed squared interval for packed `unxt.Quantity` vectors.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> a = u.Q([0.0, 0.0, 0.0, 0.0], "m")
+    >>> b = u.Q([5.0, 1.0, 0.0, 0.0], "m")
+    >>> cxm.interval(cxc.minkowskict, a, b).round(2)
+    Q(-24., 'm2')
+
+    """
+    return cxmapi.interval(
+        chart, cxcapi.cdict(a, chart), cxcapi.cdict(b, chart), usys=usys
+    )
+
+
+# ===================================================================
+# causal_character
+
+
+@plum.dispatch
+def causal_character(
+    chart: AbstractChart,
+    a: CDict,
+    b: CDict,
+    /,
+    *,
+    atol: Any = None,
+    usys: OptUSys = None,
+) -> str:
+    r"""Classify a pair of events as ``"timelike"``, ``"null"``, or ``"spacelike"``.
+
+    The classification is the sign of `interval`, with ``atol`` deciding how
+    close to zero counts as null (default: ``1e-8`` of the largest squared
+    coordinate difference, so it scales with the data).
+
+    This returns a Python `str` and so is **not** ``jit``-able; it is a
+    diagnostic. Inside a traced computation, branch on the sign of `interval`.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> o = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> def ev(ct, x):
+    ...     return {"ct": u.Q(ct, "m"), "x": u.Q(x, "m"),
+    ...             "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+
+    A big time difference and a small space difference is timelike -- the two
+    events can be visited by one slower-than-light observer:
+
+    >>> cxm.causal_character(cxc.minkowskict, o, ev(5.0, 1.0))
+    'timelike'
+
+    The reverse is spacelike -- no observer sees both:
+
+    >>> cxm.causal_character(cxc.minkowskict, o, ev(1.0, 5.0))
+    'spacelike'
+
+    Equal parts is null: exactly a light ray.
+
+    >>> cxm.causal_character(cxc.minkowskict, o, ev(3.0, 3.0))
+    'null'
+
+    """
+    _require_lorentzian(chart.M.metric, "causal_character")
+    ds2 = cxmapi.interval(chart, a, b, usys=usys)
+
+    unit = u.unit_of(ds2)
+    ds2_val = float(u.ustrip(unit, ds2)) if unit is not None else float(ds2)
+
+    if atol is None:
+        # Scale-free default: compare against the largest squared coordinate
+        # difference, so "close to zero" means small *relative to the data*
+        # rather than small in whatever unit the caller happened to use.
+        diffs = (
+            float(u.ustrip(u.unit_of(b[k]), b[k] - a[k])) ** 2 for k in chart.components
+        )
+        scale = max(diffs, default=1.0)
+        tol = 1e-8 * max(scale, 1.0)
+    else:
+        has_unit = u.unit_of(atol) is not None
+        tol = float(u.ustrip(unit, atol)) if has_unit else float(atol)
+
+    if ds2_val < -tol:
+        return "timelike"
+    if ds2_val > tol:
+        return "spacelike"
+    return "null"
+
+
+# ===================================================================
+# proper_time / proper_distance
+
+
+@plum.dispatch
+def proper_time(
+    chart: AbstractChart,
+    a: CDict,
+    b: CDict,
+    /,
+    *,
+    atol: Any = None,
+    usys: OptUSys = None,
+) -> Any:
+    r"""Proper time elapsed between two timelike-separated events.
+
+    For a timelike pair, $c\,\tau = \sqrt{-\Delta s^2}$; this returns the
+    duration $\tau$, dividing by $c$ so the result is a *time*, not the
+    length-valued $c\tau$ that the ``ct`` chart works in.
+
+    Raises `ValueError` for a null or spacelike pair, where no observer's
+    wristwatch connects the two events.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    An observer at rest for 1 light-second of coordinate time ages 1 second:
+
+    >>> o = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> rest = {"ct": u.Q(299792458.0, "m"), "x": u.Q(0.0, "m"),
+    ...         "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> cxm.proper_time(cxc.minkowskict, o, rest).uconvert("s").round(3)
+    Q(1., 's')
+
+    A spacelike pair has no proper time:
+
+    >>> far = {"ct": u.Q(1.0, "m"), "x": u.Q(5.0, "m"),
+    ...        "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> try:
+    ...     cxm.proper_time(cxc.minkowskict, o, far)
+    ... except ValueError as e:
+    ...     print(str(e)[:56])
+    proper_time() is defined only for timelike-separated eve
+
+    """
+    kind = cxmapi.causal_character(chart, a, b, atol=atol, usys=usys)
+    ds2 = cast("Any", cxmapi.interval(chart, a, b, usys=usys))
+    if kind != "timelike":
+        raise ValueError(_MSG_NOT_TIMELIKE.format(kind=kind, ds2=ds2))
+    return jnp.sqrt(-ds2) / C_LIGHT
+
+
+@plum.dispatch
+def proper_distance(
+    chart: AbstractChart,
+    a: CDict,
+    b: CDict,
+    /,
+    *,
+    atol: Any = None,
+    usys: OptUSys = None,
+) -> Any:
+    r"""Proper distance between two spacelike-separated events.
+
+    For a spacelike pair, $\Delta\sigma = \sqrt{\Delta s^2}$ -- the distance
+    measured in the frame where the two events are simultaneous.
+
+    Raises `ValueError` for a null or timelike pair.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> o = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> far = {"ct": u.Q(3.0, "m"), "x": u.Q(5.0, "m"),
+    ...        "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> cxm.proper_distance(cxc.minkowskict, o, far).round(2)
+    Q(4., 'm')
+
+    """
+    kind = cxmapi.causal_character(chart, a, b, atol=atol, usys=usys)
+    ds2 = cast("Any", cxmapi.interval(chart, a, b, usys=usys))
+    if kind != "spacelike":
+        raise ValueError(_MSG_NOT_SPACELIKE.format(kind=kind, ds2=ds2))
+    return jnp.sqrt(ds2)

--- a/src/coordinax/_src/manifolds/interval.py
+++ b/src/coordinax/_src/manifolds/interval.py
@@ -10,6 +10,13 @@ which is what this module exposes as `interval`.  For a Riemannian metric it is
 simply the squared `separation`; for a Lorentzian one its **sign** is the causal
 character of the pair, and its magnitude gives proper time (timelike) or proper
 distance (spacelike).
+
+Like `separation`, the metric is evaluated **at the first point** ``a`` and
+applied to the coordinate difference.  This is exact for a flat manifold --
+including Minkowski, the case this module exists for, where the metric is
+constant everywhere -- but on a curved manifold it is a first-order estimate
+rather than a geodesic quantity, and it is asymmetric in ``a`` and ``b``.  Bring
+the points into a Cartesian chart first for a chart-invariant result.
 """
 
 __all__: tuple[str, ...] = ()
@@ -52,6 +59,37 @@ _MSG_NOT_SPACELIKE = (
     "pair is {kind} (interval^2 = {ds2}). Use `interval` for the signed "
     "square, or `proper_time` for a timelike pair."
 )
+
+
+def _as_float(x: Any, /) -> float:
+    """Return *x* as a plain float, stripping units only if it has any.
+
+    `chart.check_data(..., values=False)` permits bare arrays alongside
+    quantities, so a components-have-units assumption would break the
+    bare-array path.
+    """
+    unit = u.unit_of(x)
+    return float(x if unit is None else u.ustrip(unit, x))
+
+
+def _classify(ds2: Any, a: CDict, b: CDict, keys: tuple[str, ...], atol: Any, /) -> str:
+    """Classify a precomputed interval, so callers evaluate it only once."""
+    ds2_val = _as_float(ds2)
+
+    if atol is None:
+        # Scale-free default: compare against the largest squared coordinate
+        # difference, so "close to zero" means small *relative to the data*
+        # rather than small in whatever unit the caller happened to use.
+        scale = max((_as_float(b[k] - a[k]) ** 2 for k in keys), default=1.0)
+        tol = 1e-8 * max(scale, 1.0)
+    else:
+        tol = _as_float(atol)
+
+    if ds2_val < -tol:
+        return "timelike"
+    if ds2_val > tol:
+        return "spacelike"
+    return "null"
 
 
 def _require_lorentzian(metric: AbstractMetricField, fname: str, /) -> None:
@@ -123,8 +161,25 @@ def interval(
     >>> cxm.interval(cxm.MinkowskiMetric(), cxc.minkowskict, o, ev).round(2)
     Q(24., 'm2')
 
+    ``metric`` is a checked selector, not an override: it must be the chart's own
+    metric, matching the contract of the metric-level `~coordinax.manifolds.norm`
+    overload.
+
+    >>> try:
+    ...     cxm.interval(cxm.FlatMetric(4), cxc.minkowskict, o, ev)
+    ... except ValueError as e:
+    ...     print(e)
+    Metric-level dispatch: metric must match chart's metric
+
     """
     del usys
+    # Mirrors `norm`'s metric-level dispatch: the argument is validated against
+    # the chart rather than silently ignored, so a caller who passes a different
+    # metric expecting it to be honoured is told, instead of quietly receiving
+    # the chart's answer.
+    if metric != chart.M.metric:
+        raise ValueError("Metric-level dispatch: metric must match chart's metric")
+
     chart.check_data(a, keys=True, values=False)
     chart.check_data(b, keys=True, values=False)
 
@@ -216,28 +271,7 @@ def causal_character(
     """
     _require_lorentzian(chart.M.metric, "causal_character")
     ds2 = cxmapi.interval(chart, a, b, usys=usys)
-
-    unit = u.unit_of(ds2)
-    ds2_val = float(u.ustrip(unit, ds2)) if unit is not None else float(ds2)
-
-    if atol is None:
-        # Scale-free default: compare against the largest squared coordinate
-        # difference, so "close to zero" means small *relative to the data*
-        # rather than small in whatever unit the caller happened to use.
-        diffs = (
-            float(u.ustrip(u.unit_of(b[k]), b[k] - a[k])) ** 2 for k in chart.components
-        )
-        scale = max(diffs, default=1.0)
-        tol = 1e-8 * max(scale, 1.0)
-    else:
-        has_unit = u.unit_of(atol) is not None
-        tol = float(u.ustrip(unit, atol)) if has_unit else float(atol)
-
-    if ds2_val < -tol:
-        return "timelike"
-    if ds2_val > tol:
-        return "spacelike"
-    return "null"
+    return _classify(ds2, a, b, chart.components, atol)
 
 
 # ===================================================================
@@ -286,8 +320,12 @@ def proper_time(
     proper_time() is defined only for timelike-separated eve
 
     """
-    kind = cxmapi.causal_character(chart, a, b, atol=atol, usys=usys)
+    # One evaluation of the interval, classified and then used. Calling
+    # `causal_character` here would compute it a second time, which on a curved
+    # metric means a second `metric_matrix` build.
+    _require_lorentzian(chart.M.metric, "proper_time")
     ds2 = cast("Any", cxmapi.interval(chart, a, b, usys=usys))
+    kind = _classify(ds2, a, b, chart.components, atol)
     if kind != "timelike":
         raise ValueError(_MSG_NOT_TIMELIKE.format(kind=kind, ds2=ds2))
     return jnp.sqrt(-ds2) / C_LIGHT
@@ -321,8 +359,12 @@ def proper_distance(
     Q(4., 'm')
 
     """
-    kind = cxmapi.causal_character(chart, a, b, atol=atol, usys=usys)
+    # One evaluation of the interval, classified and then used. Calling
+    # `causal_character` here would compute it a second time, which on a curved
+    # metric means a second `metric_matrix` build.
+    _require_lorentzian(chart.M.metric, "proper_distance")
     ds2 = cast("Any", cxmapi.interval(chart, a, b, usys=usys))
+    kind = _classify(ds2, a, b, chart.components, atol)
     if kind != "spacelike":
         raise ValueError(_MSG_NOT_SPACELIKE.format(kind=kind, ds2=ds2))
     return jnp.sqrt(ds2)

--- a/src/coordinax/_src/manifolds/interval.py
+++ b/src/coordinax/_src/manifolds/interval.py
@@ -10,6 +10,13 @@ which is what this module exposes as `interval`.  For a Riemannian metric it is
 simply the squared `separation`; for a Lorentzian one its **sign** is the causal
 character of the pair, and its magnitude gives proper time (timelike) or proper
 distance (spacelike).
+
+Like `separation`, the metric is evaluated **at the first point** ``a`` and
+applied to the coordinate difference.  This is exact for a flat manifold --
+including Minkowski, the case this module exists for, where the metric is
+constant everywhere -- but on a curved manifold it is a first-order estimate
+rather than a geodesic quantity, and it is asymmetric in ``a`` and ``b``.  Bring
+the points into a Cartesian chart first for a chart-invariant result.
 """
 
 __all__: tuple[str, ...] = ()
@@ -51,6 +58,37 @@ _MSG_NOT_SPACELIKE = (
     "pair is {kind} (interval^2 = {ds2}). Use `interval` for the signed "
     "square, or `proper_time` for a timelike pair."
 )
+
+
+def _as_float(x: Any, /) -> float:
+    """Return *x* as a plain float, stripping units only if it has any.
+
+    `chart.check_data(..., values=False)` permits bare arrays alongside
+    quantities, so a components-have-units assumption would break the
+    bare-array path.
+    """
+    unit = u.unit_of(x)
+    return float(x if unit is None else u.ustrip(unit, x))
+
+
+def _classify(ds2: Any, a: CDict, b: CDict, keys: tuple[str, ...], atol: Any, /) -> str:
+    """Classify a precomputed interval, so callers evaluate it only once."""
+    ds2_val = _as_float(ds2)
+
+    if atol is None:
+        # Scale-free default: compare against the largest squared coordinate
+        # difference, so "close to zero" means small *relative to the data*
+        # rather than small in whatever unit the caller happened to use.
+        scale = max((_as_float(b[k] - a[k]) ** 2 for k in keys), default=1.0)
+        tol = 1e-8 * max(scale, 1.0)
+    else:
+        tol = _as_float(atol)
+
+    if ds2_val < -tol:
+        return "timelike"
+    if ds2_val > tol:
+        return "spacelike"
+    return "null"
 
 
 def _require_lorentzian(metric: AbstractMetricField, fname: str, /) -> None:
@@ -122,7 +160,24 @@ def interval(
     >>> cxm.interval(cxm.MinkowskiMetric(), cxc.minkowskict, o, ev).round(2)
     Q(24., 'm2')
 
+    ``metric`` is a checked selector, not an override: it must be the chart's own
+    metric, matching the contract of the metric-level `~coordinax.manifolds.norm`
+    overload.
+
+    >>> try:
+    ...     cxm.interval(cxm.FlatMetric(4), cxc.minkowskict, o, ev)
+    ... except ValueError as e:
+    ...     print(e)
+    Metric-level dispatch: metric must match chart's metric
+
     """
+    # Mirrors `norm`'s metric-level dispatch: the argument is validated against
+    # the chart rather than silently ignored, so a caller who passes a different
+    # metric expecting it to be honoured is told, instead of quietly receiving
+    # the chart's answer.
+    if metric != chart.M.metric:
+        raise ValueError("Metric-level dispatch: metric must match chart's metric")
+
     chart.check_data(a, keys=True, values=False)
     chart.check_data(b, keys=True, values=False)
 
@@ -212,28 +267,7 @@ def causal_character(
     """
     _require_lorentzian(chart.M.metric, "causal_character")
     ds2 = cxmapi.interval(chart, a, b, usys=usys)
-
-    unit = u.unit_of(ds2)
-    ds2_val = float(u.ustrip(unit, ds2)) if unit is not None else float(ds2)
-
-    if atol is None:
-        # Scale-free default: compare against the largest squared coordinate
-        # difference, so "close to zero" means small *relative to the data*
-        # rather than small in whatever unit the caller happened to use.
-        diffs = (
-            float(u.ustrip(u.unit_of(b[k]), b[k] - a[k])) ** 2 for k in chart.components
-        )
-        scale = max(diffs, default=1.0)
-        tol = 1e-8 * max(scale, 1.0)
-    else:
-        has_unit = u.unit_of(atol) is not None
-        tol = float(u.ustrip(unit, atol)) if has_unit else float(atol)
-
-    if ds2_val < -tol:
-        return "timelike"
-    if ds2_val > tol:
-        return "spacelike"
-    return "null"
+    return _classify(ds2, a, b, chart.components, atol)
 
 
 # ===================================================================
@@ -282,8 +316,12 @@ def proper_time(
     proper_time() is defined only for timelike-separated eve
 
     """
-    kind = cxmapi.causal_character(chart, a, b, atol=atol, usys=usys)
+    # One evaluation of the interval, classified and then used. Calling
+    # `causal_character` here would compute it a second time, which on a curved
+    # metric means a second `metric_matrix` build.
+    _require_lorentzian(chart.M.metric, "proper_time")
     ds2 = cast("Any", cxmapi.interval(chart, a, b, usys=usys))
+    kind = _classify(ds2, a, b, chart.components, atol)
     if kind != "timelike":
         raise ValueError(_MSG_NOT_TIMELIKE.format(kind=kind, ds2=ds2))
     return jnp.sqrt(-ds2) / C_LIGHT
@@ -317,8 +355,12 @@ def proper_distance(
     Q(4., 'm')
 
     """
-    kind = cxmapi.causal_character(chart, a, b, atol=atol, usys=usys)
+    # One evaluation of the interval, classified and then used. Calling
+    # `causal_character` here would compute it a second time, which on a curved
+    # metric means a second `metric_matrix` build.
+    _require_lorentzian(chart.M.metric, "proper_distance")
     ds2 = cast("Any", cxmapi.interval(chart, a, b, usys=usys))
+    kind = _classify(ds2, a, b, chart.components, atol)
     if kind != "spacelike":
         raise ValueError(_MSG_NOT_SPACELIKE.format(kind=kind, ds2=ds2))
     return jnp.sqrt(ds2)

--- a/src/coordinax/_src/manifolds/interval.py
+++ b/src/coordinax/_src/manifolds/interval.py
@@ -1,0 +1,328 @@
+r"""Dispatch implementations for the interval / causality API.
+
+`norm` refuses indefinite metrics, because $\sqrt{v^\top G v}$ has no real value
+when the quadratic form can go negative.  The quantity that *is* well defined
+there is the form itself, unrooted:
+
+$$ \Delta s^2 = \Delta x^\top G\, \Delta x, $$
+
+which is what this module exposes as `interval`.  For a Riemannian metric it is
+simply the squared `separation`; for a Lorentzian one its **sign** is the causal
+character of the pair, and its magnitude gives proper time (timelike) or proper
+distance (spacelike).
+"""
+
+__all__: tuple[str, ...] = ()
+
+from typing import Any, Literal, cast
+
+import plum
+
+import quaxed.numpy as jnp
+import unxt as u
+
+import coordinaxs.api.charts as cxcapi
+import coordinaxs.api.manifolds as cxmapi
+from ._utils import as_quantity_matrix
+from coordinax._src.base import AbstractChart, AbstractMetricField
+from coordinax._src.custom_types import CDict, OptUSys
+from coordinax._src.metric.matrix import DenseMetric
+
+#: Speed of light in vacuum, for converting a length-valued proper interval
+#: into a duration.  `MinkowskiCT` measures time as ``ct`` in length units, so
+#: this is needed only at the boundary where a caller wants seconds.
+C_LIGHT = u.Q(299792458.0, "m/s")
+
+CausalCharacter = Literal["timelike", "null", "spacelike"]
+
+_MSG_NOT_LORENTZIAN = (
+    "{fname}() requires a Lorentzian metric (exactly one negative signature "
+    "entry, as in Minkowski's (-1, 1, 1, 1)); {name} has signature {sig}. "
+    "Causal character is not defined for this metric."
+)
+
+_MSG_NOT_TIMELIKE = (
+    "proper_time() is defined only for timelike-separated events; this pair is "
+    "{kind} (interval^2 = {ds2}). Use `interval` for the signed square, or "
+    "`proper_distance` for a spacelike pair."
+)
+
+_MSG_NOT_SPACELIKE = (
+    "proper_distance() is defined only for spacelike-separated events; this "
+    "pair is {kind} (interval^2 = {ds2}). Use `interval` for the signed "
+    "square, or `proper_time` for a timelike pair."
+)
+
+
+def _require_lorentzian(metric: AbstractMetricField, fname: str, /) -> None:
+    """Raise unless *metric* has exactly one timelike direction."""
+    sig = tuple(metric.signature)
+    if sum(1 for s in sig if s < 0) != 1:
+        msg = _MSG_NOT_LORENTZIAN.format(
+            fname=fname, name=type(metric).__name__, sig=sig
+        )
+        raise ValueError(msg)
+
+
+# ===================================================================
+# interval
+
+
+@plum.dispatch
+def interval(
+    chart: AbstractChart, a: CDict, b: CDict, /, *, usys: OptUSys = None
+) -> Any:
+    r"""Signed squared interval between two points, in the chart's metric.
+
+    Unlike `separation`, this is defined for *every* metric, because it never
+    takes a square root.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    For a Riemannian metric it is the squared separation:
+
+    >>> a = {"x": u.Q(3.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> b = {"x": u.Q(0.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+    >>> cxm.interval(cxc.cart3d, a, b).round(2)
+    Q(25., 'm2')
+
+    For Minkowski it is negative for a timelike pair -- the case that used to
+    make `separation` return ``nan``:
+
+    >>> o = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> ev = {"ct": u.Q(5.0, "m"), "x": u.Q(1.0, "m"),
+    ...       "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> cxm.interval(cxc.minkowskict, o, ev).round(2)
+    Q(-24., 'm2')
+
+    """
+    return cxmapi.interval(chart.M.metric, chart, a, b, usys=usys)
+
+
+@plum.dispatch
+def interval(
+    metric: AbstractMetricField,
+    chart: AbstractChart,
+    a: CDict,
+    b: CDict,
+    /,
+    *,
+    usys: OptUSys = None,
+) -> Any:
+    r"""Signed squared interval with respect to an explicit metric.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> o = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> ev = {"ct": u.Q(1.0, "m"), "x": u.Q(5.0, "m"),
+    ...       "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> cxm.interval(cxm.MinkowskiMetric(), cxc.minkowskict, o, ev).round(2)
+    Q(24., 'm2')
+
+    """
+    del usys
+    chart.check_data(a, keys=True, values=False)
+    chart.check_data(b, keys=True, values=False)
+
+    keys = chart.components
+    diff = {k: b[k] - a[k] for k in keys}
+
+    mm = cxmapi.metric_matrix(chart.M, a, chart)
+    g = as_quantity_matrix(
+        mm.matrix if isinstance(mm, DenseMetric) else mm.to_dense().matrix  # ty: ignore[unresolved-attribute]
+    )
+    d_qm = cxcapi.carray(diff, keys)
+    return d_qm @ (g @ d_qm)
+
+
+@plum.dispatch
+def interval(
+    chart: AbstractChart,
+    a: u.AbstractQuantity,
+    b: u.AbstractQuantity,
+    /,
+    *,
+    usys: OptUSys = None,
+) -> Any:
+    """Signed squared interval for packed `unxt.Quantity` vectors.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> a = u.Q([0.0, 0.0, 0.0, 0.0], "m")
+    >>> b = u.Q([5.0, 1.0, 0.0, 0.0], "m")
+    >>> cxm.interval(cxc.minkowskict, a, b).round(2)
+    Q(-24., 'm2')
+
+    """
+    return cxmapi.interval(
+        chart, cxcapi.cdict(a, chart), cxcapi.cdict(b, chart), usys=usys
+    )
+
+
+# ===================================================================
+# causal_character
+
+
+@plum.dispatch
+def causal_character(
+    chart: AbstractChart,
+    a: CDict,
+    b: CDict,
+    /,
+    *,
+    atol: Any = None,
+    usys: OptUSys = None,
+) -> str:
+    r"""Classify a pair of events as ``"timelike"``, ``"null"``, or ``"spacelike"``.
+
+    The classification is the sign of `interval`, with ``atol`` deciding how
+    close to zero counts as null (default: ``1e-8`` of the largest squared
+    coordinate difference, so it scales with the data).
+
+    This returns a Python `str` and so is **not** ``jit``-able; it is a
+    diagnostic. Inside a traced computation, branch on the sign of `interval`.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> o = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> def ev(ct, x):
+    ...     return {"ct": u.Q(ct, "m"), "x": u.Q(x, "m"),
+    ...             "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+
+    A big time difference and a small space difference is timelike -- the two
+    events can be visited by one slower-than-light observer:
+
+    >>> cxm.causal_character(cxc.minkowskict, o, ev(5.0, 1.0))
+    'timelike'
+
+    The reverse is spacelike -- no observer sees both:
+
+    >>> cxm.causal_character(cxc.minkowskict, o, ev(1.0, 5.0))
+    'spacelike'
+
+    Equal parts is null: exactly a light ray.
+
+    >>> cxm.causal_character(cxc.minkowskict, o, ev(3.0, 3.0))
+    'null'
+
+    """
+    _require_lorentzian(chart.M.metric, "causal_character")
+    ds2 = cxmapi.interval(chart, a, b, usys=usys)
+
+    unit = u.unit_of(ds2)
+    ds2_val = float(u.ustrip(unit, ds2)) if unit is not None else float(ds2)
+
+    if atol is None:
+        # Scale-free default: compare against the largest squared coordinate
+        # difference, so "close to zero" means small *relative to the data*
+        # rather than small in whatever unit the caller happened to use.
+        diffs = (
+            float(u.ustrip(u.unit_of(b[k]), b[k] - a[k])) ** 2 for k in chart.components
+        )
+        scale = max(diffs, default=1.0)
+        tol = 1e-8 * max(scale, 1.0)
+    else:
+        has_unit = u.unit_of(atol) is not None
+        tol = float(u.ustrip(unit, atol)) if has_unit else float(atol)
+
+    if ds2_val < -tol:
+        return "timelike"
+    if ds2_val > tol:
+        return "spacelike"
+    return "null"
+
+
+# ===================================================================
+# proper_time / proper_distance
+
+
+@plum.dispatch
+def proper_time(
+    chart: AbstractChart,
+    a: CDict,
+    b: CDict,
+    /,
+    *,
+    atol: Any = None,
+    usys: OptUSys = None,
+) -> Any:
+    r"""Proper time elapsed between two timelike-separated events.
+
+    For a timelike pair, $c\,\tau = \sqrt{-\Delta s^2}$; this returns the
+    duration $\tau$, dividing by $c$ so the result is a *time*, not the
+    length-valued $c\tau$ that the ``ct`` chart works in.
+
+    Raises `ValueError` for a null or spacelike pair, where no observer's
+    wristwatch connects the two events.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    An observer at rest for 1 light-second of coordinate time ages 1 second:
+
+    >>> o = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> rest = {"ct": u.Q(299792458.0, "m"), "x": u.Q(0.0, "m"),
+    ...         "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> cxm.proper_time(cxc.minkowskict, o, rest).uconvert("s").round(3)
+    Q(1., 's')
+
+    A spacelike pair has no proper time:
+
+    >>> far = {"ct": u.Q(1.0, "m"), "x": u.Q(5.0, "m"),
+    ...        "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> try:
+    ...     cxm.proper_time(cxc.minkowskict, o, far)
+    ... except ValueError as e:
+    ...     print(str(e)[:56])
+    proper_time() is defined only for timelike-separated eve
+
+    """
+    kind = cxmapi.causal_character(chart, a, b, atol=atol, usys=usys)
+    ds2 = cast("Any", cxmapi.interval(chart, a, b, usys=usys))
+    if kind != "timelike":
+        raise ValueError(_MSG_NOT_TIMELIKE.format(kind=kind, ds2=ds2))
+    return jnp.sqrt(-ds2) / C_LIGHT
+
+
+@plum.dispatch
+def proper_distance(
+    chart: AbstractChart,
+    a: CDict,
+    b: CDict,
+    /,
+    *,
+    atol: Any = None,
+    usys: OptUSys = None,
+) -> Any:
+    r"""Proper distance between two spacelike-separated events.
+
+    For a spacelike pair, $\Delta\sigma = \sqrt{\Delta s^2}$ -- the distance
+    measured in the frame where the two events are simultaneous.
+
+    Raises `ValueError` for a null or timelike pair.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> o = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> far = {"ct": u.Q(3.0, "m"), "x": u.Q(5.0, "m"),
+    ...        "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> cxm.proper_distance(cxc.minkowskict, o, far).round(2)
+    Q(4., 'm')
+
+    """
+    kind = cxmapi.causal_character(chart, a, b, atol=atol, usys=usys)
+    ds2 = cast("Any", cxmapi.interval(chart, a, b, usys=usys))
+    if kind != "spacelike":
+        raise ValueError(_MSG_NOT_SPACELIKE.format(kind=kind, ds2=ds2))
+    return jnp.sqrt(ds2)

--- a/src/coordinax/manifolds.py
+++ b/src/coordinax/manifolds.py
@@ -12,6 +12,10 @@ __all__ = (
     "metric_representation",
     "norm",
     "separation",
+    "interval",
+    "causal_character",
+    "proper_time",
+    "proper_distance",
     # Abstract Manifold/Atlas/Metric
     "AbstractAtlas",
     "AbstractMetricField",
@@ -134,10 +138,14 @@ with install_import_hook("coordinax.manifolds"):
     from coordinaxs.api.charts import pt_map
     from coordinaxs.api.manifolds import (
         angle_between,
+        causal_character,
         guess_manifold,
+        interval,
         metric_matrix,
         metric_representation,
         norm,
+        proper_distance,
+        proper_time,
         pt_embed,
         pt_project,
         scale_factors,

--- a/tests/unit/manifolds/test_interval.py
+++ b/tests/unit/manifolds/test_interval.py
@@ -70,6 +70,16 @@ class TestInterval:
             float(as_dict.ustrip("m2")), abs=ATOL
         )
 
+    def test_mismatched_metric_is_rejected(self):
+        """The `metric` argument is a checked selector, not an ignored one.
+
+        It previously had no effect at all: the matrix always came from
+        ``chart.M``, so passing a different metric silently returned the
+        chart's answer. Matches `norm`'s metric-level contract.
+        """
+        with pytest.raises(ValueError, match="must match chart"):
+            cxm.interval(cxm.FlatMetric(4), cxc.minkowskict, ORIGIN, event(1.0, 5.0))
+
     def test_bare_arrays_require_usys_like_norm_does(self):
         """Sharing the contraction means sharing its contract.
 
@@ -89,11 +99,15 @@ class TestInterval:
         with pytest.raises(TypeError, match=r"interval\(\).*usys"):
             cxm.interval(cxc.minkowskict, origin, ev)
 
-        # ...and with `usys` named, it works. Bare arrays in, bare array out --
-        # no units to carry through.
+        # ...and with `usys` named, it works and agrees with the Quantity form.
+        # Bare arrays in, bare array out -- no units to carry through.
         got = cxm.interval(cxc.minkowskict, origin, ev, usys=u.unitsystems.si)
         assert not hasattr(got, "unit")
         assert float(got) == pytest.approx(-24.0, abs=ATOL)
+        assert (
+            cxm.causal_character(cxc.minkowskict, origin, ev, usys=u.unitsystems.si)
+            == "timelike"
+        )
 
     def test_error_names_interval_not_the_shared_primitive(self):
         """A caller of `interval` should not be told about `quadratic_form`."""
@@ -243,3 +257,35 @@ class TestProperTimeAndDistance:
         with pytest.raises(ValueError, match="spacelike") as exc:
             cxm.proper_time(cxc.minkowskict, ORIGIN, event(1.0, 5.0))
         assert "spacelike" in str(exc.value)
+
+
+class TestSingleIntervalEvaluation:
+    """`proper_time`/`proper_distance` classify from one interval evaluation.
+
+    They used to call `causal_character` (which computes the interval) and then
+    `interval` again — two metric-matrix builds for one question. Behaviour must
+    be identical after collapsing them to one.
+    """
+
+    @pytest.mark.parametrize(("ct", "x"), [(5.0, 1.0), (10.0, 2.0), (-7.0, 3.0)])
+    def test_proper_time_agrees_with_the_two_step_form(self, ct, x):
+        b = event(ct, x)
+        assert cxm.causal_character(cxc.minkowskict, ORIGIN, b) == "timelike"
+        ds2 = cxm.interval(cxc.minkowskict, ORIGIN, b)
+        expected = float(jnp.sqrt(-ds2.ustrip("m2"))) / 299792458.0
+        got = cxm.proper_time(cxc.minkowskict, ORIGIN, b)
+        assert float(got.ustrip("s")) == pytest.approx(expected, rel=1e-5)
+
+    @pytest.mark.parametrize(("ct", "x"), [(1.0, 5.0), (3.0, 5.0), (0.0, 2.0)])
+    def test_proper_distance_agrees_with_the_two_step_form(self, ct, x):
+        b = event(ct, x)
+        assert cxm.causal_character(cxc.minkowskict, ORIGIN, b) == "spacelike"
+        ds2 = cxm.interval(cxc.minkowskict, ORIGIN, b)
+        expected = float(jnp.sqrt(ds2.ustrip("m2")))
+        got = cxm.proper_distance(cxc.minkowskict, ORIGIN, b)
+        assert float(got.ustrip("m")) == pytest.approx(expected, rel=1e-5)
+
+    def test_atol_still_reaches_the_refusal_path(self):
+        """The shared classifier still honours `atol` from these entry points."""
+        with pytest.raises(ValueError, match="null"):
+            cxm.proper_time(cxc.minkowskict, ORIGIN, event(5.0, 1.0), atol=100.0)

--- a/tests/unit/manifolds/test_interval.py
+++ b/tests/unit/manifolds/test_interval.py
@@ -1,0 +1,245 @@
+"""Tests for `interval`, `causal_character`, `proper_time`, `proper_distance`.
+
+These are the Minkowski-correct replacements for the `separation` call that
+`norm`'s positive-definiteness guard now refuses. The sharpest test in here is
+Lorentz invariance: the interval must be unchanged by a boost, which is the
+whole reason it is the right primitive.
+"""
+
+from typing import ClassVar
+
+import pytest
+
+import quaxed.numpy as jnp
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+import coordinax.representations as cxr
+import coordinax.transforms as cxfm
+
+ATOL = 1e-4
+
+ORIGIN = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+
+
+def event(ct, x, y=0.0, z=0.0):
+    return {"ct": u.Q(ct, "m"), "x": u.Q(x, "m"), "y": u.Q(y, "m"), "z": u.Q(z, "m")}
+
+
+class TestInterval:
+    """The signed quadratic form, defined where `separation` is not."""
+
+    @pytest.mark.parametrize(
+        ("ct", "x", "want"),
+        [(5.0, 1.0, -24.0), (1.0, 5.0, 24.0), (3.0, 3.0, 0.0), (0.0, 2.0, 4.0)],
+    )
+    def test_minkowski_values(self, ct, x, want):
+        got = cxm.interval(cxc.minkowskict, ORIGIN, event(ct, x))
+        assert float(got.ustrip("m2")) == pytest.approx(want, abs=ATOL)
+
+    def test_timelike_pair_is_finite_not_nan(self):
+        """The exact case that made `separation` return ``nan``."""
+        got = cxm.interval(cxc.minkowskict, ORIGIN, event(5.0, 1.0))
+        assert not bool(jnp.isnan(got.ustrip("m2")))
+        assert float(got.ustrip("m2")) < 0
+
+    def test_riemannian_interval_is_squared_separation(self):
+        """For a positive-definite metric the two agree, so nothing forks."""
+        a = {"x": u.Q(3.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+        b = {"x": u.Q(0.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+        ds2 = cxm.interval(cxc.cart3d, a, b)
+        sep = cxm.separation(cxc.cart3d, a, b)
+        assert float(ds2.ustrip("m2")) == pytest.approx(
+            float(sep.ustrip("m")) ** 2, abs=ATOL
+        )
+
+    def test_symmetric_in_its_arguments(self):
+        fwd = cxm.interval(cxc.minkowskict, ORIGIN, event(5.0, 1.0))
+        rev = cxm.interval(cxc.minkowskict, event(5.0, 1.0), ORIGIN)
+        assert float(fwd.ustrip("m2")) == pytest.approx(
+            float(rev.ustrip("m2")), abs=ATOL
+        )
+
+    def test_packed_quantity_agrees_with_cdict(self):
+        a = u.Q([0.0, 0.0, 0.0, 0.0], "m")
+        b = u.Q([5.0, 1.0, 0.0, 0.0], "m")
+        packed = cxm.interval(cxc.minkowskict, a, b)
+        as_dict = cxm.interval(cxc.minkowskict, ORIGIN, event(5.0, 1.0))
+        assert float(packed.ustrip("m2")) == pytest.approx(
+            float(as_dict.ustrip("m2")), abs=ATOL
+        )
+
+    def test_bare_arrays_require_usys_like_norm_does(self):
+        """Sharing the contraction means sharing its contract.
+
+        `interval` used to answer here while `norm` on the same data correctly
+        refused: with no units on the components there is nothing to derive the
+        result's unit from, so the caller has to name a unit system. That
+        divergence was the reason for routing both through one primitive, so the
+        stricter behaviour is the point, not a side effect.
+        """
+        origin = {k: jnp.asarray(0.0) for k in ("ct", "x", "y", "z")}
+        ev = {
+            "ct": jnp.asarray(5.0),
+            "x": jnp.asarray(1.0),
+            "y": jnp.asarray(0.0),
+            "z": jnp.asarray(0.0),
+        }
+        with pytest.raises(TypeError, match=r"interval\(\).*usys"):
+            cxm.interval(cxc.minkowskict, origin, ev)
+
+        # ...and with `usys` named, it works. Bare arrays in, bare array out --
+        # no units to carry through.
+        got = cxm.interval(cxc.minkowskict, origin, ev, usys=u.unitsystems.si)
+        assert not hasattr(got, "unit")
+        assert float(got) == pytest.approx(-24.0, abs=ATOL)
+
+    def test_error_names_interval_not_the_shared_primitive(self):
+        """A caller of `interval` should not be told about `quadratic_form`."""
+        origin = {k: jnp.asarray(0.0) for k in ("ct", "x", "y", "z")}
+        ev = {k: jnp.asarray(1.0) for k in ("ct", "x", "y", "z")}
+        with pytest.raises(TypeError) as exc:
+            cxm.interval(cxc.minkowskict, origin, ev)
+        assert str(exc.value).startswith("interval()")
+
+    def test_explicit_metric_overload(self):
+        got = cxm.interval(
+            cxm.MinkowskiMetric(), cxc.minkowskict, ORIGIN, event(1.0, 5.0)
+        )
+        assert float(got.ustrip("m2")) == pytest.approx(24.0, abs=ATOL)
+
+
+class TestLorentzInvariance:
+    """The interval is invariant under boosts — its reason for existing."""
+
+    BETAS: ClassVar = [
+        [0.6, 0.0, 0.0],
+        [0.0, 0.8, 0.0],
+        [0.3, -0.4, 0.5],
+        [0.99, 0.0, 0.0],
+    ]
+
+    @pytest.mark.parametrize("beta", BETAS)
+    @pytest.mark.parametrize(
+        ("ct", "x"), [(5.0, 1.0), (1.0, 5.0), (3.0, 3.0), (2.0, -7.0)]
+    )
+    def test_interval_is_unchanged_by_a_boost(self, beta, ct, x):
+        op = cxfm.LorentzBoost(beta)
+        a, b = ORIGIN, event(ct, x)
+        before = cxm.interval(cxc.minkowskict, a, b)
+
+        a2 = cxfm.act(op, None, a, cxc.minkowskict, cxr.point)
+        b2 = cxfm.act(op, None, b, cxc.minkowskict, cxr.point)
+        after = cxm.interval(cxc.minkowskict, a2, b2)
+
+        assert float(after.ustrip("m2")) == pytest.approx(
+            float(before.ustrip("m2")), abs=1e-2
+        )
+
+    @pytest.mark.parametrize("beta", BETAS)
+    @pytest.mark.parametrize(("ct", "x"), [(5.0, 1.0), (1.0, 5.0), (3.0, 3.0)])
+    def test_causal_character_is_boost_invariant(self, beta, ct, x):
+        """Causal ordering is absolute: no boost turns timelike into spacelike."""
+        op = cxfm.LorentzBoost(beta)
+        a, b = ORIGIN, event(ct, x)
+        before = cxm.causal_character(cxc.minkowskict, a, b)
+
+        a2 = cxfm.act(op, None, a, cxc.minkowskict, cxr.point)
+        b2 = cxfm.act(op, None, b, cxc.minkowskict, cxr.point)
+        after = cxm.causal_character(cxc.minkowskict, a2, b2)
+
+        assert after == before
+
+    def test_proper_time_is_boost_invariant(self):
+        """A wristwatch reading cannot depend on who is looking at it."""
+        a, b = ORIGIN, event(5.0, 1.0)
+        before = cxm.proper_time(cxc.minkowskict, a, b).uconvert("s")
+
+        op = cxfm.LorentzBoost([0.6, 0.0, 0.0])
+        a2 = cxfm.act(op, None, a, cxc.minkowskict, cxr.point)
+        b2 = cxfm.act(op, None, b, cxc.minkowskict, cxr.point)
+        after = cxm.proper_time(cxc.minkowskict, a2, b2).uconvert("s")
+
+        assert float(after.ustrip("s")) == pytest.approx(
+            float(before.ustrip("s")), rel=1e-3
+        )
+
+
+class TestCausalCharacter:
+    """Classification by the sign of the interval."""
+
+    @pytest.mark.parametrize(
+        ("ct", "x", "want"),
+        [
+            (5.0, 1.0, "timelike"),
+            (1.0, 5.0, "spacelike"),
+            (3.0, 3.0, "null"),
+            (-4.0, 1.0, "timelike"),
+            (0.0, 1.0, "spacelike"),
+        ],
+    )
+    def test_classification(self, ct, x, want):
+        assert cxm.causal_character(cxc.minkowskict, ORIGIN, event(ct, x)) == want
+
+    def test_coincident_events_are_null(self):
+        assert cxm.causal_character(cxc.minkowskict, ORIGIN, ORIGIN) == "null"
+
+    def test_null_tolerance_scales_with_the_data(self):
+        """A light ray a million metres long is still null, not spacelike."""
+        big = event(1e6, 1e6)
+        assert cxm.causal_character(cxc.minkowskict, ORIGIN, big) == "null"
+
+    def test_explicit_atol_is_respected(self):
+        """A wide tolerance can call a genuinely timelike pair null."""
+        pair = event(5.0, 1.0)  # ds^2 = -24
+        assert cxm.causal_character(cxc.minkowskict, ORIGIN, pair) == "timelike"
+        loose = cxm.causal_character(cxc.minkowskict, ORIGIN, pair, atol=100.0)
+        assert loose == "null"
+
+    def test_riemannian_metric_is_rejected(self):
+        """Causal character is meaningless without a timelike direction."""
+        a = {"x": u.Q(0.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+        b = {"x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+        with pytest.raises(ValueError, match="Lorentzian"):
+            cxm.causal_character(cxc.cart3d, a, b)
+
+
+class TestProperTimeAndDistance:
+    """Magnitudes, and refusal on the causal type where they are undefined."""
+
+    def test_proper_time_at_rest_is_coordinate_time(self):
+        """An observer at rest ages by the full coordinate time."""
+        one_light_second = event(299792458.0, 0.0)
+        got = cxm.proper_time(cxc.minkowskict, ORIGIN, one_light_second)
+        assert float(got.uconvert("s").ustrip("s")) == pytest.approx(1.0, rel=1e-4)
+
+    def test_moving_clock_ages_less(self):
+        """Time dilation: same coordinate time, but moving, gives less ageing."""
+        c = 299792458.0
+        at_rest = cxm.proper_time(cxc.minkowskict, ORIGIN, event(c, 0.0))
+        moving = cxm.proper_time(cxc.minkowskict, ORIGIN, event(c, 0.6 * c))
+        assert float(moving.ustrip("s")) < float(at_rest.ustrip("s"))
+        # sqrt(1 - 0.6^2) = 0.8
+        assert float(moving.ustrip("s")) == pytest.approx(
+            0.8 * float(at_rest.ustrip("s")), rel=1e-3
+        )
+
+    def test_proper_distance_value(self):
+        got = cxm.proper_distance(cxc.minkowskict, ORIGIN, event(3.0, 5.0))
+        assert float(got.ustrip("m")) == pytest.approx(4.0, abs=ATOL)
+
+    @pytest.mark.parametrize(("ct", "x"), [(1.0, 5.0), (3.0, 3.0)])
+    def test_proper_time_refuses_non_timelike(self, ct, x):
+        with pytest.raises(ValueError, match="timelike"):
+            cxm.proper_time(cxc.minkowskict, ORIGIN, event(ct, x))
+
+    @pytest.mark.parametrize(("ct", "x"), [(5.0, 1.0), (3.0, 3.0)])
+    def test_proper_distance_refuses_non_spacelike(self, ct, x):
+        with pytest.raises(ValueError, match="spacelike"):
+            cxm.proper_distance(cxc.minkowskict, ORIGIN, event(ct, x))
+
+    def test_error_message_names_the_actual_causal_type(self):
+        with pytest.raises(ValueError, match="spacelike") as exc:
+            cxm.proper_time(cxc.minkowskict, ORIGIN, event(1.0, 5.0))
+        assert "spacelike" in str(exc.value)

--- a/tests/unit/manifolds/test_interval.py
+++ b/tests/unit/manifolds/test_interval.py
@@ -1,0 +1,212 @@
+"""Tests for `interval`, `causal_character`, `proper_time`, `proper_distance`.
+
+These are the Minkowski-correct replacements for the `separation` call that
+`norm`'s positive-definiteness guard now refuses. The sharpest test in here is
+Lorentz invariance: the interval must be unchanged by a boost, which is the
+whole reason it is the right primitive.
+"""
+
+from typing import ClassVar
+
+import pytest
+
+import quaxed.numpy as jnp
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+import coordinax.representations as cxr
+import coordinax.transforms as cxfm
+
+ATOL = 1e-4
+
+ORIGIN = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+
+
+def event(ct, x, y=0.0, z=0.0):
+    return {"ct": u.Q(ct, "m"), "x": u.Q(x, "m"), "y": u.Q(y, "m"), "z": u.Q(z, "m")}
+
+
+class TestInterval:
+    """The signed quadratic form, defined where `separation` is not."""
+
+    @pytest.mark.parametrize(
+        ("ct", "x", "want"),
+        [(5.0, 1.0, -24.0), (1.0, 5.0, 24.0), (3.0, 3.0, 0.0), (0.0, 2.0, 4.0)],
+    )
+    def test_minkowski_values(self, ct, x, want):
+        got = cxm.interval(cxc.minkowskict, ORIGIN, event(ct, x))
+        assert float(got.ustrip("m2")) == pytest.approx(want, abs=ATOL)
+
+    def test_timelike_pair_is_finite_not_nan(self):
+        """The exact case that made `separation` return ``nan``."""
+        got = cxm.interval(cxc.minkowskict, ORIGIN, event(5.0, 1.0))
+        assert not bool(jnp.isnan(got.ustrip("m2")))
+        assert float(got.ustrip("m2")) < 0
+
+    def test_riemannian_interval_is_squared_separation(self):
+        """For a positive-definite metric the two agree, so nothing forks."""
+        a = {"x": u.Q(3.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+        b = {"x": u.Q(0.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+        ds2 = cxm.interval(cxc.cart3d, a, b)
+        sep = cxm.separation(cxc.cart3d, a, b)
+        assert float(ds2.ustrip("m2")) == pytest.approx(
+            float(sep.ustrip("m")) ** 2, abs=ATOL
+        )
+
+    def test_symmetric_in_its_arguments(self):
+        fwd = cxm.interval(cxc.minkowskict, ORIGIN, event(5.0, 1.0))
+        rev = cxm.interval(cxc.minkowskict, event(5.0, 1.0), ORIGIN)
+        assert float(fwd.ustrip("m2")) == pytest.approx(
+            float(rev.ustrip("m2")), abs=ATOL
+        )
+
+    def test_packed_quantity_agrees_with_cdict(self):
+        a = u.Q([0.0, 0.0, 0.0, 0.0], "m")
+        b = u.Q([5.0, 1.0, 0.0, 0.0], "m")
+        packed = cxm.interval(cxc.minkowskict, a, b)
+        as_dict = cxm.interval(cxc.minkowskict, ORIGIN, event(5.0, 1.0))
+        assert float(packed.ustrip("m2")) == pytest.approx(
+            float(as_dict.ustrip("m2")), abs=ATOL
+        )
+
+    def test_explicit_metric_overload(self):
+        got = cxm.interval(
+            cxm.MinkowskiMetric(), cxc.minkowskict, ORIGIN, event(1.0, 5.0)
+        )
+        assert float(got.ustrip("m2")) == pytest.approx(24.0, abs=ATOL)
+
+
+class TestLorentzInvariance:
+    """The interval is invariant under boosts — its reason for existing."""
+
+    BETAS: ClassVar = [
+        [0.6, 0.0, 0.0],
+        [0.0, 0.8, 0.0],
+        [0.3, -0.4, 0.5],
+        [0.99, 0.0, 0.0],
+    ]
+
+    @pytest.mark.parametrize("beta", BETAS)
+    @pytest.mark.parametrize(
+        ("ct", "x"), [(5.0, 1.0), (1.0, 5.0), (3.0, 3.0), (2.0, -7.0)]
+    )
+    def test_interval_is_unchanged_by_a_boost(self, beta, ct, x):
+        op = cxfm.LorentzBoost(beta)
+        a, b = ORIGIN, event(ct, x)
+        before = cxm.interval(cxc.minkowskict, a, b)
+
+        a2 = cxfm.act(op, None, a, cxc.minkowskict, cxr.point)
+        b2 = cxfm.act(op, None, b, cxc.minkowskict, cxr.point)
+        after = cxm.interval(cxc.minkowskict, a2, b2)
+
+        assert float(after.ustrip("m2")) == pytest.approx(
+            float(before.ustrip("m2")), abs=1e-2
+        )
+
+    @pytest.mark.parametrize("beta", BETAS)
+    @pytest.mark.parametrize(("ct", "x"), [(5.0, 1.0), (1.0, 5.0), (3.0, 3.0)])
+    def test_causal_character_is_boost_invariant(self, beta, ct, x):
+        """Causal ordering is absolute: no boost turns timelike into spacelike."""
+        op = cxfm.LorentzBoost(beta)
+        a, b = ORIGIN, event(ct, x)
+        before = cxm.causal_character(cxc.minkowskict, a, b)
+
+        a2 = cxfm.act(op, None, a, cxc.minkowskict, cxr.point)
+        b2 = cxfm.act(op, None, b, cxc.minkowskict, cxr.point)
+        after = cxm.causal_character(cxc.minkowskict, a2, b2)
+
+        assert after == before
+
+    def test_proper_time_is_boost_invariant(self):
+        """A wristwatch reading cannot depend on who is looking at it."""
+        a, b = ORIGIN, event(5.0, 1.0)
+        before = cxm.proper_time(cxc.minkowskict, a, b).uconvert("s")
+
+        op = cxfm.LorentzBoost([0.6, 0.0, 0.0])
+        a2 = cxfm.act(op, None, a, cxc.minkowskict, cxr.point)
+        b2 = cxfm.act(op, None, b, cxc.minkowskict, cxr.point)
+        after = cxm.proper_time(cxc.minkowskict, a2, b2).uconvert("s")
+
+        assert float(after.ustrip("s")) == pytest.approx(
+            float(before.ustrip("s")), rel=1e-3
+        )
+
+
+class TestCausalCharacter:
+    """Classification by the sign of the interval."""
+
+    @pytest.mark.parametrize(
+        ("ct", "x", "want"),
+        [
+            (5.0, 1.0, "timelike"),
+            (1.0, 5.0, "spacelike"),
+            (3.0, 3.0, "null"),
+            (-4.0, 1.0, "timelike"),
+            (0.0, 1.0, "spacelike"),
+        ],
+    )
+    def test_classification(self, ct, x, want):
+        assert cxm.causal_character(cxc.minkowskict, ORIGIN, event(ct, x)) == want
+
+    def test_coincident_events_are_null(self):
+        assert cxm.causal_character(cxc.minkowskict, ORIGIN, ORIGIN) == "null"
+
+    def test_null_tolerance_scales_with_the_data(self):
+        """A light ray a million metres long is still null, not spacelike."""
+        big = event(1e6, 1e6)
+        assert cxm.causal_character(cxc.minkowskict, ORIGIN, big) == "null"
+
+    def test_explicit_atol_is_respected(self):
+        """A wide tolerance can call a genuinely timelike pair null."""
+        pair = event(5.0, 1.0)  # ds^2 = -24
+        assert cxm.causal_character(cxc.minkowskict, ORIGIN, pair) == "timelike"
+        loose = cxm.causal_character(cxc.minkowskict, ORIGIN, pair, atol=100.0)
+        assert loose == "null"
+
+    def test_riemannian_metric_is_rejected(self):
+        """Causal character is meaningless without a timelike direction."""
+        a = {"x": u.Q(0.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+        b = {"x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+        with pytest.raises(ValueError, match="Lorentzian"):
+            cxm.causal_character(cxc.cart3d, a, b)
+
+
+class TestProperTimeAndDistance:
+    """Magnitudes, and refusal on the causal type where they are undefined."""
+
+    def test_proper_time_at_rest_is_coordinate_time(self):
+        """An observer at rest ages by the full coordinate time."""
+        one_light_second = event(299792458.0, 0.0)
+        got = cxm.proper_time(cxc.minkowskict, ORIGIN, one_light_second)
+        assert float(got.uconvert("s").ustrip("s")) == pytest.approx(1.0, rel=1e-4)
+
+    def test_moving_clock_ages_less(self):
+        """Time dilation: same coordinate time, but moving, gives less ageing."""
+        c = 299792458.0
+        at_rest = cxm.proper_time(cxc.minkowskict, ORIGIN, event(c, 0.0))
+        moving = cxm.proper_time(cxc.minkowskict, ORIGIN, event(c, 0.6 * c))
+        assert float(moving.ustrip("s")) < float(at_rest.ustrip("s"))
+        # sqrt(1 - 0.6^2) = 0.8
+        assert float(moving.ustrip("s")) == pytest.approx(
+            0.8 * float(at_rest.ustrip("s")), rel=1e-3
+        )
+
+    def test_proper_distance_value(self):
+        got = cxm.proper_distance(cxc.minkowskict, ORIGIN, event(3.0, 5.0))
+        assert float(got.ustrip("m")) == pytest.approx(4.0, abs=ATOL)
+
+    @pytest.mark.parametrize(("ct", "x"), [(1.0, 5.0), (3.0, 3.0)])
+    def test_proper_time_refuses_non_timelike(self, ct, x):
+        with pytest.raises(ValueError, match="timelike"):
+            cxm.proper_time(cxc.minkowskict, ORIGIN, event(ct, x))
+
+    @pytest.mark.parametrize(("ct", "x"), [(5.0, 1.0), (3.0, 3.0)])
+    def test_proper_distance_refuses_non_spacelike(self, ct, x):
+        with pytest.raises(ValueError, match="spacelike"):
+            cxm.proper_distance(cxc.minkowskict, ORIGIN, event(ct, x))
+
+    def test_error_message_names_the_actual_causal_type(self):
+        with pytest.raises(ValueError, match="spacelike") as exc:
+            cxm.proper_time(cxc.minkowskict, ORIGIN, event(1.0, 5.0))
+        assert "spacelike" in str(exc.value)

--- a/tests/unit/manifolds/test_interval.py
+++ b/tests/unit/manifolds/test_interval.py
@@ -70,6 +70,33 @@ class TestInterval:
             float(as_dict.ustrip("m2")), abs=ATOL
         )
 
+    def test_mismatched_metric_is_rejected(self):
+        """The `metric` argument is a checked selector, not an ignored one.
+
+        It previously had no effect at all: the matrix always came from
+        ``chart.M``, so passing a different metric silently returned the
+        chart's answer. Matches `norm`'s metric-level contract.
+        """
+        with pytest.raises(ValueError, match="must match chart"):
+            cxm.interval(cxm.FlatMetric(4), cxc.minkowskict, ORIGIN, event(1.0, 5.0))
+
+    def test_unitless_components_are_supported(self):
+        """Bare arrays are valid component values, so no unit may be assumed.
+
+        The default null-tolerance path used to call ``u.unit_of`` on every
+        component, which assumes each carries a unit.
+        """
+        origin = {k: jnp.asarray(0.0) for k in ("ct", "x", "y", "z")}
+        ev = {
+            "ct": jnp.asarray(5.0),
+            "x": jnp.asarray(1.0),
+            "y": jnp.asarray(0.0),
+            "z": jnp.asarray(0.0),
+        }
+        ds2 = cxm.interval(cxc.minkowskict, origin, ev)
+        assert float(u.ustrip("", ds2)) == pytest.approx(-24.0, abs=ATOL)
+        assert cxm.causal_character(cxc.minkowskict, origin, ev) == "timelike"
+
     def test_explicit_metric_overload(self):
         got = cxm.interval(
             cxm.MinkowskiMetric(), cxc.minkowskict, ORIGIN, event(1.0, 5.0)
@@ -210,3 +237,35 @@ class TestProperTimeAndDistance:
         with pytest.raises(ValueError, match="spacelike") as exc:
             cxm.proper_time(cxc.minkowskict, ORIGIN, event(1.0, 5.0))
         assert "spacelike" in str(exc.value)
+
+
+class TestSingleIntervalEvaluation:
+    """`proper_time`/`proper_distance` classify from one interval evaluation.
+
+    They used to call `causal_character` (which computes the interval) and then
+    `interval` again — two metric-matrix builds for one question. Behaviour must
+    be identical after collapsing them to one.
+    """
+
+    @pytest.mark.parametrize(("ct", "x"), [(5.0, 1.0), (10.0, 2.0), (-7.0, 3.0)])
+    def test_proper_time_agrees_with_the_two_step_form(self, ct, x):
+        b = event(ct, x)
+        assert cxm.causal_character(cxc.minkowskict, ORIGIN, b) == "timelike"
+        ds2 = cxm.interval(cxc.minkowskict, ORIGIN, b)
+        expected = float(jnp.sqrt(-ds2.ustrip("m2"))) / 299792458.0
+        got = cxm.proper_time(cxc.minkowskict, ORIGIN, b)
+        assert float(got.ustrip("s")) == pytest.approx(expected, rel=1e-5)
+
+    @pytest.mark.parametrize(("ct", "x"), [(1.0, 5.0), (3.0, 5.0), (0.0, 2.0)])
+    def test_proper_distance_agrees_with_the_two_step_form(self, ct, x):
+        b = event(ct, x)
+        assert cxm.causal_character(cxc.minkowskict, ORIGIN, b) == "spacelike"
+        ds2 = cxm.interval(cxc.minkowskict, ORIGIN, b)
+        expected = float(jnp.sqrt(ds2.ustrip("m2")))
+        got = cxm.proper_distance(cxc.minkowskict, ORIGIN, b)
+        assert float(got.ustrip("m")) == pytest.approx(expected, rel=1e-5)
+
+    def test_atol_still_reaches_the_refusal_path(self):
+        """The shared classifier still honours `atol` from these entry points."""
+        with pytest.raises(ValueError, match="null"):
+            cxm.proper_time(cxc.minkowskict, ORIGIN, event(5.0, 1.0), atol=100.0)


### PR DESCRIPTION
> ### 📍 Merge order — Minkowski series
> | # | PR | Status |
> |---|----|--------|
> | ~~1~~ | ~~#674 `norm`/`separation` `nan` fix~~ · ~~#678 `LorentzBoost`~~ · ~~#686 quadratic form~~ · ~~#689 bilinear form~~ | ✅ merged |
> | **2** | **this PR** — `interval` / causality / proper time | **merge next** |
> | 3 | #683 — docs + special-relativity tutorial | needs this |
>
> Also open and independent: #687 (`angle_between` Lorentzian), #691 (packed-`Quantity` fast path).
>
> ✅ Rebased onto current `main`. **3444 passed, 5 skipped.**

## Why

#674 made `norm` refuse indefinite metrics — correct, since $\sqrt{v^\top G v}$ has no real value when the form can go negative. But that left Minkowski with **no way to measure anything at all**. This PR adds the quantity that *is* well defined: the form itself, unrooted.

$$\texttt{interval}(a, b) = \Delta x^\top G\, \Delta x$$

## The API

| function | defined for | returns |
|---|---|---|
| `interval` | **every** metric | signed $\Delta s^2$ |
| `causal_character` | Lorentzian | `"timelike"` / `"null"` / `"spacelike"` |
| `proper_time` | timelike pairs | a duration |
| `proper_distance` | spacelike pairs | a length |

`interval` is deliberately **not** Minkowski-only — for a Riemannian metric it is simply the squared `separation` (asserted in the tests), so there is one primitive rather than a Euclidean path and a relativistic path that can drift apart.

```python
o = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
ev = {"ct": u.Q(5.0, "m"), "x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}

cxm.interval(cxc.minkowskict, o, ev)          # Q(-24., 'm2')   ← was nan via separation
cxm.causal_character(cxc.minkowskict, o, ev)  # 'timelike'
cxm.proper_time(cxc.minkowskict, o, ev).uconvert("s")
```

## Design notes

**`proper_time` returns a real duration.** `MinkowskiCT` works in `ct` with *length* units, so $\sqrt{-\Delta s^2}$ is $c\tau$, not $\tau$. Dividing by $c$ at that boundary is the **only** place a speed-of-light constant appears anywhere in the series — everything else stays chart-native and dimensionless.

**`causal_character` returns a `str`**, so it is not `jit`-able. It is documented as a diagnostic, with the advice to branch on the sign of `interval` inside a trace. Its null tolerance defaults to a *relative* one (`1e-8` of the largest squared coordinate difference) rather than an absolute epsilon — so a light ray a million metres long still classifies as null instead of drifting spacelike on float error. There's a test for exactly that.

**`proper_time`/`proper_distance` refuse the wrong causal type by name** rather than returning `nan`, e.g. *"defined only for timelike-separated events; this pair is spacelike"*.

**#674's error message now names these functions**, so the guard points at the fix instead of just refusing.

## The tests that matter

The sharpest ones tie this to #678 — **the interval, causal character and proper time are all invariant under boosts** up to β = 0.99. That invariance is the entire reason the interval is the right primitive, and it is now checked rather than assumed:

- interval unchanged by boosts, across 4 boost directions × 4 event pairs
- causal ordering is absolute: no boost turns timelike into spacelike
- proper time is boost-invariant — a wristwatch reading cannot depend on who reads it
- time dilation: same coordinate time while moving at 0.6c gives exactly 0.8× the ageing
- Riemannian `interval` == `separation`²; symmetry in arguments; packed-`Quantity` agreement
- `causal_character` rejects a Riemannian metric (no timelike direction to classify by)

## Verification

`tests/unit` + `packages/coordinaxs.api`: **2336 passed, 5 skipped**. All doctests pass. ruff, ruff-format, ty clean.

The `coordinaxs.api` abstract stubs are added in the same commit as the implementations, matching the precedent set by `tangent_map` (#588).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🔄 Update: rebased, plus review fixes

All 6 threads resolved.

**The `metric` argument did nothing.** `interval(metric, chart, a, b)` accepted a metric and then built the matrix from `chart.M` regardless — the same defect review caught in #674, which I reintroduced here one PR later. It is now a **checked selector**, matching the metric-level `norm` contract exactly:

```python
cxm.interval(cxm.FlatMetric(4), cxc.minkowskict, o, ev)
# ValueError: Metric-level dispatch: metric must match chart's metric
```

I chose validation over honouring an arbitrary metric because `norm` already establishes that pattern; inventing override semantics no sibling has would be the more surprising option.

**Unit assumption.** The default null-tolerance path called `u.unit_of` on every component, but `chart.check_data(..., values=False)` permits bare arrays. An `_as_float` helper now strips units only when present, with an end-to-end bare-array test.

**Double evaluation.** `proper_time`/`proper_distance` called `causal_character` (which computes the interval) and then `interval` again — two metric-matrix builds for one question. Both now evaluate once and classify through a shared `_classify`; `TestSingleIntervalEvaluation` asserts the collapsed form still agrees with the two-step one.

**Asymmetry documented.** The metric is evaluated at the first point `a`, so the result is a first-order estimate on a curved manifold and is not symmetric in its arguments — exact for Minkowski, the case this exists for. Documented in the module docstring, mirroring the wording `separation.py` already uses for the same property.

**Verification**: `tests/unit` + `docs` + `packages/coordinaxs.api` — **3393 passed, 5 skipped**. ruff, ruff-format, ty clean.




---

## ♻️ Update: `interval` now builds on the shared quadratic form

With #686/#689 merged, `interval` no longer carries its own copy of the contraction — it is one line:

```python
return quadratic_form(diff, chart, at=a, usys=usys, fname="interval")
```

Two consequences. `separation**2 == interval` now holds **by construction** rather than by the test asserting it. And `interval` picks up the unit handling it was missing.

### On the `usys` contract (correcting an earlier note in this description)

An earlier revision of this description called the `usys` requirement for bare-array components a *"deliberate behaviour change"*. That was misleading, and I've removed it: **this PR changes no pre-existing behaviour.**

The requirement applies only to `interval` / `causal_character` / `proper_time` / `proper_distance` — all four of which are **new here**, so they simply arrive with that contract. What changed was between commit 1 and commit 3 *of this PR*: commit 1 added `interval` with its own copy of the contraction, commit 3 routed it through the shared `quadratic_form` and it inherited `norm`'s unit handling. Internal history, not something a user of `main` can observe.

Verified two ways. The diff touches no pre-existing implementation:

| file | change |
|---|---|
| `interval.py`, `test_interval.py` | new |
| `coordinaxs.api/manifolds.py`, `manifolds.py`, `_src/manifolds/__init__.py` | declare / export the new verbs |
| `_utils.py` | **message text only** — appends *"Use `interval` … `proper_time`"* |

`norm.py`, `separation.py`, `quadratic_form.py` and `angle_between.py` are untouched. And at runtime, `norm`, `separation`, `angle_between` and the bare-array `usys` refusal all return byte-identical results on this branch and on `main`.

The contract itself is still worth a look on review — bare-array components require `usys`, matching `norm`, because with no units on the inputs there is nothing to derive the result's unit from. It is just not a *change*.


