### PR TITLE
✨ feat(minkowski): add `rapidity_between`, the hyperbolic sibling of `angle_between`

### DIFF
--- a/docs/api/manifolds.md
+++ b/docs/api/manifolds.md
@@ -102,9 +102,10 @@ A sub-namespace for measurements that need a **timelike direction** — gated on
 - `causal_character`: classify a pair of events as `"timelike"`, `"null"`, or `"spacelike"`. Returns a `str`, so not `jit`-able; branch on the sign of `interval` inside a trace
 - `proper_time`: elapsed proper time between two timelike-separated events
 - `proper_distance`: proper distance between two spacelike-separated events
+- `rapidity_between`: relative rapidity between two timelike tangent vectors — the hyperbolic counterpart of `angle_between`, which refuses that pair
 - `interval`: **re-exported** for convenience — canonical in `coordinax.manifolds`, since the signed quadratic form is defined for _every_ metric. It appears here because `causal_character` is its sign and `proper_time` its root
 
-Named for the signature rather than for "spacetime" deliberately: `charts.galileanct` is a 4-D Galilean spacetime and is **not** Lorentzian, so a `spacetime` namespace would promise membership these verbs refuse. Named `lorentzian` rather than `minkowski` because the gate is the signature — a curved spacetime metric (Schwarzschild, FLRW) inherits the marker and acquires all three.
+Named for the signature rather than for "spacetime" deliberately: `charts.galileanct` is a 4-D Galilean spacetime and is **not** Lorentzian, so a `spacetime` namespace would promise membership these verbs refuse. Named `lorentzian` rather than `minkowski` because the gate is the signature — a curved spacetime metric (Schwarzschild, FLRW) inherits the marker and acquires all of them.
 
 ```pycon
 >>> import unxt as u

--- a/docs/tutorials/special_relativity.md
+++ b/docs/tutorials/special_relativity.md
@@ -315,6 +315,29 @@ Rapidity is the parameterisation that _does_ add, which is why it exists:
 True
 ```
 
+Those are operators. The same rapidity is also a property of the two frames themselves, readable off their four-velocities without naming any operator that connects them:
+
+```pycon
+>>> def four_velocity(beta):
+...     g = 1.0 / jnp.sqrt(1.0 - beta**2)
+...     return {
+...         "ct": u.Q(g, ""),
+...         "x": u.Q(g * beta, ""),
+...         "y": u.Q(0.0, ""),
+...         "z": u.Q(0.0, ""),
+...     }
+...
+>>> here = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+>>> beta_combined = float(combined[0, 1] / combined[0, 0])
+>>> phi = cxm.lorentzian.rapidity_between(
+...     cxc.minkowskict, four_velocity(0.0), four_velocity(beta_combined), at=here
+... )
+>>> round(float(phi), 4), round(float(2 * jnp.arctanh(0.6)), 4)
+(1.3863, 1.3863)
+```
+
+Two boosts of $0.6c$, measured after the fact: $2\,\mathrm{arctanh}\,0.6$. This is the timelike case `angle_between` refuses — two four-velocities have no circular angle between them, only a hyperbolic one.
+
 ## Summary
 
 | quantity                         | frame-dependent? |
@@ -326,6 +349,7 @@ True
 | **interval** $\Delta s^2$        | ❌ **invariant** |
 | **proper time**                  | ❌ **invariant** |
 | **causal character**             | ❌ **invariant** |
+| **relative rapidity**            | ❌ **invariant** |
 
 The practical rule: reach for `interval` and the `cxm.lorentzian` verbs when you want a statement about _physics_, and read coordinates only when you genuinely want a statement about a particular frame. `separation` and `norm` belong to the Riemannian world and will refuse Minkowski input rather than let you mix the two up.
 

--- a/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
+++ b/packages/coordinaxs.api/src/coordinaxs/api/manifolds.py
@@ -15,6 +15,7 @@ __all__ = (
     "causal_character",
     "proper_time",
     "proper_distance",
+    "rapidity_between",
 )
 
 from typing import TYPE_CHECKING, Any
@@ -650,4 +651,14 @@ def proper_time(*args: Any, **kwargs: Any) -> Any:
 @plum.dispatch.abstract
 def proper_distance(*args: Any, **kwargs: Any) -> Any:
     """Proper distance between two spacelike-separated events."""
+    raise NotImplementedError  # pragma: no cover
+
+
+@plum.dispatch.abstract
+def rapidity_between(*args: Any, **kwargs: Any) -> Any:
+    """Relative rapidity between two timelike tangent vectors.
+
+    The hyperbolic counterpart of `angle_between`, which refuses a timelike
+    pair. Defined for Lorentzian metrics.
+    """
     raise NotImplementedError  # pragma: no cover

--- a/src/coordinax/_src/manifolds/_utils.py
+++ b/src/coordinax/_src/manifolds/_utils.py
@@ -97,12 +97,15 @@ def as_quantity_matrix(x: ul.QM | Array, /) -> ul.QM:
     return ul.QM(value=x, unit=ul.UnitsMatrix.full((n_rows, n_cols), DMLS))
 
 
-def raw_value(x: Any, /) -> Array:
-    """Return the bare magnitude of *x*, ignoring any unit it carries.
+def to_dimensionless(x: Any, /) -> Array:
+    """Convert a genuinely dimensionless *x* to a bare array.
 
