### PR TITLE
🐛 fix(charts): make `guess_chart` pick the same chart every run

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1146,7 +1146,7 @@ The `coordinax.charts` module provides the chart-facing API for representing poi
 
     Dispatches:
 
-    - Input `frozenset[str]` (component names): infer a chart whose `components` set matches exactly. The results are cached; repeated calls with the same key set return the same chart object instance.
+    - Input `frozenset[str]` (component names): infer a chart whose `components` set matches exactly. Each call constructs a chart, so repeated calls return equal — not identical — instances.
     - Input `CDict`/mapping: infer from `frozenset(obj.keys())`.
     - Input array-like or quantity-like with trailing axis length 1, 2, or 3: infer the matching low-dimensional Cartesian chart (`cart1d`/`cart2d`/`cart3d`) by that trailing size.
     - Input array-like or quantity-like with any other trailing axis length: infer the arbitrary-dimension Cartesian chart `cartnd` (`CartND`).
@@ -1159,8 +1159,9 @@ The `coordinax.charts` module provides the chart-facing API for representing poi
 
     Notes:
 
-    - There is a selection ambiguity. Key-based inference uses component names only. If multiple chart types share the same component names, the result is not uniquely identifiable from keys alone and one matching chart is returned.
-    - Inferred chart choice from keys is stable within a process due to caching, but callers should not treat key-only inference as a unique chart identifier when component-name collisions exist.
+    - There is a selection ambiguity. Key-based inference uses component names only. If multiple chart types share the same component names — `Spherical3D` and `MathSpherical3D` both carry `("r", "theta", "phi")`, and disagree about which angle is polar — the keys alone do not identify a chart.
+    - Each such collision MUST have exactly one chart declared canonical (via `register_canonical_chart`), and that chart is the one inferred. The choice is therefore the same in every process, and does not depend on the order charts are registered or scanned in. A collision with no declaration raises `ValueError` rather than returning an arbitrary member.
+    - Callers should still not treat key-only inference as a unique chart identifier when collisions exist: it resolves to the declared convention, which may not be the one intended. Pass the chart explicitly when it matters.
 
 !!! info `cdict`
 

--- a/src/coordinax/_src/charts/register_guess.py
+++ b/src/coordinax/_src/charts/register_guess.py
@@ -2,6 +2,7 @@
 
 __all__: tuple[str, ...] = ()
 
+
 from jaxtyping import ArrayLike, Shaped
 from typing import Any, cast
 
@@ -13,7 +14,7 @@ import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
 from .d1 import cart1d
 from .d2 import cart2d
