### PR TITLE
🔥 refactor(hypothesis): drop two array-API namespaces nothing uses

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/cdict.py
@@ -17,7 +17,6 @@ import numpy as np
 import plum
 import unxt as u
 import unxts.hypothesis as ust
-from hypothesis.extra.array_api import make_strategies_namespace
 
 import coordinax.charts as cxc
 
@@ -195,10 +194,6 @@ def _bounded_elements(
         return (lo is None or v >= lo) and (hi is None or v <= hi)
 
     return elements.filter(_in_domain)
-
-
-# Create array API strategies namespace for JAX
-xps = make_strategies_namespace(jnp)
 
 
 @plum.dispatch.abstract

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/cdict.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/cdict.py
@@ -13,15 +13,11 @@ from typing import Any, cast
 import hypothesis.strategies as st
 import jax.numpy as jnp
 import plum
-from hypothesis.extra.array_api import make_strategies_namespace
 
 import coordinax.charts as cxc
 import coordinax.representations as cxr
 
 from coordinaxs.hypothesis.utils import CDict, draw_if_strategy, strip_return_annotation
-
-# Create array API strategies namespace for JAX
-xps = make_strategies_namespace(jnp)
 
 
 @plum.dispatch.multi(


### PR DESCRIPTION
`representations/_src/cdict.py` and `charts/_src/cdict.py` each build

```python
xps = make_strategies_namespace(jnp)
```

and never reference `xps` again — each file contains exactly one occurrence of the name, the assignment itself. Nothing imports it from either module. Both files draw through `unxts.hypothesis`, not the array-API namespace.

Beyond the four lines, each also signals "this module generates raw arrays", which is no longer true of either.

## What I did not do, and why

My audit had the bigger half of this as folding the three *real* users — `jaxtyping_utils`, `strategy`, `distances/_src/utils` — onto one shared `xps`, for "−12 lines".

Measuring says that is not worth it:

```
make_strategies_namespace: 129.53 ms  (first call)
                            0.41 ms  (subsequent)
```

Hypothesis already memoises the namespace, so three call sites cost about **1 ms** more than one — not the repeated 129 ms the raw duplication suggests. That does not pay for a new module plus the import plumbing to reach three different subpackages, and it would put a `utils.annotations`-shaped dependency into `distances`. Leaving them.

802 tests pass; ruff and ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