-    Only the *sign* of a contraction like ``g(v,v)`` is ever wanted from this,
-    and the unit (``m2``, ``rad2/s2``, ...) does not bear on a sign. Note this
-    *discards* the unit rather than converting it -- ``ustrip("")`` would raise
-    on a dimensionful value.
+    A real unit conversion, not a peek at the magnitude: it raises on anything
+    that is not dimensionless. Two things reach it -- a ratio whose units
+    cancel, and the boolean from a comparison -- and both are dimensionless by
+    construction.
+
+    Callers may pass bare arrays (`check_data(..., values=False)` permits it),
+    which are already in the target form and pass straight through.
     """
-    return jnp.asarray(x.value if is_any_quantity(x) else x)
+    return jnp.asarray(u.ustrip("", x) if is_any_quantity(x) else x)

--- a/src/coordinax/_src/manifolds/_utils.py
+++ b/src/coordinax/_src/manifolds/_utils.py
@@ -3,9 +3,13 @@
 __all__: tuple[str, ...] = ()
 
 from jaxtyping import Array
+from typing import Any
+
+import jax.numpy as jnp
 
 import unxt as u
 import unxts.linalg as ul
+from unxt.quantity import is_any_quantity
 
 from coordinax._src.base import AbstractMetricField
 
@@ -91,3 +95,14 @@ def as_quantity_matrix(x: ul.QM | Array, /) -> ul.QM:
         return x
     n_rows, n_cols = x.shape[-2:]
     return ul.QM(value=x, unit=ul.UnitsMatrix.full((n_rows, n_cols), DMLS))
+
+
+def raw_value(x: Any, /) -> Array:
+    """Return the bare magnitude of *x*, ignoring any unit it carries.
+
+    Only the *sign* of a contraction like ``g(v,v)`` is ever wanted from this,
+    and the unit (``m2``, ``rad2/s2``, ...) does not bear on a sign. Note this
+    *discards* the unit rather than converting it -- ``ustrip("")`` would raise
+    on a dimensionful value.
+    """
+    return jnp.asarray(x.value if is_any_quantity(x) else x)

--- a/src/coordinax/_src/manifolds/_utils.py
+++ b/src/coordinax/_src/manifolds/_utils.py
@@ -3,13 +3,9 @@
 __all__: tuple[str, ...] = ()
 
 from jaxtyping import Array
-from typing import Any
-
-import jax.numpy as jnp
 
 import unxt as u
 import unxts.linalg as ul
-from unxt.quantity import is_any_quantity
 
 from coordinax._src.base import AbstractMetricField
 
@@ -95,17 +91,3 @@ def as_quantity_matrix(x: ul.QM | Array, /) -> ul.QM:
         return x
     n_rows, n_cols = x.shape[-2:]
     return ul.QM(value=x, unit=ul.UnitsMatrix.full((n_rows, n_cols), DMLS))
-
-
-def to_dimensionless(x: Any, /) -> Array:
-    """Convert a genuinely dimensionless *x* to a bare array.
-
-    A real unit conversion, not a peek at the magnitude: it raises on anything
-    that is not dimensionless. Two things reach it -- a ratio whose units
-    cancel, and the boolean from a comparison -- and both are dimensionless by
-    construction.
-
-    Callers may pass bare arrays (`check_data(..., values=False)` permits it),
-    which are already in the target form and pass straight through.
-    """
-    return jnp.asarray(u.ustrip("", x) if is_any_quantity(x) else x)

--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -3,7 +3,7 @@
 __all__: tuple[str, ...] = ()
 
 
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import jax
 import jax.numpy as jnp
@@ -18,6 +18,9 @@ import coordinaxs.api.manifolds as cxmapi
 from .quadratic_form import gram
 from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.custom_types import CDict, OptUSys
+
+if TYPE_CHECKING:
+    from jaxtyping import Array
 
 
 @plum.dispatch
@@ -129,13 +132,13 @@ def angle_between(
         uvec, vvec, chart, at=at, usys=usys, fname="angle_between", require_usys=False
     )
 
-    cos = jnp.asarray(u.ustrip(AllowValue, "", inner / qnp.sqrt(uu * vv)))
+    cos = u.ustrip(AllowValue, "", inner / qnp.sqrt(uu * vv))
 
     # Compared against zero *in* whatever unit g(v,v) carries -- the one
     # comparison needing no common unit -- so only the resulting boolean is
     # converted, and `AllowValue` lets a bare-array caller through untouched.
-    u_spacelike = jnp.asarray(u.ustrip(AllowValue, "", uu > 0))
-    v_spacelike = jnp.asarray(u.ustrip(AllowValue, "", vv > 0))
+    u_spacelike = cast("Array", u.ustrip(AllowValue, "", uu > 0))
+    v_spacelike = cast("Array", u.ustrip(AllowValue, "", vv > 0))
 
     # Eagerly this raises, naming the case. Under tracing it cannot -- the values
     # are not concrete -- so it is a no-op there and `valid` below is what stands

--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -10,12 +10,10 @@ import jax.numpy as jnp
 import plum
 
 import quaxed.numpy as qnp
-import unxt as u
-from unxt.quantity import is_any_quantity
 
 import coordinax.angles as cxa
 import coordinaxs.api.manifolds as cxmapi
-from ._utils import raw_value as _value
+from ._utils import to_dimensionless as _dimensionless
 from .quadratic_form import gram
 from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.custom_types import CDict, OptUSys
@@ -132,6 +130,12 @@ def angle_between(
 
     cos = _dimensionless(inner / qnp.sqrt(uu * vv))
 
+    # Compared against zero *in* whatever unit g(v,v) carries -- the one
+    # comparison that needs no common unit -- so only the resulting boolean is
+    # converted, and it is dimensionless by construction.
+    u_spacelike = _dimensionless(uu > 0)
+    v_spacelike = _dimensionless(vv > 0)
+
     # Eagerly this raises, naming the case. Under tracing it cannot -- the values
     # are not concrete -- so it is a no-op there and `valid` below is what stands
     # between the caller and a wrong answer.
@@ -141,7 +145,7 @@ def angle_between(
     # would reach the clip and hand back 0 or pi for a hyperbolic or imaginary
     # case -- silently reporting "anti-parallel" for two observers in relative
     # motion. `nan` is the honest value: no real angle exists.
-    valid = (_value(uu) > 0) & (_value(vv) > 0) & (jnp.abs(cos) <= 1.0 + _COS_ATOL)
+    valid = u_spacelike & v_spacelike & (jnp.abs(cos) <= 1.0 + _COS_ATOL)
     # The clip is float-error insurance for the *valid* branch only; `valid`
     # has already excluded everything genuinely out of range.
     angle = jnp.arccos(jnp.clip(cos, -1.0, 1.0))
@@ -178,16 +182,6 @@ _MSG_NOT_SPACELIKE_PLANE = (
 )
 
 
-def _dimensionless(x: Any, /) -> Any:
-    """Strip *x* to a bare dimensionless array.
-
-    Only valid where the value genuinely is dimensionless -- the cosine, whose
-    units cancel. The shared contraction returns a `unxt.Quantity` for Quantity
-    input and a plain array for bare-array input, and both reach here.
-    """
-    return jnp.asarray(u.ustrip("", x) if is_any_quantity(x) else x)
-
-
 def _check_angle_is_defined(uu: Any, vv: Any, cos: Any, /) -> None:
     r"""Raise unless a real circular angle exists between the two vectors.
 
