### PR TITLE
👷 ci: bump `build-and-inspect-python-package` to v3.0.1

### DIFF
--- a/.github/workflows/cd-coordinax.yml
+++ b/.github/workflows/cd-coordinax.yml
@@ -76,7 +76,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: .
           upload-name-suffix: -coordinax

--- a/.github/workflows/cd-coordinaxs-api.yml
+++ b/.github/workflows/cd-coordinaxs-api.yml
@@ -74,7 +74,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/coordinaxs.api
           upload-name-suffix: -coordinaxs.api

--- a/.github/workflows/cd-coordinaxs-astro.yml
+++ b/.github/workflows/cd-coordinaxs-astro.yml
@@ -74,7 +74,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/coordinaxs.astro
           upload-name-suffix: -coordinaxs.astro

--- a/.github/workflows/cd-coordinaxs-curveframes.yml
+++ b/.github/workflows/cd-coordinaxs-curveframes.yml
@@ -74,7 +74,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/coordinaxs.curveframes
           upload-name-suffix: -coordinaxs.curveframes

--- a/.github/workflows/cd-coordinaxs-hypothesis.yml
+++ b/.github/workflows/cd-coordinaxs-hypothesis.yml
@@ -74,7 +74,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/coordinaxs.hypothesis
           upload-name-suffix: -coordinaxs.hypothesis

--- a/.github/workflows/cd-coordinaxs-interop-astropy.yml
+++ b/.github/workflows/cd-coordinaxs-interop-astropy.yml
@@ -74,7 +74,7 @@ jobs:
           cat release-metadata.json
         shell: bash
 
-      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           path: packages/coordinaxs.interop.astropy
           upload-name-suffix: -coordinaxs.interop.astropy


### PR DESCRIPTION
## Problem

CD is failing on `main` ([run 31505141207](https://github.com/GalacticDynamics/coordinax/actions/runs/31505141207)):

```
Checking /tmp/baipp/dist/coordinax-0.1.dev637-py3-none-any.whl: ERROR
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Nothing is wrong with the package. hatchling now emits `Metadata-Version: 2.5`, but `build-and-inspect-python-package@v2.18.0` pins `twine==6.2.0`, which doesn't know that metadata version, so `twine check --strict` rejects the wheel.

Verified locally against a wheel built from this tree (`Metadata-Version: 2.5`):

- `twine==6.2.0` → `InvalidDistribution: ... '2.5' is not a valid metadata version`
- `twine==7.0.0` → `PASSED`

## Fix

Bump the action to v3.0.1, whose release notes call this out directly: "Twine 7 that adds support for packaging metadata 2.5". Applied to all six CD workflows — they were all on the same pinned SHA, so all six would have failed identically.

v3 stops force-tagging minor/micro releases, so the full-SHA pin already used here remains correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)