### PR TITLE
♻️ refactor(manifolds): generalize to a bilinear form; migrate `angle_between`

### DIFF
--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/register_parametric.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/register_parametric.py
@@ -13,10 +13,7 @@ from typing import Any
 from plum import add_promotion_rule
 
 # Optional dependency: absent from the lint environment by design.
-from unxts.parametric import (  # ty: ignore[unresolved-import]
-    PQ,
-    ParametricQuantity,
-)
+from unxts.parametric import PQ, ParametricQuantity
 
 from .distance_modulus import (
     DistanceModulus,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -497,6 +497,7 @@ sections = { typing = [
   "collections.abc",
   "jaxtyping",
 ] }
+split-on-trailing-comma = false
 
 [tool.ty.rules]
 invalid-argument-type = "ignore"

--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -1925,4 +1925,4 @@ def pt_map(
         "y": cosp * dt_rho + sinp * lz_over_rho,
         "z": dt_z,
     }
-    return cast("CDict", to_chart.merge_components((pos, vel)))
+    return to_chart.merge_components((pos, vel))

--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -11,14 +11,13 @@ import plum
 
 import quaxed.numpy as qnp
 import unxt as u
+from unxt.quantity import is_any_quantity
 
 import coordinax.angles as cxa
-import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
-from ._utils import as_quantity_matrix
+from .quadratic_form import gram
 from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.custom_types import CDict, OptUSys
-from coordinax._src.metric.matrix import DenseMetric
 
 
 @plum.dispatch
@@ -114,18 +113,23 @@ def angle_between(
     chart.check_data(uvec, keys=True, values=False)
     chart.check_data(vvec, keys=True, values=False)
 
-    mm = cxmapi.metric_matrix(chart.M, at, chart)
-    g = as_quantity_matrix(
-        mm.matrix if isinstance(mm, DenseMetric) else mm.to_dense().matrix  # ty: ignore[unresolved-attribute]
+    # All three contractions from one metric evaluation, via the shared
+    # primitive -- so the unit handling (mixed Quantity/bare-array rejection,
+    # per-component units surviving the contraction) is the same one `norm`
+    # uses, and the diagonal fast path comes along too. `gram` rather than three
+    # `bilinear_form` calls: those would rebuild the metric matrix three times,
+    # free under `jit` but ~1.6x eagerly.
+    #
+    # `require_usys=False`: the cosine is a ratio, so every unit cancels and the
+    # result is dimensionless whatever the inputs carry. The "declare a unit
+    # system" contract that `norm` and `interval` impose -- where the result's
+    # unit *is* derived from the inputs -- would be ceremony here, and would
+    # break callers that have always passed bare arrays.
+    inner, uu, vv = gram(
+        uvec, vvec, chart, at=at, usys=usys, fname="angle_between", require_usys=False
     )
-    u_qm = cxcapi.carray(uvec, chart.components)
-    v_qm = cxcapi.carray(vvec, chart.components)
 
-    inner = u_qm @ (g @ v_qm)
-    uu = u_qm @ (g @ u_qm)
-    vv = v_qm @ (g @ v_qm)
-
-    cos = jnp.asarray(u.ustrip("", inner / qnp.sqrt(uu * vv)))
+    cos = _dimensionless(inner / qnp.sqrt(uu * vv))
 
     # Eagerly this raises, naming the case. Under tracing it cannot -- the values
     # are not concrete -- so it is a no-op there and `valid` below is what stands
@@ -136,11 +140,7 @@ def angle_between(
     # would reach the clip and hand back 0 or pi for a hyperbolic or imaginary
     # case -- silently reporting "anti-parallel" for two observers in relative
     # motion. `nan` is the honest value: no real angle exists.
-    valid = (
-        (jnp.asarray(uu.value) > 0)
-        & (jnp.asarray(vv.value) > 0)
-        & (jnp.abs(cos) <= 1.0 + _COS_ATOL)
-    )
+    valid = (_value(uu) > 0) & (_value(vv) > 0) & (jnp.abs(cos) <= 1.0 + _COS_ATOL)
     # The clip is float-error insurance for the *valid* branch only; `valid`
     # has already excluded everything genuinely out of range.
     angle = jnp.arccos(jnp.clip(cos, -1.0, 1.0))
@@ -177,9 +177,27 @@ _MSG_NOT_SPACELIKE_PLANE = (
 )
 
 
-def _check_angle_is_defined(
-    uu: u.AbstractQuantity, vv: u.AbstractQuantity, cos: Any, /
-) -> None:
+def _dimensionless(x: Any, /) -> Any:
+    """Strip *x* to a bare dimensionless array.
+
+    Only valid where the value genuinely is dimensionless -- the cosine, whose
+    units cancel. The shared contraction returns a `unxt.Quantity` for Quantity
+    input and a plain array for bare-array input, and both reach here.
+    """
+    return jnp.asarray(u.ustrip("", x) if is_any_quantity(x) else x)
+
+
+def _value(x: Any, /) -> Any:
+    """Return the raw array behind *x*, keeping whatever unit it carried.
+
+    For ``g(v,v)`` only the *sign* is wanted, so the unit (``m2``, ``rad2/s2``,
+    ...) is irrelevant and must not be converted away -- unlike the cosine,
+    stripping it to dimensionless would raise.
+    """
+    return jnp.asarray(x.value if is_any_quantity(x) else x)
+
+
+def _check_angle_is_defined(uu: Any, vv: Any, cos: Any, /) -> None:
     r"""Raise unless a real circular angle exists between the two vectors.
 
     A metric angle needs the metric to be positive-definite *on the plane the
@@ -191,16 +209,14 @@ def _check_angle_is_defined(
     Skipped under JAX tracing, where the values are not concrete; the caller
     applies the same conditions as a mask there, yielding `nan` instead.
     """
-    values = [uu.value, vv.value, cos]
+    values = [getattr(uu, "value", uu), getattr(vv, "value", vv), cos]
     if any(isinstance(x, jax.core.Tracer) for x in values):  # ty: ignore[possibly-missing-submodule]
         return
 
-    uu_v = float(jnp.min(jnp.asarray(uu.value)))
-    vv_v = float(jnp.min(jnp.asarray(vv.value)))
+    uu_v = float(jnp.min(_value(uu)))
+    vv_v = float(jnp.min(_value(vv)))
 
-    if bool(jnp.any(jnp.asarray(uu.value) == 0)) or bool(
-        jnp.any(jnp.asarray(vv.value) == 0)
-    ):
+    if bool(jnp.any(_value(uu) == 0)) or bool(jnp.any(_value(vv) == 0)):
         raise ValueError(_MSG_NULL)
     if uu_v < 0 and vv_v < 0:
         raise ValueError(_MSG_TIMELIKE)

--- a/src/coordinax/_src/manifolds/norm.py
+++ b/src/coordinax/_src/manifolds/norm.py
@@ -15,6 +15,7 @@ from unxt.quantity import is_any_quantity
 import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
 from ._utils import require_positive_definite
+from .quadratic_form import quadratic_form
 from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.charts import Cart0D, Cart1D, Cart2D, Cart3D, CartND
 from coordinax._src.custom_types import CDict, OptUSys
@@ -229,45 +230,18 @@ def norm(
     norm() supports only positive-definite metrics, but
 
     """
-    keys = chart.components
-    qty_flags = [is_any_quantity(val) for val in v.values()]
-    if any(qty_flags) and not all(qty_flags):
-        raise TypeError(
-            "norm(): mixed CDict with both Quantity and bare Array values is not "
-            "supported. All components must be either all Quantity or all bare Array."
-        )
-    is_qty = all(qty_flags)
-
     if metric != chart.M.metric:
         raise ValueError("Metric-level dispatch: metric must match chart's metric")
 
     # After the match check, so a mismatched *indefinite* metric still reports the
     # mismatch rather than the definiteness. Guards `chart.M.metric` because that
-    # is what `metric_matrix` below actually uses.
+    # is what the metric matrix is built from.
     require_positive_definite(chart.M.metric, "norm")
 
-    if not is_qty and usys is None:
-        raise TypeError(
-            "norm(): `usys` is required when `v` is a CDict of bare arrays "
-            "(no unit information). "
-            "Example: pass `usys=unxt.unitsystems.si`."
-        )
-
-    # Evaluate the metric matrix at the base point.  ``metric_matrix`` returns a
-    # typed ``AbstractMetricMatrix`` (Diagonal/Dense) and handles both bare-array
-    # and Quantity ``at`` values; it needs no unit system.
-    mm = cxmapi.metric_matrix(chart.M, at, chart)
-
-    if not is_qty:  # Bare arrays — stack on last axis for correct batch broadcasting
-        v_vec = jnp.stack([jnp.asarray(v[k]) for k in keys], axis=-1)
-        return array_norm(mm.to_dense().matrix, v_vec)  # ty: ignore[unresolved-attribute]
-
-    # Pack CDict of quantities into a QuantityMatrix, preserving per-component units,
-    # then compute sqrt(vᵀ G v) via QuantityMatrix/AbstractMetricMatrix arithmetic,
-    # which handles all unit conversions correctly (including mixed-unit
-    # components like m/s and rad/s).
-    v_qm: ul.QM = cxcapi.carray(v, keys)  # ty: ignore[invalid-assignment]
-    return jnp.sqrt(v_qm @ (mm @ v_qm))
+    # The norm is the square root of the metric quadratic form; the form itself
+    # owns the unit handling, and is shared with the callers that need it
+    # unrooted (where an indefinite metric makes the root meaningless).
+    return jnp.sqrt(quadratic_form(v, chart, at=at, usys=usys, fname="norm"))
 
 
 @plum.dispatch

--- a/src/coordinax/_src/manifolds/quadratic_form.py
+++ b/src/coordinax/_src/manifolds/quadratic_form.py
@@ -20,7 +20,10 @@ cover the ways a caller wants to ask.
 
 __all__: tuple[str, ...] = ()
 
+from jaxtyping import Array
 from typing import Any
+
+import plum
 
 import quaxed.numpy as jnp
 import unxts.linalg as ul
@@ -30,6 +33,7 @@ import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
 from coordinax._src.base import AbstractChart
 from coordinax._src.custom_types import CDict, OptUSys
+from coordinax._src.metric.matrix import AbstractMetricMatrix, DiagonalMetric
 
 _MSG_MIXED = (
     "{fname}(): mixed CDict with both Quantity and bare Array values is not "
@@ -117,11 +121,66 @@ def quadratic_form(
 
     if not is_qty:  # Bare arrays — stack on last axis for correct batch broadcasting
         v_vec = jnp.stack([jnp.asarray(v[k]) for k in keys], axis=-1)
-        g = mm.to_dense().matrix  # ty: ignore[unresolved-attribute]
-        return jnp.einsum("...i,...ij,...j->...", v_vec, g, v_vec)
+        return _contract(mm, v_vec)
 
     # Pack into a QuantityMatrix, preserving per-component units, then contract
     # via QuantityMatrix/AbstractMetricMatrix arithmetic, which handles all unit
     # conversions correctly (including mixed-unit components like m/s and rad/s).
     v_qm: ul.QM = cxcapi.carray(v, keys)  # ty: ignore[invalid-assignment]
-    return v_qm @ (mm @ v_qm)
+    return _contract(mm, v_qm)
+
+
+@plum.dispatch
+def _contract(mm: AbstractMetricMatrix, v: ul.QM, /) -> Any:
+    r"""Fallback: densify, then contract $v^\top G v$ -- $O(n^2)$."""
+    return v @ (mm.to_dense() @ v)
+
+
+@plum.dispatch
+def _contract(mm: AbstractMetricMatrix, v: Array, /) -> Any:
+    r"""Fallback for a stacked bare array -- $O(n^2)$.
+
+    ``einsum`` rather than ``@``, so a leading batch axis stays distinct from
+    the component axis.
+    """
+    return jnp.einsum("...i,...ij,...j->...", v, mm.to_dense().matrix, v)
+
+
+@plum.dispatch
+def _contract(mm: DiagonalMetric, v: ul.QM, /) -> Any:
+    r"""Diagonal fast path -- $\sum_i g_{ii} v_i^2$, $O(n)$ instead of $O(n^2)$.
+
+    `DiagonalMetric` stores only the diagonal precisely so the full matrix need
+    never be materialised -- its own docstring says so -- but `to_dense` throws
+    that structure away. Every metric the library ships is diagonal in its
+    canonical chart (`FlatMetric`, `RoundMetric`, `MinkowskiMetric`), so this is
+    the common path, not a corner.
+
+    Measured on 100k points vmapped inside one `jit`: **2.2x** at n=2 (`sph2`),
+    **8.3x** at n=3 (`cart3d`), **3.9x** at n=4 (`minkowskict`).
+
+    Written ``(d * v) @ v`` rather than with a `sum`: a 1-D `QuantityMatrix`
+    cannot be reduced over its logical axis, and this spelling keeps
+    per-component units riding along -- the diagonal is itself a
+    `QuantityMatrix` on a mixed-unit chart such as ``sph3d``.
+    """
+    return (mm.diagonal * v) @ v
+
+
+@plum.dispatch
+def _contract(mm: DiagonalMetric, v: Array, /) -> Any:
+    r"""Diagonal fast path for a stacked bare array -- $O(n)$.
+
+    Summed explicitly rather than via ``@``, which would contract a leading
+    batch axis instead of the component axis.
+
+    A *unitful* diagonal is sent back to the dense path: on a mixed-unit chart
+    the per-component units cannot be factored out of a sum against a unitless
+    vector. That combination does not work on the dense path either (it raises
+    from the unit machinery), so this keeps the pre-existing failure rather than
+    substituting a different one.
+    """
+    d = mm.diagonal
+    if isinstance(d, ul.QM):
+        return jnp.einsum("...i,...ij,...j->...", v, mm.to_dense().matrix, v)
+    return jnp.sum(d * v * v, axis=-1)

--- a/src/coordinax/_src/manifolds/quadratic_form.py
+++ b/src/coordinax/_src/manifolds/quadratic_form.py
@@ -47,6 +47,88 @@ _MSG_USYS = (
 )
 
 
+def bilinear_form(
+    uvec: CDict,
+    vvec: CDict,
+    chart: AbstractChart,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+    fname: str = "bilinear_form",
+    require_usys: bool = True,
+) -> Any:
+    r"""Return $u^\top G(\text{at})\, v$ for the chart's metric.
+
+    The general contraction: `quadratic_form` is the ``u is v`` case, and
+    `~coordinax.manifolds.angle_between` needs all three of $g(u,v)$, $g(u,u)$
+    and $g(v,v)$. No square root is taken, so this is defined for every metric,
+    including indefinite ones.
+
+    Parameters
+    ----------
+    uvec, vvec
+        Component dictionaries of the two vectors. Within each, values must be
+        *all* `unxt.Quantity` or *all* bare arrays; a mixture raises `TypeError`.
+    chart
+        The chart whose manifold supplies the metric, evaluated at ``at``.
+        Components are read in ``chart.components`` order.
+    at
+        Base point at which to evaluate the metric.
+    usys
+        Unit system. Required when the vectors hold bare arrays, since there is
+        then no unit information to work from.
+    fname
+        Name of the calling function, used in error messages so a caller of
+        `norm` is not told about `bilinear_form`. Mirrors the ``fname``
+        argument of `require_positive_definite`.
+    require_usys
+        Whether bare-array components must be accompanied by ``usys``. True for
+        verbs whose *result* carries units derived from the inputs (`norm`,
+        ``interval``), where declaring a unit system is a meaningful contract.
+        False for verbs returning a dimensionless ratio
+        (`~coordinax.manifolds.angle_between`), where every unit cancels and the
+        demand would be ceremony.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> from coordinax._src.manifolds.quadratic_form import bilinear_form
+
+    Orthogonal directions contract to zero; a vector with itself gives its
+    squared length:
+
+    >>> at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+    >>> xhat = {"x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> yhat = {"x": u.Q(0.0, "m"), "y": u.Q(1.0, "m"), "z": u.Q(0.0, "m")}
+    >>> bilinear_form(xhat, yhat, cxc.cart3d, at=at).round(2)
+    Q(0., 'm2')
+    >>> bilinear_form(xhat, xhat, cxc.cart3d, at=at).round(2)
+    Q(1., 'm2')
+
+    It is symmetric, as the metric is:
+
+    >>> v = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+    >>> a = bilinear_form(v, xhat, cxc.cart3d, at=at)
+    >>> b = bilinear_form(xhat, v, cxc.cart3d, at=at)
+    >>> bool(a == b)
+    True
+
+    """
+    keys = chart.components
+    mm, packed = _prepare(
+        chart,
+        (uvec, vvec),
+        at=at,
+        usys=usys,
+        fname=fname,
+        keys=keys,
+        require_usys=require_usys,
+    )
+    return _contract(mm, *packed)
+
+
 def quadratic_form(
     v: CDict,
     chart: AbstractChart,
@@ -55,11 +137,15 @@ def quadratic_form(
     at: CDict,
     usys: OptUSys = None,
     fname: str = "quadratic_form",
+    require_usys: bool = True,
 ) -> Any:
     r"""Return $v^\top G(\text{at})\, v$ for the chart's metric.
 
-    No square root is taken, so this is defined for every metric — including
-    indefinite ones, where it is the signed interval rather than a magnitude.
+    The ``u is v`` case of `bilinear_form`, which is what every
+    magnitude-like verb needs: `~coordinax.manifolds.norm` is its square root,
+    and ``interval`` is it applied to a coordinate difference. No square root is
+    taken here, so it is defined for every metric -- including indefinite ones,
+    where it is a signed interval rather than a magnitude.
 
     Parameters
     ----------
@@ -67,21 +153,19 @@ def quadratic_form(
         Component dictionary of the vector to contract. Values must be *all*
         `unxt.Quantity` or *all* bare arrays; a mixture raises `TypeError`.
     chart
-        The chart whose manifold supplies the metric. The metric is evaluated at
-        ``at``, and ``v``'s components are read in ``chart.components`` order.
+        The chart whose manifold supplies the metric, evaluated at ``at``.
     at
         Base point at which to evaluate the metric.
     usys
-        Unit system. Required when ``v`` holds bare arrays, since there is then
-        no unit information to work from; optional otherwise.
+        Unit system. Required when ``v`` holds bare arrays.
     fname
-        Name of the calling function, used in error messages so a caller of
-        `norm` is not told about ``quadratic_form``. Mirrors the ``fname``
-        argument of `require_positive_definite`.
+        Name of the calling function, used in error messages.
+    require_usys
+        Whether bare-array components must be accompanied by ``usys``; see
+        `bilinear_form`.
 
     Examples
     --------
-    >>> import jax.numpy as jnp
     >>> import unxt as u
     >>> import coordinax.charts as cxc
     >>> from coordinax._src.manifolds.quadratic_form import quadratic_form
@@ -105,50 +189,122 @@ def quadratic_form(
 
     """
     keys = chart.components
+    mm, packed = _prepare(
+        chart, (v,), at=at, usys=usys, fname=fname, keys=keys, require_usys=require_usys
+    )
+    return _contract(mm, packed[0], packed[0])
 
-    qty_flags = [is_any_quantity(val) for val in v.values()]
-    if any(qty_flags) and not all(qty_flags):
-        raise TypeError(_MSG_MIXED.format(fname=fname))
-    is_qty = all(qty_flags)
 
-    if not is_qty and usys is None:
-        raise TypeError(_MSG_USYS.format(fname=fname))
+def gram(
+    uvec: CDict,
+    vvec: CDict,
+    chart: AbstractChart,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+    fname: str = "gram",
+    require_usys: bool = True,
+) -> tuple[Any, Any, Any]:
+    r"""Return $(g(u,v),\; g(u,u),\; g(v,v))$ from a *single* metric evaluation.
+
+    Three `bilinear_form` calls would rebuild the metric matrix three times.
+    Under `jax.jit` that costs nothing -- XLA common-subexpression-eliminates
+    the identical builds, which is why the compiled op count is unchanged -- but
+    eagerly it is a measured ~1.6x on `~coordinax.manifolds.angle_between`, the
+    one caller that needs all three at the same base point.
+
+    So the metric is evaluated once and each vector packed once, then contracted
+    three times. Same unit handling as `bilinear_form`, since it is the same
+    `_prepare`.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> from coordinax._src.manifolds.quadratic_form import gram
+
+    >>> at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+    >>> xhat = {"x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> v = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+    >>> uv, uu, vv = gram(xhat, v, cxc.cart3d, at=at)
+    >>> uv.round(2), uu.round(2), vv.round(2)
+    (Q(3., 'm2'), Q(1., 'm2'), Q(25., 'm2'))
+
+    """
+    mm, (u_, v_) = _prepare(
+        chart,
+        (uvec, vvec),
+        at=at,
+        usys=usys,
+        fname=fname,
+        keys=chart.components,
+        require_usys=require_usys,
+    )
+    return _contract(mm, u_, v_), _contract(mm, u_, u_), _contract(mm, v_, v_)
+
+
+def _prepare(
+    chart: AbstractChart,
+    vecs: tuple[CDict, ...],
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys,
+    fname: str,
+    keys: tuple[str, ...],
+    require_usys: bool,
+) -> tuple[Any, tuple[Any, ...]]:
+    """Validate the vectors, build the metric matrix, and pack for contraction.
+
+    All the unit handling lives here, once: it is the fiddly part, and a second
+    copy reliably ends up with a subset of the checks.
+    """
+    packed: list[Any] = []
+    for vec in vecs:
+        qty_flags = [is_any_quantity(val) for val in vec.values()]
+        if any(qty_flags) and not all(qty_flags):
+            raise TypeError(_MSG_MIXED.format(fname=fname))
+        if require_usys and not all(qty_flags) and usys is None:
+            raise TypeError(_MSG_USYS.format(fname=fname))
+        packed.append(qty_flags)
 
     # ``metric_matrix`` returns a typed ``AbstractMetricMatrix`` (Diagonal/Dense)
     # and handles both bare-array and Quantity ``at`` values; it needs no unit
     # system of its own.
     mm = cxmapi.metric_matrix(chart.M, at, chart)
 
-    if not is_qty:  # Bare arrays — stack on last axis for correct batch broadcasting
-        v_vec = jnp.stack([jnp.asarray(v[k]) for k in keys], axis=-1)
-        return _contract(mm, v_vec)
-
-    # Pack into a QuantityMatrix, preserving per-component units, then contract
-    # via QuantityMatrix/AbstractMetricMatrix arithmetic, which handles all unit
-    # conversions correctly (including mixed-unit components like m/s and rad/s).
-    v_qm: ul.QM = cxcapi.carray(v, keys)  # ty: ignore[invalid-assignment]
-    return _contract(mm, v_qm)
-
-
-@plum.dispatch
-def _contract(mm: AbstractMetricMatrix, v: ul.QM, /) -> Any:
-    r"""Fallback: densify, then contract $v^\top G v$ -- $O(n^2)$."""
-    return v @ (mm.to_dense() @ v)
+    out: list[Any] = []
+    for vec, qty_flags in zip(vecs, packed, strict=True):
+        if not all(qty_flags):
+            # Bare arrays — stack on the last axis for correct batch broadcasting.
+            out.append(jnp.stack([jnp.asarray(vec[k]) for k in keys], axis=-1))
+        else:
+            # Pack into a QuantityMatrix, preserving per-component units, so the
+            # contraction handles mixed-unit components (m/s alongside rad/s).
+            out.append(cxcapi.carray(vec, keys))
+    return mm, tuple(out)
 
 
 @plum.dispatch
-def _contract(mm: AbstractMetricMatrix, v: Array, /) -> Any:
-    r"""Fallback for a stacked bare array -- $O(n^2)$.
+def _contract(mm: AbstractMetricMatrix, uvec: ul.QM, vvec: ul.QM, /) -> Any:
+    r"""Fallback: densify, then contract $u^\top G v$ -- $O(n^2)$."""
+    return uvec @ (mm.to_dense() @ vvec)
+
+
+@plum.dispatch
+def _contract(mm: AbstractMetricMatrix, uvec: Array, vvec: Array, /) -> Any:
+    r"""Fallback for stacked bare arrays -- $O(n^2)$.
 
     ``einsum`` rather than ``@``, so a leading batch axis stays distinct from
     the component axis.
     """
-    return jnp.einsum("...i,...ij,...j->...", v, mm.to_dense().matrix, v)
+    return jnp.einsum("...i,...ij,...j->...", uvec, mm.to_dense().matrix, vvec)
 
 
 @plum.dispatch
-def _contract(mm: DiagonalMetric, v: ul.QM, /) -> Any:
-    r"""Diagonal fast path -- $\sum_i g_{ii} v_i^2$, $O(n)$ instead of $O(n^2)$.
+def _contract(mm: DiagonalMetric, uvec: ul.QM, vvec: ul.QM, /) -> Any:
+    r"""Diagonal fast path -- $\sum_i g_{ii} u_i v_i$, $O(n)$ instead of $O(n^2)$.
 
     `DiagonalMetric` stores only the diagonal precisely so the full matrix need
     never be materialised -- its own docstring says so -- but `to_dense` throws
@@ -159,28 +315,27 @@ def _contract(mm: DiagonalMetric, v: ul.QM, /) -> Any:
     Measured on 100k points vmapped inside one `jit`: **2.2x** at n=2 (`sph2`),
     **8.3x** at n=3 (`cart3d`), **3.9x** at n=4 (`minkowskict`).
 
-    Written ``(d * v) @ v`` rather than with a `sum`: a 1-D `QuantityMatrix`
+    Written ``(d * u) @ v`` rather than with a `sum`: a 1-D `QuantityMatrix`
     cannot be reduced over its logical axis, and this spelling keeps
     per-component units riding along -- the diagonal is itself a
     `QuantityMatrix` on a mixed-unit chart such as ``sph3d``.
     """
-    return (mm.diagonal * v) @ v
+    return (mm.diagonal * uvec) @ vvec
 
 
 @plum.dispatch
-def _contract(mm: DiagonalMetric, v: Array, /) -> Any:
-    r"""Diagonal fast path for a stacked bare array -- $O(n)$.
+def _contract(mm: DiagonalMetric, uvec: Array, vvec: Array, /) -> Any:
+    r"""Diagonal fast path for stacked bare arrays -- $O(n)$.
 
     Summed explicitly rather than via ``@``, which would contract a leading
     batch axis instead of the component axis.
 
     A *unitful* diagonal is sent back to the dense path: on a mixed-unit chart
-    the per-component units cannot be factored out of a sum against a unitless
-    vector. That combination does not work on the dense path either (it raises
-    from the unit machinery), so this keeps the pre-existing failure rather than
-    substituting a different one.
+    the per-component units cannot be factored out of a sum against unitless
+    vectors. That combination does not work on the dense path either, so this
+    keeps the pre-existing failure rather than substituting a different one.
     """
     d = mm.diagonal
     if isinstance(d, ul.QM):
-        return jnp.einsum("...i,...ij,...j->...", v, mm.to_dense().matrix, v)
-    return jnp.sum(d * v * v, axis=-1)
+        return jnp.einsum("...i,...ij,...j->...", uvec, mm.to_dense().matrix, vvec)
+    return jnp.sum(d * uvec * vvec, axis=-1)

--- a/src/coordinax/_src/manifolds/quadratic_form.py
+++ b/src/coordinax/_src/manifolds/quadratic_form.py
@@ -46,6 +46,12 @@ _MSG_USYS = (
     "Example: pass `usys=unxt.unitsystems.si`."
 )
 
+_MSG_CROSS_VECTOR_MIXED = (
+    "{fname}(): all vectors must be consistently either Quantity-valued or "
+    "bare-array-valued. Mixing a Quantity CDict with a bare-array CDict "
+    "across arguments is not supported."
+)
+
 
 def bilinear_form(
     uvec: CDict,
@@ -268,6 +274,14 @@ def _prepare(
         if require_usys and not all(qty_flags) and usys is None:
             raise TypeError(_MSG_USYS.format(fname=fname))
         packed.append(qty_flags)
+
+    # Cross-argument check: all vectors must be consistently Quantity or bare-array.
+    # Each element in `packed` is a list of bool flags; `all(flags)` means all-Quantity,
+    # `not all(flags)` means all-bare-array (the within-vector check above ensures no mixing).
+    if len(packed) > 1:
+        is_qty_per_vec = [all(qty_flags) for qty_flags in packed]
+        if any(is_qty_per_vec) and not all(is_qty_per_vec):
+            raise TypeError(_MSG_CROSS_VECTOR_MIXED.format(fname=fname))
 
     # ``metric_matrix`` returns a typed ``AbstractMetricMatrix`` (Diagonal/Dense)
     # and handles both bare-array and Quantity ``at`` values; it needs no unit

--- a/src/coordinax/_src/manifolds/quadratic_form.py
+++ b/src/coordinax/_src/manifolds/quadratic_form.py
@@ -1,0 +1,127 @@
+r"""The metric quadratic form, shared by every magnitude-like manifold verb.
+
+Every function that asks "how big is this, according to the metric" evaluates the
+same contraction:
+
+$$ Q_p(v) = v^\top G(p)\, v. $$
+
+`~coordinax.manifolds.norm` is its square root, and
+`~coordinax.manifolds.separation` is that applied to a coordinate difference.
+Anything defined on an *indefinite* metric — where the square root has no real
+value — needs the contraction **unrooted** instead.
+
+Keeping one implementation matters for more than line count: the unit handling
+here is fiddly (mixed-unit components, bare arrays that carry no units at all,
+per-component units that must survive the contraction), and a second copy
+reliably ends up with a subset of the checks.  It is a private helper rather than
+public API because the two public spellings, `norm` and ``interval``, already
+cover the ways a caller wants to ask.
+"""
+
+__all__: tuple[str, ...] = ()
+
+from typing import Any
+
+import quaxed.numpy as jnp
+import unxts.linalg as ul
+from unxt.quantity import is_any_quantity
+
+import coordinaxs.api.charts as cxcapi
+import coordinaxs.api.manifolds as cxmapi
+from coordinax._src.base import AbstractChart
+from coordinax._src.custom_types import CDict, OptUSys
+
+_MSG_MIXED = (
+    "{fname}(): mixed CDict with both Quantity and bare Array values is not "
+    "supported. All components must be either all Quantity or all bare Array."
+)
+
+_MSG_USYS = (
+    "{fname}(): `usys` is required when `v` is a CDict of bare arrays "
+    "(no unit information). "
+    "Example: pass `usys=unxt.unitsystems.si`."
+)
+
+
+def quadratic_form(
+    v: CDict,
+    chart: AbstractChart,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+    fname: str = "quadratic_form",
+) -> Any:
+    r"""Return $v^\top G(\text{at})\, v$ for the chart's metric.
+
+    No square root is taken, so this is defined for every metric — including
+    indefinite ones, where it is the signed interval rather than a magnitude.
+
+    Parameters
+    ----------
+    v
+        Component dictionary of the vector to contract. Values must be *all*
+        `unxt.Quantity` or *all* bare arrays; a mixture raises `TypeError`.
+    chart
+        The chart whose manifold supplies the metric. The metric is evaluated at
+        ``at``, and ``v``'s components are read in ``chart.components`` order.
+    at
+        Base point at which to evaluate the metric.
+    usys
+        Unit system. Required when ``v`` holds bare arrays, since there is then
+        no unit information to work from; optional otherwise.
+    fname
+        Name of the calling function, used in error messages so a caller of
+        `norm` is not told about ``quadratic_form``. Mirrors the ``fname``
+        argument of `require_positive_definite`.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> from coordinax._src.manifolds.quadratic_form import quadratic_form
+
+    A 3-4-0 vector in flat space contracts to ``25 m2`` -- the *square* of the
+    norm ``5 m``:
+
+    >>> at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+    >>> v = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+    >>> quadratic_form(v, cxc.cart3d, at=at).round(2)
+    Q(25., 'm2')
+
+    Unlike a norm it stays defined when the metric is indefinite, going negative
+    for a timelike vector:
+
+    >>> at4 = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> v4 = {"ct": u.Q(5.0, "m"), "x": u.Q(1.0, "m"),
+    ...       "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> quadratic_form(v4, cxc.minkowskict, at=at4).round(2)
+    Q(-24., 'm2')
+
+    """
+    keys = chart.components
+
+    qty_flags = [is_any_quantity(val) for val in v.values()]
+    if any(qty_flags) and not all(qty_flags):
+        raise TypeError(_MSG_MIXED.format(fname=fname))
+    is_qty = all(qty_flags)
+
+    if not is_qty and usys is None:
+        raise TypeError(_MSG_USYS.format(fname=fname))
+
+    # ``metric_matrix`` returns a typed ``AbstractMetricMatrix`` (Diagonal/Dense)
+    # and handles both bare-array and Quantity ``at`` values; it needs no unit
+    # system of its own.
+    mm = cxmapi.metric_matrix(chart.M, at, chart)
+
+    if not is_qty:  # Bare arrays — stack on last axis for correct batch broadcasting
+        v_vec = jnp.stack([jnp.asarray(v[k]) for k in keys], axis=-1)
+        g = mm.to_dense().matrix  # ty: ignore[unresolved-attribute]
+        return jnp.einsum("...i,...ij,...j->...", v_vec, g, v_vec)
+
+    # Pack into a QuantityMatrix, preserving per-component units, then contract
+    # via QuantityMatrix/AbstractMetricMatrix arithmetic, which handles all unit
+    # conversions correctly (including mixed-unit components like m/s and rad/s).
+    v_qm: ul.QM = cxcapi.carray(v, keys)  # ty: ignore[invalid-assignment]
+    return v_qm @ (mm @ v_qm)

--- a/src/coordinax/_src/manifolds/quadratic_form.py
+++ b/src/coordinax/_src/manifolds/quadratic_form.py
@@ -276,8 +276,9 @@ def _prepare(
         packed.append(qty_flags)
 
     # Cross-argument check: all vectors must be consistently Quantity or bare-array.
-    # Each element in `packed` is a list of bool flags; `all(flags)` means all-Quantity,
-    # `not all(flags)` means all-bare-array (the within-vector check above ensures no mixing).
+    # Each element in `packed` is a list of bool flags; `all(flags)` means
+    # all-Quantity, `not all(flags)` means all-bare-array (the within-vector
+    # check above ensures no mixing).
     if len(packed) > 1:
         is_qty_per_vec = [all(qty_flags) for qty_flags in packed]
         if any(is_qty_per_vec) and not all(is_qty_per_vec):

--- a/src/coordinax/transforms/_src/actions/linear.py
+++ b/src/coordinax/transforms/_src/actions/linear.py
@@ -307,10 +307,7 @@ def pushforward(
     p_cart = cxr.tangent_map(v, chart, rep, cart, at=at, usys=usys)  # ty: ignore[missing-argument]
     p_cart_out = _matmul_cdict(matrix, p_cart, comps_cart)
     at_out = _matmul_cdict(matrix, at_cart, comps_cart)
-    return cxr.tangent_map(
-        p_cart_out, cart, rep, chart, at=at_out, usys=usys
-    )  # ty: ignore[missing-argument]
-    )
+    return cxr.tangent_map(p_cart_out, cart, rep, chart, at=at_out, usys=usys)  # ty: ignore[missing-argument]
 
 
 @plum.dispatch

--- a/src/coordinax/transforms/_src/actions/linear.py
+++ b/src/coordinax/transforms/_src/actions/linear.py
@@ -307,9 +307,9 @@ def pushforward(
     p_cart = cxr.tangent_map(v, chart, rep, cart, at=at, usys=usys)  # ty: ignore[missing-argument]
     p_cart_out = _matmul_cdict(matrix, p_cart, comps_cart)
     at_out = _matmul_cdict(matrix, at_cart, comps_cart)
-    return cast(
-        "CDict",
-        cxr.tangent_map(p_cart_out, cart, rep, chart, at=at_out, usys=usys),  # ty: ignore[missing-argument]
+    return cxr.tangent_map(
+        p_cart_out, cart, rep, chart, at=at_out, usys=usys
+    )  # ty: ignore[missing-argument]
     )
 
 

--- a/src/coordinax/vectors/_src/tangent.py
+++ b/src/coordinax/vectors/_src/tangent.py
@@ -142,7 +142,7 @@ class Tangent(
         if isinstance(key, str):
             return self.data[key]
         data = broadcast_and_index_data(self.data, self.shape, key)
-        return replace(self, data=data)  # ty: ignore[invalid-return-type,not-subscriptable]
+        return replace(self, data=data)  # ty: ignore[invalid-return-type]
 
 
 # ===================================================================

--- a/tests/unit/manifolds/test_quadratic_form.py
+++ b/tests/unit/manifolds/test_quadratic_form.py
@@ -295,6 +295,19 @@ class TestBilinearForm:
         with pytest.raises(TypeError, match="mixed CDict"):
             bilinear_form(self.XHAT, mixed, cxc.cart3d, at=self.AT)
 
+    def test_cross_argument_mixing_quantity_and_bare_array_is_rejected(self):
+        """One Quantity CDict and one bare-array CDict across arguments is rejected.
+        
+        Without this check, the code would pass `_prepare()` but fail in `_contract()`
+        with a plum dispatch error, since there's no overload for
+        `(AbstractMetricMatrix, QuantityMatrix, Array)` or vice versa.
+        """
+        bare = {"x": jnp.asarray(1.0), "y": jnp.asarray(0.0), "z": jnp.asarray(0.0)}
+        with pytest.raises(TypeError, match="consistently either Quantity"):
+            bilinear_form(self.XHAT, bare, cxc.cart3d, at=self.AT, require_usys=False)
+        with pytest.raises(TypeError, match="consistently either Quantity"):
+            bilinear_form(bare, self.XHAT, cxc.cart3d, at=self.AT, require_usys=False)
+
 
 class TestRequireUsysIsAPolicyNotAComputation:
     """Whether bare arrays need `usys` depends on the *verb*, not the primitive.

--- a/tests/unit/manifolds/test_quadratic_form.py
+++ b/tests/unit/manifolds/test_quadratic_form.py
@@ -1,0 +1,155 @@
+"""Tests for the shared metric quadratic form.
+
+The point of extracting this is that every magnitude-like verb contracts the
+same `vᵀ G(p) v`, and a second copy of that contraction reliably ends up with a
+subset of the unit checks. So the tests here pin two things: the relationship to
+`norm` (it is exactly the square), and that the fiddly unit handling lives here
+rather than in the caller.
+"""
+
+from typing import ClassVar
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import quaxed.numpy as qnp
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+from coordinax._src.manifolds.quadratic_form import quadratic_form
+
+ATOL = 1e-5
+
+
+class TestRelationToNorm:
+    """`norm` is the square root of the form, for a positive-definite metric."""
+
+    @pytest.mark.parametrize(
+        ("v", "chart", "want"),
+        [
+            ({"x": 3.0, "y": 4.0, "z": 0.0}, cxc.cart3d, 25.0),
+            ({"x": 1.0, "y": 0.0, "z": 0.0}, cxc.cart3d, 1.0),
+            ({"x": 0.0, "y": 0.0, "z": 0.0}, cxc.cart3d, 0.0),
+            ({"x": -5.0, "y": 12.0, "z": 0.0}, cxc.cart3d, 169.0),
+        ],
+    )
+    def test_form_is_norm_squared(self, v, chart, want):
+        vq = {k: u.Q(val, "m") for k, val in v.items()}
+        at = {k: u.Q(0.0, "m") for k in v}
+
+        got = quadratic_form(vq, chart, at=at)
+        assert float(got.ustrip("m2")) == pytest.approx(want, abs=ATOL)
+
+        n = cxm.norm(vq, chart, at=at)
+        assert float(n.ustrip("m")) ** 2 == pytest.approx(want, abs=ATOL)
+
+    def test_agrees_on_a_curved_metric(self):
+        """Also holds where the metric actually varies with the base point."""
+        at = {"theta": u.Q(jnp.pi / 2, "rad"), "phi": u.Q(0.0, "rad")}
+        v = {"theta": u.Q(1.0, "rad/s"), "phi": u.Q(1.0, "rad/s")}
+        metric = cxm.RoundMetric(ndim=2)
+
+        form = quadratic_form(v, cxc.sph2, at=at)
+        n = cxm.norm(v, metric, cxc.sph2, at=at)
+        assert float(u.ustrip("rad2/s2", form)) == pytest.approx(
+            float(n.ustrip("rad/s")) ** 2, abs=ATOL
+        )
+
+
+class TestDefinedWhereNormIsNot:
+    """The reason it exists: no square root, so an indefinite metric is fine."""
+
+    AT4: ClassVar = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+
+    @staticmethod
+    def _v4(ct, x):
+        return {
+            "ct": u.Q(ct, "m"),
+            "x": u.Q(x, "m"),
+            "y": u.Q(0.0, "m"),
+            "z": u.Q(0.0, "m"),
+        }
+
+    @pytest.mark.parametrize(
+        ("ct", "x", "want"), [(5.0, 1.0, -24.0), (1.0, 5.0, 24.0), (3.0, 3.0, 0.0)]
+    )
+    def test_indefinite_metric_gives_a_signed_value(self, ct, x, want):
+        got = quadratic_form(self._v4(ct, x), cxc.minkowskict, at=self.AT4)
+        assert float(got.ustrip("m2")) == pytest.approx(want, abs=ATOL)
+        assert not bool(jnp.isnan(got.ustrip("m2")))
+
+    def test_norm_still_refuses_the_same_input(self):
+        """The form is permissive; the positive-definite guard stays on `norm`."""
+        with pytest.raises(NotImplementedError, match=r"pseudo.*indefinite"):
+            cxm.norm(
+                self._v4(5.0, 1.0), cxm.MinkowskiMetric(), cxc.minkowskict, at=self.AT4
+            )
+
+
+class TestUnitHandlingLivesHere:
+    """The checks a second copy of the contraction would have dropped."""
+
+    def test_mixed_quantity_and_array_is_rejected(self):
+        at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+        mixed = {"x": u.Q(3.0, "m"), "y": jnp.asarray(4.0), "z": u.Q(0.0, "m")}
+        with pytest.raises(TypeError, match="mixed CDict"):
+            quadratic_form(mixed, cxc.cart3d, at=at)
+
+    def test_bare_arrays_require_usys(self):
+        at = {"theta": jnp.asarray(jnp.pi / 2), "phi": jnp.asarray(0.0)}
+        v = {"theta": jnp.asarray(1.0), "phi": jnp.asarray(0.0)}
+        with pytest.raises(TypeError, match="usys"):
+            quadratic_form(v, cxc.sph2, at=at)
+
+    def test_bare_arrays_work_when_usys_is_given(self):
+        at = {"theta": jnp.asarray(jnp.pi / 2), "phi": jnp.asarray(0.0)}
+        v = {"theta": jnp.asarray(1.0), "phi": jnp.asarray(0.0)}
+        got = quadratic_form(v, cxc.sph2, at=at, usys=u.unitsystems.si)
+        assert float(got) == pytest.approx(1.0, abs=ATOL)
+
+    @pytest.mark.parametrize("fname", ["norm", "interval", "quadratic_form"])
+    def test_errors_name_the_calling_function(self, fname):
+        """A caller of `norm` should not be told about `quadratic_form`."""
+        at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+        mixed = {"x": u.Q(3.0, "m"), "y": jnp.asarray(4.0), "z": u.Q(0.0, "m")}
+        with pytest.raises(TypeError, match=rf"^{fname}\(\)"):
+            quadratic_form(mixed, cxc.cart3d, at=at, fname=fname)
+
+    def test_mixed_unit_components_contract_correctly(self):
+        """Per-component units must survive the contraction, not be flattened."""
+        at = {
+            "r": u.Q(5.0, "m"),
+            "theta": u.Q(jnp.pi / 2, "rad"),
+            "phi": u.Q(0.0, "rad"),
+        }
+        v = {"r": u.Q(1.0, "m/s"), "theta": u.Q(0.0, "rad/s"), "phi": u.Q(0.0, "rad/s")}
+        got = quadratic_form(v, cxc.sph3d, at=at)
+        assert float(u.ustrip("m2/s2", got)) == pytest.approx(1.0, abs=ATOL)
+
+
+class TestJAX:
+    """Still traceable, since `norm` routes through it."""
+
+    def test_jit(self):
+        at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+
+        @jax.jit
+        def f(v):
+            return quadratic_form(v, cxc.cart3d, at=at)
+
+        v = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+        assert float(f(v).ustrip("m2")) == pytest.approx(25.0, abs=ATOL)
+
+    def test_vmap_batches(self):
+        at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+        batch = {
+            "x": u.Q(jnp.asarray([3.0, 1.0]), "m"),
+            "y": u.Q(jnp.asarray([4.0, 0.0]), "m"),
+            "z": u.Q(jnp.asarray([0.0, 0.0]), "m"),
+        }
+        got = jax.vmap(lambda v: quadratic_form(v, cxc.cart3d, at=at))(batch)
+        assert qnp.allclose(
+            got, u.Q(jnp.asarray([25.0, 1.0]), "m2"), atol=u.Q(ATOL, "m2")
+        )

--- a/tests/unit/manifolds/test_quadratic_form.py
+++ b/tests/unit/manifolds/test_quadratic_form.py
@@ -20,7 +20,11 @@ import coordinax.charts as cxc
 import coordinax.manifolds as cxm
 import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
-from coordinax._src.manifolds.quadratic_form import _contract, quadratic_form
+from coordinax._src.manifolds.quadratic_form import (
+    _contract,
+    bilinear_form,
+    quadratic_form,
+)
 from coordinax._src.metric.matrix import DiagonalMetric
 
 ATOL = 1e-5
@@ -204,8 +208,8 @@ class TestDiagonalFastPath:
         assert isinstance(mm, DiagonalMetric), "case must exercise the fast path"
 
         v_qm = cxcapi.carray(v, chart.components)
-        fast = _contract(mm, v_qm)
-        dense = _contract(mm.to_dense(), v_qm)  # forces the generic fallback
+        fast = _contract(mm, v_qm, v_qm)
+        dense = _contract(mm.to_dense(), v_qm, v_qm)  # forces the generic fallback
 
         assert u.unit_of(fast) == u.unit_of(dense)
         assert qnp.allclose(fast, dense, atol=u.Q(1e-8, u.unit_of(dense)))
@@ -227,8 +231,8 @@ class TestDiagonalFastPath:
         mm = cxmapi.metric_matrix(chart.M, at, chart)
         stacked = jnp.stack([v_arr[k] for k in chart.components], axis=-1)
 
-        fast = _contract(mm, stacked)
-        dense = _contract(mm.to_dense(), stacked)
+        fast = _contract(mm, stacked, stacked)
+        dense = _contract(mm.to_dense(), stacked, stacked)
         assert jnp.allclose(jnp.asarray(fast), jnp.asarray(dense), atol=1e-8)
 
     def test_batched_arrays_reduce_over_components_not_the_batch(self):
@@ -236,7 +240,7 @@ class TestDiagonalFastPath:
         at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
         mm = cxmapi.metric_matrix(cxc.cart3d.M, at, cxc.cart3d)
         batch = jnp.asarray([[3.0, 4.0, 0.0], [1.0, 0.0, 0.0], [0.0, 5.0, 12.0]])
-        got = _contract(mm, batch)
+        got = _contract(mm, batch, batch)
         assert got.shape == (3,)
         assert jnp.allclose(got, jnp.asarray([25.0, 1.0, 169.0]), atol=1e-8)
 
@@ -247,3 +251,84 @@ class TestDiagonalFastPath:
         assert float(cxm.norm(v, cxc.cart3d, at=at).ustrip("m")) == pytest.approx(
             5.0, abs=ATOL
         )
+
+
+class TestBilinearForm:
+    """`quadratic_form` is the ``u is v`` case; `angle_between` needs the rest."""
+
+    AT: ClassVar = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+    XHAT: ClassVar = {"x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    YHAT: ClassVar = {"x": u.Q(0.0, "m"), "y": u.Q(1.0, "m"), "z": u.Q(0.0, "m")}
+    V: ClassVar = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+
+    def test_orthogonal_vectors_contract_to_zero(self):
+        got = bilinear_form(self.XHAT, self.YHAT, cxc.cart3d, at=self.AT)
+        assert float(got.ustrip("m2")) == pytest.approx(0.0, abs=ATOL)
+
+    def test_reduces_to_quadratic_form_when_both_vectors_are_the_same(self):
+        """The defining relationship between the two spellings."""
+        bi = bilinear_form(self.V, self.V, cxc.cart3d, at=self.AT)
+        qu = quadratic_form(self.V, cxc.cart3d, at=self.AT)
+        assert float(bi.ustrip("m2")) == pytest.approx(float(qu.ustrip("m2")), abs=ATOL)
+
+    def test_is_symmetric(self):
+        """As the metric is."""
+        a = bilinear_form(self.V, self.XHAT, cxc.cart3d, at=self.AT)
+        b = bilinear_form(self.XHAT, self.V, cxc.cart3d, at=self.AT)
+        assert float(a.ustrip("m2")) == pytest.approx(float(b.ustrip("m2")), abs=ATOL)
+
+    def test_indefinite_metric_gives_a_signed_value(self):
+        at4 = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+        t = {
+            "ct": u.Q(1.0, "m"),
+            "x": u.Q(0.0, "m"),
+            "y": u.Q(0.0, "m"),
+            "z": u.Q(0.0, "m"),
+        }
+        got = bilinear_form(t, t, cxc.minkowskict, at=at4)
+        assert float(got.ustrip("m2")) == pytest.approx(-1.0, abs=ATOL)
+
+    def test_mixed_cdict_is_rejected_in_either_argument(self):
+        mixed = {"x": u.Q(3.0, "m"), "y": jnp.asarray(4.0), "z": u.Q(0.0, "m")}
+        with pytest.raises(TypeError, match="mixed CDict"):
+            bilinear_form(mixed, self.XHAT, cxc.cart3d, at=self.AT)
+        with pytest.raises(TypeError, match="mixed CDict"):
+            bilinear_form(self.XHAT, mixed, cxc.cart3d, at=self.AT)
+
+
+class TestRequireUsysIsAPolicyNotAComputation:
+    """Whether bare arrays need `usys` depends on the *verb*, not the primitive.
+
+    `norm` and ``interval`` return a value whose unit is derived from the
+    inputs, so demanding a unit system is a meaningful contract.
+    `angle_between` returns a dimensionless ratio in which every unit cancels,
+    so the same demand would be ceremony -- and would break callers that have
+    always passed bare arrays.
+    """
+
+    BARE: ClassVar = {"theta": jnp.asarray(1.0), "phi": jnp.asarray(0.0)}
+    AT: ClassVar = {"theta": jnp.asarray(jnp.pi / 2), "phi": jnp.asarray(0.0)}
+
+    def test_default_demands_usys(self):
+        with pytest.raises(TypeError, match="usys"):
+            quadratic_form(self.BARE, cxc.sph2, at=self.AT)
+
+    def test_opting_out_allows_bare_arrays(self):
+        got = quadratic_form(self.BARE, cxc.sph2, at=self.AT, require_usys=False)
+        assert float(got) == pytest.approx(1.0, abs=ATOL)
+
+    def test_angle_between_accepts_bare_arrays(self):
+        """Regression: migrating onto the shared primitive must not tighten this."""
+        at = {"x": jnp.asarray(0.0), "y": jnp.asarray(0.0), "z": jnp.asarray(0.0)}
+        xh = {"x": jnp.asarray(1.0), "y": jnp.asarray(0.0), "z": jnp.asarray(0.0)}
+        yh = {"x": jnp.asarray(0.0), "y": jnp.asarray(1.0), "z": jnp.asarray(0.0)}
+        got = cxm.angle_between(cxc.cart3d, xh, yh, at=at)
+        assert float(u.ustrip("rad", got)) == pytest.approx(jnp.pi / 2, abs=1e-5)
+
+    def test_angle_between_still_rejects_a_mixed_cdict(self):
+        """It gains the check it never had, which is the point of sharing."""
+        at = {"x": u.Q(0.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+        mixed = {"x": u.Q(1.0, "m"), "y": jnp.asarray(0.0), "z": u.Q(0.0, "m")}
+        good = {"x": u.Q(0.0, "m"), "y": u.Q(1.0, "m"), "z": u.Q(0.0, "m")}
+        with pytest.raises(TypeError, match="mixed CDict"):
+            cxm.angle_between(cxc.cart3d, mixed, good, at=at)

--- a/tests/unit/manifolds/test_quadratic_form.py
+++ b/tests/unit/manifolds/test_quadratic_form.py
@@ -18,7 +18,10 @@ import unxt as u
 
 import coordinax.charts as cxc
 import coordinax.manifolds as cxm
-from coordinax._src.manifolds.quadratic_form import quadratic_form
+import coordinaxs.api.charts as cxcapi
+import coordinaxs.api.manifolds as cxmapi
+from coordinax._src.manifolds.quadratic_form import _contract, quadratic_form
+from coordinax._src.metric.matrix import DiagonalMetric
 
 ATOL = 1e-5
 
@@ -152,4 +155,95 @@ class TestJAX:
         got = jax.vmap(lambda v: quadratic_form(v, cxc.cart3d, at=at))(batch)
         assert qnp.allclose(
             got, u.Q(jnp.asarray([25.0, 1.0]), "m2"), atol=u.Q(ATOL, "m2")
+        )
+
+
+class TestDiagonalFastPath:
+    """`DiagonalMetric` contracts in O(n); it must agree with the O(n^2) form.
+
+    `metric_matrix` returns a `DiagonalMetric` for every metric the library
+    ships in its canonical chart, and that type exists so the full matrix need
+    never be materialised. `to_dense()` discards the structure, so the fast path
+    is the common one — and its whole job is to be indistinguishable from the
+    dense answer.
+    """
+
+    CASES: ClassVar = [
+        (
+            "cart3d",
+            cxc.cart3d,
+            {"x": (0.0, "m"), "y": (0.0, "m"), "z": (0.0, "m")},
+            {"x": (3.0, "m"), "y": (4.0, "m"), "z": (0.0, "m")},
+        ),
+        (
+            "minkowskict",
+            cxc.minkowskict,
+            {"ct": (0.0, "m"), "x": (0.0, "m"), "y": (0.0, "m"), "z": (0.0, "m")},
+            {"ct": (5.0, "m"), "x": (1.0, "m"), "y": (0.0, "m"), "z": (0.0, "m")},
+        ),
+        (
+            "sph2 (curved)",
+            cxc.sph2,
+            {"theta": (jnp.pi / 2, "rad"), "phi": (0.0, "rad")},
+            {"theta": (1.0, "rad/s"), "phi": (1.0, "rad/s")},
+        ),
+        (
+            "sph3d (mixed units)",
+            cxc.sph3d,
+            {"r": (5.0, "m"), "theta": (jnp.pi / 2, "rad"), "phi": (0.0, "rad")},
+            {"r": (1.0, "m/s"), "theta": (0.0, "rad/s"), "phi": (0.0, "rad/s")},
+        ),
+    ]
+
+    @pytest.mark.parametrize(("label", "chart", "at_spec", "v_spec"), CASES)
+    def test_agrees_with_the_dense_contraction(self, label, chart, at_spec, v_spec):
+        del label
+        at = {k: u.Q(val, un) for k, (val, un) in at_spec.items()}
+        v = {k: u.Q(val, un) for k, (val, un) in v_spec.items()}
+        mm = cxmapi.metric_matrix(chart.M, at, chart)
+        assert isinstance(mm, DiagonalMetric), "case must exercise the fast path"
+
+        v_qm = cxcapi.carray(v, chart.components)
+        fast = _contract(mm, v_qm)
+        dense = _contract(mm.to_dense(), v_qm)  # forces the generic fallback
+
+        assert u.unit_of(fast) == u.unit_of(dense)
+        assert qnp.allclose(fast, dense, atol=u.Q(1e-8, u.unit_of(dense)))
+
+    @pytest.mark.parametrize(
+        ("label", "chart", "at_spec", "v_spec"),
+        [c for c in CASES if c[0] != "sph3d (mixed units)"],
+    )
+    def test_bare_array_branch_agrees_too(self, label, chart, at_spec, v_spec):
+        """The stacked-array path has its own overload; it must match as well.
+
+        ``sph3d`` is excluded: a unitless vector against a unitful (mixed-unit)
+        diagonal is unsupported on *both* paths, before this change and after,
+        so there is no agreement to assert.
+        """
+        del label
+        at = {k: u.Q(val, un) for k, (val, un) in at_spec.items()}
+        v_arr = {k: jnp.asarray(val) for k, (val, _) in v_spec.items()}
+        mm = cxmapi.metric_matrix(chart.M, at, chart)
+        stacked = jnp.stack([v_arr[k] for k in chart.components], axis=-1)
+
+        fast = _contract(mm, stacked)
+        dense = _contract(mm.to_dense(), stacked)
+        assert jnp.allclose(jnp.asarray(fast), jnp.asarray(dense), atol=1e-8)
+
+    def test_batched_arrays_reduce_over_components_not_the_batch(self):
+        """``sum(..., axis=-1)`` rather than ``@``, which would eat the batch axis."""
+        at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+        mm = cxmapi.metric_matrix(cxc.cart3d.M, at, cxc.cart3d)
+        batch = jnp.asarray([[3.0, 4.0, 0.0], [1.0, 0.0, 0.0], [0.0, 5.0, 12.0]])
+        got = _contract(mm, batch)
+        assert got.shape == (3,)
+        assert jnp.allclose(got, jnp.asarray([25.0, 1.0, 169.0]), atol=1e-8)
+
+    def test_norm_is_unchanged_end_to_end(self):
+        """The optimisation is invisible from the public verb."""
+        at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+        v = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+        assert float(cxm.norm(v, cxc.cart3d, at=at).ustrip("m")) == pytest.approx(
+            5.0, abs=ATOL
         )

--- a/tests/unit/manifolds/test_quadratic_form.py
+++ b/tests/unit/manifolds/test_quadratic_form.py
@@ -297,7 +297,7 @@ class TestBilinearForm:
 
     def test_cross_argument_mixing_quantity_and_bare_array_is_rejected(self):
         """One Quantity CDict and one bare-array CDict across arguments is rejected.
-        
+
         Without this check, the code would pass `_prepare()` but fail in `_contract()`
         with a plum dispatch error, since there's no overload for
         `(AbstractMetricMatrix, QuantityMatrix, Array)` or vice versa.


### PR DESCRIPTION
Closes #688.

> ### 📍 Stacked on **#686**
> | # | PR | why this needs it |
> |---|----|-------------------|
> | ~~#687~~ | ~~`angle_between` conditioned on the spanned plane~~ | ✅ **merged** — rebased onto it |
> | #686 | shared `quadratic_form` + diagonal fast path | this generalizes that primitive |
> | **this** | bilinear form; `angle_between` migrated | **merge after #686** |
>
> ✅ Rebased onto current `main` (post-#687) and onto #686 — this PR is now 3 commits: #686's two plus its own. Merge order: **#686 → this**, then #680, then #683.

## Why

`angle_between` was the last site reimplementing a metric contraction. Two of its three are `quadratic_form`, but the third isn't:

```python
inner = u_qm @ (g @ v_qm)     # bilinear  g(u,v)   <-- not expressible as quadratic
uu    = u_qm @ (g @ u_qm)     # quadratic g(u,u)
vv    = v_qm @ (g @ v_qm)     # quadratic g(v,v)
```

So it kept a local copy — and that copy was already thinner than `norm`'s, missing the mixed `Quantity`/bare-array rejection. Exactly the divergence #686 exists to stop.

`bilinear_form(u, v, chart, at=)` is now the primitive; `quadratic_form(v, ...)` is its `u is v` case. `angle_between` takes all three contractions from it, gaining the unit checks **and** the diagonal fast path.

## `require_usys` is a policy, not a computation

Migrating naively broke pre-existing tests — including `TestAngleBetweenJAX::test_jit`, which predates all of this work — and it was right to.

`norm` and `interval` demand a unit system for bare arrays because their **result carries units derived from the inputs**; declaring one is a meaningful contract. `angle_between` returns a **dimensionless ratio** — every unit cancels in `g(u,v)/√(g(u,u)g(v,v))` — so the same demand is pure ceremony, and would break callers that have always passed bare arrays.

So the flag lets each verb say which it is. The default is the stricter behaviour, leaving `norm` and `interval` untouched. This is the one place I'd welcome a second opinion: a boolean parameter is a smell, but it encodes a real distinction with genuine callers on both sides, and the alternative — restating the check in `norm` and `interval` — reintroduces the duplication #686 removed.

## A bug the suite caught

Sharing the primitive means `angle_between` now receives a plain array for bare-array input where it previously always got a `Quantity`. My first attempt used one helper for both jobs; `g(v,v)` carries `m2` or `rad2/s2` and stripping it to dimensionless raises. Hence two helpers: `_dimensionless` for the cosine (genuinely unitless), `_value` for `g(v,v)` where only the **sign** is wanted and the unit must be left alone.

## Net effect on `angle_between`

| | before | after |
|---|---|---|
| mixed `Quantity`/bare-array CDict | silently proceeds | **`TypeError`** |
| bare arrays without `usys` | works | **works** (unchanged) |
| diagonal fast path | no | **yes** |
| #687's Lorentzian behaviour, jit/vmap `nan` masking, Riemannian path | — | **all unchanged** |

## Verification

`tests/unit` + `docs` + `packages/coordinaxs.api`: **3314 passed, 5 skipped**. New tests cover the bilinear form (orthogonality, symmetry, reduction to `quadratic_form`, indefinite metrics, mixed-CDict rejection in either argument) and the `require_usys` policy from both sides, including a regression test that `angle_between` still accepts bare arrays. All of #687's tests pass unchanged. ruff, ruff-format, ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## ⚡️ Performance audit — and a regression it caught

A detailed review of the primitive and its callers turned up a real regression in the first version of this PR, now fixed.

### The regression: three `bilinear_form` calls rebuild the metric three times

`angle_between` needs `g(u,v)`, `g(u,u)`, `g(v,v)` **at one base point**. Calling `bilinear_form` three times evaluated `metric_matrix` three times. Under `jit` that is free — XLA CSEs identical builds — but eagerly it was measured **~1.6× slower** than `main`, consistently across runs.

Fixed with `gram(u, v, chart, at=)`, which evaluates the metric once, packs each vector once, and contracts three times. Same `_prepare`, so identical unit handling. Interleaved A/B, 3 runs each, medians:

| | eager | jit (vmap 50k) | HLO ops |
|---|---|---|---|
| #686 (`angle_between` untouched) | 7988 µs | 596 µs | 87 |
| this PR, 3× `bilinear_form` | 13623 µs ❌ | ~768 µs | 75 |
| **this PR, with `gram`** | **7649 µs** ✅ | **511 µs** | **75** |

Net vs #686: **1.04× faster eager, ~1.17× faster jitted, 14% fewer HLO ops.** The migration is now a win on every axis rather than a trade.

### On the fast-path question

The dispatch tree was instrumented to confirm which `_contract` overload actually fires, and which callers bypass the primitive entirely:

- `norm(cdict, cart3d)`, `norm(packed_array, cart3d)`, `norm(packed_quantity, cart3d)` **never reach `quadratic_form`** — the Euclidean `FlatMetric` + Cartesian short-circuit still owns them, as it should. Jitted over 100k: **80 µs / 18 ops**, versus 573 µs / 34 ops for the generic route. That fast path is doing real work and is untouched here.
- Container type is **not** worth a dedicated channel. Jitted over 100k on `sph2`, cdict-of-Quantity 573 µs vs cdict-of-bare-array 541 µs — **the same 34 HLO ops**. The unit machinery is trace-time only.

Eagerly the picture differs sharply — bare arrays are ~12× faster than Quantities (236 µs vs 3020 µs), because `QuantityMatrix` construction dominates. But eager is 100–800× slower than jitted across the board, so that gap is a statement about interactive use, not about anything on a hot path.

### Noted, not fixed

`norm(packed_quantity, metric, chart)` on a **non**-Euclidean chart goes `Quantity → cdict → QuantityMatrix` — unpacking only to repack. Eagerly it lands at 5625 µs against 5000 µs for passing a cdict directly, i.e. the packed form is *slower* than the unpacked one, which is backwards. Pre-existing, out of scope here, and invisible under `jit`. Worth a separate issue if interactive use matters.

**Verification after the fix:** `tests/unit` + `docs` + `packages/coordinaxs.api` — **3314 passed, 5 skipped**; ruff, ruff-format, ty clean.
