### PR TITLE
⚡️ perf(charts): walk dataclass fields in `__eq__` / `__hash__`

### DIFF
--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -70,12 +70,9 @@ MISSING = object()
 
 
 def _field_values(chart: "AbstractChart[Any, Any, Any]", /) -> tuple[Any, ...]:
-    """Field values of a chart, as `dataclassish.field_values` would give them.
+    """Field values, as `dataclassish.field_values` gives them.
 
-    Every concrete chart is built by `chart_dataclass_decorator`, so the fields
-    can be walked directly. That avoids the plum dispatch in
-    `dataclassish.field_values`, which dominates `__eq__` / `__hash__` (~28 us
-    vs ~1.4 us per call).
+    Direct walk: every chart is a dataclass, and the plum dispatch costs ~25x.
     """
     return tuple(getattr(chart, f.name) for f in dataclasses.fields(chart))
 

--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -69,6 +69,17 @@ MISSING = object()
 # AbstractChart
 
 
+def _field_values(chart: "AbstractChart[Any, Any, Any]", /) -> tuple[Any, ...]:
+    """Field values of a chart, as `dataclassish.field_values` would give them.
+
+    Every concrete chart is built by `chart_dataclass_decorator`, so the fields
+    can be walked directly. That avoids the plum dispatch in
+    `dataclassish.field_values`, which dominates `__eq__` / `__hash__` (~28 us
+    vs ~1.4 us per call).
+    """
+    return tuple(getattr(chart, f.name) for f in dataclasses.fields(chart))
+
+
 @jtu.register_static
 class AbstractChart(Generic[MT, Ks, Ds], metaclass=abc.ABCMeta):
     """Abstract base class for charts (coordinate representations)."""
@@ -277,7 +288,7 @@ class AbstractChart(Generic[MT, Ks, Ds], metaclass=abc.ABCMeta):
         return (
             self.components == other.components
             and self.coord_dimensions == other.coord_dimensions
-            and (dataclassish.field_values(self) == dataclassish.field_values(other))
+            and (_field_values(self) == _field_values(other))
         )
 
     def __hash__(self) -> int:
@@ -292,12 +303,7 @@ class AbstractChart(Generic[MT, Ks, Ds], metaclass=abc.ABCMeta):
 
         """
         return hash(
-            (
-                type(self),
-                self.components,
-                self.coord_dimensions,
-                dataclassish.field_values(self),
-            )
+            (type(self), self.components, self.coord_dimensions, _field_values(self))
         )
 
 

--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -72,8 +72,11 @@ MISSING = object()
 def _field_values(chart: "AbstractChart[Any, Any, Any]", /) -> tuple[Any, ...]:
     """Field values, as `dataclassish.field_values` gives them.
 
-    Direct walk: every chart is a dataclass, and the plum dispatch costs ~25x.
+    Direct walk when the chart is a dataclass -- as all built-in ones are --
+    since the plum dispatch costs ~25x. Other charts take the general path.
     """
+    if not dataclasses.is_dataclass(chart):
+        return tuple(dataclassish.field_values(chart))
     return tuple(getattr(chart, f.name) for f in dataclasses.fields(chart))
 
 


### PR DESCRIPTION
`AbstractChart.__eq__` and `AbstractChart.__hash__` both called `dataclassish.field_values`, a plum-dispatched call. Profiling (cProfile over 20k `cxc.Cart3D()` constructions) put ~28 us per call in `plum/_signature.py:match` and `plum/_type.py:resolve_type_hint` — the dispatch, not the field walk.

Chart hashing and comparison are hot paths: `Coordinate.cconvert` hashes and compares a chart per fibre (`vectors/_src/bundle.py`), and `tangent_map` hits it on every pushforward.

Every concrete chart is built by `chart_dataclass_decorator`, so the fields can be walked directly with `dataclasses.fields` + `getattr`. Verified all 24 concrete charts in `NON_ABC_CHART_CLASSES` are dataclasses, and that the new `_field_values` matches `dataclassish.field_values` on every constructible one (including `ProlateSpheroidal3D(Delta=...)`).

```
hash(Cart3D())        24.8 us -> 0.98 us
Cart3D() == Cart3D()  48.8 us -> 1.79 us
```

`__pdoc__` still uses `dataclassish.field_items` — repr-only, not hot.

## Testing

- `uv run --no-sync pytest -q`: 9500 passed, 10 skipped, 1 xfailed
- `uv run prek run --all-files`: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)