### PR TITLE
♻️ refactor(manifolds): extract the metric quadratic form from `norm`

### DIFF
--- a/src/coordinax/_src/manifolds/norm.py
+++ b/src/coordinax/_src/manifolds/norm.py
@@ -15,6 +15,7 @@ from unxt.quantity import is_any_quantity
 import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
 from ._utils import require_positive_definite
+from .quadratic_form import quadratic_form
 from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.charts import Cart0D, Cart1D, Cart2D, Cart3D, CartND
 from coordinax._src.custom_types import CDict, OptUSys
@@ -229,45 +230,18 @@ def norm(
     norm() supports only positive-definite metrics, but
 
     """
-    keys = chart.components
-    qty_flags = [is_any_quantity(val) for val in v.values()]
-    if any(qty_flags) and not all(qty_flags):
-        raise TypeError(
-            "norm(): mixed CDict with both Quantity and bare Array values is not "
-            "supported. All components must be either all Quantity or all bare Array."
-        )
-    is_qty = all(qty_flags)
-
     if metric != chart.M.metric:
         raise ValueError("Metric-level dispatch: metric must match chart's metric")
 
     # After the match check, so a mismatched *indefinite* metric still reports the
     # mismatch rather than the definiteness. Guards `chart.M.metric` because that
-    # is what `metric_matrix` below actually uses.
+    # is what the metric matrix is built from.
     require_positive_definite(chart.M.metric, "norm")
 
-    if not is_qty and usys is None:
-        raise TypeError(
-            "norm(): `usys` is required when `v` is a CDict of bare arrays "
-            "(no unit information). "
-            "Example: pass `usys=unxt.unitsystems.si`."
-        )
-
-    # Evaluate the metric matrix at the base point.  ``metric_matrix`` returns a
-    # typed ``AbstractMetricMatrix`` (Diagonal/Dense) and handles both bare-array
-    # and Quantity ``at`` values; it needs no unit system.
-    mm = cxmapi.metric_matrix(chart.M, at, chart)
-
-    if not is_qty:  # Bare arrays — stack on last axis for correct batch broadcasting
-        v_vec = jnp.stack([jnp.asarray(v[k]) for k in keys], axis=-1)
-        return array_norm(mm.to_dense().matrix, v_vec)  # ty: ignore[unresolved-attribute]
-
-    # Pack CDict of quantities into a QuantityMatrix, preserving per-component units,
-    # then compute sqrt(vᵀ G v) via QuantityMatrix/AbstractMetricMatrix arithmetic,
-    # which handles all unit conversions correctly (including mixed-unit
-    # components like m/s and rad/s).
-    v_qm: ul.QM = cxcapi.carray(v, keys)  # ty: ignore[invalid-assignment]
-    return jnp.sqrt(v_qm @ (mm @ v_qm))
+    # The norm is the square root of the metric quadratic form; the form itself
+    # owns the unit handling, and is shared with the callers that need it
+    # unrooted (where an indefinite metric makes the root meaningless).
+    return jnp.sqrt(quadratic_form(v, chart, at=at, usys=usys, fname="norm"))
 
 
 @plum.dispatch

--- a/src/coordinax/_src/manifolds/quadratic_form.py
+++ b/src/coordinax/_src/manifolds/quadratic_form.py
@@ -20,7 +20,10 @@ cover the ways a caller wants to ask.
 
 __all__: tuple[str, ...] = ()
 
+from jaxtyping import Array
 from typing import Any
+
+import plum
 
 import quaxed.numpy as jnp
 import unxts.linalg as ul
@@ -30,6 +33,7 @@ import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
 from coordinax._src.base import AbstractChart
 from coordinax._src.custom_types import CDict, OptUSys
+from coordinax._src.metric.matrix import AbstractMetricMatrix, DiagonalMetric
 
 _MSG_MIXED = (
     "{fname}(): mixed CDict with both Quantity and bare Array values is not "
@@ -117,11 +121,66 @@ def quadratic_form(
 
     if not is_qty:  # Bare arrays — stack on last axis for correct batch broadcasting
         v_vec = jnp.stack([jnp.asarray(v[k]) for k in keys], axis=-1)
-        g = mm.to_dense().matrix  # ty: ignore[unresolved-attribute]
-        return jnp.einsum("...i,...ij,...j->...", v_vec, g, v_vec)
+        return _contract(mm, v_vec)
 
     # Pack into a QuantityMatrix, preserving per-component units, then contract
     # via QuantityMatrix/AbstractMetricMatrix arithmetic, which handles all unit
     # conversions correctly (including mixed-unit components like m/s and rad/s).
     v_qm: ul.QM = cxcapi.carray(v, keys)  # ty: ignore[invalid-assignment]
-    return v_qm @ (mm @ v_qm)
+    return _contract(mm, v_qm)
+
+
+@plum.dispatch
+def _contract(mm: AbstractMetricMatrix, v: ul.QM, /) -> Any:
+    r"""Fallback: densify, then contract $v^\top G v$ -- $O(n^2)$."""
+    return v @ (mm.to_dense() @ v)
+
+
+@plum.dispatch
+def _contract(mm: AbstractMetricMatrix, v: Array, /) -> Any:
+    r"""Fallback for a stacked bare array -- $O(n^2)$.
+
+    ``einsum`` rather than ``@``, so a leading batch axis stays distinct from
+    the component axis.
+    """
+    return jnp.einsum("...i,...ij,...j->...", v, mm.to_dense().matrix, v)
+
+
+@plum.dispatch
+def _contract(mm: DiagonalMetric, v: ul.QM, /) -> Any:
+    r"""Diagonal fast path -- $\sum_i g_{ii} v_i^2$, $O(n)$ instead of $O(n^2)$.
+
+    `DiagonalMetric` stores only the diagonal precisely so the full matrix need
+    never be materialised -- its own docstring says so -- but `to_dense` throws
+    that structure away. Every metric the library ships is diagonal in its
+    canonical chart (`FlatMetric`, `RoundMetric`, `MinkowskiMetric`), so this is
+    the common path, not a corner.
+
+    Measured on 100k points vmapped inside one `jit`: **2.2x** at n=2 (`sph2`),
+    **8.3x** at n=3 (`cart3d`), **3.9x** at n=4 (`minkowskict`).
+
+    Written ``(d * v) @ v`` rather than with a `sum`: a 1-D `QuantityMatrix`
+    cannot be reduced over its logical axis, and this spelling keeps
+    per-component units riding along -- the diagonal is itself a
+    `QuantityMatrix` on a mixed-unit chart such as ``sph3d``.
+    """
+    return (mm.diagonal * v) @ v
+
+
+@plum.dispatch
+def _contract(mm: DiagonalMetric, v: Array, /) -> Any:
+    r"""Diagonal fast path for a stacked bare array -- $O(n)$.
+
+    Summed explicitly rather than via ``@``, which would contract a leading
+    batch axis instead of the component axis.
+
+    A *unitful* diagonal is sent back to the dense path: on a mixed-unit chart
+    the per-component units cannot be factored out of a sum against a unitless
+    vector. That combination does not work on the dense path either (it raises
+    from the unit machinery), so this keeps the pre-existing failure rather than
+    substituting a different one.
+    """
+    d = mm.diagonal
+    if isinstance(d, ul.QM):
+        return jnp.einsum("...i,...ij,...j->...", v, mm.to_dense().matrix, v)
+    return jnp.sum(d * v * v, axis=-1)

--- a/src/coordinax/_src/manifolds/quadratic_form.py
+++ b/src/coordinax/_src/manifolds/quadratic_form.py
@@ -1,0 +1,127 @@
+r"""The metric quadratic form, shared by every magnitude-like manifold verb.
+
+Every function that asks "how big is this, according to the metric" evaluates the
+same contraction:
+
+$$ Q_p(v) = v^\top G(p)\, v. $$
+
+`~coordinax.manifolds.norm` is its square root, and
+`~coordinax.manifolds.separation` is that applied to a coordinate difference.
+Anything defined on an *indefinite* metric — where the square root has no real
+value — needs the contraction **unrooted** instead.
+
+Keeping one implementation matters for more than line count: the unit handling
+here is fiddly (mixed-unit components, bare arrays that carry no units at all,
+per-component units that must survive the contraction), and a second copy
+reliably ends up with a subset of the checks.  It is a private helper rather than
+public API because the two public spellings, `norm` and ``interval``, already
+cover the ways a caller wants to ask.
+"""
+
+__all__: tuple[str, ...] = ()
+
+from typing import Any
+
+import quaxed.numpy as jnp
+import unxts.linalg as ul
+from unxt.quantity import is_any_quantity
+
+import coordinaxs.api.charts as cxcapi
+import coordinaxs.api.manifolds as cxmapi
+from coordinax._src.base import AbstractChart
+from coordinax._src.custom_types import CDict, OptUSys
+
+_MSG_MIXED = (
+    "{fname}(): mixed CDict with both Quantity and bare Array values is not "
+    "supported. All components must be either all Quantity or all bare Array."
+)
+
+_MSG_USYS = (
+    "{fname}(): `usys` is required when `v` is a CDict of bare arrays "
+    "(no unit information). "
+    "Example: pass `usys=unxt.unitsystems.si`."
+)
+
+
+def quadratic_form(
+    v: CDict,
+    chart: AbstractChart,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+    fname: str = "quadratic_form",
+) -> Any:
+    r"""Return $v^\top G(\text{at})\, v$ for the chart's metric.
+
+    No square root is taken, so this is defined for every metric — including
+    indefinite ones, where it is the signed interval rather than a magnitude.
+
+    Parameters
+    ----------
+    v
+        Component dictionary of the vector to contract. Values must be *all*
+        `unxt.Quantity` or *all* bare arrays; a mixture raises `TypeError`.
+    chart
+        The chart whose manifold supplies the metric. The metric is evaluated at
+        ``at``, and ``v``'s components are read in ``chart.components`` order.
+    at
+        Base point at which to evaluate the metric.
+    usys
+        Unit system. Required when ``v`` holds bare arrays, since there is then
+        no unit information to work from; optional otherwise.
+    fname
+        Name of the calling function, used in error messages so a caller of
+        `norm` is not told about ``quadratic_form``. Mirrors the ``fname``
+        argument of `require_positive_definite`.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> from coordinax._src.manifolds.quadratic_form import quadratic_form
+
+    A 3-4-0 vector in flat space contracts to ``25 m2`` -- the *square* of the
+    norm ``5 m``:
+
+    >>> at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+    >>> v = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+    >>> quadratic_form(v, cxc.cart3d, at=at).round(2)
+    Q(25., 'm2')
+
+    Unlike a norm it stays defined when the metric is indefinite, going negative
+    for a timelike vector:
+
+    >>> at4 = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> v4 = {"ct": u.Q(5.0, "m"), "x": u.Q(1.0, "m"),
+    ...       "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> quadratic_form(v4, cxc.minkowskict, at=at4).round(2)
+    Q(-24., 'm2')
+
+    """
+    keys = chart.components
+
+    qty_flags = [is_any_quantity(val) for val in v.values()]
+    if any(qty_flags) and not all(qty_flags):
+        raise TypeError(_MSG_MIXED.format(fname=fname))
+    is_qty = all(qty_flags)
+
+    if not is_qty and usys is None:
+        raise TypeError(_MSG_USYS.format(fname=fname))
+
+    # ``metric_matrix`` returns a typed ``AbstractMetricMatrix`` (Diagonal/Dense)
+    # and handles both bare-array and Quantity ``at`` values; it needs no unit
+    # system of its own.
+    mm = cxmapi.metric_matrix(chart.M, at, chart)
+
+    if not is_qty:  # Bare arrays — stack on last axis for correct batch broadcasting
+        v_vec = jnp.stack([jnp.asarray(v[k]) for k in keys], axis=-1)
+        g = mm.to_dense().matrix  # ty: ignore[unresolved-attribute]
+        return jnp.einsum("...i,...ij,...j->...", v_vec, g, v_vec)
+
+    # Pack into a QuantityMatrix, preserving per-component units, then contract
+    # via QuantityMatrix/AbstractMetricMatrix arithmetic, which handles all unit
+    # conversions correctly (including mixed-unit components like m/s and rad/s).
+    v_qm: ul.QM = cxcapi.carray(v, keys)  # ty: ignore[invalid-assignment]
+    return v_qm @ (mm @ v_qm)

--- a/tests/unit/manifolds/test_quadratic_form.py
+++ b/tests/unit/manifolds/test_quadratic_form.py
@@ -1,0 +1,155 @@
+"""Tests for the shared metric quadratic form.
+
+The point of extracting this is that every magnitude-like verb contracts the
+same `vᵀ G(p) v`, and a second copy of that contraction reliably ends up with a
+subset of the unit checks. So the tests here pin two things: the relationship to
+`norm` (it is exactly the square), and that the fiddly unit handling lives here
+rather than in the caller.
+"""
+
+from typing import ClassVar
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import quaxed.numpy as qnp
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+from coordinax._src.manifolds.quadratic_form import quadratic_form
+
+ATOL = 1e-5
+
+
+class TestRelationToNorm:
+    """`norm` is the square root of the form, for a positive-definite metric."""
+
+    @pytest.mark.parametrize(
+        ("v", "chart", "want"),
+        [
+            ({"x": 3.0, "y": 4.0, "z": 0.0}, cxc.cart3d, 25.0),
+            ({"x": 1.0, "y": 0.0, "z": 0.0}, cxc.cart3d, 1.0),
+            ({"x": 0.0, "y": 0.0, "z": 0.0}, cxc.cart3d, 0.0),
+            ({"x": -5.0, "y": 12.0, "z": 0.0}, cxc.cart3d, 169.0),
+        ],
+    )
+    def test_form_is_norm_squared(self, v, chart, want):
+        vq = {k: u.Q(val, "m") for k, val in v.items()}
+        at = {k: u.Q(0.0, "m") for k in v}
+
+        got = quadratic_form(vq, chart, at=at)
+        assert float(got.ustrip("m2")) == pytest.approx(want, abs=ATOL)
+
+        n = cxm.norm(vq, chart, at=at)
+        assert float(n.ustrip("m")) ** 2 == pytest.approx(want, abs=ATOL)
+
+    def test_agrees_on_a_curved_metric(self):
+        """Also holds where the metric actually varies with the base point."""
+        at = {"theta": u.Q(jnp.pi / 2, "rad"), "phi": u.Q(0.0, "rad")}
+        v = {"theta": u.Q(1.0, "rad/s"), "phi": u.Q(1.0, "rad/s")}
+        metric = cxm.RoundMetric(ndim=2)
+
+        form = quadratic_form(v, cxc.sph2, at=at)
+        n = cxm.norm(v, metric, cxc.sph2, at=at)
+        assert float(u.ustrip("rad2/s2", form)) == pytest.approx(
+            float(n.ustrip("rad/s")) ** 2, abs=ATOL
+        )
+
+
+class TestDefinedWhereNormIsNot:
+    """The reason it exists: no square root, so an indefinite metric is fine."""
+
+    AT4: ClassVar = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+
+    @staticmethod
+    def _v4(ct, x):
+        return {
+            "ct": u.Q(ct, "m"),
+            "x": u.Q(x, "m"),
+            "y": u.Q(0.0, "m"),
+            "z": u.Q(0.0, "m"),
+        }
+
+    @pytest.mark.parametrize(
+        ("ct", "x", "want"), [(5.0, 1.0, -24.0), (1.0, 5.0, 24.0), (3.0, 3.0, 0.0)]
+    )
+    def test_indefinite_metric_gives_a_signed_value(self, ct, x, want):
+        got = quadratic_form(self._v4(ct, x), cxc.minkowskict, at=self.AT4)
+        assert float(got.ustrip("m2")) == pytest.approx(want, abs=ATOL)
+        assert not bool(jnp.isnan(got.ustrip("m2")))
+
+    def test_norm_still_refuses_the_same_input(self):
+        """The form is permissive; the positive-definite guard stays on `norm`."""
+        with pytest.raises(NotImplementedError, match=r"pseudo.*indefinite"):
+            cxm.norm(
+                self._v4(5.0, 1.0), cxm.MinkowskiMetric(), cxc.minkowskict, at=self.AT4
+            )
+
+
+class TestUnitHandlingLivesHere:
+    """The checks a second copy of the contraction would have dropped."""
+
+    def test_mixed_quantity_and_array_is_rejected(self):
+        at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+        mixed = {"x": u.Q(3.0, "m"), "y": jnp.asarray(4.0), "z": u.Q(0.0, "m")}
+        with pytest.raises(TypeError, match="mixed CDict"):
+            quadratic_form(mixed, cxc.cart3d, at=at)
+
+    def test_bare_arrays_require_usys(self):
+        at = {"theta": jnp.asarray(jnp.pi / 2), "phi": jnp.asarray(0.0)}
+        v = {"theta": jnp.asarray(1.0), "phi": jnp.asarray(0.0)}
+        with pytest.raises(TypeError, match="usys"):
+            quadratic_form(v, cxc.sph2, at=at)
+
+    def test_bare_arrays_work_when_usys_is_given(self):
+        at = {"theta": jnp.asarray(jnp.pi / 2), "phi": jnp.asarray(0.0)}
+        v = {"theta": jnp.asarray(1.0), "phi": jnp.asarray(0.0)}
+        got = quadratic_form(v, cxc.sph2, at=at, usys=u.unitsystems.si)
+        assert float(got) == pytest.approx(1.0, abs=ATOL)
+
+    @pytest.mark.parametrize("fname", ["norm", "interval", "quadratic_form"])
+    def test_errors_name_the_calling_function(self, fname):
+        """A caller of `norm` should not be told about `quadratic_form`."""
+        at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+        mixed = {"x": u.Q(3.0, "m"), "y": jnp.asarray(4.0), "z": u.Q(0.0, "m")}
+        with pytest.raises(TypeError, match=rf"^{fname}\(\)"):
+            quadratic_form(mixed, cxc.cart3d, at=at, fname=fname)
+
+    def test_mixed_unit_components_contract_correctly(self):
+        """Per-component units must survive the contraction, not be flattened."""
+        at = {
+            "r": u.Q(5.0, "m"),
+            "theta": u.Q(jnp.pi / 2, "rad"),
+            "phi": u.Q(0.0, "rad"),
+        }
+        v = {"r": u.Q(1.0, "m/s"), "theta": u.Q(0.0, "rad/s"), "phi": u.Q(0.0, "rad/s")}
+        got = quadratic_form(v, cxc.sph3d, at=at)
+        assert float(u.ustrip("m2/s2", got)) == pytest.approx(1.0, abs=ATOL)
+
+
+class TestJAX:
+    """Still traceable, since `norm` routes through it."""
+
+    def test_jit(self):
+        at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+
+        @jax.jit
+        def f(v):
+            return quadratic_form(v, cxc.cart3d, at=at)
+
+        v = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+        assert float(f(v).ustrip("m2")) == pytest.approx(25.0, abs=ATOL)
+
+    def test_vmap_batches(self):
+        at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+        batch = {
+            "x": u.Q(jnp.asarray([3.0, 1.0]), "m"),
+            "y": u.Q(jnp.asarray([4.0, 0.0]), "m"),
+            "z": u.Q(jnp.asarray([0.0, 0.0]), "m"),
+        }
+        got = jax.vmap(lambda v: quadratic_form(v, cxc.cart3d, at=at))(batch)
+        assert qnp.allclose(
+            got, u.Q(jnp.asarray([25.0, 1.0]), "m2"), atol=u.Q(ATOL, "m2")
+        )

--- a/tests/unit/manifolds/test_quadratic_form.py
+++ b/tests/unit/manifolds/test_quadratic_form.py
@@ -18,7 +18,10 @@ import unxt as u
 
 import coordinax.charts as cxc
 import coordinax.manifolds as cxm
-from coordinax._src.manifolds.quadratic_form import quadratic_form
+import coordinaxs.api.charts as cxcapi
+import coordinaxs.api.manifolds as cxmapi
+from coordinax._src.manifolds.quadratic_form import _contract, quadratic_form
+from coordinax._src.metric.matrix import DiagonalMetric
 
 ATOL = 1e-5
 
@@ -152,4 +155,95 @@ class TestJAX:
         got = jax.vmap(lambda v: quadratic_form(v, cxc.cart3d, at=at))(batch)
         assert qnp.allclose(
             got, u.Q(jnp.asarray([25.0, 1.0]), "m2"), atol=u.Q(ATOL, "m2")
+        )
+
+
+class TestDiagonalFastPath:
+    """`DiagonalMetric` contracts in O(n); it must agree with the O(n^2) form.
+
+    `metric_matrix` returns a `DiagonalMetric` for every metric the library
+    ships in its canonical chart, and that type exists so the full matrix need
+    never be materialised. `to_dense()` discards the structure, so the fast path
+    is the common one — and its whole job is to be indistinguishable from the
+    dense answer.
+    """
+
+    CASES: ClassVar = [
+        (
+            "cart3d",
+            cxc.cart3d,
+            {"x": (0.0, "m"), "y": (0.0, "m"), "z": (0.0, "m")},
+            {"x": (3.0, "m"), "y": (4.0, "m"), "z": (0.0, "m")},
+        ),
+        (
+            "minkowskict",
+            cxc.minkowskict,
+            {"ct": (0.0, "m"), "x": (0.0, "m"), "y": (0.0, "m"), "z": (0.0, "m")},
+            {"ct": (5.0, "m"), "x": (1.0, "m"), "y": (0.0, "m"), "z": (0.0, "m")},
+        ),
+        (
+            "sph2 (curved)",
+            cxc.sph2,
+            {"theta": (jnp.pi / 2, "rad"), "phi": (0.0, "rad")},
+            {"theta": (1.0, "rad/s"), "phi": (1.0, "rad/s")},
+        ),
+        (
+            "sph3d (mixed units)",
+            cxc.sph3d,
+            {"r": (5.0, "m"), "theta": (jnp.pi / 2, "rad"), "phi": (0.0, "rad")},
+            {"r": (1.0, "m/s"), "theta": (0.0, "rad/s"), "phi": (0.0, "rad/s")},
+        ),
+    ]
+
+    @pytest.mark.parametrize(("label", "chart", "at_spec", "v_spec"), CASES)
+    def test_agrees_with_the_dense_contraction(self, label, chart, at_spec, v_spec):
+        del label
+        at = {k: u.Q(val, un) for k, (val, un) in at_spec.items()}
+        v = {k: u.Q(val, un) for k, (val, un) in v_spec.items()}
+        mm = cxmapi.metric_matrix(chart.M, at, chart)
+        assert isinstance(mm, DiagonalMetric), "case must exercise the fast path"
+
+        v_qm = cxcapi.carray(v, chart.components)
+        fast = _contract(mm, v_qm)
+        dense = _contract(mm.to_dense(), v_qm)  # forces the generic fallback
+
+        assert u.unit_of(fast) == u.unit_of(dense)
+        assert qnp.allclose(fast, dense, atol=u.Q(1e-8, u.unit_of(dense)))
+
+    @pytest.mark.parametrize(
+        ("label", "chart", "at_spec", "v_spec"),
+        [c for c in CASES if c[0] != "sph3d (mixed units)"],
+    )
+    def test_bare_array_branch_agrees_too(self, label, chart, at_spec, v_spec):
+        """The stacked-array path has its own overload; it must match as well.
+
+        ``sph3d`` is excluded: a unitless vector against a unitful (mixed-unit)
+        diagonal is unsupported on *both* paths, before this change and after,
+        so there is no agreement to assert.
+        """
+        del label
+        at = {k: u.Q(val, un) for k, (val, un) in at_spec.items()}
+        v_arr = {k: jnp.asarray(val) for k, (val, _) in v_spec.items()}
+        mm = cxmapi.metric_matrix(chart.M, at, chart)
+        stacked = jnp.stack([v_arr[k] for k in chart.components], axis=-1)
+
+        fast = _contract(mm, stacked)
+        dense = _contract(mm.to_dense(), stacked)
+        assert jnp.allclose(jnp.asarray(fast), jnp.asarray(dense), atol=1e-8)
+
+    def test_batched_arrays_reduce_over_components_not_the_batch(self):
+        """``sum(..., axis=-1)`` rather than ``@``, which would eat the batch axis."""
+        at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+        mm = cxmapi.metric_matrix(cxc.cart3d.M, at, cxc.cart3d)
+        batch = jnp.asarray([[3.0, 4.0, 0.0], [1.0, 0.0, 0.0], [0.0, 5.0, 12.0]])
+        got = _contract(mm, batch)
+        assert got.shape == (3,)
+        assert jnp.allclose(got, jnp.asarray([25.0, 1.0, 169.0]), atol=1e-8)
+
+    def test_norm_is_unchanged_end_to_end(self):
+        """The optimisation is invisible from the public verb."""
+        at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+        v = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+        assert float(cxm.norm(v, cxc.cart3d, at=at).ustrip("m")) == pytest.approx(
+            5.0, abs=ATOL
         )


### PR DESCRIPTION
> ### 📍 Merge order: **base of the Minkowski series**
> | # | PR | Status |
> |---|----|--------|
> | ~~1~~ | ~~#674 — `norm`/`separation` `nan` fix~~ | ✅ merged |
> | ~~2~~ | ~~#678 — `LorentzBoost`~~ | ✅ merged |
> | **0** | **this PR** — shared quadratic form | **merge next** |
> | 3 | #680 — `interval` / causality / proper time | rebased onto this |
> | 4 | #683 — docs + tutorial | needs #680 |
>
> Branches off `main`, no dependencies. #680 will be restacked onto it.

## Why

Every "how big is this, according to the metric" verb evaluates the same contraction:

$$Q_p(v) = v^\top G(p)\,v$$

`norm` is its square root; `separation` is that applied to a coordinate difference. But anything defined on an **indefinite** metric needs the contraction *unrooted* — the square root has no real value there. So the next caller can't reuse `norm`, and copies the contraction instead. That already happened: `interval` in #680 is a second copy carrying **none** of `norm`'s unit checks, which shows up as real divergence:

```
                                          separation/norm            interval (the copy)
mixed-unit CDict              →  clear TypeError            raw astropy UnitConversionError
bare arrays, curved, no usys  →  TypeError: `usys` required silently returns a number
```

## What

`_src/manifolds/quadratic_form.py` holds the contraction once. The metric-level `norm` becomes:

```python
if metric != chart.M.metric: raise ValueError(...)
require_positive_definite(chart.M.metric, "norm")     # guard stays on norm, where it belongs
return jnp.sqrt(quadratic_form(v, chart, at=at, usys=usys, fname="norm"))
```

**The sharing is not for line count** — it's that the unit handling is the fiddly part, and a second copy reliably ends up with a subset of it. Now living in one place: the mixed `Quantity`/bare-array rejection, the `usys` requirement when components carry no units, per-component units surviving the contraction (`m/s` alongside `rad/s`), and the bare-array stacking that keeps batch broadcasting correct.

Errors take an `fname` so a caller of `norm` is told about `norm`, not about `quadratic_form` — mirroring the existing `require_positive_definite(metric, fname)`.

Private, not public API: `norm` and `separation` already cover how callers want to ask, and a third public spelling would be one more thing to keep consistent.

## Verification

**Pure refactor — no behaviour change.** The existing `norm`, `separation` and `angle_between` suites pass untouched. New `test_quadratic_form.py` (18 tests) pins:

- the defining relationship `norm² == form`, on flat **and** curved metrics
- the form stays finite and signed where `norm` correctly refuses (Minkowski: `-24 m²`)
- each unit check fires from the shared location, and names the calling function
- `jit` and `vmap` still trace through it

Full `tests/unit` + `docs` + `packages/coordinaxs.api`: **3285 passed, 5 skipped**. ruff and ruff-format clean; `ty` reports only 4 pre-existing warnings in unrelated files, none in the changed ones.

## Not in this PR

`angle_between` also contracts against the metric, but it needs the *bilinear* form `g(u,v)` for its inner product, not just the quadratic case. Generalising is a bigger change with a different unit story, so it keeps its own path for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ⚡️ Update: the extraction turned out to be a 2–8× win, not just a dedup

The refactor above is performance-neutral by itself. But once the contraction lived in one place, it became clear it was throwing away structure: `quadratic_form` called `to_dense()` on whatever `metric_matrix` returned, and for a **`DiagonalMetric`** that turns an O(n) contraction into O(n²). `norm` did the same before the extraction — this has always been the behaviour; sharing the code is what made it fixable once.

Every metric the library ships is diagonal in its canonical chart (`FlatMetric`, `RoundMetric`, `MinkowskiMetric`), so this is the hot path. 100k points vmapped inside one `jit`, distinct base points:

| chart | before | after | |
|---|---|---|---|
| `sph2` (n=2, RoundMetric) | 788 µs / 47 ops | 350 µs / 34 ops | **2.2×** |
| `cart3d` (n=3, FlatMetric) | 461 µs / 30 ops | 55 µs / 17 ops | **8.3×** |
| `minkowskict` (n=4) | 744 µs / 38 ops | 189 µs / 26 ops | **3.9×** |

### Dispatch is on the metric-matrix type, not the input container

That distinction was measured, not assumed. The hypothesis going in was that `quadratic_form` needed array/Quantity/CDict channels for speed. It doesn't — with the diagonal path in place, all three compile to the same HLO and run within noise:

```
diagonal + bare arrays          66.7 us   19 ops
diagonal + CDict-of-Quantity    63.9 us   19 ops
diagonal + carray packing       66.1 us   24 ops
```

The unit machinery is trace-time only. An array "fast channel" would have been API surface for ≤1.7×, and 1.0× after this. The *structure of G* was what mattered.

> A note on method: an earlier benchmark of mine suggested repeated calls were free because XLA CSE'd them. That test reused the **same base point** for every call, which is why the redundant work vanished — unrepresentative of a per-particle workload. Re-run with distinct base points, the picture changed completely. Numbers above are the corrected ones.

### Two details the measurement forced

- The `QuantityMatrix` overload is `(d * v) @ v`, not a `sum` — a 1-D `QuantityMatrix` can't be reduced over its logical axis, and this keeps per-component units riding along (the diagonal is itself a `QuantityMatrix` on a mixed-unit chart like `sph3d`).
- The bare-array overload sums over `axis=-1` rather than using `@`, which would contract a leading *batch* axis instead of the component axis. It also sends a **unitful** diagonal back to the dense path: per-component units can't be factored out of a sum against a unitless vector. That combination fails on the dense path too — before this change and after — so it keeps the pre-existing `UnitConversionError` rather than substituting a new one. Verified against `main`.

No interface change, so every caller inherits it: `norm`, `separation`, `interval` (#680), and `angle_between` once #688 lands.

**Verification:** `tests/unit` + `docs` + `packages/coordinaxs.api`: **3294 passed, 5 skipped**. New tests assert the fast and dense contractions agree in value *and* unit across flat, curved and mixed-unit charts, for both overloads, plus that a batched stack reduces over components rather than the batch. ruff, ruff-format, ty clean.
