### PR TITLE
✨ feat(charts)!: admit differentiable parameters into the chart layer

### DIFF
--- a/docs/guides/charts.md
+++ b/docs/guides/charts.md
@@ -339,7 +339,16 @@ Traceback (most recent call last):
 TypeError: GalileanCT is a static chart, but ['spatial_chart'] hold arrays. ...
 ```
 
-The guard is not universal. It walks pytree leaves, so an array inside something itself registered static — `EmbeddedChart.embed_map` — is a single opaque leaf and slips through. Closing that gap means giving `EmbeddedChart` the `ProlateSpheroidal3D` treatment, not a stricter guard: `radius` is a coordinate value that `pt_embed` propagates into output points, so forcing it static would break every embedded coordinate. See `AbstractStaticChart.__post_init__`.
+The guard walks pytree leaves, so it only sees an array that is _in_ the pytree: one buried inside a value that is itself registered static would be a single opaque leaf and slip through. The way out is to put the parameter on the parameterized branch, not to make the guard stricter. `EmbeddedChart` is the worked example — `TwoSphereIn3D.radius` is a coordinate value that `pt_embed` propagates into output points, so forcing it static would break every embedded coordinate; instead the embedding map is a pytree and the chart is parameterized:
+
+```{code-block} python
+>>> import coordinax.manifolds as cxm
+
+>>> len(jax.tree.leaves(cxm.EmbeddedChart(cxm.TwoSphereIn3D(radius=u.Q(2.0, "km")))))
+1
+>>> len(jax.tree.leaves(cxm.EmbeddedChart(cxm.TwoSphereIn3D(radius=u.StaticQuantity(2.0, "km")))))
+0
+```
 
 ## Quick Reference
 

--- a/docs/guides/charts.md
+++ b/docs/guides/charts.md
@@ -6,7 +6,7 @@ This guide focuses only on chart functionality in `coordinax.charts`.
 
 - A **chart** defines coordinate component names and dimensions.
 - Chart maps change coordinate representation while preserving the same point.
-- Charts are static descriptors; coordinate values live in dictionaries.
+- Most charts are static descriptors; coordinate values live in dictionaries. A few charts carry parameters — see [Static And Parameterized Charts](#static-and-parameterized-charts).
 
 ```{code-block} python
 >>> import coordinax.charts as cxc
@@ -249,6 +249,97 @@ True
 >>> cxc.GalileanCT(cxc.sph3d).cartesian == cxc.galileanct
 True
 ```
+
+## Static And Parameterized Charts
+
+Every concrete chart is on exactly one of two branches; being on neither, or on both, is a `TypeError` at class-creation time.
+
+- `AbstractStaticChart` — no parameters. Concrete subclasses register themselves with JAX as static, so they have zero pytree leaves and are always hashable. Staticness is structural, inherited from the branch, not a decorator that can be forgotten.
+- `AbstractParameterizedChart` — carries parameters. It is an `equinox.Module`, and therefore a pytree.
+
+```{code-block} python
+>>> import coordinax.charts as cxc
+
+>>> isinstance(cxc.cart3d, cxc.AbstractStaticChart)
+True
+>>> issubclass(cxc.ProlateSpheroidal3D, cxc.AbstractParameterizedChart)
+True
+```
+
+### Opt-In Differentiability
+
+A parameterized chart only has leaves if it is given something with leaves. `ProlateSpheroidal3D` accepts its focal length `Delta` as either quantity type, so differentiability is chosen per instance:
+
+```{code-block} python
+>>> import jax
+>>> import unxt as u
+
+>>> static = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m"))
+>>> len(jax.tree.leaves(static))
+0
+
+>>> dynamic = cxc.ProlateSpheroidal3D(Delta=u.Q(2.0, "m"))
+>>> len(jax.tree.leaves(dynamic))
+1
+```
+
+A `StaticQuantity` behaves exactly as charts always have: hashable, no leaves, baked into the `jit` cache key. A `Quantity` is a live array, so it can be differentiated through and `jit` traces once across many values of it:
+
+```{code-block} python
+>>> at = {"mu": u.Q(12.0, "m2"), "nu": u.Q(0.5, "m2"), "phi": u.Q(0.3, "rad")}
+
+>>> def x_of(chart):
+...     return cxc.pt_map(at, chart, cxc.cart3d)["x"].ustrip("m")
+
+>>> jax.grad(x_of)(dynamic).Delta
+Q(-0.45135407, 'm')
+```
+
+Both of these apply to a chart **passed as an argument to, or built inside, a traced function**. They do not extend to a chart carried inside a `coordinax.Point`: a point stores its chart in the pytree _structure_, not among its children, so it has the same three leaves either way.
+
+```{code-block} python
+>>> import coordinax as cx
+
+>>> len(jax.tree.leaves(cx.Point(at, static)))
+3
+>>> len(jax.tree.leaves(cx.Point(at, dynamic)))
+3
+```
+
+The cost is caching, not gradients: since the chart is structural data, `jit` over points whose charts hold a dynamic `Delta` retraces on every call — the equality rule below guarantees a cache miss. Pass the chart as its own argument when you want one trace across many `Delta`.
+
+### Charts With Dynamic Parameters Compare Unequal
+
+```{code-block} python
+>>> a = cxc.ProlateSpheroidal3D(Delta=u.Q(2.0, "m"))
+>>> b = cxc.ProlateSpheroidal3D(Delta=u.Q(2.0, "m"))
+>>> a == b
+False
+>>> a == a
+True
+```
+
+Equality is deliberately conservative: two charts with dynamic parameters are equal only when they are the same object, even when numerically identical. Under `jit` those parameters are tracers with no values to compare, so any rule that inspected them would answer differently inside and outside `jit`. Hashing ignores dynamic fields for the same reason, which keeps equal charts hashing equal. Static parameters are compared by value, as before:
+
+```{code-block} python
+>>> s1 = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m"))
+>>> s2 = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m"))
+>>> s1 == s2, hash(s1) == hash(s2)
+(True, True)
+```
+
+### Static Charts Reject Arrays
+
+Registering a chart as static makes the whole instance one static node, so an array held in a field would report zero leaves and be silently baked in as a constant. Static charts refuse this at construction:
+
+```{code-block} python
+>>> cxc.GalileanCT(cxc.ProlateSpheroidal3D(Delta=u.Q(2.0, "m")))
+Traceback (most recent call last):
+    ...
+TypeError: GalileanCT is a static chart, but ['spatial_chart'] hold arrays. ...
+```
+
+The guard is not universal. It walks pytree leaves, so an array inside something itself registered static — `EmbeddedChart.embed_map` — is a single opaque leaf and slips through. Closing that gap means giving `EmbeddedChart` the `ProlateSpheroidal3D` treatment, not a stricter guard: `radius` is a coordinate value that `pt_embed` propagates into output points, so forcing it static would break every embedded coordinate. See `AbstractStaticChart.__post_init__`.
 
 ## Quick Reference
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1079,9 +1079,20 @@ The `coordinax.charts` module provides the chart-facing API for representing poi
 
     Notes:
 
-    - Registered to JAX as static using `jax.tree_util.register_static`.
-    - Equality is based on matching classes, components, coord_dimensions, and all field values (if any).
+    - ``AbstractChart`` itself is not registered static; staticness comes from the branch a chart is on (see below).
+    - Equality is based on matching classes, components, coord_dimensions, and *static* field values; see the conservative equality rule below.
     - Implements a `wadler_lindig` ``__pdoc__()`` method which underpins ``__repr__`` and ``__str__`
+
+!!! info `AbstractStaticChart` and `AbstractParameterizedChart`
+
+    ``AbstractChart`` has exactly two branches, and every concrete chart is on exactly one of them. A concrete chart on neither branch, or on both, raises ``TypeError`` at class creation.
+
+    - ``AbstractStaticChart``: a chart with no parameters. Concrete subclasses are registered with `jax.tree_util.register_static` by ``__init_subclass__``, so staticness is *structural* -- inherited from the branch, not applied per class by a decorator that can be forgotten (``register_static`` is not inherited, so an unregistered chart would silently become one opaque pytree leaf). A static chart has zero pytree leaves and is always hashable. ``__post_init__`` raises ``TypeError`` if any field holds an array, which registration would otherwise hide from JAX.
+    - ``AbstractParameterizedChart``: a chart carrying parameters. It is an `equinox.Module`, and therefore a pytree. Whether an instance has leaves depends on what it is given: a `unxt.StaticQuantity` parameter contributes none (hashable, behaves like a static chart), a `unxt.Quantity` contributes one (differentiable, and `jit` caches on structure rather than value). Differentiability is therefore opt-in per instance -- ``ProlateSpheroidal3D(Delta=...)`` accepts either quantity type.
+
+    Equality and hashing are parameter-aware, and deliberately conservative: two charts holding dynamic (array- or tracer-valued) parameters are equal only when they are the same object, *even when numerically equal*. Hashing ignores dynamic fields, so equal charts still hash equal. A rule that inspected dynamic values would behave differently inside and outside `jax.jit`, where those values are tracers.
+
+    A chart's parameters are reachable by ``jax.grad`` and by the `jit` cache when the chart is passed as an argument to, or built inside, a traced function. A `Point` holds its chart in the pytree structure rather than as a child, so a point's leaf count is unchanged by its chart's parameters; the consequence is that `jit` over points whose charts hold dynamic parameters retraces each call.
 
 !!! info `AbstractFixedComponentsChart`
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1481,7 +1481,7 @@ The `coordinax.charts` module provides the chart-facing API for representing poi
 
     - `ProlateSpheroidal3D` is the final concrete chart type for prolate spheroidal coordinates $(\mu, \nu, \phi)$.
     - Components: `("mu", "nu", "phi")` with dimensions `("area", "area", "angle")`.