-from .d3 import cart3d
+from .d3 import Spherical3D, cart3d
 from .dn import cartnd
 from coordinax._src.base import (
     NON_ABC_CHART_CLASSES,
@@ -25,6 +26,34 @@ from coordinax._src.custom_types import CDict
 # ===================================================================
 # Guess Chart Classes
 
+ChartCls = type[AbstractFixedComponentsChart[Any, Any, Any]]
+
+CANONICAL_CHART_CLASSES: dict[frozenset[str], ChartCls] = {}
+"""The chart to infer when a component-name set matches several charts.
+
+Component names do not always identify a chart: `Spherical3D` and
+`MathSpherical3D` both carry ``("r", "theta", "phi")`` but disagree about which
+of the two angles is polar. Which one a bare name set means is a choice, so it
+is declared here rather than left to the order charts happen to be scanned in.
+
+Populated by `register_canonical_chart`, called from the module that defines
+the chart -- the same late-registration pattern as the ``register_*`` modules,
+which is what lets a chart from any package declare itself without
+`coordinax._src.charts` having to import that package.
+"""
+
+
+def register_canonical_chart(cls: ChartCls, /) -> ChartCls:
+    """Declare `cls` as the chart to infer for its component names.
+
+    Returns `cls`, so it can also be used as a decorator.
+    """
+    CANONICAL_CHART_CLASSES[frozenset(cls._components)] = cls
+    return cls
+
+
+register_canonical_chart(Spherical3D)  # over `MathSpherical3D`
+
 
 # TODO: speed this up. The problem is that caching the results breaks something,
 # causing functions in other modules to fail type(x) is type(y) checks.
@@ -33,16 +62,37 @@ def guess_chart_cls(obj: frozenset[str]) -> type[AbstractChart[Any, Any, Any]]:
 
     This only works on charts with fixed components.
 
-    """
-    for chart_cls in NON_ABC_CHART_CLASSES:
-        if (
-            issubclass(chart_cls, AbstractFixedComponentsChart)
-            and frozenset(chart_cls._components) == obj
-        ):
-            return chart_cls
+    Every match is collected rather than the first one returned, because
+    `NON_ABC_CHART_CLASSES` is a `weakref.WeakSet`: classes hash by `id`, so it
+    iterates in a different order in every process. Where several charts share
+    a name set, `CANONICAL_CHART_CLASSES` decides between them.
 
-    msg = f"Cannot infer representation from keys {obj}"
-    raise ValueError(msg)
+    """
+    matches = [
+        chart_cls
+        for chart_cls in NON_ABC_CHART_CLASSES
+        if issubclass(chart_cls, AbstractFixedComponentsChart)
+        and frozenset(chart_cls._components) == obj
+    ]
+
+    if not matches:
+        msg = f"Cannot infer representation from keys {obj}"
+        raise ValueError(msg)
+
+    if len(matches) == 1:
+        return matches[0]
+
+    canonical = CANONICAL_CHART_CLASSES.get(obj)
+    if canonical is None:
+        # Returning any one of these would be a coin flip between conventions.
+        names = ", ".join(sorted(cls.__name__ for cls in matches))
+        msg = (
+            f"Keys {set(obj)} match several charts ({names}) and none of them "
+            "is canonical; declare the intended one with "
+            "`register_canonical_chart`, or pass the chart explicitly."
+        )
+        raise ValueError(msg)
+    return canonical
 
 
 # ===================================================================
@@ -55,9 +105,9 @@ def guess_chart(obj: frozenset[str], /) -> AbstractChart:
 
     Note that many charts may share the same component names (e.g., Spherical3D
     and MathSpherical3D both use 'r', 'theta', 'phi'). These are completely
-    indistinguishable from component names alone, so this function will return
-    the first matching chart it finds. Since the function is cached, the result
-    will be consistent across calls.
+    indistinguishable from component names alone, so `CANONICAL_CHART_CLASSES`
+    names the one to infer -- the physics convention in both current cases.
+    Pass the chart explicitly when the convention matters.
 
     >>> import coordinax.charts as cxc
     >>> d = {"x": 1.0, "y": 2.0, "z": 3.0}
@@ -82,9 +132,9 @@ def guess_chart(obj: CDict, /) -> AbstractChart:
 
     Note that many charts may share the same component names (e.g., Spherical3D
     and MathSpherical3D both use 'r', 'theta', 'phi'). These are completely
-    indistinguishable from component names alone, so this function will return
-    the first matching chart it finds. Since the function is cached, the result
-    will be consistent across calls.
+    indistinguishable from component names alone, so `CANONICAL_CHART_CLASSES`
+    names the one to infer -- the physics convention in both current cases.
+    Pass the chart explicitly when the convention matters.
 
     >>> import coordinax.charts as cxc
     >>> d = {"x": 1.0, "y": 2.0, "z": 3.0}

--- a/src/coordinax/_src/charts/register_guess.py
+++ b/src/coordinax/_src/charts/register_guess.py
@@ -46,9 +46,22 @@ which is what lets a chart from any package declare itself without
 def register_canonical_chart(cls: ChartCls, /) -> ChartCls:
     """Declare `cls` as the chart to infer for its component names.
 
+    Redeclaring the same class is a no-op, so a module may be imported twice.
+    Declaring a *different* class for names already claimed raises: silently
+    overwriting would put the inferred chart back at the mercy of import order,
+    which is what this registry exists to take it out of.
+
     Returns `cls`, so it can also be used as a decorator.
     """
-    CANONICAL_CHART_CLASSES[frozenset(cls._components)] = cls
+    keys = frozenset(cls._components)
+    claimed = CANONICAL_CHART_CLASSES.get(keys)
+    if claimed is not None and claimed is not cls:
+        msg = (
+            f"Components {sorted(keys)} are already declared canonical for "
+            f"{claimed.__name__}; {cls.__name__} cannot also claim them."
+        )
+        raise ValueError(msg)
+    CANONICAL_CHART_CLASSES[keys] = cls
     return cls
 
 
@@ -75,8 +88,12 @@ def guess_chart_cls(obj: frozenset[str]) -> type[AbstractChart[Any, Any, Any]]:
         and frozenset(chart_cls._components) == obj
     ]
 
+    # `obj` is a frozenset, whose iteration order varies between processes;
+    # sort it so the message reads the same everywhere.
+    keys = sorted(obj)
+
     if not matches:
-        msg = f"Cannot infer representation from keys {obj}"
+        msg = f"Cannot infer representation from keys {keys}"
         raise ValueError(msg)
 
     if len(matches) == 1:
@@ -87,8 +104,8 @@ def guess_chart_cls(obj: frozenset[str]) -> type[AbstractChart[Any, Any, Any]]:
         # Returning any one of these would be a coin flip between conventions.
         names = ", ".join(sorted(cls.__name__ for cls in matches))
         msg = (
-            f"Keys {set(obj)} match several charts ({names}) and none of them "
-            "is canonical; declare the intended one with "
+            f"Keys {keys} match several charts ({names}) and none of them is "
+            "canonical; declare the intended one with "
             "`register_canonical_chart`, or pass the chart explicitly."
         )
         raise ValueError(msg)

--- a/src/coordinax/_src/spherical/guess.py
+++ b/src/coordinax/_src/spherical/guess.py
@@ -6,8 +6,16 @@ __all__: tuple[str, ...] = ()
 import plum
 
 from .atlas import HyperSphericalAtlas
-from .chart import AbstractSphericalTwoSphere
+from .chart import AbstractSphericalTwoSphere, SphericalTwoSphere
 from .manifold import HyperSphericalManifold
+from coordinax._src.charts.register_guess import register_canonical_chart
+
+# `("theta", "phi")` is also `MathSphericalTwoSphere`, which swaps the polar and
+# azimuthal angles; component names cannot tell them apart, so name the one
+# `guess_chart` should infer. Declared here rather than in
+# `coordinax._src.charts`, which is imported before this package and so cannot
+# reach `SphericalTwoSphere`.
+register_canonical_chart(SphericalTwoSphere)
 
 
 @plum.dispatch

--- a/tests/unit/charts/test_guess_chart.py
+++ b/tests/unit/charts/test_guess_chart.py
@@ -8,13 +8,14 @@
 
 2. When multiple chart types share the same component names (e.g.,
    Spherical3D and MathSpherical3D both use ('r', 'theta', 'phi')),
