### PR TITLE
📝 docs(hypothesis): warn that the subclass cache is order-dependent

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/subclasses.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/subclasses.py
@@ -104,6 +104,24 @@ def get_all_subclasses(
     (optionally) filtering the results in {class}`coordinax`.  The return value
     is cached via {func}`functools.cache`.
 
+    .. warning::
+
+        The cache is keyed on the arguments only, while ``__subclasses__()`` is
+        mutable, so **the result depends on when the cache was first warmed**.
+        A subclass defined after that first call is absent until
+        `cache_clear`; one defined before it is present. Measured, for a
+        subclass declared at runtime::
+
+            warmed before it exists : 3 -> 3   (absent)
+            warmed after it exists  : 4        (present)
+
+        In a test session that ordering decides whether classes declared *by
+        tests* — fakes and stubs — are handed out by the strategies as though
+        they were library types. Do not "fix" this by dropping the cache: that
+        makes such classes visible always, which is strictly worse. Pinning the
+        candidate set at import, as ``bases``/``geoms``/``semantics`` do, is
+        what actually keeps them out.
+
     Parameters
     ----------
     base_class : type

--- a/packages/coordinaxs.hypothesis/tests/unit/utils/test_subclasses.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/utils/test_subclasses.py
@@ -1,5 +1,6 @@
 """Tests for ``coordinaxs.hypothesis.utils._src.subclasses``."""
 
+import subprocess
 import sys
 
 import types
@@ -41,3 +42,45 @@ def test_canonicalize_real_chart_class_returns_public_class() -> None:
     canonicalize_coordinax_class.cache_clear()
 
     assert canonicalize_coordinax_class(cxc.Cart3D) is cxc.Cart3D
+
+
+#: Asks a fresh interpreter what `get_all_subclasses` returns for a subclass
+#: declared before vs after the cache is warmed.
+#:
+#: Out-of-process because declaring the subclass here would leave it in
+#: ``__subclasses__`` for the rest of the session, where the strategies would
+#: hand it out as though it were a library type.
+_CACHE_ORDER = """
+import warnings
+warnings.filterwarnings("ignore")
+import coordinax.representations as cxr
+from coordinaxs.hypothesis.utils import get_all_subclasses as g
+
+base = cxr.AbstractBasis
+warm = len(g(base, exclude_abstract=True))          # warm the cache first
+class LateBasis(cxr.AbstractLinearBasis): pass      # ... then declare
+print(len(g(base, exclude_abstract=True)) - warm)   # 0: absent
+
+g.cache_clear()                                     # cold cache, class exists
+print(len(g(base, exclude_abstract=True)) - warm)   # 1: present
+"""
+
+
+def test_result_depends_on_when_the_cache_was_warmed() -> None:
+    """The cached candidate set is order-dependent, as the docstring warns.
+
+    Pinned so the warning cannot quietly stop being true. If someone makes the
+    candidate set import-time — the fix the docstring points at — this fails and
+    says so, rather than the warning rotting into fiction.
+    """
+    proc = subprocess.run(  # noqa: S603  # fixed literal script, this interpreter
+        [sys.executable, "-c", _CACHE_ORDER],
+        capture_output=True,
+        text=True,
+        timeout=600,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    declared_after_warming, declared_before_warming = proc.stdout.split()
+    assert declared_after_warming == "0", "a later subclass leaked into a warm cache"
+    assert declared_before_warming == "1", "a cold cache missed an existing subclass"


### PR DESCRIPTION
`get_all_subclasses` is `@ft.cache`d over `__subclasses__()`, which is mutable. So what it returns depends on **when the cache was first warmed**. Measured, for a subclass declared at runtime:

```
warmed before it exists : 3 -> 3   (absent)
warmed after it exists  : 4        (present)
```

In a test session that ordering decides whether classes declared *by tests* — fakes and stubs — get handed out by the strategies as though they were library types.

That is not hypothetical. It is why **#659 failed**: removing the import-time snapshots in `bases`/`geoms`/`semantics` left only this cache, it warmed after `test_cdicts.py` had declared its fakes, and `FakeSemantic` started being drawn into coordinax's own semantic-kind invariant tests. Five tests, eight platforms, deterministic.

## Behaviour is unchanged, deliberately

My audit listed "remove the cache" as the fix. That is backwards. Dropping it makes test-declared classes visible **always** rather than sometimes — strictly worse. What actually keeps them out is pinning the candidate set at import, which those three modules already do and which #659 broke.

So this is documentation, plus one guard.

## The warning gets a test

Prose rots. If someone later makes the candidate set import-time — the fix the docstring points at — the test fails and says so, instead of the warning quietly becoming fiction.

It runs out-of-process, because declaring the subclass in-process would leave it in `__subclasses__` for the rest of the session — the exact leak being documented. (I hit that while writing #659's test, where hypothesis' internal caches kept the class reachable and it broke a sibling test.)

## Not attempted

Making the strategies immune to test-declared classes in general. That is a design change across several modules, and there is no live trigger: the astro plugin — the one real late importer — registers no chart or manifold subclasses (24 charts before and after importing it), so nothing is currently mis-generated.

803 tests pass; ruff and ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
