### PR TITLE
fix(manifolds): make angle_between's zero-norm check consistent under tracing

### DIFF
--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -3,6 +3,7 @@
 __all__: tuple[str, ...] = ()
 
 
+import equinox as eqx
 import jax
 import plum
 
@@ -101,19 +102,27 @@ def angle_between(
     uu = u_qm @ (g @ u_qm)
     vv = v_qm @ (g @ v_qm)
 
-    _check_nonzero_norm(uu, vv)
+    uu, vv = _check_nonzero_norm(uu, vv)
 
     cosine = inner / qnp.sqrt(uu * vv)
     cosine_value = qnp.clip(u.ustrip("", cosine), -1.0, 1.0)
     return cxa.Angle(qnp.arccos(cosine_value), "rad")
 
 
-def _check_nonzero_norm(*norms: u.AbstractQuantity) -> None:
-    """Raise when a norm-squared is zero or negative outside JAX tracing."""
+def _check_nonzero_norm(*norms: u.AbstractQuantity) -> tuple[u.AbstractQuantity, ...]:
+    """Raise when a norm-squared is zero or negative, traced or not.
+
+    Mirrors `coordinax._src.charts.checks.strictly_positive`: under tracing
+    (jit/vmap/grad) the check is deferred to `eqx.error_if`, so its output
+    must be threaded back into the computation or the check gets DCE'd.
+    """
+    msg = "angle_between is undefined for zero-norm tangent vectors."
+    checked = []
     for norm in norms:
-        value = norm.value
-        if isinstance(value, jax.core.Tracer):  # ty: ignore[possibly-missing-submodule]
-            continue
-        if bool(qnp.any(value <= 0)):
-            msg = "angle_between is undefined for zero-norm tangent vectors."
+        pred = u.ustrip("", qnp.any(norm <= 0))
+        if isinstance(pred, jax.core.Tracer):  # ty: ignore[possibly-missing-submodule]
+            norm = eqx.error_if(norm, pred, msg)  # noqa: PLW2901
+        elif bool(pred):
             raise ValueError(msg)
+        checked.append(norm)
+    return tuple(checked)


### PR DESCRIPTION
## Summary
- `_check_nonzero_norm` in `angle_between` silently skipped its zero-norm check whenever a norm's value was a `jax.core.Tracer` (i.e. under `jit`/`vmap`/`grad`), so a zero-norm tangent vector would silently produce `NaN` instead of raising, unlike the eager path.
- Fix mirrors the `eqx.error_if` pattern already used by `coordinax._src.charts.checks.strictly_positive`: raise via `eqx.error_if` under tracing, and keep the eager `ValueError` path for concrete values.
- The checked values are threaded back into the computation (`uu, vv = _check_nonzero_norm(uu, vv)`) since `eqx.error_if`'s check is dead-code-eliminated if its output isn't used downstream.

## Test plan
- [x] `pytest --doctest-modules src/coordinax/_src/manifolds/angle_between.py` passes
- [x] `pytest tests/unit/manifolds/test_angle_between_dispatch.py` passes (includes the eager `ValueError` zero-norm test)
- [x] Manually verified: eager zero-norm raises `ValueError`; jitted zero-norm now raises (previously silent `NaN`); non-zero-norm inputs unaffected in both eager and jit

🤖 Generated with [Claude Code](https://claude.com/claude-code)