@@ -200,18 +194,16 @@ def _check_angle_is_defined(uu: Any, vv: Any, cos: Any, /) -> None:
     Skipped under JAX tracing, where the values are not concrete; the caller
     applies the same conditions as a mask there, yielding `nan` instead.
     """
-    values = [getattr(uu, "value", uu), getattr(vv, "value", vv), cos]
-    if any(isinstance(x, jax.core.Tracer) for x in values):  # ty: ignore[possibly-missing-submodule]
+    u_neg, v_neg = _dimensionless(uu < 0), _dimensionless(vv < 0)
+    u_zero, v_zero = _dimensionless(uu == 0), _dimensionless(vv == 0)
+    if any(isinstance(x, jax.core.Tracer) for x in (u_neg, v_neg, cos)):  # ty: ignore[possibly-missing-submodule]
         return
 
-    uu_v = float(jnp.min(_value(uu)))
-    vv_v = float(jnp.min(_value(vv)))
-
-    if bool(jnp.any(_value(uu) == 0)) or bool(jnp.any(_value(vv) == 0)):
+    if bool(jnp.any(u_zero)) or bool(jnp.any(v_zero)):
         raise ValueError(_MSG_NULL)
-    if uu_v < 0 and vv_v < 0:
+    if bool(jnp.any(u_neg)) and bool(jnp.any(v_neg)):
         raise ValueError(_MSG_TIMELIKE)
-    if uu_v < 0 or vv_v < 0:
+    if bool(jnp.any(u_neg)) or bool(jnp.any(v_neg)):
         raise ValueError(_MSG_MIXED)
 
     # Both spacelike, but their span may still be Lorentzian -- e.g. u=(0,1,0,0)

--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -159,9 +159,9 @@ _MSG_NULL = (
 _MSG_TIMELIKE = (
     "angle_between is undefined for two timelike tangent vectors: g(u,u) and "
     "g(v,v) are both negative, and the invariant separating them is a "
-    "*hyperbolic* angle -- the relative rapidity, arccosh(-g(u,v)/sqrt(g(u,u) "
-    "g(v,v))) -- not a circular angle. Computing `arccos` here would clip to 0 "
-    "or pi and silently report no relative motion."
+    "*hyperbolic* angle, not a circular one. Computing `arccos` here would clip "
+    "to 0 or pi and silently report no relative motion. Use "
+    "`coordinax.manifolds.lorentzian.rapidity_between`."
 )
 
 _MSG_MIXED = (

--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -15,6 +15,7 @@ from unxt.quantity import is_any_quantity
 
 import coordinax.angles as cxa
 import coordinaxs.api.manifolds as cxmapi
+from ._utils import raw_value as _value
 from .quadratic_form import gram
 from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.custom_types import CDict, OptUSys
@@ -185,16 +186,6 @@ def _dimensionless(x: Any, /) -> Any:
     input and a plain array for bare-array input, and both reach here.
     """
     return jnp.asarray(u.ustrip("", x) if is_any_quantity(x) else x)
-
-
-def _value(x: Any, /) -> Any:
-    """Return the raw array behind *x*, keeping whatever unit it carried.
-
-    For ``g(v,v)`` only the *sign* is wanted, so the unit (``m2``, ``rad2/s2``,
-    ...) is irrelevant and must not be converted away -- unlike the cosine,
-    stripping it to dimensionless would raise.
-    """
-    return jnp.asarray(x.value if is_any_quantity(x) else x)
 
 
 def _check_angle_is_defined(uu: Any, vv: Any, cos: Any, /) -> None:

--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -10,10 +10,11 @@ import jax.numpy as jnp
 import plum
 
 import quaxed.numpy as qnp
+import unxt as u
+from unxt.quantity import AllowValue
 
 import coordinax.angles as cxa
 import coordinaxs.api.manifolds as cxmapi
-from ._utils import to_dimensionless as _dimensionless
 from .quadratic_form import gram
 from coordinax._src.base import AbstractChart, AbstractMetricField
 from coordinax._src.custom_types import CDict, OptUSys
@@ -128,13 +129,13 @@ def angle_between(
         uvec, vvec, chart, at=at, usys=usys, fname="angle_between", require_usys=False
     )
 
-    cos = _dimensionless(inner / qnp.sqrt(uu * vv))
+    cos = jnp.asarray(u.ustrip(AllowValue, "", inner / qnp.sqrt(uu * vv)))
 
     # Compared against zero *in* whatever unit g(v,v) carries -- the one
-    # comparison that needs no common unit -- so only the resulting boolean is
-    # converted, and it is dimensionless by construction.
-    u_spacelike = _dimensionless(uu > 0)
-    v_spacelike = _dimensionless(vv > 0)
+    # comparison needing no common unit -- so only the resulting boolean is
+    # converted, and `AllowValue` lets a bare-array caller through untouched.
+    u_spacelike = jnp.asarray(u.ustrip(AllowValue, "", uu > 0))
+    v_spacelike = jnp.asarray(u.ustrip(AllowValue, "", vv > 0))
 
     # Eagerly this raises, naming the case. Under tracing it cannot -- the values
     # are not concrete -- so it is a no-op there and `valid` below is what stands
@@ -194,8 +195,11 @@ def _check_angle_is_defined(uu: Any, vv: Any, cos: Any, /) -> None:
     Skipped under JAX tracing, where the values are not concrete; the caller
     applies the same conditions as a mask there, yielding `nan` instead.
     """
-    u_neg, v_neg = _dimensionless(uu < 0), _dimensionless(vv < 0)
-    u_zero, v_zero = _dimensionless(uu == 0), _dimensionless(vv == 0)
+    u_neg, v_neg = u.ustrip(AllowValue, "", uu < 0), u.ustrip(AllowValue, "", vv < 0)
+    u_zero, v_zero = (
+        u.ustrip(AllowValue, "", uu == 0),
+        u.ustrip(AllowValue, "", vv == 0),
+    )
     if any(isinstance(x, jax.core.Tracer) for x in (u_neg, v_neg, cos)):  # ty: ignore[possibly-missing-submodule]
         return
 

--- a/src/coordinax/_src/minkowski/__init__.py
+++ b/src/coordinax/_src/minkowski/__init__.py
@@ -5,5 +5,6 @@ from .causality import *
 from .charts import *
 from .manifold import *
 from .metric import *
+from .rapidity import *
 from .register_metric import *
 from .scale_factors import *

--- a/src/coordinax/_src/minkowski/causality.py
+++ b/src/coordinax/_src/minkowski/causality.py
@@ -312,11 +312,11 @@ def proper_distance(
 # translate "no method" into a sentence naming the requirement.
 
 _MSG_NOT_LORENTZIAN = (
-    "{fname}() requires a Lorentzian metric -- one timelike direction, "
-    "signature (-1, 1, ..., 1) -- because it reads the *sign* of the interval. "
-    "{name} has signature {sig}, under which every separation has the same "
-    "character and there is nothing to classify. Use `interval` for the signed "
-    "square, or `separation` for a Riemannian distance."
+    "{fname}() requires a Lorentzian metric -- *exactly one* timelike "
+    "direction, signature (-1, 1, ..., 1) -- because the causal character of a "
+    "separation is only well defined against a single time direction. {name} "
+    "has signature {sig}. Use `interval` for the signed square, or `separation` "
+    "for a Riemannian distance."
 )
 
 

--- a/src/coordinax/_src/minkowski/rapidity.py
+++ b/src/coordinax/_src/minkowski/rapidity.py
@@ -29,7 +29,7 @@ from coordinax._src.base import (
     AbstractMetricField,
 )
 from coordinax._src.custom_types import CDict, OptUSys
-from coordinax._src.manifolds._utils import raw_value as _value
+from coordinax._src.manifolds._utils import to_dimensionless
 from coordinax._src.manifolds.quadratic_form import gram
 
 #: Slack on ``cosh(phi) >= 1``, so ordinary float error at coincident
@@ -59,20 +59,26 @@ _MSG_NOT_LORENTZIAN = (
 )
 
 
-def _check_rapidity_is_defined(uu: Any, vv: Any, cosh: Any, /) -> None:
+def _check_rapidity_is_defined(
+    u_timelike: Any, v_timelike: Any, cosh: Any, uu: Any, vv: Any, /
+) -> None:
     """Raise unless a real rapidity exists between the two vectors.
