### PR TITLE
📝 docs(charts): unbreak the Jacobian LaTeX, drop a dead branch

### DIFF
--- a/src/coordinax/_src/charts/jacobian.py
+++ b/src/coordinax/_src/charts/jacobian.py
@@ -9,11 +9,11 @@ Mathematical background:
 Given charts $C_1$ and $C_2$ with a transition map $\tau: C_1 \to C_2$, the
 Jacobian at a base point $p$ (expressed in $C_1$ coordinates) is
 
-$$ J^j{}_i(p) = \frac{\\partial \tau^j}{\partial q^i}\bigg|_p $$
+$$ J^j{}_i(p) = \frac{\partial \tau^j}{\partial q^i}\bigg|_p $$
 
 where $q^i$ are the $C_1$ coordinates and $\tau^j$ are the $C_2$ coordinates.
 The result is a 2-D {class}`~unxts.linalg.QuantityMatrix` of shape
-$(n_\\mathrm{out},\\, n_\\mathrm{in})$ whose $(j, i)$ element carries units
+$(n_\mathrm{out},\, n_\mathrm{in})$ whose $(j, i)$ element carries units
 
 $$ \mathrm{unit}(J^j{}_i) = \frac{\mathrm{unit}(\tau^j)}{\mathrm{unit}(q^i)} $$
 

--- a/src/coordinax/_src/charts/scale_factors.py
+++ b/src/coordinax/_src/charts/scale_factors.py
@@ -13,7 +13,6 @@ from .d1 import Cart1D
 from .d2 import Cart2D
 from .d3 import Cart3D
 from .dn import CartND
-from coordinax._src.base import AbstractDimensionalFlag
 from coordinax._src.custom_types import CDict, OptUSys
 from coordinax._src.euclidean import FlatMetric
 
@@ -45,9 +44,5 @@ def scale_factors(
 
     """
     del metric, at, usys
-    n = (
-        chart.ndim
-        if isinstance(chart, AbstractDimensionalFlag)
-        else len(chart.components)
-    )
+    n = chart.ndim
     return ul.QM(jnp.ones((n,)), unit=ul.UnitsMatrix.full(n, ""))


### PR DESCRIPTION
Two small things found while auditing `_src/charts`. Independent of #704.

**`jacobian.py` module docstring.** It is an `r"""` string, so `\\partial`, `\\mathrm` and `\\,` reach LaTeX as literal double backslashes — which MathJax reads as a line break, mid-expression. Every neighbouring macro in the same formula uses a single backslash, so this was a slip, not a convention:

```python
$$ J^j{}_i(p) = \frac{\\partial \tau^j}{\partial q^i}\bigg|_p $$
$(n_\\mathrm{out},\\, n_\\mathrm{in})$ whose $(j, i)$ element ...
```

**A branch that could not run.** `scale_factors` chose between `chart.ndim` and `len(chart.components)`, but `AbstractChart.ndim` is *defined* as `len(self.components)`, and all five charts this dispatch accepts (`Cart0D`…`CartND`) are `AbstractDimensionalFlag` subclasses. So the fallback was unreachable, and would have returned the same value if it had been reached.

`pytest tests/unit/charts tests/unit/manifolds src/coordinax/_src/charts` → 1723 passed; `prek run` clean.

---

Noted while here, **not** fixed — it needs the metric layer in view, so I'll take it in the manifolds/metric slice rather than guess at the intended semantics:

`scale_factors` and `metric_matrix` disagree for `CartND`. The scale-factor fast path sizes its result from the *chart* (`CartND.ndim == 1`, since its single component `q` holds the whole N-vector), while `metric_matrix` sizes from the *manifold*:

```pycon
>>> at = {"q": u.Q(jnp.array([1., 2., 3.]), "m")}
>>> cxm.scale_factors(cxm.FlatMetric(3), cxc.cartnd, at=at)
QM(Array([1.]), unit='(,)')            # length 1
>>> cxm.metric_matrix(cxm.R3, at, cxc.cartnd)
DiagonalMetric(diagonal=f32[3])        # 3x3
```

The API docstring says `scale_factors` returns "the diagonal entries of the metric matrix", so one of the two is wrong. `FlatMetric` carries an `ndim` field that the fast path currently `del`s, which is likely the intended source — but whether `CartND` should present 1 or N scale factors is a question about the chart's contract, not a typo. There is also no `cartnd` case in `tests/unit/manifolds/test_scale_factors_dispatch.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)