-   `guess_chart` returns whichever it finds first in iteration order.
-   This is by design - component names alone don't uniquely identify
-   chart types.
+   `guess_chart` has to pick one: component names alone don't uniquely
+   identify chart types. `CANONICAL_CHART_CLASSES` names which, and
+   `TestAmbiguousComponentNames` pins it -- the alternatives disagree about
+   what ``theta`` means, so the choice is a numerical answer, not a detail.
 
 """
 
-from typing import TypeAlias
+from typing import ClassVar, TypeAlias
 
 import numpy as np
 import pytest
@@ -25,6 +26,8 @@ import unxts.hypothesis as ust
 import coordinax.charts as cxc
 import coordinaxs.hypothesis.main as cxst
 from .conftest import SHAPE_CART_MAP, xps
+from coordinax._src.base import NON_ABC_CHART_CLASSES, AbstractFixedComponentsChart
+from coordinax._src.charts.register_guess import CANONICAL_CHART_CLASSES
 
 Shape: TypeAlias = tuple[int, ...]
 
@@ -97,6 +100,57 @@ class TestGuessChartCaching:
         result1 = cxc.guess_chart(d1)
         result2 = cxc.guess_chart(d2)
         assert type(result1) is type(result2)
+
+
+class TestAmbiguousComponentNames:
+    """Charts sharing a component-name set resolve to one declared chart.
+
+    `guess_chart` scans `NON_ABC_CHART_CLASSES`, a `weakref.WeakSet`, which
+    iterates in `id`-hash order and so differs between processes. What makes
+    the answer a function of the component names is `CANONICAL_CHART_CLASSES`,
+    which names the chart to infer; the alternatives disagree about which angle
+    is polar, so picking the other one silently moves the point.
+    """
+
+    #: Component-name sets shared by several charts, and the one to infer.
+    #: Both pairs are physics convention vs maths convention.
+    AMBIGUOUS: ClassVar = [
+        pytest.param(("r", "theta", "phi"), "Spherical3D", id="sph3d"),
+        pytest.param(("theta", "phi"), "SphericalTwoSphere", id="sph2"),
+    ]
+
+    def test_every_ambiguous_component_set_is_declared(self) -> None:
+        """The invariant `guess_chart_cls` relies on, over every chart."""
+        by_components: dict[frozenset[str], list[str]] = {}
+        for cls in NON_ABC_CHART_CLASSES:
+            if issubclass(cls, AbstractFixedComponentsChart):
+                by_components.setdefault(frozenset(cls._components), []).append(
+                    cls.__name__
+                )
+
+        ambiguous = {k for k, v in by_components.items() if len(v) > 1}
+        undeclared = {
+            tuple(sorted(k)): sorted(by_components[k])
+            for k in ambiguous - set(CANONICAL_CHART_CLASSES)
+        }
+        assert not undeclared, (
+            f"Component names no longer identify a chart: {undeclared}. Add "
+            "the intended one to `CANONICAL_CHART_CLASSES`."
+        )
+
+    @pytest.mark.parametrize(("components", "expected"), AMBIGUOUS)
+    def test_ambiguity_resolves_to_the_declared_chart(
+        self, components: tuple[str, ...], expected: str
+    ) -> None:
+        """The physics-convention chart is inferred, in every process."""
+        assert type(cxc.guess_chart(frozenset(components))).__name__ == expected
+
+    @pytest.mark.parametrize(("components", "expected"), AMBIGUOUS)
+    def test_the_declaration_names_that_chart(
+        self, components: tuple[str, ...], expected: str
+    ) -> None:
+        """The choice is declared, not a by-product of scan order."""
+        assert CANONICAL_CHART_CLASSES[frozenset(components)].__name__ == expected
 
 
 class TestGuessChartFromArrayLike:

--- a/tests/unit/charts/test_guess_chart.py
+++ b/tests/unit/charts/test_guess_chart.py
@@ -110,6 +110,20 @@ class TestGuessChartRepeatability:
         assert type(result1) is type(result2)
 
 
+class TestGuessChartFailureModes:
+    """No chart matches, and the messages that come back."""
+
+    def test_unknown_component_names_raise(self) -> None:
+        """The spec's failure semantics: an unmatched key set is a `ValueError`."""
+        with pytest.raises(ValueError, match="Cannot infer representation"):
+            cxc.guess_chart(frozenset(("nope", "nada")))
+
+    def test_the_message_lists_the_keys_in_a_stable_order(self) -> None:
+        """`frozenset` iterates in `id`-hash order; the message must not."""
+        with pytest.raises(ValueError, match=r"\['nada', 'nope'\]"):
+            guess_chart_cls(frozenset(("nope", "nada")))
+
+
 class TestAmbiguousComponentNames:
     """Charts sharing a component-name set resolve to one declared chart.
 

--- a/tests/unit/charts/test_guess_chart.py
+++ b/tests/unit/charts/test_guess_chart.py
@@ -27,7 +27,11 @@ import coordinax.charts as cxc
 import coordinaxs.hypothesis.main as cxst
 from .conftest import SHAPE_CART_MAP, xps
 from coordinax._src.base import NON_ABC_CHART_CLASSES, AbstractFixedComponentsChart
-from coordinax._src.charts.register_guess import CANONICAL_CHART_CLASSES
+from coordinax._src.charts.register_guess import (
+    CANONICAL_CHART_CLASSES,
+    guess_chart_cls,
+    register_canonical_chart,
+)
 
 Shape: TypeAlias = tuple[int, ...]
 
@@ -83,8 +87,12 @@ def test_guess_chart_from_dict_returns_same_components(
     assert guessed.components == chart.components
 
 
-class TestGuessChartCaching:
-    """Test that guess_chart caching works correctly."""
+class TestGuessChartRepeatability:
+    """Repeated inference agrees.
+
+    Note it is *not* cached: each call builds a chart, so the results are equal
+    but not identical.
+    """
 
     def test_frozenset_dispatch(self) -> None:
         """The frozenset dispatch should return equal objects."""
@@ -135,7 +143,7 @@ class TestAmbiguousComponentNames:
         }
         assert not undeclared, (
             f"Component names no longer identify a chart: {undeclared}. Add "
-            "the intended one to `CANONICAL_CHART_CLASSES`."
+            "the intended one with `register_canonical_chart`."
         )
 
     @pytest.mark.parametrize(("components", "expected"), AMBIGUOUS)
@@ -151,6 +159,30 @@ class TestAmbiguousComponentNames:
     ) -> None:
         """The choice is declared, not a by-product of scan order."""
         assert CANONICAL_CHART_CLASSES[frozenset(components)].__name__ == expected
+
+    def test_redeclaring_the_same_chart_is_a_no_op(self) -> None:
+        """A module may be imported twice without tripping the guard."""
+        before = dict(CANONICAL_CHART_CLASSES)
+        register_canonical_chart(cxc.Spherical3D)
+        assert before == CANONICAL_CHART_CLASSES
+
+    def test_a_second_chart_cannot_claim_the_same_names(self) -> None:
+        """Overwriting would hand the choice back to import order."""
+        with pytest.raises(ValueError, match="already declared canonical"):
+            register_canonical_chart(cxc.MathSpherical3D)
+        assert CANONICAL_CHART_CLASSES[frozenset(("r", "theta", "phi"))] is (
+            cxc.Spherical3D
+        )
+
+    def test_unresolvable_ambiguity_names_the_candidates(self) -> None:
+        """An undeclared collision raises rather than picking one."""
+        keys = frozenset(("r", "theta", "phi"))
+        canonical = CANONICAL_CHART_CLASSES.pop(keys)
+        try:
+            with pytest.raises(ValueError, match="none of them is canonical"):
+                guess_chart_cls(keys)
+        finally:
+            CANONICAL_CHART_CLASSES[keys] = canonical
 
 
 class TestGuessChartFromArrayLike:


### PR DESCRIPTION
First finding of the `_src/charts` audit slice, and a live numerical bug.

## The bug

`guess_chart_cls` returned the first match while iterating `NON_ABC_CHART_CLASSES`. That is a `weakref.WeakSet`; classes hash by `id()`, so **its iteration order differs between processes**. Two component-name sets are shared by two charts each, and in both cases the pair are the physics and maths conventions, which swap `theta` and `phi`:

| Components | Candidates |
|---|---|
| `r, theta, phi` | `Spherical3D`, `MathSpherical3D` |
| `theta, phi` | `SphericalTwoSphere`, `MathSphericalTwoSphere` |

So identical input produced a different physical point from run to run:

```console
$ for i in $(seq 6); do
    python -c "d={'r':Q(1.,'m'),'theta':Angle(.3,'rad'),'phi':Angle(1.2,'rad')}
               ch=cxc.guess_chart(d); print(type(ch).__name__, cxc.pt_map(d,ch,cxc.cart3d)['z'])"
  done
MathSpherical3D  z=+0.362358
Spherical3D      z=+0.955337
Spherical3D      z=+0.955337
Spherical3D      z=+0.955337
MathSpherical3D  z=+0.362358
Spherical3D      z=+0.955337
```

That reaches anyone who lets the chart be inferred — `cx.cdict` on a component dict, `guess_chart`, and everything downstream.

## The fix

`guess_chart_cls` collects every match rather than returning the first, so scan order can no longer decide the answer. Where a name set matches several charts, `CANONICAL_CHART_CLASSES` names the one to infer. Both current entries are the physics convention — what two-thirds of runs already produced, and what the docstrings describe. An undeclared collision now raises, naming the candidates, instead of picking one:

```
Keys {'r', 'theta', 'phi'} match several charts (MathSpherical3D, Spherical3D)
and none of them is canonical; declare the intended one with
`register_canonical_chart`, or pass the chart explicitly.
```

The declaration lives in the guessing code, not on the chart — a chart has no business knowing that something guesses at it. It uses the same late-registration pattern as the `register_*` modules: `_src/charts/register_guess.py` declares `Spherical3D`, and `_src/spherical/guess.py` — which already imports `_src.charts` — declares `SphericalTwoSphere`. Registering in that direction is what avoids the import cycle (a module-scope import the other way fails with `partially initialized module 'coordinax.charts' has no attribute 'sph3d'`), and it means a chart in any package, including a downstream one, can declare itself without `_src.charts` importing that package.

## Stale docstrings

Two `guess_chart` docstrings claimed *"Since the function is cached, the result will be consistent across calls."* The caching was removed — there is a `TODO` about it directly above `guess_chart_cls` — so nothing backed that guarantee. The test module's docstring had likewise recorded the symptom ("returns whichever it finds first in iteration order... this is by design") without noticing that order is not deterministic.

## Tests

`TestAmbiguousComponentNames` pins both winners, asserts the declaration names them, and sweeps every registered chart so that a *new* component-name collision fails there rather than at whichever call site gets unlucky.

## Verification

- 8/8 fresh processes now return `Spherical3D` / `SphericalTwoSphere`
- Full suite: **10084 passed**, 10 skipped, 1 xfailed (main: 10079 — the 5 new tests)
- `prek run --all-files` clean, including `ty`
- The six `Exception ignored in: quax ... _fin` lines at shutdown are pre-existing: a clean-tree full run emits exactly the same six, after the summary line

🤖 Generated with [Claude Code](https://claude.com/claude-code)