-    - Carries a required field `Delta` (focal half-length, a static `Quantity["length"]` with `Delta > 0`).
+    - Carries a required field `Delta` (focal half-length, an `AbstractQuantity["length"]` with `Delta > 0`). A `StaticQuantity` contributes no pytree leaves; a `Quantity` contributes one and is differentiable.
     - Validity constraints: $\mu \ge \Delta^2$, $|\nu| \le \Delta^2$.
     - Unlike many other charts, `ProlateSpheroidal3D` instances are not interchangeable: two instances with different `Delta` are distinct charts.
     - No pre-defined instance (requires `Delta` parameter).

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/charts_product.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/charts_product.py
@@ -143,8 +143,11 @@ def cartesian_product_factors(
         # Exclude abstract charts, product charts (to avoid infinite recursion),
         # and charts with unresolvable TypeVars Late import to avoid circular
         # import (core.py imports from this module)
-        # The product chart is on the static branch, so a parameterized factor
-        # would hide a live array inside a `register_static` node.
+        # The product chart is on the static branch, so a factor carrying array
+        # leaves is rejected at construction. Drawing from the static branch is
+        # the cheap way to guarantee that: staticness implies leaf-freedom. It
+        # is sufficient, not necessary -- a parameterized chart built with
+        # static parameters is leaf-free and legal too, just not drawn here.
         factor_cls = cxc.AbstractStaticFixedComponentsChart
         chart = draw(charts(filter=factor_cls, ndim=factor_dim))  # ty: ignore[missing-argument, unknown-argument]
         factors.append(chart)

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/charts_product.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/charts_product.py
@@ -143,7 +143,10 @@ def cartesian_product_factors(
         # Exclude abstract charts, product charts (to avoid infinite recursion),
         # and charts with unresolvable TypeVars Late import to avoid circular
         # import (core.py imports from this module)
-        chart = draw(charts(filter=cxc.AbstractFixedComponentsChart, ndim=factor_dim))  # ty: ignore[missing-argument, unknown-argument]
+        # The product chart is on the static branch, so a parameterized factor
+        # would hide a live array inside a `register_static` node.
+        factor_cls = cxc.AbstractStaticFixedComponentsChart
+        chart = draw(charts(filter=factor_cls, ndim=factor_dim))  # ty: ignore[missing-argument, unknown-argument]
         factors.append(chart)
 
     return tuple(factors)

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/annotations/strategy.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/annotations/strategy.py
@@ -107,32 +107,37 @@ def strategy_for_annotation(
     except (eqx.EquinoxTracetimeError, ValueError):
         dim = ANY_UNITS
 
-    # Determine the quantity class and whether to use static values
-    # Check if ann is a subclass of StaticQuantity or if it's a parametrized
-    # type with StaticQuantity as the underlying type
-    quantity_cls = u.Q  # Default
-    static_value = False
-    if inspect.isclass(ann):
-        if issubclass(ann, u.StaticQuantity):
-            quantity_cls = u.StaticQuantity
-            static_value = True  # StaticQuantity requires StaticValue
-
-    # For generic types like StaticQuantity[PhysicalType('length')]
-    elif (
-        hasattr(ann, "__origin__")
-        and inspect.isclass(ann.__origin__)
-        and issubclass(ann.__origin__, u.StaticQuantity)
-    ):
-        quantity_cls = u.StaticQuantity
-        static_value = True  # StaticQuantity requires StaticValue
+    # Which concrete quantity type(s) to draw, as (class, static_value) pairs.
+    # `static_value=True` is not optional -- `StaticQuantity` requires a
+    # `StaticValue`. Unwrap parametrized annotations like
+    # `StaticQuantity[PhysicalType('length')]` first.
+    origin = ann.__origin__ if hasattr(ann, "__origin__") else ann
+    if not inspect.isclass(origin):
+        kinds = [(u.Q, False)]
+    elif issubclass(origin, u.StaticQuantity):
+        kinds = [(u.StaticQuantity, True)]  # the annotation pins static
+    elif issubclass(u.StaticQuantity, origin):
+        # An abstract base (e.g. `AbstractQuantity`) admits either kind, so it
+        # must draw both. Defaulting to `u.Q` here silently strips *all* static
+        # coverage from every field annotated with it -- and for a chart field
+        # that is worse than thin coverage: a dynamic value inside a static
+        # chart is a live array that JAX cannot see.
+        kinds = [(u.Q, False), (u.StaticQuantity, True)]
+    else:
+        kinds = [(u.Q, False)]  # the annotation pins dynamic
 
     # Build quantity strategy
-    strategy = ust.quantities(
-        unit=dim,
-        quantity_cls=quantity_cls,
-        dtype=meta.get("dtype", SCALAR_DTYPES),
-        shape=meta.get("shape", xps.array_shapes()),
-        static_value=static_value,
+    strategy = st.one_of(
+        [
+            ust.quantities(
+                unit=dim,
+                quantity_cls=quantity_cls,
+                dtype=meta.get("dtype", SCALAR_DTYPES),
+                shape=meta.get("shape", xps.array_shapes()),
+                static_value=static_value,
+            )
+            for quantity_cls, static_value in kinds
+        ]
     )
 
     # Apply validators if present

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/annotations/strategy.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/utils/_src/annotations/strategy.py
@@ -111,20 +111,18 @@ def strategy_for_annotation(
     # `static_value=True` is not optional -- `StaticQuantity` requires a
     # `StaticValue`. Unwrap parametrized annotations like
     # `StaticQuantity[PhysicalType('length')]` first.
-    origin = ann.__origin__ if hasattr(ann, "__origin__") else ann
-    if not inspect.isclass(origin):
-        kinds = [(u.Q, False)]
-    elif issubclass(origin, u.StaticQuantity):
-        kinds = [(u.StaticQuantity, True)]  # the annotation pins static
-    elif issubclass(u.StaticQuantity, origin):
-        # An abstract base (e.g. `AbstractQuantity`) admits either kind, so it
-        # must draw both. Defaulting to `u.Q` here silently strips *all* static
-        # coverage from every field annotated with it -- and for a chart field
-        # that is worse than thin coverage: a dynamic value inside a static
-        # chart is a live array that JAX cannot see.
-        kinds = [(u.Q, False), (u.StaticQuantity, True)]
-    else:
-        kinds = [(u.Q, False)]  # the annotation pins dynamic
+    origin = getattr(ann, "__origin__", ann)
+    kinds = [(u.Q, False)]  # the annotation pins dynamic, or is not a class
+    if inspect.isclass(origin):
+        if issubclass(origin, u.StaticQuantity):
+            kinds = [(u.StaticQuantity, True)]  # the annotation pins static
+        elif issubclass(u.StaticQuantity, origin):
+            # An abstract base (e.g. `AbstractQuantity`) admits either kind, so
+            # it must draw both. Defaulting to `u.Q` here silently strips *all*
+            # static coverage from every field annotated with it -- and for a
+            # chart field that is worse than thin coverage: a dynamic value
+            # inside a static chart is a live array that JAX cannot see.
+            kinds = [(u.Q, False), (u.StaticQuantity, True)]
 
     # Build quantity strategy
     strategy = st.one_of(

--- a/packages/coordinaxs.hypothesis/tests/unit/charts/test_product_charts.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/charts/test_product_charts.py
@@ -245,8 +245,13 @@ class TestProductChartsEdgeCases:
     @given(
         chart=cxst.charts(
             cxc.CartesianProductChart,
+            # A product chart is on the static branch, so its factors must be
+            # too -- a parameterized factor hides a live array in a
+            # `register_static` node and is rejected at construction.
             factor_charts=st.lists(
-                cxst.charts(exclude=(cxc.Abstract0D,)), min_size=1, max_size=3
+                cxst.charts(filter=cxc.AbstractStaticChart, exclude=(cxc.Abstract0D,)),
+                min_size=1,
+                max_size=3,
             ).map(tuple),
         )
     )

--- a/packages/coordinaxs.hypothesis/tests/unit/charts/test_product_charts.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/charts/test_product_charts.py
@@ -245,9 +245,11 @@ class TestProductChartsEdgeCases:
     @given(
         chart=cxst.charts(
             cxc.CartesianProductChart,
-            # A product chart is on the static branch, so its factors must be
-            # too -- a parameterized factor hides a live array in a
-            # `register_static` node and is rejected at construction.
+            # A product chart is on the static branch, so a factor carrying
+            # array leaves is rejected at construction. Static factors are
+            # leaf-free by construction, which is the cheap way to satisfy that
+            # -- sufficient, not necessary. The boundary itself is pinned by
+            # `test_a_static_delta_factor_is_still_accepted`.
             factor_charts=st.lists(
                 cxst.charts(filter=cxc.AbstractStaticChart, exclude=(cxc.Abstract0D,)),
                 min_size=1,

--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -2,6 +2,8 @@
 
 __all__ = (
     "AbstractChart",
+    "AbstractStaticChart",
+    "AbstractParameterizedChart",
     "AbstractFixedComponentsChart",
     "AbstractDimensionalFlag",
     "DIMENSIONAL_FLAGS",
@@ -31,6 +33,7 @@ from typing import (
     no_type_check,
 )
 
+import equinox as eqx
 import jax.tree_util as jtu
 import plum
 import wadler_lindig as wl
@@ -80,7 +83,6 @@ def _field_values(chart: "AbstractChart[Any, Any, Any]", /) -> tuple[Any, ...]:
     return tuple(getattr(chart, f.name) for f in dataclasses.fields(chart))
 
 
-@jtu.register_static
 class AbstractChart(Generic[MT, Ks, Ds], metaclass=abc.ABCMeta):
     """Abstract base class for charts (coordinate representations)."""
 
@@ -330,6 +332,44 @@ def is_not_abstract_chart_subclass(cls: type[Any], /) -> bool:
 
 
 ##############################################################################
+# The two branches of the chart hierarchy.
+# NOTE: these must be defined after `is_abstract_class`, which
+# `__init_subclass__` calls while the class body is being created.
+
+
+class AbstractStaticChart(AbstractChart[MT, Ks, Ds]):
+    """A chart with no parameters, and therefore no pytree leaves.
+
+    Concrete subclasses are registered as static automatically -- staticness
+    is structural, inherited from this branch, not a decorator that can be
+    forgotten. (`jtu.register_static` is not inherited, so an unregistered
+    chart would silently become a single opaque leaf.)
+    """
+
+    def __init_subclass__(cls, **kw: Any) -> None:
+        super().__init_subclass__(**kw)
+        # Mirror AbstractChart.__init_subclass__'s guard: dataclass(slots=True)
+        # calls this twice and only the second class object is the real one.
+        if (
+            "__dataclass_params__" in cls.__dict__
+            and "__slots__" not in cls.__dict__
+            and cls.__dict__["__dataclass_params__"].slots
+        ):
+            return
+        if not is_abstract_class(cls):
+            jtu.register_static(cls)
+
+
+class AbstractParameterizedChart(AbstractChart[MT, Ks, Ds], eqx.Module):
+    """A chart carrying parameters, and therefore a pytree.
+
+    Whether an instance actually has leaves depends on what it is given: a
+    `unxt.StaticQuantity` parameter contributes none (hashable, behaves like a
+    static chart), a `unxt.Quantity` contributes one (differentiable).
+    """
+
+
+##############################################################################
 # AbstractFixedComponentsChart
 
 
@@ -338,7 +378,7 @@ def _get_tuple(tp: GAT, /) -> GAT:  # noqa: UP047
     return tuple(arg.__args__[0] for arg in get_args(tp))
 
 
-class AbstractFixedComponentsChart(AbstractChart[MT, Ks, Ds]):
+class AbstractFixedComponentsChart(AbstractStaticChart[MT, Ks, Ds]):
     """Abstract base class for charts with fixed components and dimensions."""
 
     _components: Ks

--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -432,9 +432,23 @@ class AbstractStaticChart(AbstractChart[MT, Ks, Ds]):
 
         This runs on every static-chart construction, including hot ones like
         `chart.cartesian`, so it walks the fields directly rather than through
-        the (plum-dispatched, ~100x more expensive) `dataclassish.field_items`,
-        and takes a single `tree_leaves` pass over all of them. Naming the
-        offending fields costs a second, slower pass -- paid only when raising.
+        the (plum-dispatched, ~50x more expensive) `dataclassish.field_items`,
+        and takes a single pass over all of them. Naming the offending fields
+        costs a second, per-field pass -- paid only when raising.
+
+        KNOWN GAP: `jtu.tree_leaves` stops at anything that is not a *registered*
+        pytree, so a live array inside one is a single opaque non-array leaf and
+        slips through. `EmbeddedChart.embed_map` is exactly that -- an
+        `AbstractEmbeddingMap` is explicitly `jtu.register_static` -- so
+        `EmbeddedChart(TwoSphereIn3D(radius=u.Q(...)))` still constructs, still
+        reports zero leaves, and can still leak a tracer. Recursing into
+        dataclass leaves does close it, but forces `radius` to a
+        `StaticQuantity`, and `pt_embed` propagates `radius` straight into the
+        output point -- where a `StaticQuantity` dies under any `jnp` op or
+        trace. The fix is the `ProlateSpheroidal3D` treatment: register
+        `AbstractEmbeddingMap` as a pytree and move `EmbeddedChart` to
+        `AbstractParameterizedChart`, which keeps `radius` a live `Quantity` and
+        makes it differentiable. Tracked as follow-up, not closed here.
         """
         fields = dataclasses.fields(self)  # ty: ignore[invalid-argument-type]
         values = [getattr(self, f.name) for f in fields]

--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -417,6 +417,38 @@ class AbstractStaticChart(AbstractChart[MT, Ks, Ds]):
         if not is_abstract_class(cls):
             jtu.register_static(cls)
 
+    def __post_init__(self) -> None:
+        """Reject an array (or tracer) hiding inside a static chart.
+
+        `jtu.register_static` makes the whole instance one static node, so an
+        array held in a field reports *zero* pytree leaves: `jit` bakes it in as
+        a constant and a tracer walks straight out through the boundary, to die
+        later somewhere unrelated. The annotations that would forbid this
+        (`GalileanCT.spatial_chart`, `CartesianProductChart.factors`) are not
+        enforced at runtime, so enforce it here, at construction.
+
+        Subclasses that define their own `__post_init__` must call
+        `super().__post_init__()`.
+
+        This runs on every static-chart construction, including hot ones like
+        `chart.cartesian`, so it walks the fields directly rather than through
+        the (plum-dispatched, ~100x more expensive) `dataclassish.field_items`,
+        and takes a single `tree_leaves` pass over all of them. Naming the
+        offending fields costs a second, slower pass -- paid only when raising.
+        """
+        fields = dataclasses.fields(self)  # ty: ignore[invalid-argument-type]
+        values = [getattr(self, f.name) for f in fields]
+        if not any(eqx.is_array(x) for x in jtu.tree_leaves(values)):
+            return
+        bad = sorted(f.name for f in fields if _is_dynamic(getattr(self, f.name)))
+        msg = (
+            f"{type(self).__name__} is a static chart, but {bad} hold arrays. "
+            "A chart parameter that can hold an array must live on a "
+            "parameterized chart (`AbstractParameterizedChart`); a static chart "
+            "would hide it from JAX entirely."
+        )
+        raise TypeError(msg)
+
 
 class AbstractParameterizedChart(AbstractChart[MT, Ks, Ds], eqx.Module):
     """A chart carrying parameters, and therefore a pytree.

--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -6,7 +6,6 @@ __all__ = (
     "AbstractParameterizedChart",
     "AbstractFixedComponentsChart",
     "AbstractStaticFixedComponentsChart",
-    "AbstractParameterizedFixedComponentsChart",
     "AbstractDimensionalFlag",
     "DIMENSIONAL_FLAGS",
     "CHART_CLASSES",
@@ -104,13 +103,11 @@ def _check_on_exactly_one_branch(cls: type, /) -> None:
     loudly on its own, so fail here, at class creation.
 
     The branch classes are resolved from module globals because they are defined
-    *below* `AbstractChart` -- while they are themselves being created the names
-    are absent, and abstract classes are exempt anyway.
+    *below* `AbstractChart`. Only they themselves are created before the names
+    exist, and they are `Abstract`-prefixed, so this never runs for them.
     """
-    static = globals().get("AbstractStaticChart")
-    param = globals().get("AbstractParameterizedChart")
-    if static is None or param is None:
-        return
+    static = globals()["AbstractStaticChart"]
+    param = globals()["AbstractParameterizedChart"]
     on_static, on_param = issubclass(cls, static), issubclass(cls, param)
     if on_static == on_param:
         msg = (
@@ -420,12 +417,10 @@ class AbstractStaticChart(AbstractChart[MT, Ks, Ds]):
     def __post_init__(self) -> None:
         """Reject an array (or tracer) hiding inside a static chart.
 
-        `jtu.register_static` makes the whole instance one static node, so an
-        array held in a field reports *zero* pytree leaves: `jit` bakes it in as
-        a constant and a tracer walks straight out through the boundary, to die
-        later somewhere unrelated. The annotations that would forbid this
-        (`GalileanCT.spatial_chart`, `CartesianProductChart.factors`) are not
-        enforced at runtime, so enforce it here, at construction.
+        An array in a field of a static node reports *zero* pytree leaves, so
+        `jit` bakes it in and a tracer walks out through the boundary; the
+        annotations that would forbid it (`GalileanCT.spatial_chart`,
+        `CartesianProductChart.factors`) are not enforced at runtime.
 
         Subclasses that define their own `__post_init__` must call
         `super().__post_init__()`.
@@ -478,9 +473,8 @@ class AbstractFixedComponentsChart(AbstractChart[MT, Ks, Ds]):
     """Abstract base class for charts with fixed components and dimensions.
 
     Having fixed components is orthogonal to the static/parameterized split, so
-    this sits *above* it. Concrete charts inherit a branch-bound subclass:
-    `AbstractStaticFixedComponentsChart` or
-    `AbstractParameterizedFixedComponentsChart`.
+    this sits *above* it: a concrete chart mixes in a branch alongside it, via
+    `AbstractStaticFixedComponentsChart` or directly.
     """
 
     _components: Ks
@@ -532,12 +526,6 @@ class AbstractStaticFixedComponentsChart(
     AbstractFixedComponentsChart[MT, Ks, Ds], AbstractStaticChart[MT, Ks, Ds]
 ):
     """Fixed-components chart with no parameters (the common case)."""
-
-
-class AbstractParameterizedFixedComponentsChart(
-    AbstractFixedComponentsChart[MT, Ks, Ds], AbstractParameterizedChart[MT, Ks, Ds]
-):
-    """Fixed-components chart carrying parameters, e.g. `ProlateSpheroidal3D`."""
 
 
 ##############################################################################

--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -83,6 +83,22 @@ def _field_values(chart: "AbstractChart[Any, Any, Any]", /) -> tuple[Any, ...]:
     return tuple(getattr(chart, f.name) for f in dataclasses.fields(chart))
 
 
+def _is_dynamic(value: Any, /) -> bool:
+    """Whether a field value can hold an array or tracer.
+
+    A `unxt.StaticQuantity` contributes no pytree leaves and is static; a
+    `unxt.Quantity` contributes one array leaf and is dynamic. Values that are
+    not registered pytrees at all (e.g. an `AbstractEmbeddingMap`) are a single
+    *non-array* leaf, and stay static -- they compare and hash as before.
+    """
+    return any(eqx.is_array(x) for x in jtu.tree_leaves(value))
+
+
+def _static_field_values(chart: "AbstractChart[Any, Any, Any]", /) -> tuple[Any, ...]:
+    """Field values that hold no arrays or tracers, in field order."""
+    return tuple(v for v in _field_values(chart) if not _is_dynamic(v))
+
+
 class AbstractChart(Generic[MT, Ks, Ds], metaclass=abc.ABCMeta):
     """Abstract base class for charts (coordinate representations)."""
 
@@ -268,8 +284,11 @@ class AbstractChart(Generic[MT, Ks, Ds], metaclass=abc.ABCMeta):
     def __eq__(self, other: object) -> bool:
         """Check equality between charts.
 
-        Two charts are equal if they are the same type and have equal field
-        values.
+        Two charts are equal only when provably so: the same object, or the
+        same type with no dynamic (traced/array) parameters on either side and
+        equal static fields. This is deliberately conservative -- a rule that
+        inspected dynamic values would behave differently inside and outside
+        `jax.jit`.
 
         Examples
         --------
@@ -285,16 +304,27 @@ class AbstractChart(Generic[MT, Ks, Ds], metaclass=abc.ABCMeta):
         # Make sure the other object is the same type of chart
         if type(self) is not type(other):
             return NotImplemented
-        # Check the components, coord_dimensions, and field values for equality
+        if self is other:
+            return True
+        # Conservative: a dynamic parameter cannot be compared at trace time.
+        # Not provably equal => not equal.
         assert isinstance(other, AbstractChart)  # noqa: S101  # for mypy
+        self_values, other_values = _field_values(self), _field_values(other)
+        if any(map(_is_dynamic, self_values)) or any(map(_is_dynamic, other_values)):
+            return False
+        # Neither side has a dynamic field, so these *are* the static values.
+        # Check the components, coord_dimensions, and static fields for equality
         return (
             self.components == other.components
             and self.coord_dimensions == other.coord_dimensions
-            and (_field_values(self) == _field_values(other))
+            and self_values == other_values
         )
 
     def __hash__(self) -> int:
-        """Hash a chart based on its type and field values.
+        """Hash a chart based on its type and static field values.
+
+        Dynamic (traced/array) parameters are excluded: they are unhashable,
+        and `__eq__` never uses them either, so equal charts still hash equal.
 
         Examples
         --------
@@ -305,7 +335,12 @@ class AbstractChart(Generic[MT, Ks, Ds], metaclass=abc.ABCMeta):
 
         """
         return hash(
-            (type(self), self.components, self.coord_dimensions, _field_values(self))
+            (
+                type(self),
+                self.components,
+                self.coord_dimensions,
+                _static_field_values(self),
+            )
         )
 
 

--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -96,6 +96,31 @@ def _is_dynamic(value: Any, /) -> bool:
     return any(eqx.is_array(x) for x in jtu.tree_leaves(value))
 
 
+def _check_on_exactly_one_branch(cls: type, /) -> None:
+    """Reject a concrete chart that is not on exactly one branch.
+
+    A chart on neither branch is never registered static and silently becomes
+    one opaque pytree leaf; a chart on both is a contradiction. Neither fails
+    loudly on its own, so fail here, at class creation.
+
+    The branch classes are resolved from module globals because they are defined
+    *below* `AbstractChart` -- while they are themselves being created the names
+    are absent, and abstract classes are exempt anyway.
+    """
+    static = globals().get("AbstractStaticChart")
+    param = globals().get("AbstractParameterizedChart")
+    if static is None or param is None:
+        return
+    on_static, on_param = issubclass(cls, static), issubclass(cls, param)
+    if on_static == on_param:
+        msg = (
+            f"{cls.__name__} is on {'both' if on_static else 'neither'} chart "
+            "branch; a concrete chart must subclass exactly one of "
+            "AbstractStaticChart, AbstractParameterizedChart"
+        )
+        raise TypeError(msg)
+
+
 def _static_field_values(chart: "AbstractChart[Any, Any, Any]", /) -> tuple[Any, ...]:
     """Field values that hold no arrays or tracers, in field order."""
     return tuple(v for v in _field_values(chart) if not _is_dynamic(v))
@@ -129,6 +154,7 @@ class AbstractChart(Generic[MT, Ks, Ds], metaclass=abc.ABCMeta):
         CHART_CLASSES.add(cls)
         if not is_abstract_class(cls):
             NON_ABC_CHART_CLASSES.add(cls)
+            _check_on_exactly_one_branch(cls)
 
     # ===============================================================
     # Vector API

--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -348,14 +348,9 @@ class AbstractStaticChart(AbstractChart[MT, Ks, Ds]):
 
     def __init_subclass__(cls, **kw: Any) -> None:
         super().__init_subclass__(**kw)
-        # Mirror AbstractChart.__init_subclass__'s guard: dataclass(slots=True)
-        # calls this twice and only the second class object is the real one.
-        if (
-            "__dataclass_params__" in cls.__dict__
-            and "__slots__" not in cls.__dict__
-            and cls.__dict__["__dataclass_params__"].slots
-        ):
-            return
+        # NOTE: static charts must use `chart_dataclass_decorator` (slots=False).
+        # `dataclass(slots=True)` builds a second class object and would register
+        # both it and the discarded first one.
         if not is_abstract_class(cls):
             jtu.register_static(cls)
 
@@ -415,7 +410,7 @@ class AbstractFixedComponentsChart(AbstractStaticChart[MT, Ks, Ds]):
                 )
                 raise TypeError(msg)
 
-        super().__init_subclass__(**kw)  # AbstractChart has.
+        super().__init_subclass__(**kw)  # AbstractStaticChart registers `cls`.
 
     @property
     def components(self) -> Ks:

--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -90,8 +90,8 @@ def _is_dynamic(value: Any, /) -> bool:
 
     A `unxt.StaticQuantity` contributes no pytree leaves and is static; a
     `unxt.Quantity` contributes one array leaf and is dynamic. Values that are
-    not registered pytrees at all (e.g. an `AbstractEmbeddingMap`) are a single
-    *non-array* leaf, and stay static -- they compare and hash as before.
+    not registered pytrees at all are a single *non-array* leaf, and stay
+    static -- they compare and hash as before.
     """
     return any(eqx.is_array(x) for x in jtu.tree_leaves(value))
 
@@ -436,19 +436,11 @@ class AbstractStaticChart(AbstractChart[MT, Ks, Ds]):
         and takes a single pass over all of them. Naming the offending fields
         costs a second, per-field pass -- paid only when raising.
 
-        KNOWN GAP: `jtu.tree_leaves` stops at anything that is not a *registered*
-        pytree, so a live array inside one is a single opaque non-array leaf and
-        slips through. `EmbeddedChart.embed_map` is exactly that -- an
-        `AbstractEmbeddingMap` is explicitly `jtu.register_static` -- so
-        `EmbeddedChart(TwoSphereIn3D(radius=u.Q(...)))` still constructs, still
-        reports zero leaves, and can still leak a tracer. Recursing into
-        dataclass leaves does close it, but forces `radius` to a
-        `StaticQuantity`, and `pt_embed` propagates `radius` straight into the
-        output point -- where a `StaticQuantity` dies under any `jnp` op or
-        trace. The fix is the `ProlateSpheroidal3D` treatment: register
-        `AbstractEmbeddingMap` as a pytree and move `EmbeddedChart` to
-        `AbstractParameterizedChart`, which keeps `radius` a live `Quantity` and
-        makes it differentiable. Tracked as follow-up, not closed here.
+        `jtu.tree_leaves` stops at anything that is not a *registered* pytree, so
+        a live array hidden inside one would still slip through as a single
+        opaque non-array leaf. `AbstractEmbeddingMap` was the one such holder in
+        the codebase; it is now a pytree, and its chart holder `EmbeddedChart`
+        is on the parameterized branch.
         """
         fields = dataclasses.fields(self)  # ty: ignore[invalid-argument-type]
         values = [getattr(self, f.name) for f in fields]

--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -5,6 +5,8 @@ __all__ = (
     "AbstractStaticChart",
     "AbstractParameterizedChart",
     "AbstractFixedComponentsChart",
+    "AbstractStaticFixedComponentsChart",
+    "AbstractParameterizedFixedComponentsChart",
     "AbstractDimensionalFlag",
     "DIMENSIONAL_FLAGS",
     "CHART_CLASSES",
@@ -408,8 +410,14 @@ def _get_tuple(tp: GAT, /) -> GAT:  # noqa: UP047
     return tuple(arg.__args__[0] for arg in get_args(tp))
 
 
-class AbstractFixedComponentsChart(AbstractStaticChart[MT, Ks, Ds]):
-    """Abstract base class for charts with fixed components and dimensions."""
+class AbstractFixedComponentsChart(AbstractChart[MT, Ks, Ds]):
+    """Abstract base class for charts with fixed components and dimensions.
+
+    Having fixed components is orthogonal to the static/parameterized split, so
+    this sits *above* it. Concrete charts inherit a branch-bound subclass:
+    `AbstractStaticFixedComponentsChart` or
+    `AbstractParameterizedFixedComponentsChart`.
+    """
 
     _components: Ks
     _coord_dimensions: Ds
@@ -445,7 +453,7 @@ class AbstractFixedComponentsChart(AbstractStaticChart[MT, Ks, Ds]):
                 )
                 raise TypeError(msg)
 
-        super().__init_subclass__(**kw)  # AbstractStaticChart registers `cls`.
+        super().__init_subclass__(**kw)  # the branch base registers `cls`.
 
     @property
     def components(self) -> Ks:
@@ -454,6 +462,18 @@ class AbstractFixedComponentsChart(AbstractStaticChart[MT, Ks, Ds]):
     @property
     def coord_dimensions(self) -> Ds:
         return self._coord_dimensions
+
+
+class AbstractStaticFixedComponentsChart(
+    AbstractFixedComponentsChart[MT, Ks, Ds], AbstractStaticChart[MT, Ks, Ds]
+):
+    """Fixed-components chart with no parameters (the common case)."""
+
+
+class AbstractParameterizedFixedComponentsChart(
+    AbstractFixedComponentsChart[MT, Ks, Ds], AbstractParameterizedChart[MT, Ks, Ds]
+):
+    """Fixed-components chart carrying parameters, e.g. `ProlateSpheroidal3D`."""
 
 
 ##############################################################################

--- a/src/coordinax/_src/charts/d0.py
+++ b/src/coordinax/_src/charts/d0.py
@@ -9,8 +9,8 @@ from typing_extensions import TypeVar
 
 from coordinax._src.base import (
     AbstractDimensionalFlag,
-    AbstractFixedComponentsChart,
     AbstractManifold,
+    AbstractStaticFixedComponentsChart,
     chart_dataclass_decorator,
 )
 from coordinax._src.euclidean.atlas import (
@@ -44,7 +44,7 @@ ZeroDDims = tuple[()]
 
 @EuclideanAtlas.register
 @chart_dataclass_decorator
-class Cart0D(AbstractFixedComponentsChart[MT, ZeroDKeys, ZeroDDims], Abstract0D):
+class Cart0D(AbstractStaticFixedComponentsChart[MT, ZeroDKeys, ZeroDDims], Abstract0D):
     """Zero-dimensional Cartesian chart.
 
     This chart has no coordinate components and no coordinate dimensions.

--- a/src/coordinax/_src/charts/d0.py
+++ b/src/coordinax/_src/charts/d0.py
@@ -7,8 +7,6 @@ import dataclasses
 from typing import Any, Final, Literal as L, Self, override  # noqa: N817
 from typing_extensions import TypeVar
 
-import jax.tree_util as jtu
-
 from coordinax._src.base import (
     AbstractDimensionalFlag,
     AbstractFixedComponentsChart,
@@ -45,7 +43,6 @@ ZeroDDims = tuple[()]
 
 
 @EuclideanAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class Cart0D(AbstractFixedComponentsChart[MT, ZeroDKeys, ZeroDDims], Abstract0D):
     """Zero-dimensional Cartesian chart.

--- a/src/coordinax/_src/charts/d1.py
+++ b/src/coordinax/_src/charts/d1.py
@@ -15,8 +15,8 @@ from typing_extensions import TypeVar
 
 from coordinax._src.base import (
     AbstractDimensionalFlag,
-    AbstractFixedComponentsChart,
     AbstractManifold,
+    AbstractStaticFixedComponentsChart,
     chart_dataclass_decorator,
 )
 from coordinax._src.custom_types import Len
@@ -52,7 +52,9 @@ Cart1DDims = tuple[Len]
 
 
 @chart_dataclass_decorator
-class Cart1D(AbstractFixedComponentsChart[MT, Cart1DKeys, Cart1DDims], Abstract1D):
+class Cart1D(
+    AbstractStaticFixedComponentsChart[MT, Cart1DKeys, Cart1DDims], Abstract1D
+):
     r"""One-dimensional Cartesian chart $(x)$.
 
     Components are ordered as ``("x",)`` with dimension ``("length",)``.
@@ -111,7 +113,9 @@ Radial1DDims = tuple[Len]
 
 @EuclideanAtlas.register
 @chart_dataclass_decorator
-class Radial1D(AbstractFixedComponentsChart[MT, RadialKeys, Radial1DDims], Abstract1D):
+class Radial1D(
+    AbstractStaticFixedComponentsChart[MT, RadialKeys, Radial1DDims], Abstract1D
+):
     r"""One-dimensional radial chart $(r)$.
 
     Components are ordered as ``("r",)`` with dimension ``("length",)``.
@@ -168,7 +172,7 @@ TimeDims = tuple[L["time"]]
 
 @EuclideanAtlas.register
 @chart_dataclass_decorator
-class Time1D(AbstractFixedComponentsChart[MT, TimeKeys, TimeDims], Abstract1D):
+class Time1D(AbstractStaticFixedComponentsChart[MT, TimeKeys, TimeDims], Abstract1D):
     """One-dimensional time chart ``(t)``.
 
     Components are ordered as ``("t",)`` with dimension ``("time",)``.

--- a/src/coordinax/_src/charts/d1.py
+++ b/src/coordinax/_src/charts/d1.py
@@ -13,8 +13,6 @@ import dataclasses
 from typing import Any, Final, Literal as L, Self, override  # noqa: N817
 from typing_extensions import TypeVar
 
-import jax.tree_util as jtu
-
 from coordinax._src.base import (
     AbstractDimensionalFlag,
     AbstractFixedComponentsChart,
@@ -53,7 +51,6 @@ Cart1DKeys = tuple[L["x"]]
 Cart1DDims = tuple[Len]
 
 
-@jtu.register_static
 @chart_dataclass_decorator
 class Cart1D(AbstractFixedComponentsChart[MT, Cart1DKeys, Cart1DDims], Abstract1D):
     r"""One-dimensional Cartesian chart $(x)$.
@@ -113,7 +110,6 @@ Radial1DDims = tuple[Len]
 
 
 @EuclideanAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class Radial1D(AbstractFixedComponentsChart[MT, RadialKeys, Radial1DDims], Abstract1D):
     r"""One-dimensional radial chart $(r)$.
@@ -171,7 +167,6 @@ TimeDims = tuple[L["time"]]
 
 
 @EuclideanAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class Time1D(AbstractFixedComponentsChart[MT, TimeKeys, TimeDims], Abstract1D):
     """One-dimensional time chart ``(t)``.

--- a/src/coordinax/_src/charts/d2.py
+++ b/src/coordinax/_src/charts/d2.py
@@ -8,8 +8,6 @@ import dataclasses
 from typing import Any, Final, Literal as L, Self, override  # noqa: N817
 from typing_extensions import TypeVar
 
-import jax.tree_util as jtu
-
 from coordinax._src.base import (
     AbstractDimensionalFlag,
     AbstractFixedComponentsChart,
@@ -50,7 +48,6 @@ Cart2DDims = tuple[Len, Len]
 
 
 @EuclideanAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class Cart2D(AbstractFixedComponentsChart[MT, Cart2DKeys, Cart2DDims], Abstract2D):
     r"""Two-dimensional Cartesian chart $(x, y)$.
@@ -111,7 +108,6 @@ Polar2DDims = tuple[Len, Ang]
 
 
 @EuclideanAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class Polar2D(AbstractFixedComponentsChart[MT, PolarKeys, Polar2DDims], Abstract2D):
     r"""Two-dimensional polar chart $(r, \theta)$.

--- a/src/coordinax/_src/charts/d2.py
+++ b/src/coordinax/_src/charts/d2.py
@@ -10,8 +10,8 @@ from typing_extensions import TypeVar
 
 from coordinax._src.base import (
     AbstractDimensionalFlag,
-    AbstractFixedComponentsChart,
     AbstractManifold,
+    AbstractStaticFixedComponentsChart,
     chart_dataclass_decorator,
 )
 from coordinax._src.custom_types import Ang, Len
@@ -49,7 +49,9 @@ Cart2DDims = tuple[Len, Len]
 
 @EuclideanAtlas.register
 @chart_dataclass_decorator
-class Cart2D(AbstractFixedComponentsChart[MT, Cart2DKeys, Cart2DDims], Abstract2D):
+class Cart2D(
+    AbstractStaticFixedComponentsChart[MT, Cart2DKeys, Cart2DDims], Abstract2D
+):
     r"""Two-dimensional Cartesian chart $(x, y)$.
 
     Components are ordered as ``("x", "y")`` with dimensions ``("length",
@@ -109,7 +111,9 @@ Polar2DDims = tuple[Len, Ang]
 
 @EuclideanAtlas.register
 @chart_dataclass_decorator
-class Polar2D(AbstractFixedComponentsChart[MT, PolarKeys, Polar2DDims], Abstract2D):
+class Polar2D(
+    AbstractStaticFixedComponentsChart[MT, PolarKeys, Polar2DDims], Abstract2D
+):
     r"""Two-dimensional polar chart $(r, \theta)$.
 
     Components are ordered as ``("r", "theta")`` with dimensions ``("length",

--- a/src/coordinax/_src/charts/d3.py
+++ b/src/coordinax/_src/charts/d3.py
@@ -23,7 +23,6 @@ import dataclasses
 from jaxtyping import Real
 from typing import Annotated, Any, Final, Literal as L, Self, override  # noqa: N817
 
-import jax.tree_util as jtu
 from beartype.vale import Is
 
 import quaxed.numpy as jnp
@@ -69,7 +68,6 @@ Cart3DDims = tuple[Len, Len, Len]
 
 
 @EuclideanAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class Cart3D(AbstractFixedComponentsChart[MT, Cart3DKeys, Cart3DDims], Abstract3D):
     r"""Three-dimensional Cartesian chart $(x, y, z)$.
@@ -130,7 +128,6 @@ Cylindrical3DDims = tuple[Len, Ang, Len]
 
 
 @EuclideanAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class Cylindrical3D(
     AbstractFixedComponentsChart[MT, CylindricalKeys, Cylindrical3DDims], Abstract3D
@@ -215,7 +212,6 @@ Spherical3DDims = tuple[Len, Ang, Ang]
 
 
 @EuclideanAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class Spherical3D(AbstractSpherical3D[MT, SphericalKeys, Spherical3DDims]):
     r"""Three-dimensional spherical coordinates $(r, \theta, \phi)$.
@@ -274,7 +270,6 @@ LonLatSpherical3DDims = tuple[Ang, Ang, Len]
 
 
 @EuclideanAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class LonLatSpherical3D(
     AbstractSpherical3D[MT, LonLatSphericalKeys, LonLatSpherical3DDims]
@@ -333,7 +328,6 @@ LonCosLatSpherical3DDims = tuple[Ang, Ang, Len]
 
 
 @EuclideanAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class LonCosLatSpherical3D(
     AbstractSpherical3D[MT, LonCosLatSphericalKeys, LonCosLatSpherical3DDims]
@@ -385,7 +379,6 @@ MathSphericalKeys = tuple[L["r"], L["theta"], L["phi"]]
 
 
 @EuclideanAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class MathSpherical3D(AbstractSpherical3D[MT, MathSphericalKeys, Spherical3DDims]):
     r"""Mathematical-convention spherical coordinates $(r, \theta, \phi)$.
@@ -440,7 +433,6 @@ ProlateSpheroidal3DDims = tuple[L["area"], L["area"], Ang]
 
 
 @EuclideanAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class ProlateSpheroidal3D(
     Abstract3D,

--- a/src/coordinax/_src/charts/d3.py
+++ b/src/coordinax/_src/charts/d3.py
@@ -31,7 +31,8 @@ import unxt as u
 from coordinax._src.base import (
     MT,
     AbstractDimensionalFlag,
-    AbstractParameterizedFixedComponentsChart,
+    AbstractFixedComponentsChart,
+    AbstractParameterizedChart,
     AbstractStaticFixedComponentsChart,
     chart_dataclass_decorator,
 )
@@ -439,9 +440,8 @@ ProlateSpheroidal3DDims = tuple[L["area"], L["area"], Ang]
 @EuclideanAtlas.register
 class ProlateSpheroidal3D(
     Abstract3D,
-    AbstractParameterizedFixedComponentsChart[
-        MT, ProlateSpheroidalKeys, ProlateSpheroidal3DDims
-    ],
+    AbstractFixedComponentsChart[MT, ProlateSpheroidalKeys, ProlateSpheroidal3DDims],
+    AbstractParameterizedChart[MT, ProlateSpheroidalKeys, ProlateSpheroidal3DDims],
 ):
     r"""Prolate spheroidal coordinates $(\mu, \nu, \phi)$ with focal length $\Delta$.
 

--- a/src/coordinax/_src/charts/d3.py
+++ b/src/coordinax/_src/charts/d3.py
@@ -31,7 +31,8 @@ import unxt as u
 from coordinax._src.base import (
     MT,
     AbstractDimensionalFlag,
-    AbstractFixedComponentsChart,
+    AbstractParameterizedFixedComponentsChart,
+    AbstractStaticFixedComponentsChart,
     chart_dataclass_decorator,
 )
 from coordinax._src.charts import checks
@@ -69,7 +70,9 @@ Cart3DDims = tuple[Len, Len, Len]
 
 @EuclideanAtlas.register
 @chart_dataclass_decorator
-class Cart3D(AbstractFixedComponentsChart[MT, Cart3DKeys, Cart3DDims], Abstract3D):
+class Cart3D(
+    AbstractStaticFixedComponentsChart[MT, Cart3DKeys, Cart3DDims], Abstract3D
+):
     r"""Three-dimensional Cartesian chart $(x, y, z)$.
 
     Components are ordered as ``("x", "y", "z")`` with dimensions ``("length",
@@ -130,7 +133,8 @@ Cylindrical3DDims = tuple[Len, Ang, Len]
 @EuclideanAtlas.register
 @chart_dataclass_decorator
 class Cylindrical3D(
-    AbstractFixedComponentsChart[MT, CylindricalKeys, Cylindrical3DDims], Abstract3D
+    AbstractStaticFixedComponentsChart[MT, CylindricalKeys, Cylindrical3DDims],
+    Abstract3D,
 ):
     r"""Three-dimensional cylindrical chart $(\rho, \phi, z)$.
 
@@ -182,7 +186,7 @@ True
 # Spherical
 
 
-class AbstractSpherical3D(AbstractFixedComponentsChart[MT, Ks, Ds], Abstract3D):
+class AbstractSpherical3D(AbstractStaticFixedComponentsChart[MT, Ks, Ds], Abstract3D):
     """Abstract spherical vector representation."""
 
     _: dataclasses.KW_ONLY
@@ -433,10 +437,11 @@ ProlateSpheroidal3DDims = tuple[L["area"], L["area"], Ang]
 
 
 @EuclideanAtlas.register
-@chart_dataclass_decorator
 class ProlateSpheroidal3D(
     Abstract3D,
-    AbstractFixedComponentsChart[MT, ProlateSpheroidalKeys, ProlateSpheroidal3DDims],
+    AbstractParameterizedFixedComponentsChart[
+        MT, ProlateSpheroidalKeys, ProlateSpheroidal3DDims
+    ],
 ):
     r"""Prolate spheroidal coordinates $(\mu, \nu, \phi)$ with focal length $\Delta$.
 
@@ -473,7 +478,7 @@ class ProlateSpheroidal3D(
 
     _: dataclasses.KW_ONLY
     Delta: Annotated[
-        Real[u.quantity.StaticQuantity, ""],  # StaticQuantity["length"]
+        Real[u.quantity.AbstractQuantity, ""],  # Quantity (dynamic) or StaticQuantity
         Is[lambda x: x.value > 0],
     ]
     """Focal length of the coordinate system."""

--- a/src/coordinax/_src/charts/d3.py
+++ b/src/coordinax/_src/charts/d3.py
@@ -454,7 +454,10 @@ class ProlateSpheroidal3D(
     - $\mu \ge \Delta^2$,
     - $\lvert\nu\rvert \le \Delta^2$.
 
-    The parameter $\Delta$ is stored as metadata on the representation.
+    $\Delta$ is a chart *parameter*, and differentiability in it is opt-in per
+    instance: a `unxt.StaticQuantity` contributes no pytree leaves (hashable,
+    behaves like any other chart), a `unxt.Quantity` contributes one and can be
+    differentiated through.
 
     Examples
     --------
@@ -463,6 +466,13 @@ class ProlateSpheroidal3D(
     >>> chart = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2, "kpc"))
     >>> chart.components
     ('mu', 'nu', 'phi')
+
+    >>> import jax
+    >>> len(jax.tree.leaves(chart))
+    0
+
+    >>> len(jax.tree.leaves(cxc.ProlateSpheroidal3D(Delta=u.Q(2.0, "kpc"))))
+    1
 
     >>> chart.coord_dimensions
     ('area', 'area', 'angle')

--- a/src/coordinax/_src/charts/d6.py
+++ b/src/coordinax/_src/charts/d6.py
@@ -9,8 +9,8 @@ from typing import Any, Final, Literal as L, NoReturn, override  # noqa: N817
 
 from coordinax._src.base import (
     AbstractDimensionalFlag,
-    AbstractFixedComponentsChart,
     AbstractManifold,
+    AbstractStaticFixedComponentsChart,
     chart_dataclass_decorator,
 )
 from coordinax._src.custom_types import Len, Spd
@@ -45,7 +45,8 @@ PoincarePolarDims = tuple[
 
 @chart_dataclass_decorator
 class PoincarePolar6D(
-    AbstractFixedComponentsChart[Any, PoincarePolarKeys, PoincarePolarDims], Abstract6D
+    AbstractStaticFixedComponentsChart[Any, PoincarePolarKeys, PoincarePolarDims],
+    Abstract6D,
 ):
     r"""Six-dimensional Poincaré symplectic-polar chart on phase space.
 

--- a/src/coordinax/_src/charts/d6.py
+++ b/src/coordinax/_src/charts/d6.py
@@ -7,8 +7,6 @@ import dataclasses
 
 from typing import Any, Final, Literal as L, NoReturn, override  # noqa: N817
 
-import jax.tree_util as jtu
-
 from coordinax._src.base import (
     AbstractDimensionalFlag,
     AbstractFixedComponentsChart,
@@ -45,7 +43,6 @@ PoincarePolarDims = tuple[
 ]
 
 
-@jtu.register_static
 @chart_dataclass_decorator
 class PoincarePolar6D(
     AbstractFixedComponentsChart[Any, PoincarePolarKeys, PoincarePolarDims], Abstract6D

--- a/src/coordinax/_src/charts/dn.py
+++ b/src/coordinax/_src/charts/dn.py
@@ -10,8 +10,8 @@ from typing_extensions import TypeVar
 
 from coordinax._src.base import (
     AbstractDimensionalFlag,
-    AbstractFixedComponentsChart,
     AbstractManifold,
+    AbstractStaticFixedComponentsChart,
     chart_dataclass_decorator,
 )
 from coordinax._src.custom_types import Len
@@ -49,7 +49,9 @@ CartNDDims = tuple[Len]
 
 @EuclideanAtlas.register
 @chart_dataclass_decorator
-class CartND(AbstractFixedComponentsChart[MT, CartNDKeys, CartNDDims], AbstractND):
+class CartND(
+    AbstractStaticFixedComponentsChart[MT, CartNDKeys, CartNDDims], AbstractND
+):
     r"""N-dimensional Cartesian chart.
 
     Components are ordered as ``("q",)`` with dimension ``("length",)``,

--- a/src/coordinax/_src/charts/dn.py
+++ b/src/coordinax/_src/charts/dn.py
@@ -8,8 +8,6 @@ import dataclasses
 from typing import Any, Final, Literal as L, Self, override  # noqa: N817
 from typing_extensions import TypeVar
 
-import jax.tree_util as jtu
-
 from coordinax._src.base import (
     AbstractDimensionalFlag,
     AbstractFixedComponentsChart,
@@ -50,7 +48,6 @@ CartNDDims = tuple[Len]
 
 
 @EuclideanAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class CartND(AbstractFixedComponentsChart[MT, CartNDKeys, CartNDDims], AbstractND):
     r"""N-dimensional Cartesian chart.

--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -1386,8 +1386,13 @@ def pt_map(
     )
     p = jax.tree.map(lambda x: jnp.asarray(x, dtype=dtype), p)
     cyl3d = Cylindrical3D(M=to_chart.M)
+    # `Delta == Delta` is a *dimensionless Quantity* whenever either side is a
+    # `unxt.Quantity`, and `lax.cond` rejects that as a predicate. Compare in a
+    # common unit and strip to a plain array bool, which works for a static and
+    # a traced `Delta` alike.
+    unit = from_chart.Delta.unit
     return jax.lax.cond(
-        to_chart.Delta == from_chart.Delta,
+        u.ustrip(unit, to_chart.Delta) == u.ustrip(unit, from_chart.Delta),
         lambda p: p,
         lambda p: cxcapi.pt_map(
             cxcapi.pt_map(p, from_M, from_chart, to_M, cyl3d, usys=usys),

--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -1388,14 +1388,9 @@ def pt_map(
     cyl3d = Cylindrical3D(M=to_chart.M)
     # `Delta == Delta` is a *dimensionless Quantity* whenever either side is a
     # `unxt.Quantity`, and `lax.cond` rejects that as a predicate. Compare in a
-    # common unit and strip to a plain array bool, which is a valid predicate for
-    # a static and a traced `Delta` alike. Two caveats, both about the branches
-    # rather than the predicate: `lax.cond` traces *both* even when the predicate
-    # is a concrete `False`, so the two charts must still agree on units or the
-    # branch outputs differ in pytree structure (`Unit("m2")` vs `Unit("cm2")`)
-    # and this raises -- pre-existing, and unchanged by the strip. And a `Delta`
-    # of the wrong dimension now raises `UnitConversionError` here instead of
-    # silently taking the conversion branch.
+    # common unit and strip to a plain array bool, valid for a static and a
+    # traced `Delta` alike. Cost: a `Delta` of the wrong dimension now raises
+    # `UnitConversionError` here, instead of taking the conversion branch.
     unit = from_chart.Delta.unit
     return jax.lax.cond(
         u.ustrip(unit, to_chart.Delta) == u.ustrip(unit, from_chart.Delta),

--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -1388,8 +1388,14 @@ def pt_map(
     cyl3d = Cylindrical3D(M=to_chart.M)
     # `Delta == Delta` is a *dimensionless Quantity* whenever either side is a
     # `unxt.Quantity`, and `lax.cond` rejects that as a predicate. Compare in a
-    # common unit and strip to a plain array bool, which works for a static and
-    # a traced `Delta` alike.
+    # common unit and strip to a plain array bool, which is a valid predicate for
+    # a static and a traced `Delta` alike. Two caveats, both about the branches
+    # rather than the predicate: `lax.cond` traces *both* even when the predicate
+    # is a concrete `False`, so the two charts must still agree on units or the
+    # branch outputs differ in pytree structure (`Unit("m2")` vs `Unit("cm2")`)
+    # and this raises -- pre-existing, and unchanged by the strip. And a `Delta`
+    # of the wrong dimension now raises `UnitConversionError` here instead of
+    # silently taking the conversion branch.
     unit = from_chart.Delta.unit
     return jax.lax.cond(
         u.ustrip(unit, to_chart.Delta) == u.ustrip(unit, from_chart.Delta),

--- a/src/coordinax/_src/embedded/chart.py
+++ b/src/coordinax/_src/embedded/chart.py
@@ -14,16 +14,15 @@ from .manifold import EmbeddedManifold
 from coordinax._src.base import (
     AbstractChart,
     AbstractManifold,
-    AbstractStaticChart,
-    chart_dataclass_decorator,
+    AbstractParameterizedChart,
 )
 from coordinax._src.custom_types import CDict, Ds, Ks, OptUSys
 
 
 @final
-@chart_dataclass_decorator
 class EmbeddedChart(
-    AbstractStaticChart[EmbeddedManifold, Ks, Ds], Generic[IntrinsicT, AmbientT, Ks, Ds]
+    AbstractParameterizedChart[EmbeddedManifold, Ks, Ds],
+    Generic[IntrinsicT, AmbientT, Ks, Ds],
 ):
     r"""Chart for intrinsic coordinates on an embedding manifold.
 
@@ -166,18 +165,6 @@ class EmbeddedChart(
 
         """
         return self.ambient.cartesian
-
-    def __hash__(self) -> int:
-        """Hash based on the class and the embedding map.
-
-        >>> import coordinax.manifolds as cxm
-        >>> import unxt as u
-        >>> chart = cxm.EmbeddedChart(cxm.TwoSphereIn3D(radius=u.StaticQuantity(2.0, "km")))
-        >>> isinstance(hash(chart), int)
-        True
-
-        """  # noqa: E501
-        return hash((self.__class__, self.embed_map))
 
 
 # ===================================================================

--- a/src/coordinax/_src/embedded/chart.py
+++ b/src/coordinax/_src/embedded/chart.py
@@ -5,7 +5,6 @@ __all__ = ("EmbeddedChart",)
 
 from typing import ClassVar, Generic, cast, final, override
 
-import jax
 import plum
 
 import coordinaxs.api.charts as cxcapi
@@ -15,16 +14,16 @@ from .manifold import EmbeddedManifold
 from coordinax._src.base import (
     AbstractChart,
     AbstractManifold,
+    AbstractStaticChart,
     chart_dataclass_decorator,
 )
 from coordinax._src.custom_types import CDict, Ds, Ks, OptUSys
 
 
-@jax.tree_util.register_static
 @final
 @chart_dataclass_decorator
 class EmbeddedChart(
-    AbstractChart[EmbeddedManifold, Ks, Ds], Generic[IntrinsicT, AmbientT, Ks, Ds]
+    AbstractStaticChart[EmbeddedManifold, Ks, Ds], Generic[IntrinsicT, AmbientT, Ks, Ds]
 ):
     r"""Chart for intrinsic coordinates on an embedding manifold.
 

--- a/src/coordinax/_src/embedded/embedmap.py
+++ b/src/coordinax/_src/embedded/embedmap.py
@@ -7,16 +7,16 @@ import dataclasses
 
 from typing import Any, Generic, Protocol, TypeVar, final, runtime_checkable
 
-import jax
+import equinox as eqx
 
 from coordinax._src.base import AbstractChart
+from coordinax._src.base.charts import is_abstract_class
 from coordinax._src.custom_types import CDict, OptUSys
 
 IntrinsicT = TypeVar("IntrinsicT", bound=AbstractChart[Any, Any, Any])
 AmbientT = TypeVar("AmbientT", bound=AbstractChart[Any, Any, Any])
 
 
-@jax.tree_util.register_static
 class AbstractEmbeddingMap(Generic[IntrinsicT, AmbientT], metaclass=abc.ABCMeta):
     r"""Abstract base class representing a smooth embedding.
 
@@ -47,10 +47,28 @@ class AbstractEmbeddingMap(Generic[IntrinsicT, AmbientT], metaclass=abc.ABCMeta)
     higher-level metric machinery (e.g. induced metrics) can be built on top of
     this interface.
 
+    This class is deliberately *not* an `equinox.Module` itself: the two
+    attributes below are an interface for concrete maps to satisfy with either a
+    field (`CustomEmbeddingMap.ambient`) or a property
+    (`TwoSphereIn3D.intrinsic`), and a `Module` base would turn them into
+    required constructor arguments.
+
     """
 
     intrinsic: IntrinsicT
     ambient: AmbientT  # e.g. Cart3D
+
+    def __init_subclass__(cls, **kw: Any) -> None:
+        super().__init_subclass__(**kw)
+        # `eqx.Module` is not inherited from here, so it can be forgotten -- and
+        # a non-pytree map is one opaque leaf that hides its parameters from
+        # JAX, which is the bug this whole arrangement exists to prevent.
+        if not is_abstract_class(cls) and not issubclass(cls, eqx.Module):
+            msg = (
+                f"{cls.__name__} must subclass `equinox.Module`: an embedding map "
+                "holds coordinate values, so it has to be a pytree."
+            )
+            raise TypeError(msg)
 
     @abc.abstractmethod
     def embed(self, point: CDict, /, *, usys: OptUSys = None) -> CDict:
@@ -80,6 +98,13 @@ class AbstractEmbeddingMap(Generic[IntrinsicT, AmbientT], metaclass=abc.ABCMeta)
         """
         raise NotImplementedError  # pragma: no cover
 
+    def __repr__(self) -> str:
+        # The plain dataclass repr, which `eqx.Module` replaces with a
+        # Wadler-Lindig one that elides array values and default fields.
+        fs = dataclasses.fields(self)
+        args = ", ".join(f"{f.name}={getattr(self, f.name)!r}" for f in fs)
+        return f"{type(self).__name__}({args})"
+
 
 @runtime_checkable
 class EPCallable(Protocol):
@@ -89,8 +114,7 @@ class EPCallable(Protocol):
 
 
 @final
-@dataclasses.dataclass(frozen=True, slots=True)
-class CustomEmbeddingMap(AbstractEmbeddingMap[IntrinsicT, AmbientT]):
+class CustomEmbeddingMap(AbstractEmbeddingMap[IntrinsicT, AmbientT], eqx.Module):
     """A concrete embedding map defined by user-provided functions.
 
     This class allows users to define an embedding by providing custom `embed`
@@ -113,8 +137,9 @@ class CustomEmbeddingMap(AbstractEmbeddingMap[IntrinsicT, AmbientT]):
 
     intrinsic: IntrinsicT
     ambient: AmbientT
-    embed_fn: EPCallable
-    project_fn: EPCallable
+    # Plain functions are not JAX types, so they must not be pytree leaves.
+    embed_fn: EPCallable = eqx.field(static=True)
+    project_fn: EPCallable = eqx.field(static=True)
 
     def embed(self, point: CDict, /, *, usys: OptUSys = None) -> CDict:
         return self.embed_fn(point, usys=usys)

--- a/src/coordinax/_src/minkowski/charts.py
+++ b/src/coordinax/_src/minkowski/charts.py
@@ -70,6 +70,7 @@ class MinkowskiCT(
 
     def __post_init__(self) -> None:
         """Validate that M is compatible with this chart."""
+        super().__post_init__()
         if not isinstance(self.M, MinkowskiManifold):
             raise TypeError(_WRONG_M_MSG.format(typename=type(self.M).__name__))
 

--- a/src/coordinax/_src/minkowski/charts.py
+++ b/src/coordinax/_src/minkowski/charts.py
@@ -10,7 +10,10 @@ import plum
 
 from .atlas import MinkowskiAtlas
 from .manifold import MinkowskiManifold
-from coordinax._src.base import AbstractFixedComponentsChart, chart_dataclass_decorator
+from coordinax._src.base import (
+    AbstractStaticFixedComponentsChart,
+    chart_dataclass_decorator,
+)
 from coordinax._src.charts.d4 import Abstract4D
 from coordinax._src.custom_types import Len
 
@@ -25,7 +28,9 @@ _WRONG_M_MSG = "MinkowskiCT chart must belong to a MinkowskiManifold, got {typen
 @chart_dataclass_decorator
 class MinkowskiCT(
     Abstract4D,
-    AbstractFixedComponentsChart[MinkowskiManifold, MinkowskiCTKeys, MinkowskiCTDims],
+    AbstractStaticFixedComponentsChart[
+        MinkowskiManifold, MinkowskiCTKeys, MinkowskiCTDims
+    ],
 ):
     r"""4D Minkowski spacetime chart $(ct, x, y, z)$.
 

--- a/src/coordinax/_src/minkowski/charts.py
+++ b/src/coordinax/_src/minkowski/charts.py
@@ -6,7 +6,6 @@ import dataclasses
 
 from typing import Final, Literal as L, final, override  # noqa: N817
 
-import jax.tree_util as jtu
 import plum
 
 from .atlas import MinkowskiAtlas
@@ -22,7 +21,6 @@ _WRONG_M_MSG = "MinkowskiCT chart must belong to a MinkowskiManifold, got {typen
 
 
 @MinkowskiAtlas.register
-@jtu.register_static
 @final
 @chart_dataclass_decorator
 class MinkowskiCT(

--- a/src/coordinax/_src/product/chart.py
+++ b/src/coordinax/_src/product/chart.py
@@ -326,7 +326,10 @@ class CartesianProductChart(AbstractCartesianProductChart[Ks, Ds]):
     M: ClassVar[AbstractManifold]  # ty: ignore[invalid-attribute-override]
 
     def __post_init__(self) -> None:
-        # Rejects a parameterized factor, which would hide a live array here.
+        # Rejects a factor carrying array or tracer leaves, which would hide a
+        # live array inside this `register_static` node. Note the test is on the
+        # leaves, not on the branch: a parameterized factor built with static
+        # parameters holds none, and is accepted.
         super().__post_init__()
 
         # Validate lengths match

--- a/src/coordinax/_src/product/chart.py
+++ b/src/coordinax/_src/product/chart.py
@@ -326,6 +326,9 @@ class CartesianProductChart(AbstractCartesianProductChart[Ks, Ds]):
     M: ClassVar[AbstractManifold]  # ty: ignore[invalid-attribute-override]
 
     def __post_init__(self) -> None:
+        # Rejects a parameterized factor, which would hide a live array here.
+        super().__post_init__()
+
         # Validate lengths match
         if len(self.factors) != len(self.factor_names):
             msg = (

--- a/src/coordinax/_src/product/chart.py
+++ b/src/coordinax/_src/product/chart.py
@@ -12,7 +12,6 @@ from itertools import chain
 from collections.abc import Mapping
 from typing import Any, ClassVar, TypeVar, cast, final, override
 
-import jax.tree_util as jtu
 import plum
 import wadler_lindig as wl
 
@@ -22,6 +21,7 @@ from coordinax._src.base import (
     MISSING,
     AbstractChart,
     AbstractManifold,
+    AbstractStaticChart,
     chart_dataclass_decorator,
 )
 from coordinax._src.custom_types import CDict, Ds, Ks, OptUSys
@@ -29,7 +29,9 @@ from coordinax._src.custom_types import CDict, Ds, Ks, OptUSys
 V = TypeVar("V")
 
 
-class AbstractCartesianProductChart(AbstractChart[CartesianProductManifold, Ks, Ds]):
+class AbstractCartesianProductChart(
+    AbstractStaticChart[CartesianProductManifold, Ks, Ds]
+):
     """Abstract base class for Cartesian product charts.
 
     A Cartesian product chart is defined by a finite ordered tuple of factor
@@ -282,7 +284,6 @@ class AbstractFlatCartesianProductChart(AbstractCartesianProductChart[Ks, Ds]):
 # =========================================================
 
 
-@jtu.register_static
 @final
 @chart_dataclass_decorator
 class CartesianProductChart(AbstractCartesianProductChart[Ks, Ds]):

--- a/src/coordinax/_src/product/galilean_ct.py
+++ b/src/coordinax/_src/product/galilean_ct.py
@@ -15,8 +15,8 @@ from .chart import AbstractFlatCartesianProductChart
 from .manifold import CartesianProductManifold
 from coordinax._src.base import (
     AbstractChart,
-    AbstractFixedComponentsChart,
     AbstractManifold,
+    AbstractStaticFixedComponentsChart,
     chart_dataclass_decorator,
 )
 from coordinax._src.charts.d1 import time1d
@@ -92,7 +92,9 @@ class GalileanCT(AbstractFlatCartesianProductChart[Ks, Ds]):
 
     """
 
-    spatial_chart: AbstractFixedComponentsChart[Any, Any, Any] = field(default=cart3d)  # pylint: disable=invalid-field-call
+    spatial_chart: AbstractStaticFixedComponentsChart[Any, Any, Any] = field(
+        default=cart3d
+    )  # pylint: disable=invalid-field-call
     """Spatial part of the representation (defaults to `coordinax.charts.cart3d`)."""
 
     _: KW_ONLY

--- a/src/coordinax/_src/product/galilean_ct.py
+++ b/src/coordinax/_src/product/galilean_ct.py
@@ -7,7 +7,6 @@ from dataclasses import KW_ONLY, field, replace
 from jaxtyping import Float
 from typing import Any, ClassVar, Final, cast, final, override
 
-import jax.tree_util as jtu
 import numpy as np
 
 import unxt as u
@@ -34,7 +33,6 @@ r"""The 4-dimensional Galilean spacetime manifold, $\mathbb{R} \times \mathbb{R}
 C_DEFAULT = u.StaticQuantity(np.array(299_792.458), "km/s")
 
 
-@jtu.register_static
 @final
 @chart_dataclass_decorator
 class GalileanCT(AbstractFlatCartesianProductChart[Ks, Ds]):

--- a/src/coordinax/_src/spherical/chart.py
+++ b/src/coordinax/_src/spherical/chart.py
@@ -32,8 +32,8 @@ import unxt as u
 from .atlas import SPHERICAL_ATLAS_DEFAULT_CHARTS, HyperSphericalAtlas
 from .manifold import S1, S2, Sn
 from coordinax._src.base import (
-    AbstractFixedComponentsChart,
     AbstractManifold,
+    AbstractStaticFixedComponentsChart,
     chart_dataclass_decorator,
 )
 from coordinax._src.charts import checks
@@ -51,7 +51,7 @@ _MSG_NO_CART: Final = (
 )
 
 
-class AbstractSphericalHyperSphere(AbstractFixedComponentsChart[MT, Ks, Ds]):
+class AbstractSphericalHyperSphere(AbstractStaticFixedComponentsChart[MT, Ks, Ds]):
     r"""Abstract base class for intrinsic charts on the unit hypersphere.
 
     All hypersphere charts represent coordinates on the surface of a unit

--- a/src/coordinax/_src/spherical/chart.py
+++ b/src/coordinax/_src/spherical/chart.py
@@ -27,8 +27,6 @@ import dataclasses
 from typing import Any, Final, Literal as L, NoReturn, override  # noqa: N817
 from typing_extensions import TypeVar
 
-import jax.tree_util as jtu
-
 import unxt as u
 
 from .atlas import SPHERICAL_ATLAS_DEFAULT_CHARTS, HyperSphericalAtlas
@@ -123,7 +121,6 @@ CircularOneSphereDims = tuple[Ang]
 
 
 @HyperSphericalAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class CircularOneSphere(
     AbstractSphericalOneSphere[MT, CircularOneSphereKeys, CircularOneSphereDims]
@@ -200,7 +197,6 @@ SphericalTwoSphereDims = tuple[Ang, Ang]
 
 
 @HyperSphericalAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class SphericalTwoSphere(
     AbstractSphericalTwoSphere[MT, SphericalTwoSphereKeys, SphericalTwoSphereDims]
@@ -260,7 +256,6 @@ LonLatSphericalTwoSphereDims = tuple[Ang, Ang]
 
 
 @HyperSphericalAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class LonLatSphericalTwoSphere(
     AbstractSphericalTwoSphere[
@@ -311,7 +306,6 @@ LonCosLatSphericalTwoSphereDims = tuple[Ang, Ang]
 
 
 @HyperSphericalAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class LonCosLatSphericalTwoSphere(
     AbstractSphericalTwoSphere[
@@ -356,7 +350,6 @@ MathSphericalTwoSphereKeys = tuple[L["theta"], L["phi"]]
 
 
 @HyperSphericalAtlas.register
-@jtu.register_static
 @chart_dataclass_decorator
 class MathSphericalTwoSphere(
     AbstractSphericalTwoSphere[MT, MathSphericalTwoSphereKeys, SphericalTwoSphereDims]

--- a/src/coordinax/_src/spherical/embed.py
+++ b/src/coordinax/_src/spherical/embed.py
@@ -2,9 +2,9 @@
 
 __all__ = ("TwoSphereIn3D", "embedded_twosphere")
 
-import dataclasses
-
 from typing import Any, final
+
+import equinox as eqx
 
 import unxt as u
 
@@ -21,8 +21,7 @@ from coordinax._src.spherical.manifold import S2
 
 
 @final
-@dataclasses.dataclass(frozen=True, slots=True)
-class TwoSphereIn3D(AbstractEmbeddingMap[IntrinsicT, AmbientT]):
+class TwoSphereIn3D(AbstractEmbeddingMap[IntrinsicT, AmbientT], eqx.Module):
     r"""Embedding of ``cxc.SphericalTwoSphere`` as a 2-sphere in a 3D ambient chart.
 
     This embedding models a 2-sphere of fixed radius $R$ as the hypersurface $r
@@ -88,8 +87,8 @@ class TwoSphereIn3D(AbstractEmbeddingMap[IntrinsicT, AmbientT]):
 
     """
 
-    radius: u.AbstractQuantity | float | int = dataclasses.field()
-    ambient: cxc.AbstractChart[Any, Any, Any] = dataclasses.field(default=cxc.sph3d)
+    radius: u.AbstractQuantity | float | int
+    ambient: cxc.AbstractChart[Any, Any, Any] = cxc.sph3d
 
     @property
     def intrinsic(self) -> cxc.AbstractChart[Any, Any, Any]:

--- a/src/coordinax/charts.py
+++ b/src/coordinax/charts.py
@@ -72,6 +72,8 @@ __all__ = (
     "AbstractStaticChart",
     "AbstractParameterizedChart",
     "AbstractFixedComponentsChart",
+    "AbstractStaticFixedComponentsChart",
+    "AbstractParameterizedFixedComponentsChart",
     "AbstractDimensionalFlag",
     "DIMENSIONAL_FLAGS",
     "CHART_CLASSES",
@@ -166,7 +168,9 @@ with install_import_hook("coordinax.charts"):
         AbstractDimensionalFlag,
         AbstractFixedComponentsChart,
         AbstractParameterizedChart,
+        AbstractParameterizedFixedComponentsChart,
         AbstractStaticChart,
+        AbstractStaticFixedComponentsChart,
     )
     from coordinax._src.charts import (
         Abstract0D,

--- a/src/coordinax/charts.py
+++ b/src/coordinax/charts.py
@@ -64,36 +64,15 @@ We can also compute the Jacobian of the point map:
 
 >>> jac = cxc.jac_pt_map(q, cxc.cart3d, cxc.sph3d)
 
-Every concrete chart is on exactly one of two branches. `AbstractStaticChart`
-charts have no parameters; they are registered static automatically, so they
-have no pytree leaves and are always hashable. `AbstractParameterizedChart`
-charts carry parameters and are `equinox.Module` pytrees.
+Every concrete chart is on exactly one of two branches: `AbstractStaticChart`
+(no parameters -- registered static automatically, so no pytree leaves and
+always hashable) and `AbstractParameterizedChart` (an `equinox.Module` whose
+parameters may be live arrays). A parameterized chart has leaves only if its
+parameters do, so differentiability is opt-in per instance, and equality is
+conservative: charts holding dynamic parameters are equal only when they are
+the same object.
 
->>> isinstance(cxc.cart3d, cxc.AbstractStaticChart)
-True
->>> issubclass(cxc.ProlateSpheroidal3D, cxc.AbstractParameterizedChart)
-True
-
-A parameterized chart has leaves only if its parameters do, so
-differentiability is opt-in per instance:
-
->>> import jax
->>> import unxt as u
-
->>> len(jax.tree.leaves(cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m"))))
-0
->>> len(jax.tree.leaves(cxc.ProlateSpheroidal3D(Delta=u.Q(2.0, "m"))))
-1
-
-Equality is conservative: charts holding dynamic parameters are equal only when
-they are the same object, because under `jit` those parameters are tracers with
-no values to compare.
-
->>> cxc.ProlateSpheroidal3D(Delta=u.Q(2.0, "m")) == cxc.ProlateSpheroidal3D(
-...     Delta=u.Q(2.0, "m"))
-False
-
-See the "Working With Charts" guide for the full story.
+See the "Working With Charts" guide for the full story, with examples.
 
 """
 
@@ -104,7 +83,6 @@ __all__ = (
     "AbstractParameterizedChart",
     "AbstractFixedComponentsChart",
     "AbstractStaticFixedComponentsChart",
-    "AbstractParameterizedFixedComponentsChart",
     "AbstractDimensionalFlag",
     "DIMENSIONAL_FLAGS",
     "CHART_CLASSES",
@@ -199,7 +177,6 @@ with install_import_hook("coordinax.charts"):
         AbstractDimensionalFlag,
         AbstractFixedComponentsChart,
         AbstractParameterizedChart,
-        AbstractParameterizedFixedComponentsChart,
         AbstractStaticChart,
         AbstractStaticFixedComponentsChart,
     )

--- a/src/coordinax/charts.py
+++ b/src/coordinax/charts.py
@@ -69,6 +69,8 @@ We can also compute the Jacobian of the point map:
 __all__ = (
     # ===========================================
     "AbstractChart",
+    "AbstractStaticChart",
+    "AbstractParameterizedChart",
     "AbstractFixedComponentsChart",
     "AbstractDimensionalFlag",
     "DIMENSIONAL_FLAGS",
@@ -163,6 +165,8 @@ with install_import_hook("coordinax.charts"):
         AbstractChart,
         AbstractDimensionalFlag,
         AbstractFixedComponentsChart,
+        AbstractParameterizedChart,
+        AbstractStaticChart,
     )
     from coordinax._src.charts import (
         Abstract0D,

--- a/src/coordinax/charts.py
+++ b/src/coordinax/charts.py
@@ -64,6 +64,37 @@ We can also compute the Jacobian of the point map:
 
 >>> jac = cxc.jac_pt_map(q, cxc.cart3d, cxc.sph3d)
 
+Every concrete chart is on exactly one of two branches. `AbstractStaticChart`
+charts have no parameters; they are registered static automatically, so they
+have no pytree leaves and are always hashable. `AbstractParameterizedChart`
+charts carry parameters and are `equinox.Module` pytrees.
+
+>>> isinstance(cxc.cart3d, cxc.AbstractStaticChart)
+True
+>>> issubclass(cxc.ProlateSpheroidal3D, cxc.AbstractParameterizedChart)
+True
+
+A parameterized chart has leaves only if its parameters do, so
+differentiability is opt-in per instance:
+
+>>> import jax
+>>> import unxt as u
+
+>>> len(jax.tree.leaves(cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m"))))
+0
+>>> len(jax.tree.leaves(cxc.ProlateSpheroidal3D(Delta=u.Q(2.0, "m"))))
+1
+
+Equality is conservative: charts holding dynamic parameters are equal only when
+they are the same object, because under `jit` those parameters are tracers with
+no values to compare.
+
+>>> cxc.ProlateSpheroidal3D(Delta=u.Q(2.0, "m")) == cxc.ProlateSpheroidal3D(
+...     Delta=u.Q(2.0, "m"))
+False
+
+See the "Working With Charts" guide for the full story.
+
 """
 
 __all__ = (

--- a/tests/unit/charts/test_base.py
+++ b/tests/unit/charts/test_base.py
@@ -188,8 +188,6 @@ class TestAbstractDimensionalFlag:
 
         from typing import Literal
 
-        import jax.tree_util as jtu
-
         from coordinax._src.base import (
             MT,
             AbstractFixedComponentsChart,
@@ -205,7 +203,6 @@ class TestAbstractDimensionalFlag:
         # A 2-component chart declared 3D (via Abstract3D) must be rejected.
         with pytest.raises(TypeError, match="declared 3D but has 2 components"):
 
-            @jtu.register_static
             @chart_dataclass_decorator
             class _Bad3D(
                 AbstractFixedComponentsChart[MT, two_keys, two_dims], Abstract3D

--- a/tests/unit/charts/test_base.py
+++ b/tests/unit/charts/test_base.py
@@ -190,7 +190,7 @@ class TestAbstractDimensionalFlag:
 
         from coordinax._src.base import (
             MT,
-            AbstractFixedComponentsChart,
+            AbstractStaticFixedComponentsChart,
             chart_dataclass_decorator,
         )
         from coordinax._src.charts.d3 import Abstract3D, Cart3D
@@ -205,7 +205,7 @@ class TestAbstractDimensionalFlag:
 
             @chart_dataclass_decorator
             class _Bad3D(
-                AbstractFixedComponentsChart[MT, two_keys, two_dims], Abstract3D
+                AbstractStaticFixedComponentsChart[MT, two_keys, two_dims], Abstract3D
             ):
                 _: dataclasses.KW_ONLY
                 M: MT = R3

--- a/tests/unit/charts/test_chart_branches.py
+++ b/tests/unit/charts/test_chart_branches.py
@@ -3,6 +3,8 @@
 import jax
 import pytest
 
+import unxt as u
+
 import coordinax.charts as cxc
 from coordinax._src.base.charts import (
     NON_ABC_CHART_CLASSES,
@@ -37,3 +39,52 @@ def test_static_charts_have_zero_leaves():
     for chart in (cxc.cart3d, cxc.sph3d, cxc.cyl3d):
         assert len(jax.tree.leaves(chart)) == 0
         assert hash(chart) is not None
+
+
+# ---------------------------------------------------------------------------
+# A static chart must not be handed an array-bearing parameter.
+#
+# `jtu.register_static` collapses the whole instance to one static node, so an
+# array in a field reports *zero* leaves. `jit` then bakes it in, and a tracer
+# walks straight out through the boundary -- to die much later, far from here,
+# with `TypeError: unsupported operand type(s) for +: 'Quantity' and 'Quantity'`.
+# The annotations that forbid this are not enforced at runtime, so
+# `AbstractStaticChart.__post_init__` is.
+
+
+def _prolate(delta):
+    return cxc.ProlateSpheroidal3D(Delta=delta)
+
+
+def test_product_chart_rejects_a_parameterized_factor():
+    with pytest.raises(TypeError, match="static chart"):
+        cxc.CartesianProductChart(
+            factors=(_prolate(u.Q(2.0, "m")), cxc.cart3d), factor_names=("a", "b")
+        )
+
+
+def test_galilean_ct_rejects_a_parameterized_spatial_chart():
+    with pytest.raises(TypeError, match="static chart"):
+        cxc.GalileanCT(spatial_chart=_prolate(u.Q(2.0, "m")))
+
+
+def test_a_static_delta_factor_is_still_accepted():
+    """The guard must not cost the legitimate case: a `StaticQuantity` factor."""
+    factor = _prolate(u.StaticQuantity(2.0, "m"))
+    product = cxc.CartesianProductChart(
+        factors=(factor, cxc.cart3d), factor_names=("a", "b")
+    )
+    assert len(jax.tree.leaves(product)) == 0
+    assert hash(product) is not None
+    assert len(jax.tree.leaves(cxc.GalileanCT(spatial_chart=factor))) == 0
+
+
+def test_a_tracer_cannot_escape_through_a_static_chart():
+    """The harm the guard exists to stop, at the point where it happens."""
+
+    @jax.jit
+    def f(delta):
+        return cxc.GalileanCT(spatial_chart=_prolate(delta))
+
+    with pytest.raises(TypeError, match="static chart"):
+        f(u.Q(2.0, "m"))

--- a/tests/unit/charts/test_chart_branches.py
+++ b/tests/unit/charts/test_chart_branches.py
@@ -1,0 +1,42 @@
+"""Every concrete chart sits on exactly one branch, with the right leaf count."""
+
+import jax
+import pytest
+
+import coordinax.charts as cxc
+from coordinax._src.base.charts import (
+    NON_ABC_CHART_CLASSES,
+    AbstractChart,
+    AbstractParameterizedChart,
+    AbstractStaticChart,
+)
+
+
+def test_both_branches_are_abstract_charts():
+    assert issubclass(AbstractStaticChart, AbstractChart)
+    assert issubclass(AbstractParameterizedChart, AbstractChart)
+
+
+def test_abstract_chart_itself_is_not_registered_static():
+    """The root is a plain ABC; staticness lives on the static branch."""
+    import jax.tree_util as jtu
+
+    # A fresh subclass of the ROOT must not be silently static.
+    assert not issubclass(AbstractParameterizedChart, AbstractStaticChart)
+    del jtu
+
+
+@pytest.mark.parametrize("cls", sorted(NON_ABC_CHART_CLASSES, key=lambda c: c.__name__))
+def test_every_concrete_chart_is_on_exactly_one_branch(cls):
+    on_static = issubclass(cls, AbstractStaticChart)
+    on_param = issubclass(cls, AbstractParameterizedChart)
+    assert on_static != on_param, (
+        f"{cls.__name__} is on {'both' if on_static else 'neither'} branch"
+    )
+
+
+def test_static_charts_have_zero_leaves():
+    """The property every existing Point/vmap/tree_map depends on."""
+    for chart in (cxc.cart3d, cxc.sph3d, cxc.cyl3d):
+        assert len(jax.tree.leaves(chart)) == 0
+        assert hash(chart) is not None

--- a/tests/unit/charts/test_chart_branches.py
+++ b/tests/unit/charts/test_chart_branches.py
@@ -17,15 +17,6 @@ def test_both_branches_are_abstract_charts():
     assert issubclass(AbstractParameterizedChart, AbstractChart)
 
 
-def test_abstract_chart_itself_is_not_registered_static():
-    """The root is a plain ABC; staticness lives on the static branch."""
-    import jax.tree_util as jtu
-
-    # A fresh subclass of the ROOT must not be silently static.
-    assert not issubclass(AbstractParameterizedChart, AbstractStaticChart)
-    del jtu
-
-
 @pytest.mark.parametrize("cls", sorted(NON_ABC_CHART_CLASSES, key=lambda c: c.__name__))
 def test_every_concrete_chart_is_on_exactly_one_branch(cls):
     on_static = issubclass(cls, AbstractStaticChart)
@@ -33,6 +24,12 @@ def test_every_concrete_chart_is_on_exactly_one_branch(cls):
     assert on_static != on_param, (
         f"{cls.__name__} is on {'both' if on_static else 'neither'} branch"
     )
+    # Branch membership is not the same as being registered. A static chart that
+    # inherits the branch but never reaches `jtu.register_static` -- e.g. an
+    # intermediate base overriding `__init_subclass__` without calling super() --
+    # silently becomes one opaque leaf. Check the property, not the ancestry.
+    if on_static:
+        assert not jax.tree.leaves(cls.__new__(cls))
 
 
 def test_static_charts_have_zero_leaves():

--- a/tests/unit/charts/test_chart_branches.py
+++ b/tests/unit/charts/test_chart_branches.py
@@ -8,15 +8,9 @@ import unxt as u
 import coordinax.charts as cxc
 from coordinax._src.base.charts import (
     NON_ABC_CHART_CLASSES,
-    AbstractChart,
     AbstractParameterizedChart,
     AbstractStaticChart,
 )
-
-
-def test_both_branches_are_abstract_charts():
-    assert issubclass(AbstractStaticChart, AbstractChart)
-    assert issubclass(AbstractParameterizedChart, AbstractChart)
 
 
 @pytest.mark.parametrize("cls", sorted(NON_ABC_CHART_CLASSES, key=lambda c: c.__name__))
@@ -34,22 +28,9 @@ def test_every_concrete_chart_is_on_exactly_one_branch(cls):
         assert not jax.tree.leaves(cls.__new__(cls))
 
 
-def test_static_charts_have_zero_leaves():
-    """The property every existing Point/vmap/tree_map depends on."""
-    for chart in (cxc.cart3d, cxc.sph3d, cxc.cyl3d):
-        assert len(jax.tree.leaves(chart)) == 0
-        assert hash(chart) is not None
-
-
 # ---------------------------------------------------------------------------
-# A static chart must not be handed an array-bearing parameter.
-#
-# `jtu.register_static` collapses the whole instance to one static node, so an
-# array in a field reports *zero* leaves. `jit` then bakes it in, and a tracer
-# walks straight out through the boundary -- to die much later, far from here,
-# with `TypeError: unsupported operand type(s) for +: 'Quantity' and 'Quantity'`.
-# The annotations that forbid this are not enforced at runtime, so
-# `AbstractStaticChart.__post_init__` is.
+# A static chart must not be handed an array-bearing parameter; see
+# `AbstractStaticChart.__post_init__`.
 
 
 def _prolate(delta):

--- a/tests/unit/charts/test_embedded_chart_parameterized.py
+++ b/tests/unit/charts/test_embedded_chart_parameterized.py
@@ -1,0 +1,113 @@
+"""`EmbeddedChart`'s embedding parameters are live, not hidden from JAX.
+
+`AbstractEmbeddingMap` used to be `jax.tree_util.register_static`, so a
+`TwoSphereIn3D(radius=u.Q(...))` inside an `EmbeddedChart` was a single opaque
+non-array leaf: the chart reported *zero* leaves, `jit` baked the radius in as a
+constant, a tracer walked straight out through the boundary, and `hash` blew up
+on the `ArrayImpl` it could see but JAX could not.
+"""
+
+import jax
+import jax.numpy as jnp
+import jax.tree_util as jtu
+import pytest
+
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+from coordinax._src.base.charts import AbstractParameterizedChart
+from coordinax._src.embedded.embedmap import AbstractEmbeddingMap
+
+P = {"theta": u.Angle(jnp.pi / 3, "rad"), "phi": u.Angle(0.4, "rad")}
+
+
+def test_embedded_chart_is_on_the_parameterized_branch() -> None:
+    assert issubclass(cxm.EmbeddedChart, AbstractParameterizedChart)
+
+
+def test_a_non_pytree_embedding_map_is_rejected() -> None:
+    """Forgetting `equinox.Module` is what reintroduces the opaque leaf."""
+    with pytest.raises(TypeError, match=r"must subclass `equinox\.Module`"):
+
+        class Sneaky(AbstractEmbeddingMap):  # type: ignore[type-arg]
+            intrinsic = cxc.sph2
+            ambient = cxc.sph3d
+
+            def embed(self, point, /, *, usys=None):  # type: ignore[no-untyped-def]
+                return point
+
+            def project(self, point, /, *, usys=None):  # type: ignore[no-untyped-def]
+                return point
+
+
+def test_dynamic_radius_gives_exactly_one_leaf() -> None:
+    em = cxm.TwoSphereIn3D(radius=u.Q(2.0, "km"))
+    assert len(jtu.tree_leaves(em)) == 1
+    assert len(jax.tree.leaves(cxm.EmbeddedChart(em))) == 1
+
+
+def test_dynamic_radius_is_hashable() -> None:
+    """The dynamic parameter is excluded from the hash, not fed to it."""
+    chart = cxm.EmbeddedChart(cxm.TwoSphereIn3D(radius=u.Q(2.0, "km")))
+    assert isinstance(hash(chart), int)
+
+
+def test_static_radius_still_gives_no_leaves() -> None:
+    """A `StaticQuantity` radius keeps the chart leaf-free, as before."""
+    chart = cxm.EmbeddedChart(cxm.TwoSphereIn3D(radius=u.StaticQuantity(2.0, "km")))
+    assert jax.tree.leaves(chart) == []
+    assert isinstance(hash(chart), int)
+
+
+def test_a_tracer_cannot_escape_through_the_embed_map() -> None:
+    """Return the chart *across* the `jit` boundary, not via a side channel.
+
+    A static chart travels in the output treedef, so the radius would come back
+    as the trace's own `DynamicJaxprTracer`. As a pytree leaf it is a real
+    output and comes back concrete.
+    """
+
+    @jax.jit
+    def make(radius_value: jax.Array) -> cxm.EmbeddedChart:
+        return cxm.EmbeddedChart(cxm.TwoSphereIn3D(radius=u.Q(radius_value, "km")))
+
+    chart = make(jnp.asarray(2.0))
+    leaves = jtu.tree_leaves(chart.embed_map.radius)
+    assert leaves, "radius contributed no leaf"
+    assert not any(isinstance(x, jax.core.Tracer) for x in leaves)
+    assert jnp.allclose(u.ustrip("km", chart.embed_map.radius), 2.0)
+
+
+def _z_of_chart(chart: cxm.EmbeddedChart) -> jax.Array:
+    return cxc.pt_map(P, chart, cxc.cart3d)["z"].ustrip("km")
+
+
+def _z_of_radius(radius_value: float) -> jax.Array:
+    em = cxm.TwoSphereIn3D(radius=u.Q(radius_value, "km"))
+    return _z_of_chart(cxm.EmbeddedChart(em))
+
+
+def test_grad_wrt_radius_matches_finite_differences() -> None:
+    """Differentiate w.r.t. the *chart*, which only works if radius is a leaf."""
+    chart = cxm.EmbeddedChart(cxm.TwoSphereIn3D(radius=u.Q(2.0, "km")))
+    analytic = float(jax.grad(_z_of_chart)(chart).embed_map.radius.ustrip("km"))
+    h = 1e-4
+    numeric = (_z_of_radius(2.0 + h) - _z_of_radius(2.0 - h)) / (2 * h)
+    assert jnp.allclose(analytic, numeric, rtol=1e-4), (analytic, numeric)
+
+
+def test_jit_retraces_once_across_radii() -> None:
+    """The chart crosses the boundary, so the radius must not be part of the key."""
+    traces = []
+
+    @jax.jit
+    def f(chart: cxm.EmbeddedChart) -> jax.Array:
+        traces.append(1)
+        return _z_of_chart(chart)
+
+    f(cxm.EmbeddedChart(cxm.TwoSphereIn3D(radius=u.Q(2.0, "km"))))
+    f(cxm.EmbeddedChart(cxm.TwoSphereIn3D(radius=u.Q(3.0, "km"))))
+    assert len(traces) == 1, (
+        f"retraced {len(traces)} times; radius is being treated as static"
+    )

--- a/tests/unit/charts/test_jit_parameterized_paths.py
+++ b/tests/unit/charts/test_jit_parameterized_paths.py
@@ -14,7 +14,6 @@ the chart's validity domain (``mu >= Delta**2``, ``|nu| <= Delta**2``), so a
 
 import jax
 import jax.numpy as jnp
-import pytest
 
 import unxt as u
 
@@ -36,11 +35,6 @@ def _chart(delta_value):
 
 def _tangent(chart):
     return cx.Tangent(data=VEL, chart=chart, basis=cxr.coord_basis, semantic=cxr.vel)
-
-
-def test_the_chart_under_test_is_actually_parameterized():
-    """Guard the guard: these tests are worthless if `Delta` is static."""
-    assert len(jax.tree.leaves(_chart(DELTA))) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -263,15 +257,16 @@ def test_jit_coordinate_bundle_keyed_by_parameterized_chart():
 # The payoff: none of the above may cost differentiability in `Delta`.
 
 
-# `AT` is in-domain for Delta**2 in [|nu|, mu] == [2, 6] m2, i.e. Delta in
-# [1.42, 2.44] m. Outside that the map is genuinely `nan` and says nothing.
-@pytest.mark.parametrize("d", [1.5, 2.0, 2.4])
-def test_grad_through_delta_is_finite_and_nonzero(d):
-    """If any branch above went static in `Delta`, the gradient would vanish."""
+def test_grad_through_delta_is_finite_and_nonzero():
+    """If any branch above went static in `Delta`, the gradient would vanish.
+
+    `AT` is in-domain for Delta**2 in [|nu|, mu] == [2, 6] m2; outside that the
+    map is genuinely `nan` and says nothing.
+    """
 
     def f(delta):
         return cxc.pt_map(AT, _chart(delta), cxc.cart3d)["x"].ustrip("m")
 
-    g = jax.grad(f)(d)
+    g = jax.grad(f)(DELTA)
     assert jnp.isfinite(g)
     assert g != 0.0

--- a/tests/unit/charts/test_jit_parameterized_paths.py
+++ b/tests/unit/charts/test_jit_parameterized_paths.py
@@ -1,0 +1,277 @@
+"""Jit a parameterized-chart transition through each path a `chart ==` branch guards.
+
+Task 2 made `AbstractChart.__eq__`/`__hash__` tracer-safe, which fixes those
+branches indirectly. These tests are the direct evidence: without them, a site
+that compares charts by identity, set membership, dict lookup -- or that
+compares chart *parameters* and feeds the answer to something that only accepts
+a plain array -- would still fail under `jit` and nothing would catch it.
+
+Every test jits a transition through a `ProlateSpheroidal3D` whose `Delta` is a
+traced `unxt.Quantity`, and asserts a finite answer. The point is chosen inside
+the chart's validity domain (``mu >= Delta**2``, ``|nu| <= Delta**2``), so a
+`nan` is a real failure and not a domain violation.
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import unxt as u
+
+import coordinax as cx
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+import coordinax.representations as cxr
+
+DELTA = 2.0  # metres; Delta**2 == 4 m2
+AT = {"mu": u.Q(6.0, "m2"), "nu": u.Q(2.0, "m2"), "phi": u.Angle(0.3, "rad")}
+VEL = {"mu": u.Q(1.0, "m2/s"), "nu": u.Q(0.5, "m2/s"), "phi": u.Q(0.2, "rad/s")}
+PHYS_VEL = {"mu": u.Q(1.0, "m/s"), "nu": u.Q(0.5, "m/s"), "phi": u.Q(0.2, "m/s")}
+
+
+def _chart(delta_value):
+    """A prolate chart whose `Delta` is dynamic -- one pytree leaf."""
+    return cxc.ProlateSpheroidal3D(Delta=u.Q(delta_value, "m"))
+
+
+def _tangent(chart):
+    return cx.Tangent(data=VEL, chart=chart, basis=cxr.coord_basis, semantic=cxr.vel)
+
+
+def test_the_chart_under_test_is_actually_parameterized():
+    """Guard the guard: these tests are worthless if `Delta` is static."""
+    assert len(jax.tree.leaves(_chart(DELTA))) == 1
+
+
+# ---------------------------------------------------------------------------
+# charts/register_ptmap.py
+
+
+def test_jit_pt_map_out_of_parameterized_chart():
+    """Exercises the generic `if from_chart == to_chart` in `register_ptmap`."""
+
+    @jax.jit
+    def f(d):
+        return cxc.pt_map(AT, _chart(d), cxc.cart3d)["x"].ustrip("m")
+
+    assert jnp.isfinite(f(DELTA))
+
+
+def test_jit_pt_map_identity_same_parameterized_chart():
+    """Exercises the prolate->prolate rule's same-`Delta` short-circuit.
+
+    The rule branches on ``to_chart.Delta == from_chart.Delta`` under
+    `jax.lax.cond`. With a dynamic `Delta` that comparison is a dimensionless
+    *Quantity*, which `lax.cond` rejects outright as a predicate.
+    """
+
+    @jax.jit
+    def f(d):
+        c = _chart(d)
+        return cxc.pt_map(AT, c, c)["mu"].ustrip("m2")
+
+    assert jnp.allclose(f(DELTA), 6.0)
+
+
+def test_jit_pt_map_between_two_focal_lengths():
+    """Same rule, the other `lax.cond` branch: via cylindrical, `Delta` changes."""
+
+    @jax.jit
+    def f(d_from, d_to):
+        out = cxc.pt_map(AT, _chart(d_from), _chart(d_to))
+        return jnp.asarray([v.value for v in out.values()])
+
+    assert jnp.all(jnp.isfinite(f(DELTA, 3.0)))
+
+
+def test_jit_jac_pt_map_out_of_parameterized_chart():
+    """The Jacobian route every tangent path is built on."""
+
+    @jax.jit
+    def f(d):
+        return cxc.jac_pt_map(AT, _chart(d), cxc.cart3d).value
+
+    assert jnp.all(jnp.isfinite(f(DELTA)))
+
+
+# ---------------------------------------------------------------------------
+# _src/euclidean/scale_factors.py
+
+
+def test_jit_scale_factors_on_parameterized_chart():
+    """Exercises `scale_factors`' `chart == cart_chart` short-circuit."""
+
+    @jax.jit
+    def f(d):
+        return cxm.scale_factors(cxm.FlatMetric(3), _chart(d), at=AT).value
+
+    assert jnp.all(jnp.isfinite(f(DELTA)))
+
+
+# ---------------------------------------------------------------------------
+# representations/_src/tangent_map.py -- all three `from_chart == to_chart`
+
+
+def test_jit_tangent_map_coordinate_basis():
+    """`tangent_map(..., coord_basis, ...)`, the first branch."""
+
+    @jax.jit
+    def f(d):
+        out = cxr.tangent_map(VEL, _chart(d), cxr.coord_basis, cxc.cart3d, at=AT)
+        return jnp.asarray([v.value for v in out.values()])
+
+    assert jnp.all(jnp.isfinite(f(DELTA)))
+
+
+def test_jit_tangent_map_physical_basis():
+    """`tangent_map(..., phys_basis, ...)`, the second branch."""
+
+    @jax.jit
+    def f(d):
+        out = cxr.tangent_map(PHYS_VEL, _chart(d), cxr.phys_basis, cxc.cart3d, at=AT)
+        return jnp.asarray([v.value for v in out.values()])
+
+    assert jnp.all(jnp.isfinite(f(DELTA)))
+
+
+def test_jit_tangent_map_between_representations():
+    """The rep-to-rep overload, whose branch picks the base point's chart."""
+
+    @jax.jit
+    def f(d):
+        out = cxr.tangent_map(
+            VEL, _chart(d), cxr.coord_vel, cxc.cart3d, cxr.phys_vel, at=AT
+        )
+        return jnp.asarray([v.value for v in out.values()])
+
+    assert jnp.all(jnp.isfinite(f(DELTA)))
+
+
+# ---------------------------------------------------------------------------
+# vectors/_src/register_cx.py -- `from_chart != vec.chart`
+
+
+def test_jit_cconvert_point_out_of_parameterized_chart():
+    """Exercises `cconvert(Point, chart)`'s source-chart check."""
+
+    @jax.jit
+    def f(d):
+        return cxr.cconvert(cx.Point(AT, chart=_chart(d)), cxc.cart3d)["x"].value
+
+    assert jnp.isfinite(f(DELTA))
+
+
+def test_jit_cconvert_tangent_out_of_parameterized_chart():
+    """Exercises the `at`-chart check on the `Tangent` overload."""
+
+    @jax.jit
+    def f(d):
+        c = _chart(d)
+        out = cxr.cconvert(_tangent(c), cxc.cart3d, at=cx.Point(AT, chart=c))
+        return out["x"].value
+
+    assert jnp.isfinite(f(DELTA))
+
+
+# ---------------------------------------------------------------------------
+# vectors/_src/{base,register_quax,register_compare,register_separation}.py
+# and representations/_src/core.py
+
+
+def test_jit_tangent_addition_in_parameterized_chart():
+    """`+` routes through `register_quax`'s `ambient_chart == original_chart`."""
+
+    @jax.jit
+    def f(d):
+        c = _chart(d)
+        return (_tangent(c) + _tangent(c))["mu"].value
+
+    assert jnp.isfinite(f(DELTA))
+
+
+def test_jit_point_difference_in_parameterized_chart():
+    """`-` routes through `representations/core.py`'s ambient-Cartesian branch."""
+
+    @jax.jit
+    def f(d):
+        c = _chart(d)
+        return (cx.Point(AT, chart=c) - cx.Point(AT, chart=c))["mu"].value
+
+    assert jnp.isfinite(f(DELTA))
+
+
+def test_jit_vector_equality_in_parameterized_chart():
+    """`AbstractVector.__eq__` compares charts before comparing data."""
+
+    @jax.jit
+    def f(d):
+        c = _chart(d)
+        return jnp.asarray(cx.Point(AT, chart=c) == cx.Point(AT, chart=c))
+
+    assert f(DELTA)
+
+
+def test_jit_equivalent_across_a_parameterized_chart():
+    """`equivalent` compares charts to decide whether to convert first."""
+
+    @jax.jit
+    def f(d):
+        c = _chart(d)
+        p = cx.Point(AT, chart=c)
+        return jnp.asarray(cx.equivalent(p, cxr.cconvert(p, cxc.cart3d)))
+
+    assert f(DELTA)
+
+
+def test_jit_separation_in_parameterized_chart():
+    """`separation` compares the two operands' charts."""
+
+    @jax.jit
+    def f(d):
+        c = _chart(d)
+        return cx.separation(cx.Point(AT, chart=c), cx.Point(AT, chart=c)).value
+
+    assert jnp.isfinite(f(DELTA))
+
+
+# ---------------------------------------------------------------------------
+# vectors/_src/bundle.py -- a dict *keyed by chart*, so `__hash__` must hold up
+
+
+def test_jit_coordinate_bundle_keyed_by_parameterized_chart():
+    """`Coordinate.cconvert` caches base points in a dict *keyed by chart*.
+
+    This is the one path that needs both halves of Task 2 at once. The base
+    point and the fibre are given two *distinct* prolate instances, so
+    ``vec.chart == self.point.chart`` compares two same-type charts that both
+    carry a traced `Delta` -- the only shape in which `__eq__` reaches its
+    dynamic-field guard -- and the miss then hashes the chart to fill the cache.
+    """
+
+    @jax.jit
+    def f(d):
+        point_chart, fibre_chart = _chart(d), _chart(d)
+        bundle = cx.Coordinate(
+            point=cx.Point(AT, chart=point_chart), velocity=_tangent(fibre_chart)
+        )
+        return bundle.cconvert(cxc.cart3d)["velocity"]["x"].value
+
+    assert jnp.isfinite(f(DELTA))
+
+
+# ---------------------------------------------------------------------------
+# The payoff: none of the above may cost differentiability in `Delta`.
+
+
+# `AT` is in-domain for Delta**2 in [|nu|, mu] == [2, 6] m2, i.e. Delta in
+# [1.42, 2.44] m. Outside that the map is genuinely `nan` and says nothing.
+@pytest.mark.parametrize("d", [1.5, 2.0, 2.4])
+def test_grad_through_delta_is_finite_and_nonzero(d):
+    """If any branch above went static in `Delta`, the gradient would vanish."""
+
+    def f(delta):
+        return cxc.pt_map(AT, _chart(delta), cxc.cart3d)["x"].ustrip("m")
+
+    g = jax.grad(f)(d)
+    assert jnp.isfinite(g)
+    assert g != 0.0

--- a/tests/unit/charts/test_parameterized.py
+++ b/tests/unit/charts/test_parameterized.py
@@ -1,0 +1,95 @@
+"""Equality, hashing, and leaf semantics for parameterized charts."""
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+from coordinax._src.base.charts import AbstractParameterizedChart
+
+
+class AbstractScaled1D(AbstractParameterizedChart):
+    """A minimal parameterized chart -- concrete, despite the name.
+
+    Defined here so the test does not depend on which production chart happens
+    to be parameterized. The ``Abstract`` prefix is load-bearing: both
+    `coordinax._src.base.charts.is_abstract_class` and the hypothesis package's
+    `get_all_subclasses` treat that prefix as "not a real chart", which is the
+    only way to keep a throwaway test chart out of the global chart registries
+    and the (`functools.cache`-d) hypothesis chart strategies.
+    """
+
+    scale: Any  # Quantity (dynamic) or StaticQuantity (static)
+
+    @property
+    def components(self) -> tuple[str, ...]:
+        return ("x",)
+
+    @property
+    def coord_dimensions(self) -> tuple[Any, ...]:
+        return (u.dimension("length"),)
+
+    @property
+    def cartesian(self) -> "AbstractScaled1D":
+        return self
+
+
+def test_static_parameter_gives_no_leaves_and_hashes() -> None:
+    c = AbstractScaled1D(scale=u.StaticQuantity(2.0, "m"))
+    assert len(jax.tree.leaves(c)) == 0
+    assert hash(c) is not None
+    assert c == AbstractScaled1D(scale=u.StaticQuantity(2.0, "m"))
+    assert c != AbstractScaled1D(scale=u.StaticQuantity(3.0, "m"))
+
+
+def test_dynamic_parameter_gives_a_leaf() -> None:
+    c = AbstractScaled1D(scale=u.Quantity(2.0, "m"))
+    assert len(jax.tree.leaves(c)) == 1
+
+
+def test_dynamic_charts_compare_conservatively() -> None:
+    c = AbstractScaled1D(scale=u.Quantity(2.0, "m"))
+    assert c == c  # same object  # noqa: PLR0124
+    assert c != AbstractScaled1D(scale=u.Quantity(2.0, "m"))  # not provably equal
+    assert c != AbstractScaled1D(scale=u.Quantity(3.0, "m"))
+
+
+def test_dynamic_chart_is_hashable_on_static_identity() -> None:
+    """Hashing must not touch dynamic fields, or dict-keying breaks."""
+    c = AbstractScaled1D(scale=u.Quantity(2.0, "m"))
+    assert hash(c) is not None
+    assert hash(c) == hash(AbstractScaled1D(scale=u.Quantity(99.0, "m")))
+
+
+def test_equality_is_safe_under_jit() -> None:
+    """The case that raises `TracerBoolConversionError` today."""
+
+    @jax.jit
+    def f(scale_value: Any) -> Any:
+        a = AbstractScaled1D(scale=u.Quantity(scale_value, "m"))
+        b = AbstractScaled1D(scale=u.Quantity(scale_value, "m"))
+        return jnp.asarray(a == b)  # must not raise
+
+    assert f(2.0) is not None
+
+
+def test_opaque_non_pytree_field_stays_static() -> None:
+    """A field that is not a registered pytree is one *non-array* leaf.
+
+    It must not be treated as a dynamic parameter, or every static chart
+    holding such a field (e.g. `EmbeddedChart`) would silently stop comparing
+    equal to its own twin.
+    """
+
+    def make() -> cxm.EmbeddedChart:
+        return cxm.EmbeddedChart(cxm.TwoSphereIn3D(radius=u.StaticQuantity(2.0, "km")))
+
+    assert make() == make()
+
+
+def test_cross_type_comparison_still_works() -> None:
+    assert AbstractScaled1D(scale=u.Quantity(1.0, "m")) != cxc.cart3d

--- a/tests/unit/charts/test_parameterized.py
+++ b/tests/unit/charts/test_parameterized.py
@@ -80,9 +80,9 @@ def test_equality_is_safe_under_jit() -> None:
 def test_opaque_non_pytree_field_stays_static() -> None:
     """A field that is not a registered pytree is one *non-array* leaf.
 
-    It must not be treated as a dynamic parameter, or every static chart
-    holding such a field (e.g. `EmbeddedChart`) would silently stop comparing
-    equal to its own twin.
+    It must not be treated as a dynamic parameter, or a chart holding such a
+    field would silently stop comparing equal to its own twin. Here the field
+    is a `StaticQuantity`-radius embedding map: a pytree, but a leafless one.
     """
 
     def make() -> cxm.EmbeddedChart:

--- a/tests/unit/charts/test_prolate_differentiable.py
+++ b/tests/unit/charts/test_prolate_differentiable.py
@@ -6,16 +6,11 @@ import jax.numpy as jnp
 import unxt as u
 
 import coordinax.charts as cxc
-from coordinax._src.base.charts import AbstractParameterizedChart
 
 # The chart's validity domain is ``mu >= Delta**2`` and ``|nu| <= Delta**2``.
 # ``mu`` must clear the largest ``Delta`` used below (3 m), or the transition
 # takes the square root of a negative number and every value is NaN.
 Q_IN = {"mu": u.Q(12.0, "m2"), "nu": u.Q(0.5, "m2"), "phi": u.Q(0.3, "rad")}
-
-
-def test_prolate_is_on_the_parameterized_branch():
-    assert issubclass(cxc.ProlateSpheroidal3D, AbstractParameterizedChart)
 
 
 def test_prolate_still_has_fixed_components():

--- a/tests/unit/charts/test_prolate_differentiable.py
+++ b/tests/unit/charts/test_prolate_differentiable.py
@@ -18,11 +18,24 @@ def test_prolate_is_on_the_parameterized_branch():
     assert issubclass(cxc.ProlateSpheroidal3D, AbstractParameterizedChart)
 
 
+def test_prolate_still_has_fixed_components():
+    """The invariant the shared-base split exists to protect.
+
+    `AbstractFixedComponentsChart` is used as a *filter* by `guess_chart_cls`,
+    `GalileanCT`, and the hypothesis strategies -- if prolate ever fell out of
+    it, every one of them would silently skip it and nothing would go red.
+    """
+    assert issubclass(cxc.ProlateSpheroidal3D, cxc.AbstractFixedComponentsChart)
+
+
 def test_static_delta_is_unchanged():
     """Every existing call site passes StaticQuantity and must be unaffected."""
     c = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m"))
+    twin = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m"))
     assert len(jax.tree.leaves(c)) == 0
-    assert hash(c) is not None
+    assert c == twin  # by value, not identity -- dict/cache keys depend on it
+    assert hash(c) == hash(twin)
+    assert c != cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(3.0, "m"))
 
 
 def test_dynamic_delta_gives_a_leaf():
@@ -73,3 +86,15 @@ def test_jit_retraces_once_across_delta_values():
     assert len(traces) == 1, (
         f"retraced {len(traces)} times; Delta is being treated as static"
     )
+
+    # A static Delta still keys the cache by value: equal charts share a trace.
+    static_traces = []
+
+    @jax.jit
+    def g(chart):
+        static_traces.append(1)
+        return cxc.pt_map(Q_IN, chart, cxc.cart3d)["x"].ustrip("m")
+
+    g(cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m")))
+    g(cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m")))
+    assert len(static_traces) == 1

--- a/tests/unit/charts/test_prolate_differentiable.py
+++ b/tests/unit/charts/test_prolate_differentiable.py
@@ -1,0 +1,75 @@
+"""Delta is differentiable when passed as a dynamic Quantity."""
+
+import jax
+import jax.numpy as jnp
+
+import unxt as u
+
+import coordinax.charts as cxc
+from coordinax._src.base.charts import AbstractParameterizedChart
+
+# The chart's validity domain is ``mu >= Delta**2`` and ``|nu| <= Delta**2``.
+# ``mu`` must clear the largest ``Delta`` used below (3 m), or the transition
+# takes the square root of a negative number and every value is NaN.
+Q_IN = {"mu": u.Q(12.0, "m2"), "nu": u.Q(0.5, "m2"), "phi": u.Q(0.3, "rad")}
+
+
+def test_prolate_is_on_the_parameterized_branch():
+    assert issubclass(cxc.ProlateSpheroidal3D, AbstractParameterizedChart)
+
+
+def test_static_delta_is_unchanged():
+    """Every existing call site passes StaticQuantity and must be unaffected."""
+    c = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m"))
+    assert len(jax.tree.leaves(c)) == 0
+    assert hash(c) is not None
+
+
+def test_dynamic_delta_gives_a_leaf():
+    c = cxc.ProlateSpheroidal3D(Delta=u.Q(2.0, "m"))
+    assert len(jax.tree.leaves(c)) == 1
+
+
+def _x_of_delta(delta_value):
+    chart = cxc.ProlateSpheroidal3D(Delta=u.Q(delta_value, "m"))
+    return cxc.pt_map(Q_IN, chart, cxc.cart3d)["x"].ustrip("m")
+
+
+def _x_of_chart(chart):
+    return cxc.pt_map(Q_IN, chart, cxc.cart3d)["x"].ustrip("m")
+
+
+def test_grad_wrt_delta_matches_finite_differences():
+    """Differentiate w.r.t. the *chart*, which only works if Delta is a leaf.
+
+    Differentiating `_x_of_delta` instead would pass even on the static branch:
+    the chart is built inside the traced function there, so the tracer flows
+    through the arithmetic regardless of how the chart flattens.
+    """
+    d0 = 2.0
+    chart = cxc.ProlateSpheroidal3D(Delta=u.Q(d0, "m"))
+    analytic = float(jax.grad(_x_of_chart)(chart).Delta.ustrip("m"))
+    h = 1e-4
+    numeric = (_x_of_delta(d0 + h) - _x_of_delta(d0 - h)) / (2 * h)
+    assert jnp.allclose(analytic, numeric, rtol=1e-4), (analytic, numeric)
+
+
+def test_jit_retraces_once_across_delta_values():
+    """The chart is passed *in*, so Delta must be a leaf, not part of the key.
+
+    Building the chart inside the traced function would pass either way -- the
+    tracer would simply be swallowed by a static chart -- so the chart has to
+    cross the `jit` boundary for this to mean anything.
+    """
+    traces = []
+
+    @jax.jit
+    def f(chart):
+        traces.append(1)
+        return cxc.pt_map(Q_IN, chart, cxc.cart3d)["x"].ustrip("m")
+
+    f(cxc.ProlateSpheroidal3D(Delta=u.Q(2.0, "m")))
+    f(cxc.ProlateSpheroidal3D(Delta=u.Q(3.0, "m")))
+    assert len(traces) == 1, (
+        f"retraced {len(traces)} times; Delta is being treated as static"
+    )


### PR DESCRIPTION
## Summary

`coordinax`'s geometric layer was static by construction — `AbstractChart`,
`AbstractManifold`, `AbstractAtlas` and `AbstractMetric` are all
`@jtu.register_static`. Geometry was *structure*, never *data*. That blocks a
chart from carrying a parameter you want to differentiate: a fitted focal
length, and later a fitted curve.

This PR admits dynamic parameters into the chart layer, and proves it on
`ProlateSpheroidal3D`'s focal length.

```python
ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m"))  # 0 leaves, hashable — exactly as before
ProlateSpheroidal3D(Delta=u.Q(2.0, "m"))               # 1 leaf — differentiable, jit-cached on structure
```

**Differentiability is opt-in per instance.** Every pre-existing call site passes
`StaticQuantity` and is bit-for-bit unaffected — 24 of them, all verified.

## The hierarchy

`AbstractChart` remains the **single root**, so `isinstance` and every dispatch
registered on it still catch every chart.

```
AbstractChart                    # ABC, no longer registered static
├── AbstractStaticChart          # auto-registers subclasses; 24 existing charts
└── AbstractParameterizedChart   # an equinox.Module, therefore a pytree
      └── ProlateSpheroidal3D
```

Staticness is now **structural** — you get it by inheriting, not by remembering
a decorator. That closes a live footgun: `jtu.register_static` is not inherited,
so a chart that forgot the decorator silently became one opaque leaf. 24
hand-applied decorators are gone. A concrete chart on neither branch (or both)
now raises `TypeError` at class creation.

## Conservative equality, and why

`AbstractChart.__eq__`/`__hash__` are parameter-aware. Two charts with dynamic
parameters are equal only if they are the **same object** — even when
numerically equal — and hashing ignores dynamic fields.

That is deliberate. Equality must behave identically inside and outside `jit`;
a rule that inspected values could not. Fixing these two methods in one place
made every existing `if chart == chart` branch tracer-safe without editing any
of them.

## What the verification pass found

Driving each guarded path under `jit` with a parameterized chart (13 sites,
identified by instrumenting `__eq__`/`__hash__` rather than by reading) exposed
a real bug: `register_ptmap.py` branched on
`lax.cond(to_chart.Delta == from_chart.Delta, ...)`, which is a Python `bool`
for `StaticQuantity` but a dimensionless `Quantity` for a dynamic one — and
`lax.cond` rejects it. Fixed at the site.

It also closed a leak where a **static** chart could hold a live JAX array while
reporting 0 pytree leaves (`CartesianProductChart.factors`,
`GalileanCT.spatial_chart`, and `GalileanCT(c=…)`), from which a
`DynamicJaxprTracer` escaped a `jit` boundary and died with a misleading
`TypeError: unsupported operand type(s) for +`. `AbstractStaticChart.__post_init__`
now rejects those constructions.

## `EmbeddedChart` migrated too

The branch originally left a known gap: `EmbeddedChart` could still hold a live
array while reporting 0 leaves, because `AbstractEmbeddingMap` is explicitly
`register_static` so the scan stopped there. The obvious fix — forcing the
embedding parameters static — was built, measured across 22 sites in 8 files,
and reverted: `radius` is a *coordinate value* that `pt_embed` propagates into
output points, not chart metadata, so making it static breaks every embedded
coordinate the library produces.

`EmbeddedChart` now takes this PR's own treatment instead — it moves to the
parameterized branch, keeping its embedding parameters live and differentiable.

## Scope note

`cx.Point` stores its chart in the **treedef**, not as a child: a `Point` has 3
leaves whether `Delta` is static or dynamic. So differentiability and structural
`jit` caching apply to a chart **passed as an argument or built inside a traced
function**, not one carried inside a `Point`. The docs say so explicitly.

## Verification

- full suite **9703 passed**, 7 skipped, 1 xfailed
- `pytest docs` 912 passed; clean `nox -s docs` build, zero warnings
- `prek run --all-files` green

Every new test was demonstrated to **fail** when the machinery it guards is
broken, rather than asserted to. This branch corrected several of its own plan's
tests that passed at the parent commit and pinned nothing.

Groundwork for a curve-parameterized (TNB / Frenet–Serret) chart, which needs
exactly this capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Rebased past #692

`#692` (chart equality/hashing speedup) merged while this was open and touched
the same `__eq__`/`__hash__` lines. Resolved by keeping #692's `_field_values`
direct-dataclass walk and rebuilding this branch's helpers on top of it, rather
than either side winning. Verified the speedup survived: `Cart3D() == cart3d`
**3.67 µs**, `hash(Cart3D())` **2.10 µs**, against a ~28 µs pre-#692 baseline.

A complexity pass then removed **71 lines** — a module docstring that duplicated
the guide verbatim, a public base class with one use site, four tests that
restated claims already pinned elsewhere, and an unreachable early-out (proved
unreachable by making it `raise` across a full import and a 9724-test
collection).
