### PR TITLE
⚡️ perf(manifolds): send a packed `Quantity` straight to the contraction

### DIFF
--- a/src/coordinax/_src/manifolds/norm.py
+++ b/src/coordinax/_src/manifolds/norm.py
@@ -282,10 +282,16 @@ def norm(
         # Single-component chart: wrap the (scalar or length-1) quantity in a
         # one-element CDict, squeezing the trailing component axis if present.
         v_dict = {keys[0]: v if v.ndim == 0 else v[..., 0]}
-    else:
-        # Multi-component chart: split the packed quantity across components.
-        v_dict = cxcapi.cdict(v, chart)
-    return cxmapi.norm(v_dict, metric, chart, at=at, usys=usys)  # ty: ignore[invalid-return-type]
+        return cxmapi.norm(v_dict, metric, chart, at=at, usys=usys)  # ty: ignore[invalid-return-type]
+
+    # Multi-component: hand the packed quantity straight down. Splitting it into
+    # a CDict here only for `quadratic_form` to repack it into a QuantityMatrix
+    # was measurable trace-time waste -- and tracing is 30-46% of compile time,
+    # so it showed up as slower `jit` compilation, not just slower eager calls.
+    if metric != chart.M.metric:
+        raise ValueError("Metric-level dispatch: metric must match chart's metric")
+    require_positive_definite(chart.M.metric, "norm")
+    return jnp.sqrt(quadratic_form(v, chart, at=at, usys=usys, fname="norm"))
 
 
 @plum.dispatch

--- a/src/coordinax/_src/manifolds/quadratic_form.py
+++ b/src/coordinax/_src/manifolds/quadratic_form.py
@@ -35,6 +35,16 @@ from coordinax._src.base import AbstractChart
 from coordinax._src.custom_types import CDict, OptUSys
 from coordinax._src.metric.matrix import AbstractMetricMatrix, DiagonalMetric
 
+_MSG_PACKED_SHAPE = (
+    "{fname}(): packed Quantity has trailing dimension {got}, but chart "
+    "component{plural} {comps} expect{verb} {want}."
+)
+
+_MSG_PACKED_NDIM = (
+    "{fname}(): packed Quantity is a scalar, but chart components {comps} "
+    "expect a trailing axis of length {want}."
+)
+
 _MSG_MIXED = (
     "{fname}(): mixed CDict with both Quantity and bare Array values is not "
     "supported. All components must be either all Quantity or all bare Array."
@@ -250,6 +260,32 @@ def gram(
     return _contract(mm, u_, v_), _contract(mm, u_, u_), _contract(mm, v_, v_)
 
 
+def _check_packed_shape(v: Any, keys: tuple[str, ...], fname: str, /) -> None:
+    """Validate a packed Quantity's trailing axis against the chart.
+
+    Splitting the quantity into a CDict used to perform this check on the way
+    past. Skipping the round-trip skipped the check with it, so a mis-sized
+    quantity reached `QuantityMatrix` and failed there -- still an error, never a
+    silent broadcast, but phrased in terms of matrix internals rather than the
+    chart contract the caller actually broke.
+    """
+    want = len(keys)
+    shape = jnp.shape(v.value)
+    if not shape:
+        raise ValueError(_MSG_PACKED_NDIM.format(fname=fname, comps=keys, want=want))
+    if shape[-1] != want:
+        raise ValueError(
+            _MSG_PACKED_SHAPE.format(
+                fname=fname,
+                got=shape[-1],
+                plural="" if want == 1 else "s",
+                comps=keys,
+                verb="s" if want == 1 else "",
+                want=want,
+            )
+        )
+
+
 def _prepare(
     chart: AbstractChart,
     vecs: tuple[Any, ...],
@@ -271,6 +307,9 @@ def _prepare(
         if is_any_quantity(vec):
             # Already packed: nothing to validate component-wise, and the dict
             # round-trip below would only take it apart to put it back together.
+            # The shape check that round-trip used to perform is kept, though --
+            # see `_check_packed_shape`.
+            _check_packed_shape(vec, keys, fname)
             packed.append(None)
             continue
         qty_flags = [is_any_quantity(val) for val in vec.values()]

--- a/src/coordinax/_src/manifolds/quadratic_form.py
+++ b/src/coordinax/_src/manifolds/quadratic_form.py
@@ -252,7 +252,7 @@ def gram(
 
 def _prepare(
     chart: AbstractChart,
-    vecs: tuple[CDict, ...],
+    vecs: tuple[Any, ...],
     /,
     *,
     at: CDict,
@@ -268,6 +268,11 @@ def _prepare(
     """
     packed: list[Any] = []
     for vec in vecs:
+        if is_any_quantity(vec):
+            # Already packed: nothing to validate component-wise, and the dict
+            # round-trip below would only take it apart to put it back together.
+            packed.append(None)
+            continue
         qty_flags = [is_any_quantity(val) for val in vec.values()]
         if any(qty_flags) and not all(qty_flags):
             raise TypeError(_MSG_MIXED.format(fname=fname))
@@ -291,7 +296,14 @@ def _prepare(
 
     out: list[Any] = []
     for vec, qty_flags in zip(vecs, packed, strict=True):
-        if not all(qty_flags):
+        if qty_flags is None:
+            # Packed Quantity -> QuantityMatrix directly, one uniform unit.
+            out.append(
+                ul.QuantityMatrix(
+                    vec.value, unit=ul.UnitsMatrix.full((len(keys),), vec.unit)
+                )
+            )
+        elif not all(qty_flags):
             # Bare arrays — stack on the last axis for correct batch broadcasting.
             out.append(jnp.stack([jnp.asarray(vec[k]) for k in keys], axis=-1))
         else:

--- a/tests/unit/manifolds/test_quadratic_form.py
+++ b/tests/unit/manifolds/test_quadratic_form.py
@@ -374,22 +374,24 @@ class TestPackedQuantityAvoidsTheDictRoundTrip:
             float(as_dict.ustrip("rad/s")), abs=ATOL
         )
 
-    def test_no_cdict_round_trip_happens(self):
+    def test_no_cdict_round_trip_happens(self, monkeypatch):
         """Pins the shortcut itself, not just the value it produces."""
         import coordinaxs.api.charts as charts_api
 
         calls = []
         real = charts_api.cdict
-        charts_api.cdict = lambda *a, **k: (calls.append(1), real(*a, **k))[1]
-        try:
-            cxm.norm(
-                u.Q(jnp.asarray([1.0, 1.0]), "rad/s"),
-                cxm.RoundMetric(2),
-                cxc.sph2,
-                at=self.AT,
-            )
-        finally:
-            charts_api.cdict = real
+
+        def counting_cdict(*args, **kwargs):
+            calls.append(1)
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(charts_api, "cdict", counting_cdict)
+        cxm.norm(
+            u.Q(jnp.asarray([1.0, 1.0]), "rad/s"),
+            cxm.RoundMetric(2),
+            cxc.sph2,
+            at=self.AT,
+        )
         assert calls == [], "packed Quantity should not be split into a CDict"
 
     def test_one_component_chart_still_works(self):
@@ -401,3 +403,40 @@ class TestPackedQuantityAvoidsTheDictRoundTrip:
             at={"x": jnp.asarray(0.0)},
         )
         assert float(got.ustrip("m")) == pytest.approx(5.0, abs=ATOL)
+
+
+class TestPackedQuantityShapeIsStillChecked:
+    """Skipping the CDict round-trip must not skip the shape check it did.
+
+    `cdict` validated the trailing axis against `chart.components` on the way
+    past. Without that, a mis-sized quantity still failed -- never silently
+    broadcast -- but from inside `QuantityMatrix`, phrased in terms of matrix
+    internals rather than the chart contract the caller actually broke.
+    """
+
+    AT: ClassVar = {"theta": u.Q(jnp.pi / 2, "rad"), "phi": u.Q(0.0, "rad")}
+
+    def _norm(self, q):
+        return cxm.norm(q, cxm.RoundMetric(2), cxc.sph2, at=self.AT)
+
+    @pytest.mark.parametrize("n", [1, 3, 4])
+    def test_wrong_trailing_dimension_names_the_chart(self, n):
+        with pytest.raises(ValueError, match=r"norm\(\).*trailing dimension"):
+            self._norm(u.Q(jnp.ones((n,)), "rad/s"))
+
+    def test_scalar_is_rejected(self):
+        with pytest.raises(ValueError, match=r"norm\(\).*scalar"):
+            self._norm(u.Q(jnp.asarray(1.0), "rad/s"))
+
+    def test_batched_wrong_trailing_dimension_is_rejected(self):
+        """A leading batch axis must not disguise a wrong component count."""
+        with pytest.raises(ValueError, match=r"norm\(\).*trailing dimension"):
+            self._norm(u.Q(jnp.ones((4, 3)), "rad/s"))
+
+    def test_correct_shapes_still_work(self):
+        """Positive control, scalar and batched."""
+        assert float(
+            self._norm(u.Q(jnp.asarray([1.0, 1.0]), "rad/s")).ustrip("rad/s")
+        ) == pytest.approx(jnp.sqrt(2.0), abs=ATOL)
+        batched = self._norm(u.Q(jnp.ones((4, 2)), "rad/s"))
+        assert batched.shape == (4,)

--- a/tests/unit/manifolds/test_quadratic_form.py
+++ b/tests/unit/manifolds/test_quadratic_form.py
@@ -345,3 +345,59 @@ class TestRequireUsysIsAPolicyNotAComputation:
         good = {"x": u.Q(0.0, "m"), "y": u.Q(1.0, "m"), "z": u.Q(0.0, "m")}
         with pytest.raises(TypeError, match="mixed CDict"):
             cxm.angle_between(cxc.cart3d, mixed, good, at=at)
+
+
+class TestPackedQuantityAvoidsTheDictRoundTrip:
+    """A packed `Quantity` goes straight to a `QuantityMatrix`.
+
+    It used to be split into a CDict only for the contraction to repack it,
+    which cost ~1.5x eagerly -- and eager cost is trace cost, so it showed up as
+    slower `jit` compilation too, not merely slower interactive calls.
+    """
+
+    AT: ClassVar = {"theta": u.Q(jnp.pi / 2, "rad"), "phi": u.Q(0.0, "rad")}
+
+    def test_packed_and_cdict_agree(self):
+        """The shortcut must not change the answer."""
+        metric = cxm.RoundMetric(2)
+        packed = cxm.norm(
+            u.Q(jnp.asarray([1.0, 1.0]), "rad/s"), metric, cxc.sph2, at=self.AT
+        )
+        as_dict = cxm.norm(
+            {"theta": u.Q(1.0, "rad/s"), "phi": u.Q(1.0, "rad/s")},
+            metric,
+            cxc.sph2,
+            at=self.AT,
+        )
+        assert u.unit_of(packed) == u.unit_of(as_dict)
+        assert float(packed.ustrip("rad/s")) == pytest.approx(
+            float(as_dict.ustrip("rad/s")), abs=ATOL
+        )
+
+    def test_no_cdict_round_trip_happens(self):
+        """Pins the shortcut itself, not just the value it produces."""
+        import coordinaxs.api.charts as charts_api
+
+        calls = []
+        real = charts_api.cdict
+        charts_api.cdict = lambda *a, **k: (calls.append(1), real(*a, **k))[1]
+        try:
+            cxm.norm(
+                u.Q(jnp.asarray([1.0, 1.0]), "rad/s"),
+                cxm.RoundMetric(2),
+                cxc.sph2,
+                at=self.AT,
+            )
+        finally:
+            charts_api.cdict = real
+        assert calls == [], "packed Quantity should not be split into a CDict"
+
+    def test_one_component_chart_still_works(self):
+        """The 1-D chart takes a different branch; it must be unaffected."""
+        got = cxm.norm(
+            u.Q(jnp.asarray([5.0]), "m"),
+            cxm.FlatMetric(1),
+            cxc.cart1d,
+            at={"x": jnp.asarray(0.0)},
+        )
+        assert float(got.ustrip("m")) == pytest.approx(5.0, abs=ATOL)


### PR DESCRIPTION
Closes #690.

> ### 📍 Stacked on **#686 → #689**
> Merge order: **#686 → #689 → this**, then #680, then #683. Until the parents merge this diff carries their commits.

## The waste

`norm(packed_quantity, metric, chart)` split the quantity into a CDict only for `quadratic_form` to repack it into a `QuantityMatrix`:

```
cdict(q, chart)          551 us
carray(dict, keys)       597 us
round-trip total        1105 us
direct QuantityMatrix     27 us     <-- 40x
```

~40% of the whole eager call, to arrive back where it started.

## Result

| | `cdict` calls | eager | trace |
|---|---|---|---|
| before | 2 | 3801 µs | 23.1 ms |
| after | **0** | **2545 µs** | **20.8 ms** |
| | | **1.49×** | **1.11×** |

Consistent across three interleaved runs with no overlap.

## Why eager matters here

Not just interactive ergonomics: **tracing executes the eager path**, so eager cost is compile cost. Measured on this call, tracing is **30–46%** of trace+compile:

| path | trace ms | XLA ms | trace share |
|---|---|---|---|
| `quadratic_form` cdict-Quantity | 14.8 | 22.9 | 39% |
| `quadratic_form` cdict-bare | 9.7 | 23.0 | 30% |
| `norm` packed-Quantity | 17.2 | 23.7 | 42% |
| `angle_between` | 25.9 | 31.0 | 46% |

So Python-level work removed here shows up in `jit` compilation, not only in the REPL.

## Implementation

`_prepare` recognises an already-packed `Quantity` and wraps it as a `QuantityMatrix` directly. There is nothing to validate component-wise in that form — the uniform unit is the quantity's own — so the CDict guards do not apply. The one-component chart keeps its existing squeeze branch, with a test.

## A note on method

The first A/B of this change said it was **neutral**, and I nearly reported that. It was wrong: the change was *uncommitted*, so it followed every `git checkout` and both "branches" measured the same tree. The numbers above come from a committed branch, and a test now asserts the round-trip is genuinely gone (`cdict` calls 2 → 0) rather than trusting timing alone — timings on this machine swing ±30% run-to-run, so a behavioural assertion is the durable guard.

## Verification

`tests/unit` + `docs` + `packages/coordinaxs.api`: **3317 passed, 5 skipped**. ruff, ruff-format, ty clean.

## Context: where eager time actually goes

Profiling one eager `norm` (68 plum dispatches; `angle_between` 161) shows the cost is **dispatch volume and unit bookkeeping**, not arithmetic — 31 `convert`, 11 `ustrip`, 8 `unit` per call, with actual JAX primitives at ~1%. Runtime typechecking is off; the beartype frames come from plum's own matching.

The lever is therefore **fewer unit-carrying operations per verb**, which is exactly what `gram` did in #689 (3 contraction chains → 1, 1.6× eager) and what this PR does for the packed path. Micro-optimising any single step would not have moved it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)