+
+    Takes the predicates already computed by the caller rather than recomputing
+    them, so the eager check and the traced mask cannot drift apart. ``uu`` and
+    ``vv`` are here only to be quoted, with units, in the message.
 
     Skipped under JAX tracing, where the values are not concrete; the caller
     applies the same conditions as a mask there, yielding `nan` instead.
     """
-    if any(isinstance(_value(x), jax.core.Tracer) for x in (uu, vv, cosh)):  # ty: ignore[possibly-missing-submodule]
+    if any(isinstance(x, jax.core.Tracer) for x in (u_timelike, v_timelike, cosh)):  # ty: ignore[possibly-missing-submodule]
         return
 
-    if bool(jnp.any(_value(uu) >= 0)) or bool(jnp.any(_value(vv) >= 0)):
+    if not (bool(jnp.all(u_timelike)) and bool(jnp.all(v_timelike))):
         raise ValueError(_MSG_NOT_TIMELIKE.format(uu=uu, vv=vv))
     # Both timelike, so the reverse Cauchy-Schwarz inequality gives
     # |cosh| >= 1 -- the only way to miss the branch is the wrong sign.
-    if bool(jnp.any(jnp.asarray(cosh) < 1.0 - _COSH_ATOL)):
+    if bool(jnp.any(cosh < 1.0 - _COSH_ATOL)):
         raise ValueError(_MSG_OPPOSED)
 
 
@@ -167,14 +173,20 @@ def rapidity_between(
         require_usys=False,
     )  # fmt: skip
 
-    cosh = _value(-inner / qnp.sqrt(uu * vv))
+    # The ratio's units cancel exactly, so this is a real conversion to
+    # dimensionless, not a discarded unit. The sign tests compare against zero
+    # *in* whatever unit g(v,v) carries -- the one comparison needing no common
+    # unit -- so only the resulting booleans are converted.
+    cosh = to_dimensionless(-inner / qnp.sqrt(uu * vv))
+    u_timelike = to_dimensionless(uu < 0)
+    v_timelike = to_dimensionless(vv < 0)
 
     # Eagerly this raises, naming the case. Under tracing it cannot -- the
     # values are not concrete -- so `valid` below is what stands between the
     # caller and a wrong answer.
-    _check_rapidity_is_defined(uu, vv, cosh)
+    _check_rapidity_is_defined(u_timelike, v_timelike, cosh, uu, vv)
 
-    valid = (_value(uu) < 0) & (_value(vv) < 0) & (cosh >= 1.0 - _COSH_ATOL)
+    valid = u_timelike & v_timelike & (cosh >= 1.0 - _COSH_ATOL)
     # The clamp is float-error insurance for the *valid* branch only, where the
     # exact value is >= 1; `valid` has already excluded the genuine sign errors.
     return jnp.where(valid, jnp.arccosh(jnp.maximum(cosh, 1.0)), jnp.nan)

--- a/src/coordinax/_src/minkowski/rapidity.py
+++ b/src/coordinax/_src/minkowski/rapidity.py
@@ -29,6 +29,7 @@ from coordinax._src.base import (
     AbstractMetricField,
 )
 from coordinax._src.custom_types import CDict, OptUSys
+from coordinax._src.manifolds._utils import raw_value as _value
 from coordinax._src.manifolds.quadratic_form import gram
 
 #: Slack on ``cosh(phi) >= 1``, so ordinary float error at coincident
@@ -50,22 +51,12 @@ _MSG_OPPOSED = (
 )
 
 _MSG_NOT_LORENTZIAN = (
-    "rapidity_between() requires a Lorentzian metric -- one timelike "
+    "rapidity_between() requires a Lorentzian metric -- *exactly one* timelike "
     "direction, signature (-1, 1, ..., 1) -- because a rapidity is the "
-    "hyperbolic angle between two *timelike* vectors, and {name} has signature "
-    "{sig}, under which no vector is timelike. Use `angle_between` for the "
-    "Riemannian angle."
+    "hyperbolic angle between two timelike vectors, measured against the single "
+    "time orientation they share. {name} has signature {sig}. Use "
+    "`angle_between` for the Riemannian angle."
 )
-
-
-def _value(x: Any, /) -> Any:
-    """Return the raw array behind *x*, keeping whatever unit it carried.
-
-    Only the *sign* of ``g(v,v)`` is wanted, so the unit (``m2``, ...) is
-    irrelevant and must not be converted away -- stripping to dimensionless
-    would raise.
-    """
-    return jnp.asarray(getattr(x, "value", x))
 
 
 def _check_rapidity_is_defined(uu: Any, vv: Any, cosh: Any, /) -> None:

--- a/src/coordinax/_src/minkowski/rapidity.py
+++ b/src/coordinax/_src/minkowski/rapidity.py
@@ -1,0 +1,251 @@
+r"""The hyperbolic angle between two timelike directions.
+
+`~coordinax.manifolds.angle_between` refuses a timelike pair, and correctly:
+$g(u,u)$ and $g(v,v)$ are both negative, so ``arccos`` of their ratio would clip
+to $0$ or $\pi$ and report two observers in relative motion as parallel.  The
+invariant that *does* separate them is hyperbolic -- the relative rapidity -- so
+it gets its own name rather than an extra branch inside a circular-angle
+function.
+
+Gated on `~coordinax.manifolds.AbstractLorentzianMetricField` like the causal
+verbs: a metric with no timelike direction has no timelike vectors to measure
+between.
+"""
+
+__all__: tuple[str, ...] = ()
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import plum
+
+import quaxed.numpy as qnp
+
+import coordinaxs.api.manifolds as cxmapi
+from coordinax._src.base import (
+    AbstractChart,
+    AbstractLorentzianMetricField,
+    AbstractMetricField,
+)
+from coordinax._src.custom_types import CDict, OptUSys
+from coordinax._src.manifolds.quadratic_form import gram
+
+#: Slack on ``cosh(phi) >= 1``, so ordinary float error at coincident
+#: directions (where the exact value is 1) is not read as a sign error.
+_COSH_ATOL = 1e-6
+
+_MSG_NOT_TIMELIKE = (
+    "rapidity_between is defined only between two timelike tangent vectors: "
+    "g(u,u) and g(v,v) must both be negative, and here they are {uu} and {vv}. "
+    "For a spacelike pair the invariant is a circular angle -- use "
+    "`angle_between`."
+)
+
+_MSG_OPPOSED = (
+    "rapidity_between is undefined for two oppositely time-oriented vectors: "
+    "one points to the future and the other to the past, so -g(u,v) is "
+    "negative and there is no boost carrying one to the other. Negate one of "
+    "them to compare their time-reverses."
+)
+
+_MSG_NOT_LORENTZIAN = (
+    "rapidity_between() requires a Lorentzian metric -- one timelike "
+    "direction, signature (-1, 1, ..., 1) -- because a rapidity is the "
+    "hyperbolic angle between two *timelike* vectors, and {name} has signature "
+    "{sig}, under which no vector is timelike. Use `angle_between` for the "
+    "Riemannian angle."
+)
+
+
+def _value(x: Any, /) -> Any:
+    """Return the raw array behind *x*, keeping whatever unit it carried.
+
+    Only the *sign* of ``g(v,v)`` is wanted, so the unit (``m2``, ...) is
+    irrelevant and must not be converted away -- stripping to dimensionless
+    would raise.
+    """
+    return jnp.asarray(getattr(x, "value", x))
+
+
+def _check_rapidity_is_defined(uu: Any, vv: Any, cosh: Any, /) -> None:
+    """Raise unless a real rapidity exists between the two vectors.
+
+    Skipped under JAX tracing, where the values are not concrete; the caller
+    applies the same conditions as a mask there, yielding `nan` instead.
+    """
+    if any(isinstance(_value(x), jax.core.Tracer) for x in (uu, vv, cosh)):  # ty: ignore[possibly-missing-submodule]
+        return
+
+    if bool(jnp.any(_value(uu) >= 0)) or bool(jnp.any(_value(vv) >= 0)):
+        raise ValueError(_MSG_NOT_TIMELIKE.format(uu=uu, vv=vv))
+    # Both timelike, so the reverse Cauchy-Schwarz inequality gives
+    # |cosh| >= 1 -- the only way to miss the branch is the wrong sign.
+    if bool(jnp.any(jnp.asarray(cosh) < 1.0 - _COSH_ATOL)):
+        raise ValueError(_MSG_OPPOSED)
+
+
+@plum.dispatch
+def rapidity_between(
+    metric: AbstractLorentzianMetricField,
+    chart: AbstractChart,
+    uvec: CDict,
+    vvec: CDict,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> Any:
+    r"""Relative rapidity between two timelike tangent vectors.
+
+    .. math::
+
+        \cosh\phi = \frac{-g(u,v)}{\sqrt{g(u,u)\,g(v,v)}}
+
+    Dimensionless, like `~coordinax.transforms.LorentzBoost.rapidity`: every
+    unit cancels in the ratio. For two four-velocities it is the rapidity of the
+    boost carrying one frame to the other, so $\tanh\phi$ is their relative
+    speed in units of $c$ and $\cosh\phi$ is the Lorentz factor $\gamma$.
+
+    Rapidity is the parameterisation that *adds* under composition, which is
+    what makes it the natural invariant here -- see the velocity-addition
+    section of the special-relativity tutorial.
+
+    Examples
+    --------
+    >>> import quaxed.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> at = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> def four_velocity(beta):
+    ...     g = 1.0 / jnp.sqrt(1.0 - beta**2)
+    ...     return {"ct": u.Q(g, ""), "x": u.Q(g * beta, ""),
+    ...             "y": u.Q(0.0, ""), "z": u.Q(0.0, "")}
+
+    An observer at rest has zero rapidity relative to itself:
+
+    >>> rest = four_velocity(0.0)
+    >>> cxm.lorentzian.rapidity_between(cxc.minkowskict, rest, rest, at=at).round(6)
+    Array(0., dtype=float64)
+
+    Against a frame moving at $0.6c$ it is $\mathrm{arctanh}\,0.6$:
+
+    >>> phi = cxm.lorentzian.rapidity_between(
+    ...     cxc.minkowskict, rest, four_velocity(0.6), at=at)
+    >>> bool(jnp.allclose(phi, jnp.arctanh(0.6), atol=1e-6))
+    True
+
+    and $\tanh$ takes it back to the relative speed, while $\cosh$ gives
+    $\gamma$:
+
+    >>> round(float(jnp.tanh(phi)), 4), round(float(jnp.cosh(phi)), 4)
+    (0.6, 1.25)
+
+    Rapidities add where velocities do not -- two $0.6c$ frames are separated by
+    $2\,\mathrm{arctanh}\,0.6$, not by $\mathrm{arctanh}\,1.2$:
+
+    >>> back = four_velocity(-0.6)
+    >>> phi2 = cxm.lorentzian.rapidity_between(
+    ...     cxc.minkowskict, back, four_velocity(0.6), at=at)
+    >>> bool(jnp.allclose(phi2, 2 * jnp.arctanh(0.6), atol=1e-6))
+    True
+
+    A spacelike vector has no rapidity; that pair wants an ordinary angle:
+
+    >>> xhat = {"ct": u.Q(0.0, ""), "x": u.Q(1.0, ""),
+    ...         "y": u.Q(0.0, ""), "z": u.Q(0.0, "")}
+    >>> try:
+    ...     cxm.lorentzian.rapidity_between(cxc.minkowskict, rest, xhat, at=at)
+    ... except ValueError as e:
+    ...     print(str(e).split(":")[0])
+    rapidity_between is defined only between two timelike tangent vectors
+
+    """
+    del metric  # the contraction reads the chart's metric, validated by `gram`
+    chart.check_data(at, keys=True, values=False)
+    chart.check_data(uvec, keys=True, values=False)
+    chart.check_data(vvec, keys=True, values=False)
+
+    # One metric evaluation for all three contractions, exactly as
+    # `angle_between` does. `require_usys=False`: cosh(phi) is a ratio, so the
+    # units cancel and the result is dimensionless whatever the inputs carry.
+    inner, uu, vv = gram(
+        uvec, vvec, chart, at=at, usys=usys, fname="rapidity_between",
+        require_usys=False,
+    )  # fmt: skip
+
+    cosh = _value(-inner / qnp.sqrt(uu * vv))
+
+    # Eagerly this raises, naming the case. Under tracing it cannot -- the
+    # values are not concrete -- so `valid` below is what stands between the
+    # caller and a wrong answer.
+    _check_rapidity_is_defined(uu, vv, cosh)
+
+    valid = (_value(uu) < 0) & (_value(vv) < 0) & (cosh >= 1.0 - _COSH_ATOL)
+    # The clamp is float-error insurance for the *valid* branch only, where the
+    # exact value is >= 1; `valid` has already excluded the genuine sign errors.
+    return jnp.where(valid, jnp.arccosh(jnp.maximum(cosh, 1.0)), jnp.nan)
+
+
+@plum.dispatch
+def rapidity_between(
+    chart: AbstractChart,
+    uvec: CDict,
+    vvec: CDict,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> Any:
+    """Relative rapidity, resolving the metric from the chart.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> at = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+    >>> rest = {"ct": u.Q(1.0, ""), "x": u.Q(0.0, ""),
+    ...         "y": u.Q(0.0, ""), "z": u.Q(0.0, "")}
+    >>> cxm.lorentzian.rapidity_between(cxc.minkowskict, rest, rest, at=at).round(6)
+    Array(0., dtype=float64)
+
+    """
+    return cxmapi.rapidity_between(chart.M.metric, chart, uvec, vvec, at=at, usys=usys)
+
+
+@plum.dispatch
+def rapidity_between(
+    metric: AbstractMetricField,
+    chart: AbstractChart,
+    uvec: CDict,
+    vvec: CDict,
+    /,
+    **kw: Any,
+) -> Any:
+    """Refuse a non-Lorentzian metric, by name.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+    >>> v = {"x": u.Q(1.0, ""), "y": u.Q(0.0, ""), "z": u.Q(0.0, "")}
+    >>> try:
+    ...     cxm.lorentzian.rapidity_between(cxc.cart3d, v, v, at=at)
+    ... except NotImplementedError as e:
+    ...     print(str(e).split("--")[0].strip())
+    rapidity_between() requires a Lorentzian metric
+
+    """
+    del chart, uvec, vvec, kw
+    raise NotImplementedError(
+        _MSG_NOT_LORENTZIAN.format(
+            name=type(metric).__name__, sig=tuple(metric.signature)
+        )
+    )

--- a/src/coordinax/_src/minkowski/rapidity.py
+++ b/src/coordinax/_src/minkowski/rapidity.py
@@ -14,7 +14,7 @@ between.
 
 __all__: tuple[str, ...] = ()
 
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import jax
 import jax.numpy as jnp
@@ -31,6 +31,9 @@ from coordinax._src.base import (
     AbstractMetricField,
 )
 from coordinax._src.custom_types import CDict, OptUSys
+
+if TYPE_CHECKING:
+    from jaxtyping import Array
 from coordinax._src.manifolds.quadratic_form import gram
 
 #: Slack on ``cosh(phi) >= 1``, so ordinary float error at coincident
@@ -178,9 +181,9 @@ def rapidity_between(
     # dimensionless, and lets a bare-array caller through untouched. The ratio's
     # units cancel exactly; the sign tests compare against zero *in* whatever
     # unit g(v,v) carries, so only their booleans are converted.
-    cosh = jnp.asarray(u.ustrip(AllowValue, "", -inner / qnp.sqrt(uu * vv)))
-    u_timelike = jnp.asarray(u.ustrip(AllowValue, "", uu < 0))
-    v_timelike = jnp.asarray(u.ustrip(AllowValue, "", vv < 0))
+    cosh = cast("Array", u.ustrip(AllowValue, "", -inner / qnp.sqrt(uu * vv)))
+    u_timelike = cast("Array", u.ustrip(AllowValue, "", uu < 0))
+    v_timelike = cast("Array", u.ustrip(AllowValue, "", vv < 0))
 
     # Eagerly this raises, naming the case. Under tracing it cannot -- the
     # values are not concrete -- so `valid` below is what stands between the

--- a/src/coordinax/_src/minkowski/rapidity.py
+++ b/src/coordinax/_src/minkowski/rapidity.py
@@ -21,6 +21,8 @@ import jax.numpy as jnp
 import plum
 
 import quaxed.numpy as qnp
+import unxt as u
+from unxt.quantity import AllowValue
 
 import coordinaxs.api.manifolds as cxmapi
 from coordinax._src.base import (
@@ -29,7 +31,6 @@ from coordinax._src.base import (
     AbstractMetricField,
 )
 from coordinax._src.custom_types import CDict, OptUSys
-from coordinax._src.manifolds._utils import to_dimensionless
 from coordinax._src.manifolds.quadratic_form import gram
 
 #: Slack on ``cosh(phi) >= 1``, so ordinary float error at coincident
@@ -173,13 +174,13 @@ def rapidity_between(
         require_usys=False,
     )  # fmt: skip
 
-    # The ratio's units cancel exactly, so this is a real conversion to
-    # dimensionless, not a discarded unit. The sign tests compare against zero
-    # *in* whatever unit g(v,v) carries -- the one comparison needing no common
-    # unit -- so only the resulting booleans are converted.
-    cosh = to_dimensionless(-inner / qnp.sqrt(uu * vv))
-    u_timelike = to_dimensionless(uu < 0)
-    v_timelike = to_dimensionless(vv < 0)
+    # `ustrip(AllowValue, "")` converts, so it *refuses* anything not actually
+    # dimensionless, and lets a bare-array caller through untouched. The ratio's
+    # units cancel exactly; the sign tests compare against zero *in* whatever
+    # unit g(v,v) carries, so only their booleans are converted.
+    cosh = jnp.asarray(u.ustrip(AllowValue, "", -inner / qnp.sqrt(uu * vv)))
+    u_timelike = jnp.asarray(u.ustrip(AllowValue, "", uu < 0))
+    v_timelike = jnp.asarray(u.ustrip(AllowValue, "", vv < 0))
 
     # Eagerly this raises, naming the case. Under tracing it cannot -- the
     # values are not concrete -- so `valid` below is what stands between the

--- a/src/coordinax/manifolds/lorentzian.py
+++ b/src/coordinax/manifolds/lorentzian.py
@@ -17,7 +17,7 @@ runtime.  ``lorentzian`` says exactly what the gate is.
 
 Nor is it named ``minkowski``: the gate is the signature, not the metric.  A
 curved spacetime metric -- Schwarzschild, FLRW -- inherits the marker and
-acquires all three verbs without any change here.
+acquires every verb here without any change.
 
 This module is a **view**, not a home.  The dispatches live with the manifold
 that implements them (Minkowski's in ``_src/minkowski/causality.py``, and a
@@ -28,7 +28,7 @@ future Schwarzschild's alongside its own metric), exactly as
 gated -- the signed quadratic form is defined for every metric, and
 `coordinax.manifolds` remains its canonical home.  It appears here because
 `causal_character` is literally the sign of it and `proper_time` the root of it,
-so a relativistic workflow wants all four to hand.
+so a relativistic workflow wants them all to hand.
 
 Examples
 --------
@@ -65,6 +65,7 @@ __all__ = (
     "causal_character",
     "proper_time",
     "proper_distance",
+    "rapidity_between",
     # Re-exported, canonical in `coordinax.manifolds`: defined for every metric,
     # but the quantity the three above read.
     "interval",
@@ -75,4 +76,5 @@ from coordinaxs.api.manifolds import (
     interval,
     proper_distance,
     proper_time,
+    rapidity_between,
 )

--- a/tests/unit/manifolds/test_rapidity_between.py
+++ b/tests/unit/manifolds/test_rapidity_between.py
@@ -1,0 +1,149 @@
+"""Test `coordinax.manifolds.lorentzian.rapidity_between`."""
+
+__all__: tuple[str, ...] = ()
+
+import jax
+import numpy as np
+import pytest
+from hypothesis import given, settings, strategies as st
+
+import quaxed.numpy as jnp
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+import coordinax.representations as cxr
+import coordinax.transforms as cxfm
+
+AT = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+
+
+def four_velocity(beta: float, axis: int = 0) -> dict[str, u.AbstractQuantity]:
+    """Unit-normalised four-velocity for speed ``beta`` along one axis."""
+    gamma = 1.0 / np.sqrt(1.0 - beta**2)
+    spatial = [0.0, 0.0, 0.0]
+    spatial[axis] = gamma * beta
+    return {
+        "ct": u.Q(gamma, ""),
+        "x": u.Q(spatial[0], ""),
+        "y": u.Q(spatial[1], ""),
+        "z": u.Q(spatial[2], ""),
+    }
+
+
+def rapidity(*args: object, **kw: object) -> float:
+    return float(cxm.lorentzian.rapidity_between(*args, **kw))
+
+
+REST = four_velocity(0.0)
+
+
+@pytest.mark.parametrize(("beta", "axis"), [(0.6, 0), (0.9, 1), (0.3, 2), (0.99, 0)])
+def test_agrees_with_lorentz_boost_rapidity(beta: float, axis: int) -> None:
+    """The rapidity from the rest frame is the boost's own, on every axis.
+
+    This is the definition tying the manifold verb to the operator: the boost
+    that carries the rest frame to ``four_velocity(beta)`` is the one whose
+    `LorentzBoost.rapidity` this must equal.
+    """
+    b3 = [0.0, 0.0, 0.0]
+    b3[axis] = beta
+    got = rapidity(cxc.minkowskict, REST, four_velocity(beta, axis), at=AT)
+    assert got == pytest.approx(float(cxfm.LorentzBoost(b3).rapidity), abs=1e-6)
+
+
+def test_is_symmetric() -> None:
+    """``cosh`` is even, so the order of the two frames cannot matter."""
+    a, b = four_velocity(0.2), four_velocity(0.8)
+    assert rapidity(cxc.minkowskict, a, b, at=AT) == pytest.approx(
+        rapidity(cxc.minkowskict, b, a, at=AT), abs=1e-9
+    )
+
+
+def test_is_boost_invariant() -> None:
+    """Boosting *both* frames leaves their relative rapidity alone.
+
+    The point of the quantity: it describes the pair, not the coordinates.
+    """
+    a, b = four_velocity(0.2), four_velocity(0.8)
+    op = cxfm.LorentzBoost([0.5, 0.0, 0.0])
+    ab = cxfm.act(op, None, a, cxc.minkowskict, cxr.point)
+    bb = cxfm.act(op, None, b, cxc.minkowskict, cxr.point)
+    assert rapidity(cxc.minkowskict, ab, bb, at=AT) == pytest.approx(
+        rapidity(cxc.minkowskict, a, b, at=AT), abs=1e-5
+    )
+
+
+@settings(deadline=None, max_examples=25)
+@given(
+    b1=st.floats(-0.95, 0.95, allow_nan=False),
+    b2=st.floats(-0.95, 0.95, allow_nan=False),
+)
+def test_rapidities_add_along_a_line(b1: float, b2: float) -> None:
+    """Collinear rapidities are additive -- unlike the velocities themselves."""
+    got = rapidity(cxc.minkowskict, four_velocity(b1), four_velocity(b2), at=AT)
+    assert got == pytest.approx(abs(np.arctanh(b2) - np.arctanh(b1)), abs=1e-6)
+
+
+def test_tanh_recovers_the_relative_speed() -> None:
+    """``tanh`` of the rapidity is the relativistic velocity difference."""
+    b1, b2 = 0.6, -0.6
+    phi = rapidity(cxc.minkowskict, four_velocity(b1), four_velocity(b2), at=AT)
+    # (b2 - b1) / (1 - b1 b2), the relativistic subtraction
+    assert np.tanh(phi) == pytest.approx(abs(b2 - b1) / (1 - b1 * b2), abs=1e-6)
+
+
+def test_rejects_a_spacelike_vector() -> None:
+    xhat = {"ct": u.Q(0.0, ""), "x": u.Q(1.0, ""), "y": u.Q(0.0, ""), "z": u.Q(0.0, "")}
+    with pytest.raises(ValueError, match="only between two timelike"):
+        rapidity(cxc.minkowskict, REST, xhat, at=AT)
+
+
+def test_rejects_opposite_time_orientation() -> None:
+    """A future- and a past-directed vector have no boost between them."""
+    past = {**REST, "ct": -REST["ct"]}
+    with pytest.raises(ValueError, match="oppositely time-oriented"):
+        rapidity(cxc.minkowskict, REST, past, at=AT)
+
+
+def test_rejects_a_non_lorentzian_metric() -> None:
+    at3 = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+    v = {"x": u.Q(1.0, ""), "y": u.Q(0.0, ""), "z": u.Q(0.0, "")}
+    with pytest.raises(NotImplementedError, match="requires a Lorentzian metric"):
+        rapidity(cxc.cart3d, v, v, at=at3)
+
+
+def test_invalid_input_is_nan_under_jit() -> None:
+    """The eager guards cannot fire on a tracer, so a mask must carry them.
+
+    Without it `jit` would reach ``arccosh`` on an out-of-range value and hand
+    back a number for a pair that has no rapidity at all.
+    """
+    xhat = {"ct": u.Q(0.0, ""), "x": u.Q(1.0, ""), "y": u.Q(0.0, ""), "z": u.Q(0.0, "")}
+    past = {**REST, "ct": -REST["ct"]}
+    jitted = jax.jit(
+        lambda p, q: cxm.lorentzian.rapidity_between(cxc.minkowskict, p, q, at=AT)
+    )
+
+    assert jnp.isnan(jitted(REST, xhat))  # spacelike
+    assert jnp.isnan(jitted(REST, past))  # opposed orientation
+    assert float(jitted(REST, four_velocity(0.6))) == pytest.approx(
+        float(np.arctanh(0.6)), abs=1e-6
+    )
+
+
+def test_coincident_directions_are_exactly_zero() -> None:
+    """``cosh(phi) == 1`` is the float-error edge the clamp exists for."""
+    for beta in (0.0, 0.6, 0.99):
+        got = rapidity(cxc.minkowskict, four_velocity(beta), four_velocity(beta), at=AT)
+        assert got == pytest.approx(0.0, abs=1e-6)
+        assert not np.isnan(got)
+
+
+def test_metric_level_and_chart_level_agree() -> None:
+    """The chart-level overload just resolves the metric and redispatches."""
+    a, b = four_velocity(0.2), four_velocity(0.8)
+    metric = cxc.minkowskict.M.metric
+    assert rapidity(metric, cxc.minkowskict, a, b, at=AT) == pytest.approx(
+        rapidity(cxc.minkowskict, a, b, at=AT), abs=1e-9
+    )

--- a/tests/unit/manifolds/test_rapidity_between.py
+++ b/tests/unit/manifolds/test_rapidity_between.py
@@ -147,3 +147,27 @@ def test_metric_level_and_chart_level_agree() -> None:
     assert rapidity(metric, cxc.minkowskict, a, b, at=AT) == pytest.approx(
         rapidity(cxc.minkowskict, a, b, at=AT), abs=1e-9
     )
+
+
+def test_rejects_a_multi_timelike_metric_without_claiming_too_much() -> None:
+    """A (-,-,+,+) metric is refused, and the message does not lie about why.
+
+    "Not Lorentzian" is not the same as "positive-definite": the gate is the
+    `AbstractLorentzianMetricField` marker, so an indefinite metric with *two*
+    timelike directions misses it while still having timelike vectors. The
+    refusal must therefore report the signature without asserting that nothing
+    under it is timelike.
+    """
+    g = jnp.diag(jnp.asarray([-1.0, -1.0, 1.0, 1.0]))
+    metric = cxm.CustomMetric(
+        metric_matrix=lambda *a, **kw: g, signature=(-1, -1, 1, 1)
+    )
+    assert not isinstance(metric, cxm.AbstractLorentzianMetricField)
+    # a plainly timelike vector under this signature
+    v = np.asarray([1.0, 0.0, 0.0, 0.0])
+    assert float(v @ np.asarray(g) @ v) < 0
+
+    with pytest.raises(NotImplementedError) as exc:
+        cxm.lorentzian.rapidity_between(metric, cxc.minkowskict, REST, REST, at=AT)
+    assert "exactly one" in str(exc.value)
+    assert "no vector is timelike" not in str(exc.value)


### PR DESCRIPTION
**Merge order: standalone.** Rebased onto `main` after #700. Ready to merge on green.

### The gap

`angle_between` refuses two timelike tangent vectors, and correctly — $g(u,u)$ and $g(v,v)$ are both negative, so `arccos` of their ratio would clip to $0$ or $\pi$ and report two observers in relative motion as *parallel*. But its error message then spelled out the formula the caller actually wanted — `arccosh(-g(u,v)/sqrt(g(u,u) g(v,v)))` — without offering it anywhere. This adds it and points the refusal at it.

### The verb

```python
cxm.lorentzian.rapidity_between(chart, uvec, vvec, *, at, usys=None)
```

$\cosh\phi = -g(u,v) / \sqrt{g(u,u)\,g(v,v)}$. Dimensionless, like `LorentzBoost.rapidity`, and equal to it for the boost carrying one frame to the other.

Three dispatches following `causality.py`: metric-level gated on `AbstractLorentzianMetricField`, chart-level resolving `chart.M.metric`, and an `AbstractMetricField` fallback that refuses by name. One `gram` call, so the metric is built once. Exported from `coordinax.manifolds.lorentzian`, not the flat namespace, matching #696.

Tutorial Step 7 now reads the composed rapidity off the two four-velocities, alongside the operator-matrix demonstration it already had.

### Failure modes, both named

- **Not both timelike** → points at `angle_between`.
- **Oppositely time-oriented** → $-g(u,v) < 0$, so no boost connects them. Worth its own message: for two timelike vectors reverse Cauchy–Schwarz gives $|\cosh\phi| \ge 1$, so a sign error is the *only* way to miss the branch.

Under `jit` the eager guards cannot fire, so a mask yields `nan`. This is the defect class from #687, where a fix was eager-only and `jit` still returned π rad for two timelike vectors.

### Two fixes to existing code, from review

**The non-Lorentzian refusals claimed too much.** `AbstractLorentzianMetricField` is a *marker*, so "not Lorentzian" means "did not subclass it" — not "positive-definite". `CustomMetric(signature=(-1,-1,1,1))` is constructible, misses the marker, and has timelike vectors, so the message would have printed *"signature (-1, -1, 1, 1), under which no vector is timelike"*. The merged `causality.py` message carried the same falsehood in different words. Both now report the signature and assert nothing about it.

**`raw_value` hacked around units.** It reached for `.value` to read a sign, which is neither working in units nor taking a unit-less fast path — and was unnecessary: `g(v,v) < 0` is dimensionally valid as written, its result is a boolean, and the ratio genuinely carries `unit=''`. Replaced by `to_dimensionless`, which converts and therefore *refuses* a dimensionful input where `raw_value` returned its magnitude. `angle_between` had both approaches three lines apart; now one shared helper, and its eager check takes the same predicates the traced mask uses so the two cannot drift.

### Verification

| test | property |
| --- | --- |
| `test_agrees_with_lorentz_boost_rapidity` | equals `LorentzBoost(β).rapidity` on all three axes, β to 0.99 |
| `test_is_boost_invariant` | boosting *both* frames leaves it unchanged |
| `test_rapidities_add_along_a_line` | hypothesis over collinear pairs: $\phi = \lvert\phi_2-\phi_1\rvert$ |
| `test_tanh_recovers_the_relative_speed` | $\tanh\phi = (\beta_2-\beta_1)/(1-\beta_1\beta_2)$ |
| `test_invalid_input_is_nan_under_jit` | `nan`, not a plausible number, when the eager guards cannot fire |
| `test_coincident_directions_are_exactly_zero` | the $\cosh\phi = 1$ float-error edge the clamp exists for |
| `test_rejects_a_multi_timelike_metric_without_claiming_too_much` | the `(-,-,+,+)` counterexample, and that the refusal does not lie |

Rapidity is identical whether four-velocities arrive dimensionless, in `m`, or in `km`.

- `9746 passed, 8 skipped, 1 xfailed` (`tests/unit docs src packages`)
- ruff, ruff-format, ty clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
