### PR TITLE
♻️ refactor(manifolds): move the causal verbs to a `lorentzian` sub-namespace

### DIFF
--- a/docs/api/manifolds.md
+++ b/docs/api/manifolds.md
@@ -56,6 +56,7 @@ ang = cxm.angle_between(cxc.cart3d, uvec, vvec, at=at)
 
 ### Manifolds
 
+- `AbstractLorentzianMetricField`: structural marker for metrics with a Lorentzian signature; gates the `lorentzian` sub-namespace below
 - `AbstractManifold`: base manifold interface
 - `EuclideanManifold` / `R3`: Euclidean manifold family and 3D convenience
 - `HyperSphericalManifold`: intrinsic two-sphere manifold
@@ -90,4 +91,35 @@ ang = cxm.angle_between(cxc.cart3d, uvec, vvec, at=at)
 .. automodule:: coordinax.manifolds
     :exclude-members: aval, default, materialise, enable_materialise
 
+```
+
+## `coordinax.manifolds.lorentzian`
+
+A sub-namespace for measurements that need a **timelike direction** — gated on the metric type `AbstractLorentzianMetricField` (signature $(-,+,\ldots,+)$), not on a chart. A metric without one has no method here, rather than a method that accepts and then refuses.
+
+- `causal_character`: classify a pair of events as `"timelike"`, `"null"`, or `"spacelike"`. Returns a `str`, so not `jit`-able; branch on the sign of `interval` inside a trace
+- `proper_time`: elapsed proper time between two timelike-separated events
+- `proper_distance`: proper distance between two spacelike-separated events
+- `interval`: **re-exported** for convenience — canonical in `coordinax.manifolds`, since the signed quadratic form is defined for _every_ metric. It appears here because `causal_character` is its sign and `proper_time` its root
+
+Named for the signature rather than for "spacetime" deliberately: `charts.galileanct` is a 4-D Galilean spacetime and is **not** Lorentzian, so a `spacetime` namespace would promise membership these verbs refuse. Named `lorentzian` rather than `minkowski` because the gate is the signature — a curved spacetime metric (Schwarzschild, FLRW) inherits the marker and acquires all three.
+
+```pycon
+>>> import unxt as u
+>>> import coordinax.charts as cxc
+>>> import coordinax.manifolds as cxm
+
+>>> birth = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+>>> death = {
+...     "ct": u.Q(5.0, "m"),
+...     "x": u.Q(1.0, "m"),
+...     "y": u.Q(0.0, "m"),
+...     "z": u.Q(0.0, "m"),
+... }
+
+>>> cxm.lorentzian.causal_character(cxc.minkowskict, birth, death)
+'timelike'
+
+>>> cxm.lorentzian.proper_time(cxc.minkowskict, birth, death).uconvert("ns").round(2)
+Q(16.34, 'ns')
 ```

--- a/src/coordinax/_src/minkowski/causality.py
+++ b/src/coordinax/_src/minkowski/causality.py
@@ -112,17 +112,17 @@ def causal_character(
     A big time difference and a small space difference is timelike -- the two
     events can be visited by one slower-than-light observer:
 
-    >>> cxm.causal_character(cxc.minkowskict, o, ev(5.0, 1.0))
+    >>> cxm.lorentzian.causal_character(cxc.minkowskict, o, ev(5.0, 1.0))
     'timelike'
 
     The reverse is spacelike -- no observer sees both:
 
-    >>> cxm.causal_character(cxc.minkowskict, o, ev(1.0, 5.0))
+    >>> cxm.lorentzian.causal_character(cxc.minkowskict, o, ev(1.0, 5.0))
     'spacelike'
 
     Equal parts is null: exactly a light ray.
 
-    >>> cxm.causal_character(cxc.minkowskict, o, ev(3.0, 3.0))
+    >>> cxm.lorentzian.causal_character(cxc.minkowskict, o, ev(3.0, 3.0))
     'null'
 
     """
@@ -167,7 +167,7 @@ def proper_time(
     >>> o = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
     >>> rest = {"ct": u.Q(299792458.0, "m"), "x": u.Q(0.0, "m"),
     ...         "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
-    >>> cxm.proper_time(cxc.minkowskict, o, rest).uconvert("s").round(3)
+    >>> cxm.lorentzian.proper_time(cxc.minkowskict, o, rest).uconvert("s").round(3)
     Q(1., 's')
 
     A spacelike pair has no proper time:
@@ -175,7 +175,7 @@ def proper_time(
     >>> far = {"ct": u.Q(1.0, "m"), "x": u.Q(5.0, "m"),
     ...        "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
     >>> try:
-    ...     cxm.proper_time(cxc.minkowskict, o, far)
+    ...     cxm.lorentzian.proper_time(cxc.minkowskict, o, far)
     ... except ValueError as e:
     ...     print(str(e)[:56])
     proper_time() is defined only for timelike-separated eve
@@ -218,7 +218,7 @@ def proper_distance(
     >>> o = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
     >>> far = {"ct": u.Q(3.0, "m"), "x": u.Q(5.0, "m"),
     ...        "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
-    >>> cxm.proper_distance(cxc.minkowskict, o, far).round(2)
+    >>> cxm.lorentzian.proper_distance(cxc.minkowskict, o, far).round(2)
     Q(4., 'm')
 
     """
@@ -265,7 +265,7 @@ def causal_character(
     >>> o = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
     >>> ev = {"ct": u.Q(5.0, "m"), "x": u.Q(1.0, "m"),
     ...       "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
-    >>> cxm.causal_character(cxc.minkowskict, o, ev)
+    >>> cxm.lorentzian.causal_character(cxc.minkowskict, o, ev)
     'timelike'
 
     """
@@ -341,7 +341,7 @@ def causal_character(
     >>> a = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
     >>> b = {"x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
     >>> try:
-    ...     cxm.causal_character(cxc.cart3d, a, b)
+    ...     cxm.lorentzian.causal_character(cxc.cart3d, a, b)
     ... except NotImplementedError as e:
     ...     print(str(e).split("--")[0].strip())
     causal_character() requires a Lorentzian metric

--- a/src/coordinax/_src/minkowski/causality.py
+++ b/src/coordinax/_src/minkowski/causality.py
@@ -34,13 +34,13 @@ C_LIGHT = u.Q(299792458.0, "m/s")
 
 _MSG_NOT_TIMELIKE = (
     "proper_time() is defined only for timelike-separated events; this pair is "
-    "{kind} (interval^2 = {ds2}). Use `interval` for the signed square, or "
+    "{kind} (interval = {ds2}). Use `interval` for the signed square, or "
     "`proper_distance` for a spacelike pair."
 )
 
 _MSG_NOT_SPACELIKE = (
     "proper_distance() is defined only for spacelike-separated events; this "
-    "pair is {kind} (interval^2 = {ds2}). Use `interval` for the signed "
+    "pair is {kind} (interval = {ds2}). Use `interval` for the signed "
     "square, or `proper_time` for a timelike pair."
 )
 

--- a/src/coordinax/manifolds/__init__.py
+++ b/src/coordinax/manifolds/__init__.py
@@ -13,9 +13,8 @@ __all__ = (
     "norm",
     "separation",
     "interval",
-    "causal_character",
-    "proper_time",
-    "proper_distance",
+    # Sub-namespaces
+    "lorentzian",
     # Abstract Manifold/Atlas/Metric
     "AbstractAtlas",
     "AbstractMetricField",
@@ -76,25 +75,26 @@ __all__ = (
     "galilean_spacetime",
 )
 
-from ._src.setup_package import install_import_hook
+from coordinax._src.setup_package import install_import_hook
 
 with install_import_hook("coordinax.manifolds"):
-    from ._src.base import (
+    from . import lorentzian
+    from coordinax._src.base import (
         AbstractAtlas,
         AbstractDiagonalMetricField,
         AbstractLorentzianMetricField,
         AbstractManifold,
         AbstractMetricField,
     )
-    from ._src.custom import CustomAtlas, CustomManifold, CustomMetric
-    from ._src.embedded import (
+    from coordinax._src.custom import CustomAtlas, CustomManifold, CustomMetric
+    from coordinax._src.embedded import (
         AbstractEmbeddingMap,
         CustomEmbeddingMap,
         EmbeddedChart,
         EmbeddedManifold,
         PullbackMetric,
     )
-    from ._src.euclidean import (
+    from coordinax._src.euclidean import (
         R0,
         R1,
         R2,
@@ -105,15 +105,15 @@ with install_import_hook("coordinax.manifolds"):
         FlatMetric,
         Rn,
     )
-    from ._src.manifolds import *  # noqa: F403
-    from ._src.metric import AbstractMetricMatrix, DenseMetric, DiagonalMetric
-    from ._src.minkowski import (
+    from coordinax._src.manifolds import *
+    from coordinax._src.metric import AbstractMetricMatrix, DenseMetric, DiagonalMetric
+    from coordinax._src.minkowski import (
         MinkowskiAtlas,
         MinkowskiManifold,
         MinkowskiMetric,
         minkowski4d,
     )
-    from ._src.null import (
+    from coordinax._src.null import (
         NoAtlas,
         NoManifold,
         NoMetric,
@@ -121,13 +121,13 @@ with install_import_hook("coordinax.manifolds"):
         no_manifold,
         no_metric,
     )
-    from ._src.product import (
+    from coordinax._src.product import (
         CartesianProductAtlas,
         CartesianProductManifold,
         ProductMetric,
     )
-    from ._src.product.galilean_ct import galilean_spacetime
-    from ._src.spherical import (
+    from coordinax._src.product.galilean_ct import galilean_spacetime
+    from coordinax._src.spherical import (
         S1,
         S2,
         HyperSphericalAtlas,
@@ -140,14 +140,11 @@ with install_import_hook("coordinax.manifolds"):
     from coordinaxs.api.charts import pt_map
     from coordinaxs.api.manifolds import (
         angle_between,
-        causal_character,
         guess_manifold,
         interval,
         metric_matrix,
         metric_representation,
         norm,
-        proper_distance,
-        proper_time,
         pt_embed,
         pt_project,
         scale_factors,

--- a/src/coordinax/manifolds/lorentzian.py
+++ b/src/coordinax/manifolds/lorentzian.py
@@ -1,0 +1,78 @@
+r"""Measurements that need a timelike direction.
+
+The verbs here are gated on the metric having a **Lorentzian** signature
+$(-,+,\ldots,+)$ -- exactly one timelike direction -- expressed as the type
+`~coordinax.manifolds.AbstractLorentzianMetricField`.  Without such a direction
+there is no causal structure: every separation has the same character and there
+is nothing to classify, no proper time to elapse.
+
+Why this namespace is named for the *signature* and not for "spacetime": the
+library already ships a spacetime that is **not** Lorentzian.
+`~coordinax.charts.galileanct` is a 4-D Galilean spacetime chart on a
+`~coordinax.manifolds.CartesianProductManifold` with a `ProductMetric`, and none
+of these verbs apply to it.  A ``spacetime`` namespace would therefore promise
+membership its dispatch refuses -- the same dishonesty that used to live in the
+dispatch itself, where these functions accepted any chart and rejected it at
+runtime.  ``lorentzian`` says exactly what the gate is.
+
+Nor is it named ``minkowski``: the gate is the signature, not the metric.  A
+curved spacetime metric -- Schwarzschild, FLRW -- inherits the marker and
+acquires all three verbs without any change here.
+
+This module is a **view**, not a home.  The dispatches live with the manifold
+that implements them (Minkowski's in ``_src/minkowski/causality.py``, and a
+future Schwarzschild's alongside its own metric), exactly as
+`coordinax.transforms.groups` is a view over markers defined elsewhere.
+
+`~coordinax.manifolds.interval` is re-exported here even though it is *not*
+gated -- the signed quadratic form is defined for every metric, and
+`coordinax.manifolds` remains its canonical home.  It appears here because
+`causal_character` is literally the sign of it and `proper_time` the root of it,
+so a relativistic workflow wants all four to hand.
+
+Examples
+--------
+>>> import unxt as u
+>>> import coordinax.charts as cxc
+>>> import coordinax.manifolds as cxm
+
+>>> o = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+>>> ev = {"ct": u.Q(5.0, "m"), "x": u.Q(1.0, "m"),
+...       "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+
+>>> cxm.lorentzian.interval(cxc.minkowskict, o, ev).round(2)
+Q(-24., 'm2')
+
+>>> cxm.lorentzian.causal_character(cxc.minkowskict, o, ev)
+'timelike'
+
+>>> cxm.lorentzian.proper_time(cxc.minkowskict, o, ev).uconvert("ns").round(2)
+Q(16.34, 'ns')
+
+A metric with no timelike direction is refused, by name:
+
+>>> a = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+>>> b = {"x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+>>> try:
+...     cxm.lorentzian.causal_character(cxc.cart3d, a, b)
+... except NotImplementedError as e:
+...     print(str(e).split("--")[0].strip())
+causal_character() requires a Lorentzian metric
+
+"""
+
+__all__ = (
+    "causal_character",
+    "proper_time",
+    "proper_distance",
+    # Re-exported, canonical in `coordinax.manifolds`: defined for every metric,
+    # but the quantity the three above read.
+    "interval",
+)
+
+from coordinaxs.api.manifolds import (
+    causal_character,
+    interval,
+    proper_distance,
+    proper_time,
+)

--- a/tests/unit/manifolds/test_interval.py
+++ b/tests/unit/manifolds/test_interval.py
@@ -106,7 +106,9 @@ class TestInterval:
         assert not hasattr(got, "unit")
         assert float(got) == pytest.approx(-24.0, abs=ATOL)
         assert (
-            cxm.causal_character(cxc.minkowskict, origin, ev, usys=u.unitsystems.si)
+            cxm.lorentzian.causal_character(
+                cxc.minkowskict, origin, ev, usys=u.unitsystems.si
+            )
             == "timelike"
         )
 
@@ -158,23 +160,23 @@ class TestLorentzInvariance:
         """Causal ordering is absolute: no boost turns timelike into spacelike."""
         op = cxfm.LorentzBoost(beta)
         a, b = ORIGIN, event(ct, x)
-        before = cxm.causal_character(cxc.minkowskict, a, b)
+        before = cxm.lorentzian.causal_character(cxc.minkowskict, a, b)
 
         a2 = cxfm.act(op, None, a, cxc.minkowskict, cxr.point)
         b2 = cxfm.act(op, None, b, cxc.minkowskict, cxr.point)
-        after = cxm.causal_character(cxc.minkowskict, a2, b2)
+        after = cxm.lorentzian.causal_character(cxc.minkowskict, a2, b2)
 
         assert after == before
 
     def test_proper_time_is_boost_invariant(self):
         """A wristwatch reading cannot depend on who is looking at it."""
         a, b = ORIGIN, event(5.0, 1.0)
-        before = cxm.proper_time(cxc.minkowskict, a, b).uconvert("s")
+        before = cxm.lorentzian.proper_time(cxc.minkowskict, a, b).uconvert("s")
 
         op = cxfm.LorentzBoost([0.6, 0.0, 0.0])
         a2 = cxfm.act(op, None, a, cxc.minkowskict, cxr.point)
         b2 = cxfm.act(op, None, b, cxc.minkowskict, cxr.point)
-        after = cxm.proper_time(cxc.minkowskict, a2, b2).uconvert("s")
+        after = cxm.lorentzian.proper_time(cxc.minkowskict, a2, b2).uconvert("s")
 
         assert float(after.ustrip("s")) == pytest.approx(
             float(before.ustrip("s")), rel=1e-3
@@ -195,21 +197,30 @@ class TestCausalCharacter:
         ],
     )
     def test_classification(self, ct, x, want):
-        assert cxm.causal_character(cxc.minkowskict, ORIGIN, event(ct, x)) == want
+        assert (
+            cxm.lorentzian.causal_character(cxc.minkowskict, ORIGIN, event(ct, x))
+            == want
+        )
 
     def test_coincident_events_are_null(self):
-        assert cxm.causal_character(cxc.minkowskict, ORIGIN, ORIGIN) == "null"
+        assert (
+            cxm.lorentzian.causal_character(cxc.minkowskict, ORIGIN, ORIGIN) == "null"
+        )
 
     def test_null_tolerance_scales_with_the_data(self):
         """A light ray a million metres long is still null, not spacelike."""
         big = event(1e6, 1e6)
-        assert cxm.causal_character(cxc.minkowskict, ORIGIN, big) == "null"
+        assert cxm.lorentzian.causal_character(cxc.minkowskict, ORIGIN, big) == "null"
 
     def test_explicit_atol_is_respected(self):
         """A wide tolerance can call a genuinely timelike pair null."""
         pair = event(5.0, 1.0)  # ds^2 = -24
-        assert cxm.causal_character(cxc.minkowskict, ORIGIN, pair) == "timelike"
-        loose = cxm.causal_character(cxc.minkowskict, ORIGIN, pair, atol=100.0)
+        assert (
+            cxm.lorentzian.causal_character(cxc.minkowskict, ORIGIN, pair) == "timelike"
+        )
+        loose = cxm.lorentzian.causal_character(
+            cxc.minkowskict, ORIGIN, pair, atol=100.0
+        )
         assert loose == "null"
 
     @pytest.mark.parametrize(
@@ -227,7 +238,7 @@ class TestCausalCharacter:
         a = {"x": u.Q(0.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
         b = {"x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
         with pytest.raises(NotImplementedError, match="requires a Lorentzian metric"):
-            getattr(cxm, verb)(cxc.cart3d, a, b)
+            getattr(cxm.lorentzian, verb)(cxc.cart3d, a, b)
 
     def test_the_precondition_is_a_type_not_a_runtime_scan(self):
         """`MinkowskiMetric` carries the marker; Riemannian metrics do not.
@@ -245,7 +256,7 @@ class TestCausalCharacter:
         at = {"theta": u.Q(jnp.pi / 2, "rad"), "phi": u.Q(0.0, "rad")}
         b = {"theta": u.Q(1.0, "rad"), "phi": u.Q(0.0, "rad")}
         with pytest.raises(NotImplementedError, match="requires a Lorentzian metric"):
-            cxm.causal_character(cxc.sph2, at, b)
+            cxm.lorentzian.causal_character(cxc.sph2, at, b)
 
 
 class TestProperTimeAndDistance:
@@ -254,14 +265,14 @@ class TestProperTimeAndDistance:
     def test_proper_time_at_rest_is_coordinate_time(self):
         """An observer at rest ages by the full coordinate time."""
         one_light_second = event(299792458.0, 0.0)
-        got = cxm.proper_time(cxc.minkowskict, ORIGIN, one_light_second)
+        got = cxm.lorentzian.proper_time(cxc.minkowskict, ORIGIN, one_light_second)
         assert float(got.uconvert("s").ustrip("s")) == pytest.approx(1.0, rel=1e-4)
 
     def test_moving_clock_ages_less(self):
         """Time dilation: same coordinate time, but moving, gives less ageing."""
         c = 299792458.0
-        at_rest = cxm.proper_time(cxc.minkowskict, ORIGIN, event(c, 0.0))
-        moving = cxm.proper_time(cxc.minkowskict, ORIGIN, event(c, 0.6 * c))
+        at_rest = cxm.lorentzian.proper_time(cxc.minkowskict, ORIGIN, event(c, 0.0))
+        moving = cxm.lorentzian.proper_time(cxc.minkowskict, ORIGIN, event(c, 0.6 * c))
         assert float(moving.ustrip("s")) < float(at_rest.ustrip("s"))
         # sqrt(1 - 0.6^2) = 0.8
         assert float(moving.ustrip("s")) == pytest.approx(
@@ -269,22 +280,22 @@ class TestProperTimeAndDistance:
         )
 
     def test_proper_distance_value(self):
-        got = cxm.proper_distance(cxc.minkowskict, ORIGIN, event(3.0, 5.0))
+        got = cxm.lorentzian.proper_distance(cxc.minkowskict, ORIGIN, event(3.0, 5.0))
         assert float(got.ustrip("m")) == pytest.approx(4.0, abs=ATOL)
 
     @pytest.mark.parametrize(("ct", "x"), [(1.0, 5.0), (3.0, 3.0)])
     def test_proper_time_refuses_non_timelike(self, ct, x):
         with pytest.raises(ValueError, match="timelike"):
-            cxm.proper_time(cxc.minkowskict, ORIGIN, event(ct, x))
+            cxm.lorentzian.proper_time(cxc.minkowskict, ORIGIN, event(ct, x))
 
     @pytest.mark.parametrize(("ct", "x"), [(5.0, 1.0), (3.0, 3.0)])
     def test_proper_distance_refuses_non_spacelike(self, ct, x):
         with pytest.raises(ValueError, match="spacelike"):
-            cxm.proper_distance(cxc.minkowskict, ORIGIN, event(ct, x))
+            cxm.lorentzian.proper_distance(cxc.minkowskict, ORIGIN, event(ct, x))
 
     def test_error_message_names_the_actual_causal_type(self):
         with pytest.raises(ValueError, match="spacelike") as exc:
-            cxm.proper_time(cxc.minkowskict, ORIGIN, event(1.0, 5.0))
+            cxm.lorentzian.proper_time(cxc.minkowskict, ORIGIN, event(1.0, 5.0))
         assert "spacelike" in str(exc.value)
 
 
@@ -299,25 +310,29 @@ class TestSingleIntervalEvaluation:
     @pytest.mark.parametrize(("ct", "x"), [(5.0, 1.0), (10.0, 2.0), (-7.0, 3.0)])
     def test_proper_time_agrees_with_the_two_step_form(self, ct, x):
         b = event(ct, x)
-        assert cxm.causal_character(cxc.minkowskict, ORIGIN, b) == "timelike"
+        assert cxm.lorentzian.causal_character(cxc.minkowskict, ORIGIN, b) == "timelike"
         ds2 = cxm.interval(cxc.minkowskict, ORIGIN, b)
         expected = float(jnp.sqrt(-ds2.ustrip("m2"))) / 299792458.0
-        got = cxm.proper_time(cxc.minkowskict, ORIGIN, b)
+        got = cxm.lorentzian.proper_time(cxc.minkowskict, ORIGIN, b)
         assert float(got.ustrip("s")) == pytest.approx(expected, rel=1e-5)
 
     @pytest.mark.parametrize(("ct", "x"), [(1.0, 5.0), (3.0, 5.0), (0.0, 2.0)])
     def test_proper_distance_agrees_with_the_two_step_form(self, ct, x):
         b = event(ct, x)
-        assert cxm.causal_character(cxc.minkowskict, ORIGIN, b) == "spacelike"
+        assert (
+            cxm.lorentzian.causal_character(cxc.minkowskict, ORIGIN, b) == "spacelike"
+        )
         ds2 = cxm.interval(cxc.minkowskict, ORIGIN, b)
         expected = float(jnp.sqrt(ds2.ustrip("m2")))
-        got = cxm.proper_distance(cxc.minkowskict, ORIGIN, b)
+        got = cxm.lorentzian.proper_distance(cxc.minkowskict, ORIGIN, b)
         assert float(got.ustrip("m")) == pytest.approx(expected, rel=1e-5)
 
     def test_atol_still_reaches_the_refusal_path(self):
         """The shared classifier still honours `atol` from these entry points."""
         with pytest.raises(ValueError, match="null"):
-            cxm.proper_time(cxc.minkowskict, ORIGIN, event(5.0, 1.0), atol=100.0)
+            cxm.lorentzian.proper_time(
+                cxc.minkowskict, ORIGIN, event(5.0, 1.0), atol=100.0
+            )
 
 
 class TestCausalVerbsValidateTheirMetricArgument:


### PR DESCRIPTION
> ### 📍 Stacked on #680 → #695
> Merge order: **#680 → #695 → this → #683**. #683 follows because the tutorial documents the final spelling.

## Why

`causal_character`, `proper_time` and `proper_distance` sat flat in `coordinax.manifolds` next to `norm` and `separation`, which apply to every manifold. Of the seven metrics in the library, **exactly one** satisfies their precondition — so `cxm.<tab>` advertised three verbs most callers can never use.

```python
cxm.lorentzian.causal_character(cxc.minkowskict, birth, death)   # 'timelike'
cxm.lorentzian.proper_time(cxc.minkowskict, birth, death)
```

## Where the line falls

`interval` and `angle_between` stay flat — and that boundary was measured, not assumed. `angle_between` is **not** Riemannian-only; since #687 it handles spacelike pairs under an indefinite metric:

| verb | Euclid | Sphere | Minkowski | |
|---|---|---|---|---|
| `angle_between` | ✅ | ✅ | ✅ | stays flat |
| `interval` | ✅ | ✅ | ✅ | stays flat (+ re-exported) |
| `causal_character` / `proper_time` / `proper_distance` | ❌ | ❌ | ✅ | **moved** |

## Why `lorentzian` and not `spacetime`

The library already ships a spacetime that is **not** Lorentzian:

```
minkowskict  ndim=4  MinkowskiManifold         MinkowskiMetric  Lorentzian=True
galileanct   ndim=4  CartesianProductManifold  ProductMetric    Lorentzian=False
```

`cxm.spacetime.proper_time(galileanct, …)` would refuse, with the namespace name promising otherwise — the same dishonesty #695 just removed from the dispatch, reintroduced one level up. `lorentzian` names exactly the gate.

Not `minkowski` either: the gate is the *signature*, so a curved spacetime metric (Schwarzschild, FLRW) inherits `AbstractLorentzianMetricField` and joins the namespace with no change here.

If spacetime *kinematics* later wants a home (four-velocity, worldlines), `cxm.spacetime` can be added alongside without contradiction — `lorentzian` stays the signature-gated set.

## `interval` is re-exported

Canonical in `coordinax.manifolds` (it is defined for every metric), and re-exported here because `causal_character` is literally its sign and `proper_time` its root. The one duplication that earns itself.

## A view, not a home

The module only re-exports. Dispatches stay with the manifold implementing them — `_src/minkowski/causality.py` today, `_src/schwarzschild/` tomorrow — exactly as `coordinax.transforms.groups` is a view over markers defined elsewhere. That existing sub-namespace is also the precedent making this shape available.

## Mechanics

`manifolds.py` → `manifolds/__init__.py`, since a module cannot host a sub-namespace (this is why `transforms` can and `manifolds` could not). Parent-relative imports became absolute to satisfy the project's `TID252` rule. Otherwise `cxm.*` resolves identically — 60 exports, with `norm`, `separation`, `angle_between` and `interval` untouched, verified by assertion rather than inspection.

## Verification

`tests/unit` + `docs` + `packages/coordinaxs.api`: **3400 passed, 5 skipped**. ruff and ruff-format clean; the one `ty` warning is pre-existing in `distances/`. `docs/api/manifolds.md` gains a section for the sub-namespace with executed examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)