### PR TITLE
✨ fix(hypothesis): return only coordinax's own classes from the subclass walk

### DIFF
--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/bases.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/bases.py
@@ -2,16 +2,12 @@
 
 __all__ = ("basis_classes", "bases")
 
-from typing import Final
-
 import hypothesis.strategies as st
 
 import coordinax.representations as cxr
 
 from ._common import draw_subclass
 from coordinaxs.hypothesis.utils import get_all_subclasses
-
-BASES: Final = get_all_subclasses(cxr.AbstractBasis, exclude_abstract=True)
 
 
 @st.composite
@@ -53,7 +49,13 @@ def basis_classes(
     ...     assert issubclass(basis_cls, cxr.NoBasis)
 
     """
-    return draw_subclass(draw, BASES, include=include, exclude=exclude, kind="basis")  # ty: ignore[invalid-return-type]
+    return draw_subclass(
+        draw,
+        get_all_subclasses(cxr.AbstractBasis, exclude_abstract=True),
+        include=include,
+        exclude=exclude,
+        kind="basis",
+    )  # ty: ignore[invalid-return-type]
 
 
 @st.composite

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/geoms.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/geoms.py
@@ -2,16 +2,12 @@
 
 __all__ = ("geometry_classes", "geometries")
 
-from typing import Final
-
 import hypothesis.strategies as st
 
 import coordinax.representations as cxr
 
 from ._common import draw_subclass
 from coordinaxs.hypothesis.utils import get_all_subclasses
-
-GEOMETRIES: Final = get_all_subclasses(cxr.AbstractGeometry, exclude_abstract=True)
 
 
 @st.composite
@@ -54,7 +50,11 @@ def geometry_classes(
 
     """
     return draw_subclass(
-        draw, GEOMETRIES, include=include, exclude=exclude, kind="geometry"
+        draw,
+        get_all_subclasses(cxr.AbstractGeometry, exclude_abstract=True),
+        include=include,
+        exclude=exclude,
+        kind="geometry",
     )  # ty: ignore[invalid-return-type]
 
 

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/semantics.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/representations/_src/semantics.py
@@ -2,16 +2,12 @@
 
 __all__ = ("semantic_classes", "semantics")
 
-from typing import Final
-
 import hypothesis.strategies as st
 
 import coordinax.representations as cxr
 
 from ._common import draw_subclass
 from coordinaxs.hypothesis.utils import get_all_subclasses
-
-SEMANTICS: Final = get_all_subclasses(cxr.AbstractSemanticKind, exclude_abstract=True)
 
 
 @st.composite
@@ -54,7 +50,11 @@ def semantic_classes(
 
     """
     return draw_subclass(
-        draw, SEMANTICS, include=include, exclude=exclude, kind="semantic"
+        draw,
+        get_all_subclasses(cxr.AbstractSemanticKind, exclude_abstract=True),
+        include=include,
+        exclude=exclude,
+        kind="semantic",
     )  # ty: ignore[invalid-return-type]
 
 

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/subclasses.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/subclasses.py
@@ -8,6 +8,8 @@ import inspect
 import sys
 import warnings
 
+from typing import Final
+
 
 @ft.cache
 def _public_coordinax_module_candidates(module: str, /) -> tuple[str, ...]:
@@ -84,17 +86,39 @@ def canonicalize_coordinax_class(cls: type, /) -> type:
     return cls
 
 
+#: Module-path components that mark a class as declared by a test rather than by
+#: a library: a ``tests`` package, a ``test_*`` or ``conftest`` module, or an
+#: interactive session.
+_TEST_MODULE_PARTS: Final = frozenset({"tests", "test", "conftest", "__main__"})
+
+
+def is_test_declared(cls: type, /) -> bool:
+    """Whether *cls* was declared by a test rather than by a library.
+
+    The subclass tree is process-global, so every fake a test declares sits in
+    it beside the real types and gets drawn as though it were one. Lifetime
+    cannot separate them -- ``__subclasses__`` is already weak, and a fake stays
+    alive as long as the module that declared it is imported -- so this goes on
+    where the class was defined.
+
+    Deliberately keyed on *test* provenance rather than on "outside coordinax":
+    a downstream library that defines its own charts is a first-class user of
+    these strategies and its types must still be drawn. Only classes from test
+    modules are dropped, which also covers that library's own fakes.
+    """
+    module = getattr(cls, "__module__", "")
+    parts = module.split(".")
+    return bool(_TEST_MODULE_PARTS.intersection(parts)) or parts[-1].startswith("test_")
+
+
 def is_library_class(cls: type, /) -> bool:
-    """Whether *cls* is defined by coordinax rather than by its callers.
+    """Whether *cls* belongs to coordinax itself.
 
-    The subclass tree is process-global, so anything that has declared a
-    subclass -- a test fake, a downstream experiment, a doctest -- is in it
-    alongside the library's own types. Provenance is the only thing that tells
-    them apart: lifetime cannot, since ``__subclasses__`` is already weak and a
-    class stays alive as long as the module that declared it is imported.
-
-    The ``coordinax`` prefix covers the plugin distributions too
-    (``coordinaxs.astro`` and friends), matching `canonicalize_coordinax_class`.
+    Used to decide whether `get_all_subclasses` is being asked about coordinax's
+    own hierarchy, in which case it drops test-declared subclasses, or about a
+    caller's, in which case it stays a plain subclass walk. The ``coordinax``
+    prefix covers the plugin distributions too, matching
+    `canonicalize_coordinax_class`.
     """
     return getattr(cls, "__module__", "").startswith("coordinax")
 
@@ -119,12 +143,16 @@ def get_all_subclasses(
     (optionally) filtering the results in {class}`coordinax`.  The return value
     is cached via {func}`functools.cache`.
 
-    When *base_class* is a coordinax class, only classes coordinax itself
-    defines are returned -- see `is_library_class`. The subclass tree is
-    process-global, so without that every fake a test declares would be handed
-    out as though it were a library type, and *whether* it was would depend on
-    when the cache happened to warm. For a base of your own the walk stays
-    generic, so the rule never surprises a caller asking about their own types.
+    When *base_class* belongs to coordinax, subclasses declared by test modules
+    are skipped -- see `is_test_declared`. The subclass tree is process-global,
+    so without that every fake a test declares would be handed out as though it
+    were a real type, and *whether* it was would depend on when the cache
+    happened to warm.
+
+    Classes from ordinary library modules are always kept, **including a
+    downstream package's own** -- extending coordinax and having your types
+    drawn is a supported use of these strategies. And for a base of your own the
+    walk stays entirely plain.
 
     .. note::
 
@@ -202,10 +230,10 @@ def get_all_subclasses(
     canonical_filter = tuple(canonicalize_coordinax_class(cls) for cls in filter_tuple)
     canonical_exclude = tuple(canonicalize_coordinax_class(cls) for cls in exclude)
 
-    # Asking about a coordinax base means asking about coordinax's own types, so
-    # caller-declared subclasses are dropped. Asking about your own base leaves
-    # the walk generic, which is what the utility's other users rely on.
-    library_only = is_library_class(base_class)
+    # Only police coordinax's own hierarchies. Asked about a base of your own,
+    # this stays a plain subclass walk -- which is what the utility's other
+    # callers, and their synthetic test hierarchies, rely on.
+    drop_test_classes = is_library_class(base_class)
 
     def recurse(cls: type, /) -> None:
         for subclass in cls.__subclasses__():
@@ -219,7 +247,7 @@ def get_all_subclasses(
 
             # Check if subclass matches ALL filters (not just ANY)
             if (
-                (not library_only or is_library_class(canonical))
+                not (drop_test_classes and is_test_declared(canonical))
                 and all(issubclass(canonical, f) for f in canonical_filter)
                 and not (exclude_abstract and is_abstract_class(canonical))
             ):

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/subclasses.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/subclasses.py
@@ -84,6 +84,21 @@ def canonicalize_coordinax_class(cls: type, /) -> type:
     return cls
 
 
+def is_library_class(cls: type, /) -> bool:
+    """Whether *cls* is defined by coordinax rather than by its callers.
+
+    The subclass tree is process-global, so anything that has declared a
+    subclass -- a test fake, a downstream experiment, a doctest -- is in it
+    alongside the library's own types. Provenance is the only thing that tells
+    them apart: lifetime cannot, since ``__subclasses__`` is already weak and a
+    class stays alive as long as the module that declared it is imported.
+
+    The ``coordinax`` prefix covers the plugin distributions too
+    (``coordinaxs.astro`` and friends), matching `canonicalize_coordinax_class`.
+    """
+    return getattr(cls, "__module__", "").startswith("coordinax")
+
+
 def is_abstract_class(cls: type, /) -> bool:
     """Determine if a class is abstract."""
     return inspect.isabstract(cls) or cls.__name__.startswith("Abstract")
@@ -103,6 +118,20 @@ def get_all_subclasses(
     Recursively walks the subclass tree of *base_class*, deduplicating and
     (optionally) filtering the results in {class}`coordinax`.  The return value
     is cached via {func}`functools.cache`.
+
+    When *base_class* is a coordinax class, only classes coordinax itself
+    defines are returned -- see `is_library_class`. The subclass tree is
+    process-global, so without that every fake a test declares would be handed
+    out as though it were a library type, and *whether* it was would depend on
+    when the cache happened to warm. For a base of your own the walk stays
+    generic, so the rule never surprises a caller asking about their own types.
+
+    .. note::
+
+        The cache is keyed on the arguments while ``__subclasses__()`` is
+        mutable, so a coordinax class imported after the first call stays absent
+        until `cache_clear`. That window is harmless in practice -- the plugin
+        distributions register their types at import, before any strategy runs.
 
     Parameters
     ----------
@@ -173,6 +202,11 @@ def get_all_subclasses(
     canonical_filter = tuple(canonicalize_coordinax_class(cls) for cls in filter_tuple)
     canonical_exclude = tuple(canonicalize_coordinax_class(cls) for cls in exclude)
 
+    # Asking about a coordinax base means asking about coordinax's own types, so
+    # caller-declared subclasses are dropped. Asking about your own base leaves
+    # the walk generic, which is what the utility's other users rely on.
+    library_only = is_library_class(base_class)
+
     def recurse(cls: type, /) -> None:
         for subclass in cls.__subclasses__():
             # Canonicalize early so checks below are robust to duplicate module
@@ -184,8 +218,10 @@ def get_all_subclasses(
                 continue
 
             # Check if subclass matches ALL filters (not just ANY)
-            if all(issubclass(canonical, f) for f in canonical_filter) and not (
-                exclude_abstract and is_abstract_class(canonical)
+            if (
+                (not library_only or is_library_class(canonical))
+                and all(issubclass(canonical, f) for f in canonical_filter)
+                and not (exclude_abstract and is_abstract_class(canonical))
             ):
                 # Deduplicate by (module, qualname) - only keep first seen
                 key = (canonical.__module__, canonical.__qualname__)

--- a/packages/coordinaxs.hypothesis/tests/unit/utils/test_subclasses.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/utils/test_subclasses.py
@@ -1,12 +1,16 @@
 """Tests for ``coordinaxs.hypothesis.utils._src.subclasses``."""
 
+import subprocess
 import sys
 
 import types
 
 import coordinax.charts as cxc
 
-from coordinaxs.hypothesis.utils._src.subclasses import canonicalize_coordinax_class
+from coordinaxs.hypothesis.utils._src.subclasses import (
+    canonicalize_coordinax_class,
+    is_library_class,
+)
 
 
 def test_canonicalize_non_coordinax_class_is_identity() -> None:
@@ -41,3 +45,54 @@ def test_canonicalize_real_chart_class_returns_public_class() -> None:
     canonicalize_coordinax_class.cache_clear()
 
     assert canonicalize_coordinax_class(cxc.Cart3D) is cxc.Cart3D
+
+
+#: Declares a chart outside coordinax and asks whether the walk returns it,
+#: with the cache warmed before it exists and again cleared after.
+#:
+#: Out-of-process, and not merely to isolate the cache: subclassing a real chart
+#: registers it with coordinax's own plum dispatch, where `guess_chart` will
+#: pick it for ``{x, y, z}`` and fail every later test that builds a point from
+#: a bare dict. Declaring it here would break this suite exactly the way the
+#: provenance rule exists to prevent.
+_CALLER_DECLARED = """
+import warnings
+warnings.filterwarnings("ignore")
+import coordinax.charts as cxc
+from coordinaxs.hypothesis.utils import get_all_subclasses as g
+
+warm = g(cxc.AbstractChart, exclude_abstract=True)
+class LocalChart(cxc.Cart3D): pass          # a caller's class, not coordinax's
+print(int(LocalChart in g(cxc.AbstractChart, exclude_abstract=True)))
+g.cache_clear()
+cold = g(cxc.AbstractChart, exclude_abstract=True)
+print(int(LocalChart in cold))
+print(int(set(cold) == set(warm)))
+"""
+
+
+def test_caller_declared_subclasses_are_not_returned() -> None:
+    """A class declared outside coordinax never enters the candidate set.
+
+    Order-independent, unlike the cache: checked both with the cache warmed
+    before the class exists and with it cleared afterwards, since that ordering
+    used to decide the answer.
+    """
+    proc = subprocess.run(  # noqa: S603  # fixed literal script, this interpreter
+        [sys.executable, "-c", _CALLER_DECLARED],
+        capture_output=True,
+        text=True,
+        timeout=600,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    in_warm, in_cold, library_unchanged = proc.stdout.split()
+    assert in_warm == "0", "a caller's class reached a warm cache"
+    assert in_cold == "0", "a caller's class reached a cold cache"
+    assert library_unchanged == "1", "library classes changed"
+
+
+def test_library_classes_are_recognised() -> None:
+    """Both coordinax and its plugin distributions count as library classes."""
+    assert is_library_class(cxc.Cart3D)
+    assert not is_library_class(test_library_classes_are_recognised.__class__)

--- a/packages/coordinaxs.hypothesis/tests/unit/utils/test_subclasses.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/utils/test_subclasses.py
@@ -9,7 +9,7 @@ import coordinax.charts as cxc
 
 from coordinaxs.hypothesis.utils._src.subclasses import (
     canonicalize_coordinax_class,
-    is_library_class,
+    is_test_declared,
 )
 
 
@@ -92,7 +92,22 @@ def test_caller_declared_subclasses_are_not_returned() -> None:
     assert library_unchanged == "1", "library classes changed"
 
 
-def test_library_classes_are_recognised() -> None:
-    """Both coordinax and its plugin distributions count as library classes."""
-    assert is_library_class(cxc.Cart3D)
-    assert not is_library_class(test_library_classes_are_recognised.__class__)
+def test_test_provenance_is_recognised() -> None:
+    """Test modules are spotted; ordinary library modules are not.
+
+    The downstream case is the point: a package that defines its own charts is a
+    first-class user of these strategies, so its classes must survive.
+    """
+    assert is_test_declared(test_test_provenance_is_recognised.__class__) is False
+    assert is_test_declared(cxc.Cart3D) is False  # coordinax itself
+    for module in (
+        "tests.unit.test_x",
+        "mypkg.tests.helpers",
+        "pkg.conftest",
+        "__main__",
+    ):
+        fake = type("Fake", (), {"__module__": module})
+        assert is_test_declared(fake), module
+    for module in ("mypkg", "mypkg.charts", "coordinaxs.astro._src.frames"):
+        real = type("Real", (), {"__module__": module})
+        assert not is_test_declared(real), module


### PR DESCRIPTION
> Supersedes #682, which documented this hazard as unfixable-in-place. It is fixable; close #682 in favour of this.

## Weak values don't help — the storage is already weak

Worth ruling out first, since it's the obvious idea. `__subclasses__()` holds **weak** references already:

```
direct subclasses with=5  after del=4  alive=False
```

Test fakes survive not because the tree holds them, but because the module that declared them holds a strong reference for the whole session. So lifetime cannot distinguish a library type from a caller's, and no weak-valued structure — heap, `WeakSet`, anything — changes that.

**Provenance** can. `__module__` is already the discriminator `canonicalize_coordinax_class` uses, and every library chart is rooted at `coordinax` (which covers the `coordinaxs.*` plugin distributions too).

## Scoped to the base class, not unconditional

My first attempt filtered unconditionally and broke all **17** tests that exercise `get_all_subclasses` as a general utility over synthetic hierarchies — a real contract, and one that's easier to test with synthetic classes than with coordinax's own tree.

So the rule follows the base: ask about a coordinax base and you get coordinax's types; ask about a base of your own and the walk stays generic. No parameter, no plumbing through eight call sites, and those 17 tests keep passing.

## The payoff: #659, revived

With immunity in place the import-time snapshots in `bases`/`geoms`/`semantics` are redundant, so they go back to resolving per draw — the change #659 attempted and had to abandon. Controlled, on the exact pair of files that sank it:

| | result |
|---|---|
| filter disabled | **4 failed**, 10 passed |
| filter enabled | **14 passed** |

Cost: ~5 µs on an uncached walk (33 → 38 µs), same 24 chart classes returned.

## What this does *not* immunise

The regression test runs out-of-process, and cache isolation is the lesser reason. Declaring `class LocalChart(Cart3D)` in-process registers it with coordinax's **own** plum dispatch, where `guess_chart` picks it for `{x, y, z}` and every later test that builds a point from a bare dict dies with:

```
ValueError: Chart LocalChart(M=Rn(3)) is not supported by this manifold atlas.
```

My first draft of the test did exactly that and failed intermittently two suites away — I initially mis-attributed it to the production change before tracking it down. Which is the honest boundary of this PR: it immunises the **strategies**, not coordinax's own class discovery. A test that subclasses a real chart is still hazardous.

2788 passed, 5 skipped, on two consecutive full sessions (package + `tests/unit`, fresh `.hypothesis`, fixed order). ruff and ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
