### PR TITLE
🐛 fix(manifolds): condition `angle_between` on the spanned plane, not the metric

### DIFF
--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -4,6 +4,7 @@ __all__: tuple[str, ...] = ()
 
 
 import jax
+import jax.numpy as jnp
 import plum
 
 import quaxed.numpy as qnp
@@ -12,7 +13,7 @@ import unxt as u
 import coordinax.angles as cxa
 import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
-from ._utils import as_quantity_matrix, require_positive_definite
+from ._utils import as_quantity_matrix
 from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.custom_types import CDict, OptUSys
 from coordinax._src.metric.matrix import DenseMetric
@@ -80,12 +81,33 @@ def angle_between(
     >>> cxm.angle_between(metric, cxc.sph3d, uvec, vvec, at=at)
     Angle(1.57079633, 'rad')
 
-    """
-    # Guards `chart.M.metric` rather than the `metric` argument: the matrix below
-    # comes from `chart.M`, so checking the argument would validate one metric
-    # while computing with another.
-    require_positive_definite(chart.M.metric, "angle_between")
+    An indefinite metric is not rejected outright. Two *spacelike* directions
+    span a plane on which the Minkowski metric is positive-definite, so the
+    angle between them is an ordinary one:
 
+    >>> at4 = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> xhat = {"ct": u.Q(0.0, "m"), "x": u.Q(1.0, "m"),
+    ...         "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> yhat = {"ct": u.Q(0.0, "m"), "x": u.Q(0.0, "m"),
+    ...         "y": u.Q(1.0, "m"), "z": u.Q(0.0, "m")}
+    >>> cxm.angle_between(cxc.minkowskict, xhat, yhat, at=at4)
+    Angle(1.57079633, 'rad')
+
+    Two *timelike* directions have no circular angle between them -- the
+    invariant is a hyperbolic one, the relative rapidity -- so this raises
+    rather than clipping ``arccos`` to a meaningless value:
+
+    >>> obs = {"ct": u.Q(1.0, "m"), "x": u.Q(0.0, "m"),
+    ...        "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> moving = {"ct": u.Q(1.25, "m"), "x": u.Q(0.75, "m"),
+    ...           "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> try:
+    ...     cxm.angle_between(cxc.minkowskict, obs, moving, at=at4)
+    ... except ValueError as e:
+    ...     print(str(e).split(":")[0])
+    angle_between is undefined for two timelike tangent vectors
+
+    """
     chart.check_data(at, keys=True, values=False)
     chart.check_data(uvec, keys=True, values=False)
     chart.check_data(vvec, keys=True, values=False)
@@ -101,19 +123,74 @@ def angle_between(
     uu = u_qm @ (g @ u_qm)
     vv = v_qm @ (g @ v_qm)
 
-    _check_nonzero_norm(uu, vv)
+    _check_angle_is_defined(uu, vv, inner)
 
     cosine = inner / qnp.sqrt(uu * vv)
+    # The clip is float-error insurance only. Under a positive-definite metric
+    # Cauchy-Schwarz guarantees |cosine| <= 1; under an indefinite one it does
+    # not, which is why `_check_angle_is_defined` verifies it rather than
+    # letting the clip quietly flatten an out-of-range value to 0 or pi.
     cosine_value = qnp.clip(u.ustrip("", cosine), -1.0, 1.0)
     return cxa.Angle(qnp.arccos(cosine_value), "rad")
 
 
-def _check_nonzero_norm(*norms: u.AbstractQuantity) -> None:
-    """Raise when a norm-squared is zero or negative outside JAX tracing."""
-    for norm in norms:
-        value = norm.value
-        if isinstance(value, jax.core.Tracer):  # ty: ignore[possibly-missing-submodule]
-            continue
-        if bool(qnp.any(value <= 0)):
-            msg = "angle_between is undefined for zero-norm tangent vectors."
-            raise ValueError(msg)
+_MSG_NULL = (
+    "angle_between is undefined for null (zero-norm) tangent vectors: the "
+    "cosine's denominator vanishes."
+)
+
+_MSG_TIMELIKE = (
+    "angle_between is undefined for two timelike tangent vectors: g(u,u) and "
+    "g(v,v) are both negative, and the invariant separating them is a "
+    "*hyperbolic* angle -- the relative rapidity, arccosh(-g(u,v)/sqrt(g(u,u) "
+    "g(v,v))) -- not a circular angle. Computing `arccos` here would clip to 0 "
+    "or pi and silently report no relative motion."
+)
+
+_MSG_MIXED = (
+    "angle_between is undefined between a timelike and a spacelike tangent "
+    "vector: g(u,u) g(v,v) < 0, so the cosine's denominator is imaginary."
+)
+
+_MSG_NOT_SPACELIKE_PLANE = (
+    "angle_between is undefined here: both tangent vectors are spacelike, but "
+    "they span a plane that is not, so |g(u,v)| > sqrt(g(u,u) g(v,v)) and the "
+    "ratio is not a cosine. This cannot happen under a positive-definite "
+    "metric, where Cauchy-Schwarz guarantees the bound."
+)
+
+
+def _check_angle_is_defined(
+    uu: u.AbstractQuantity, vv: u.AbstractQuantity, inner: u.AbstractQuantity, /
+) -> None:
+    r"""Raise unless a real circular angle exists between the two vectors.
+
+    A metric angle needs the metric to be positive-definite *on the plane the
+    two vectors span* -- which is a condition on the arguments, not on the
+    metric. Under a Riemannian metric it always holds, so none of these fire.
+    Under a Lorentzian one it holds exactly for a spacelike pair spanning a
+    spacelike plane, which is the case this function serves.
+
+    Skipped under JAX tracing, where the values are not concrete.
+    """
+    values = [q.value for q in (uu, vv, inner)]
+    if any(isinstance(x, jax.core.Tracer) for x in values):  # ty: ignore[possibly-missing-submodule]
+        return
+
+    uu_v = float(jnp.min(jnp.asarray(uu.value)))
+    vv_v = float(jnp.min(jnp.asarray(vv.value)))
+
+    if bool(jnp.any(jnp.asarray(uu.value) == 0)) or bool(
+        jnp.any(jnp.asarray(vv.value) == 0)
+    ):
+        raise ValueError(_MSG_NULL)
+    if uu_v < 0 and vv_v < 0:
+        raise ValueError(_MSG_TIMELIKE)
+    if uu_v < 0 or vv_v < 0:
+        raise ValueError(_MSG_MIXED)
+
+    # Both spacelike, but their span may still be Lorentzian -- e.g. u=(0,1,0,0)
+    # and v=(1,2,0,0) are each spacelike while their span contains (1,0,0,0).
+    cos = jnp.asarray(u.ustrip("", inner / qnp.sqrt(uu * vv)))
+    if bool(jnp.any(jnp.abs(cos) > 1.0 + 1e-6)):
+        raise ValueError(_MSG_NOT_SPACELIKE_PLANE)

--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -3,6 +3,8 @@
 __all__: tuple[str, ...] = ()
 
 
+from typing import Any
+
 import jax
 import jax.numpy as jnp
 import plum
@@ -123,16 +125,31 @@ def angle_between(
     uu = u_qm @ (g @ u_qm)
     vv = v_qm @ (g @ v_qm)
 
-    _check_angle_is_defined(uu, vv, inner)
+    cos = jnp.asarray(u.ustrip("", inner / qnp.sqrt(uu * vv)))
 
-    cosine = inner / qnp.sqrt(uu * vv)
-    # The clip is float-error insurance only. Under a positive-definite metric
-    # Cauchy-Schwarz guarantees |cosine| <= 1; under an indefinite one it does
-    # not, which is why `_check_angle_is_defined` verifies it rather than
-    # letting the clip quietly flatten an out-of-range value to 0 or pi.
-    cosine_value = qnp.clip(u.ustrip("", cosine), -1.0, 1.0)
-    return cxa.Angle(qnp.arccos(cosine_value), "rad")
+    # Eagerly this raises, naming the case. Under tracing it cannot -- the values
+    # are not concrete -- so it is a no-op there and `valid` below is what stands
+    # between the caller and a wrong answer.
+    _check_angle_is_defined(uu, vv, cos)
 
+    # The traced counterpart of the same conditions. Without it, `jit`/`vmap`
+    # would reach the clip and hand back 0 or pi for a hyperbolic or imaginary
+    # case -- silently reporting "anti-parallel" for two observers in relative
+    # motion. `nan` is the honest value: no real angle exists.
+    valid = (
+        (jnp.asarray(uu.value) > 0)
+        & (jnp.asarray(vv.value) > 0)
+        & (jnp.abs(cos) <= 1.0 + _COS_ATOL)
+    )
+    # The clip is float-error insurance for the *valid* branch only; `valid`
+    # has already excluded everything genuinely out of range.
+    angle = jnp.arccos(jnp.clip(cos, -1.0, 1.0))
+    return cxa.Angle(jnp.where(valid, angle, jnp.nan), "rad")
+
+
+#: Slack on |cos| <= 1, so ordinary float error in a valid Riemannian case is
+#: not mistaken for a genuinely non-spacelike plane.
+_COS_ATOL = 1e-6
 
 _MSG_NULL = (
     "angle_between is undefined for null (zero-norm) tangent vectors: the "
@@ -161,7 +178,7 @@ _MSG_NOT_SPACELIKE_PLANE = (
 
 
 def _check_angle_is_defined(
-    uu: u.AbstractQuantity, vv: u.AbstractQuantity, inner: u.AbstractQuantity, /
+    uu: u.AbstractQuantity, vv: u.AbstractQuantity, cos: Any, /
 ) -> None:
     r"""Raise unless a real circular angle exists between the two vectors.
 
@@ -171,9 +188,10 @@ def _check_angle_is_defined(
     Under a Lorentzian one it holds exactly for a spacelike pair spanning a
     spacelike plane, which is the case this function serves.
 
-    Skipped under JAX tracing, where the values are not concrete.
+    Skipped under JAX tracing, where the values are not concrete; the caller
+    applies the same conditions as a mask there, yielding `nan` instead.
     """
-    values = [q.value for q in (uu, vv, inner)]
+    values = [uu.value, vv.value, cos]
     if any(isinstance(x, jax.core.Tracer) for x in values):  # ty: ignore[possibly-missing-submodule]
         return
 
@@ -191,6 +209,5 @@ def _check_angle_is_defined(
 
     # Both spacelike, but their span may still be Lorentzian -- e.g. u=(0,1,0,0)
     # and v=(1,2,0,0) are each spacelike while their span contains (1,0,0,0).
-    cos = jnp.asarray(u.ustrip("", inner / qnp.sqrt(uu * vv)))
-    if bool(jnp.any(jnp.abs(cos) > 1.0 + 1e-6)):
+    if bool(jnp.any(jnp.abs(jnp.asarray(cos)) > 1.0 + _COS_ATOL)):
         raise ValueError(_MSG_NOT_SPACELIKE_PLANE)

--- a/tests/unit/manifolds/test_angle_between_dispatch.py
+++ b/tests/unit/manifolds/test_angle_between_dispatch.py
@@ -1,5 +1,7 @@
 """Tests for the angle_between() manifold API and wrappers."""
 
+from typing import ClassVar
+
 import jax
 import jax.numpy as jnp
 import pytest
@@ -142,3 +144,67 @@ class TestAngleBetweenJAX:
         got = jax.vmap(compute)(thetas)
         expected = jnp.arccos(1 / jnp.sqrt(1 + jnp.sin(thetas) ** 2))
         assert jnp.allclose(got, expected, atol=1e-6)
+
+
+class TestTransformedCodepathsDoNotSilentlyClip:
+    """The eager guard cannot fire under tracing, so the mask must.
+
+    Regression: with only the eager check, `jax.jit` reached the `clip` and
+    returned pi rad for two timelike vectors -- reporting "anti-parallel" for
+    two observers in relative motion -- and 0 rad for a spacelike pair spanning
+    a Lorentzian plane. Both are the wrong-but-real failure this whole change
+    exists to remove, so they must be covered under transformation too.
+    """
+
+    AT: ClassVar = {k: jnp.array(0.0) for k in ("ct", "x", "y", "z")}
+
+    @staticmethod
+    def _angle(uvec, vvec, at):
+        return cxm.angle_between(cxc.minkowskict, uvec, vvec, at=at)
+
+    @pytest.mark.parametrize(
+        ("label", "uvec", "vvec"),
+        [
+            ("timelike-timelike", (1.0, 0.0, 0.0, 0.0), (1.25, 0.75, 0.0, 0.0)),
+            (
+                "spacelike pair, Lorentzian span",
+                (0.0, 1.0, 0.0, 0.0),
+                (1.0, 2.0, 0.0, 0.0),
+            ),
+            ("mixed causal types", (1.0, 0.0, 0.0, 0.0), (0.0, 1.0, 0.0, 0.0)),
+            ("null", (1.0, 1.0, 0.0, 0.0), (0.0, 1.0, 0.0, 0.0)),
+        ],
+    )
+    def test_jit_yields_nan_not_a_plausible_angle(self, label, uvec, vvec):
+        del label
+        fn = jax.jit(lambda a, b: self._angle(a, b, self.AT))
+        got = fn(_m4(*uvec), _m4(*vvec))
+        assert bool(jnp.isnan(u.ustrip("rad", got))), f"expected nan, got {got}"
+
+    def test_jit_still_returns_the_angle_when_it_is_defined(self):
+        fn = jax.jit(lambda a, b: self._angle(a, b, self.AT))
+        got = fn(_m4(0.0, 1.0, 0.0, 0.0), _m4(0.0, 0.0, 1.0, 0.0))
+        assert float(u.ustrip("rad", got)) == pytest.approx(jnp.pi / 2, abs=1e-5)
+
+    def test_vmap_marks_only_the_invalid_entries(self):
+        """A mixed batch must not poison the valid entries, nor hide the bad."""
+        us = {
+            k: jnp.stack([_m4(1.0, 0.0, 0.0, 0.0)[k], _m4(0.0, 1.0, 0.0, 0.0)[k]])
+            for k in ("ct", "x", "y", "z")
+        }
+        vs = {
+            k: jnp.stack([_m4(1.25, 0.75, 0.0, 0.0)[k], _m4(0.0, 0.0, 1.0, 0.0)[k]])
+            for k in ("ct", "x", "y", "z")
+        }
+        got = jax.vmap(lambda a, b: self._angle(a, b, self.AT))(us, vs)
+        vals = u.ustrip("rad", got)
+        assert bool(jnp.isnan(vals[0]))
+        assert float(vals[1]) == pytest.approx(jnp.pi / 2, abs=1e-5)
+
+    def test_riemannian_jit_is_untouched(self):
+        """The mask must not introduce nan on the positive-definite path."""
+        at = {"x": jnp.array(0.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
+        xh = {"x": jnp.array(1.0), "y": jnp.array(0.0), "z": jnp.array(0.0)}
+        yh = {"x": jnp.array(0.0), "y": jnp.array(1.0), "z": jnp.array(0.0)}
+        fn = jax.jit(lambda a, b: cxm.angle_between(cxc.cart3d, a, b, at=at))
+        assert float(u.ustrip("rad", fn(xh, yh))) == pytest.approx(jnp.pi / 2, abs=1e-5)

--- a/tests/unit/manifolds/test_angle_between_dispatch.py
+++ b/tests/unit/manifolds/test_angle_between_dispatch.py
@@ -11,6 +11,16 @@ import coordinax.manifolds as cxm
 from coordinax.angles import AbstractAngle
 
 
+def _m4(ct, x, y, z):
+    """A Minkowski tangent-vector CDict."""
+    return {
+        "ct": jnp.array(ct),
+        "x": jnp.array(x),
+        "y": jnp.array(y),
+        "z": jnp.array(z),
+    }
+
+
 class TestAngleBetweenEuclidean:
     """Tests for angle_between on Euclidean metrics and manifolds."""
 
@@ -38,52 +48,65 @@ class TestAngleBetweenFailureModes:
         with pytest.raises(ValueError, match="zero"):
             cxm.angle_between(metric, cxc.cart2d, zero, other, at=at)
 
-    def test_indefinite_metric_is_not_supported(self):
-        metric = cxm.MinkowskiMetric()
-        at = {
-            "ct": jnp.array(0),
-            "x": jnp.array(0),
-            "y": jnp.array(0),
-            "z": jnp.array(0),
-        }
-        uvec = {
-            "ct": jnp.array(0),
-            "x": jnp.array(1),
-            "y": jnp.array(0),
-            "z": jnp.array(0),
-        }
-        vvec = {
-            "ct": jnp.array(0),
-            "x": jnp.array(0),
-            "y": jnp.array(1),
-            "z": jnp.array(0),
-        }
+    def test_spacelike_pair_in_minkowski_has_an_ordinary_angle(self):
+        """The metric on a spacelike 2-plane is positive-definite.
 
-        with pytest.raises(NotImplementedError, match=r"pseudo.*indefinite"):
-            cxm.angle_between(metric, cxc.minkowskict, uvec, vvec, at=at)
-
-    def test_guard_follows_the_metric_actually_used(self):
-        """A positive-definite argument cannot bypass an indefinite chart metric.
-
-        The matrix comes from ``chart.M``, so the guard must check that rather
-        than the ``metric`` argument, else the two disagree.
+        This used to be rejected wholesale, on the metric's signature. The
+        condition is really on the plane the two vectors span, not the metric.
         """
-        at = {k: jnp.array(0) for k in ("ct", "x", "y", "z")}
-        uvec = {
-            "ct": jnp.array(1),
-            "x": jnp.array(0),
-            "y": jnp.array(0),
-            "z": jnp.array(0),
-        }
-        vvec = {
-            "ct": jnp.array(0),
-            "x": jnp.array(1),
-            "y": jnp.array(0),
-            "z": jnp.array(0),
-        }
+        at = {k: jnp.array(0.0) for k in ("ct", "x", "y", "z")}
+        xhat = _m4(0.0, 1.0, 0.0, 0.0)
+        yhat = _m4(0.0, 0.0, 1.0, 0.0)
+        got = cxm.angle_between(cxc.minkowskict, xhat, yhat, at=at)
+        assert float(u.ustrip("rad", got)) == pytest.approx(jnp.pi / 2, abs=1e-5)
 
-        with pytest.raises(NotImplementedError, match=r"pseudo.*indefinite"):
-            cxm.angle_between(cxm.FlatMetric(4), cxc.minkowskict, uvec, vvec, at=at)
+    def test_spacelike_pair_at_45_degrees(self):
+        at = {k: jnp.array(0.0) for k in ("ct", "x", "y", "z")}
+        got = cxm.angle_between(
+            cxc.minkowskict, _m4(0.0, 1.0, 0.0, 0.0), _m4(0.0, 1.0, 1.0, 0.0), at=at
+        )
+        assert float(u.ustrip("rad", got)) == pytest.approx(jnp.pi / 4, abs=1e-5)
+
+    def test_two_timelike_vectors_are_a_hyperbolic_angle_not_a_circular_one(self):
+        """`arccos` would clip to pi and report no relative motion.
+
+        For two timelike vectors ``g(u,v)/sqrt(g(u,u) g(v,v))`` has magnitude
+        >= 1 by the reverse Cauchy-Schwarz inequality, so it is a ``cosh``, not
+        a ``cos``. The invariant is the relative rapidity.
+        """
+        at = {k: jnp.array(0.0) for k in ("ct", "x", "y", "z")}
+        obs = _m4(1.0, 0.0, 0.0, 0.0)
+        moving = _m4(1.25, 0.75, 0.0, 0.0)  # beta = 0.6, gamma = 1.25
+        with pytest.raises(ValueError, match="timelike"):
+            cxm.angle_between(cxc.minkowskict, obs, moving, at=at)
+
+    def test_mixed_causal_types_are_rejected(self):
+        """``g(u,u) g(v,v) < 0`` makes the denominator imaginary."""
+        at = {k: jnp.array(0.0) for k in ("ct", "x", "y", "z")}
+        with pytest.raises(ValueError, match="timelike and a spacelike"):
+            cxm.angle_between(
+                cxc.minkowskict, _m4(1.0, 0.0, 0.0, 0.0), _m4(0.0, 1.0, 0.0, 0.0), at=at
+            )
+
+    def test_null_vector_is_rejected(self):
+        at = {k: jnp.array(0.0) for k in ("ct", "x", "y", "z")}
+        with pytest.raises(ValueError, match="null"):
+            cxm.angle_between(
+                cxc.minkowskict, _m4(1.0, 1.0, 0.0, 0.0), _m4(0.0, 1.0, 0.0, 0.0), at=at
+            )
+
+    def test_spacelike_pair_spanning_a_lorentzian_plane_is_rejected(self):
+        """Both spacelike is *not* sufficient — the span can still be timelike.
+
+        ``u = (0,1,0,0)`` and ``v = (1,2,0,0)`` are each spacelike, but their
+        span contains the timelike ``(1,0,0,0)``, and ``|cos| = 1.15 > 1``.
+        Clipping would silently report a 0 angle.
+        """
+        at = {k: jnp.array(0.0) for k in ("ct", "x", "y", "z")}
+        with pytest.raises(ValueError, match="span a plane that is not"):
+            cxm.angle_between(
+                cxc.minkowskict, _m4(0.0, 1.0, 0.0, 0.0), _m4(1.0, 2.0, 0.0, 0.0), at=at
+            )
 
 
 class TestAngleBetweenJAX:


### PR DESCRIPTION
> **Independent of the Minkowski stack** — branches off `main`, touches only `angle_between.py`. No ordering constraint against #686 / #680 / #683.

## The guard was on the wrong object

`angle_between` rejected any metric with a non-positive signature entry — in this library, exactly one: `MinkowskiMetric`. But whether a circular angle exists is a property of **the plane the two tangent vectors span**, not of the metric as a whole. The Minkowski metric restricted to a spacelike 2-plane *is* positive-definite, so the angle between two spatial directions in a given frame is an ordinary angle — and it was refused:

```python
cxm.angle_between(cxc.minkowskict, xhat, yhat, at=at4)   # before: NotImplementedError
                                                          # after:  Angle(1.5708, 'rad')
```

## Why simply deleting the guard would have been worse

For two **timelike** vectors nothing blows up — and that is the trap. The formula computes `sqrt(uu * vv)` with *both* negative, so the product is positive and the root is **real**:

```
g(u,u)=-1.0  g(v,v)=-1.0  ratio=-1.2500      <-- |·| > 1, so not a cosine
clip(-1,1) -> arccos -> 180 degrees          <-- two observers in relative motion, reported as anti-parallel
correct:   arccosh(1.25) = 0.6931 = arctanh(0.6)
```

That 0.6931 is the **relative rapidity** — a *hyperbolic* angle, and `LorentzBoost.rapidity`. Not this function's business, but it must not be silently mistaken for π.

And both-spacelike is **not** sufficient either:

```
u = (0,1,0,0)  spacelike   g(u,u)=1
v = (1,2,0,0)  spacelike   g(v,v)=3
|cos| = 2/sqrt(3) = 1.1547 > 1     <-- their span contains the timelike (1,0,0,0)
```

So the real condition is **Cauchy–Schwarz itself**, which holds automatically under a positive-definite metric and must be *checked* under an indefinite one. The `clip(-1, 1)` is now documented as float-error insurance, rather than the thing standing between a caller and a wrong answer.

## Behaviour

| pair | before | after |
|---|---|---|
| spacelike ⟂ spacelike | rejected (metric) | **90°** |
| spacelike, 45° apart | rejected (metric) | **45°** |
| timelike, timelike | rejected (metric) | rejected — *"the invariant is a hyperbolic angle… relative rapidity"* |
| timelike vs spacelike | rejected (metric) | rejected — *"g(u,u) g(v,v) < 0, denominator imaginary"* |
| null | rejected (metric) | rejected — *"the cosine's denominator vanishes"* |
| spacelike pair, Lorentzian span | rejected (metric) | rejected — *"span a plane that is not [spacelike]"* |
| **any Riemannian metric** | works | **unchanged** |

## The message was also wrong

The old text was *"undefined for zero-norm tangent vectors"* — false for three of the four rejected cases. Worse, since #674 routed this through the shared positive-definiteness helper, what a Minkowski caller actually saw was:

> …Under such a metric `sqrt(v^T G v)` is `nan` for timelike vectors… Use `interval` for the signed square, or `proper_time` / `proper_distance`…

Neither clause applies: nothing is `nan` here (shown above), and those are not the alternatives. That regression was mine, from the #674 dedup; each case now explains itself.

## Verification

Riemannian behaviour is unchanged — Cauchy–Schwarz makes every new check a no-op there, and the existing `angle_between` suite passes untouched. Six new tests cover the cases in the table, including the subtle spacelike-pair-spanning-a-Lorentzian-plane one. Full `tests/unit` + `docs` + `packages/coordinaxs.api`: **3271 passed, 5 skipped**. ruff, ruff-format, ty clean.

## Possible follow-up

A sibling `rapidity_between` would give the timelike–timelike case its correct answer instead of an error. Deliberately not in this PR: it is new API rather than a fix, and it returns a dimensionless rapidity rather than an `Angle`, so it wants its own name and its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)