### PR TITLE
🐛 fix(tests): silence hypothesis deadline in `test_wrap_array_angle`

### DIFF
--- a/tests/unit/angles/test_angle.py
+++ b/tests/unit/angles/test_angle.py
@@ -200,6 +200,8 @@ class TestAngleWrapTo:
         assert jnp.allclose(wrapped.value, expected, atol=1e-4)
 
     @given(angle=cxst.angles(unit="deg", shape=(4,)))
+    # Same first-call JAX compile as `test_wrap_to_range` above; see its comment.
+    @settings(deadline=None)
     def test_wrap_array_angle(self, angle: cxa.Angle) -> None:
         """wrap_to acts element-wise on array-valued Angles."""
         wrapped = angle.wrap_to(u.Q(0, "deg"), u.Q(360, "deg"))


### PR DESCRIPTION
## Problem

`tests/unit/angles/test_angle.py::TestAngleWrapTo::test_wrap_array_angle` is intermittently flaky:

```
- during generate phase (0.47 seconds):
  - Typical runtimes: ~ 1-421 ms, of which ~ 1-74 ms in data generation
  - 8 passing examples, 1 failing examples, 1 invalid examples
  - Found 1 distinct error in this phase
- Stopped because test was flaky
```

The first example costs ~421ms because JAX traces/compiles `wrap_to` on the first call, exceeding hypothesis's 200ms default deadline. On replay it takes 2ms and passes, so hypothesis reports it as flaky and aborts. It only fires when this test happens to be the first `wrap_to` caller under pytest-randomly ordering, and under machine load.

The sibling `test_wrap_to_range` in the same class already carries `@settings(deadline=None)` with a comment naming exactly this cause. `test_wrap_array_angle` has a bare `@given` and never got it.

## Fix

Add `@settings(deadline=None)`, with a comment pointing at `test_wrap_to_range`'s explanation rather than repeating it.

## Other exposure in the file

Checked by timing every `@given` test in `test_angle.py` in its own process (so each pays its own first-call compile). Only `test_wrap_array_angle` is exposed — 509ms in that run. Every other test tops out at 14ms against the 200ms deadline, so none of them need the override.

## Verification

Before, the test stopped early as flaky. After:

```
- during generate phase (0.72 seconds):
  - Typical runtimes: ~ 0-3 ms, of which ~ 0-1 ms in data generation
  - 100 passing examples, 0 failing examples, 36 invalid examples
- Stopped because settings.max_examples=100
```

`pytest tests/unit/angles/` — 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)