### PR TITLE
🐛 fix(manifolds): make every metric-level dispatch honour its metric

### DIFF
--- a/src/coordinax/_src/base/__init__.py
+++ b/src/coordinax/_src/base/__init__.py
@@ -2,5 +2,6 @@
 
 from .atlas import *
 from .charts import *
+from .checks import *
 from .manifold import *
 from .metric import *

--- a/src/coordinax/_src/base/checks.py
+++ b/src/coordinax/_src/base/checks.py
@@ -1,0 +1,41 @@
+"""Preconditions shared by the metric-level dispatches."""
+
+__all__ = ("check_metric_is_charts",)
+
+from .charts import AbstractChart
+from .metric import AbstractMetricField
+
+
+def check_metric_is_charts(
+    metric: AbstractMetricField, chart: AbstractChart, fname: str, /
+) -> None:
+    """Refuse a metric that is not the one ``chart`` carries.
+
+    Metric-level dispatch takes a metric for *dispatch* -- to gate on its type
+    -- not as data. Every primitive underneath (`quadratic_form`, `gram`,
+    `metric_matrix`) reads ``chart.M.metric``, so a metric that differs from
+    the chart's cannot be honoured. Answering with the chart's metric anyway
+    would silently answer a question the caller did not ask.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> v = {"x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+    >>> try:
+    ...     cxm.norm(v, cxm.MinkowskiMetric(), cxc.cart3d, at=at)
+    ... except ValueError as e:
+    ...     print(str(e)[:52])
+    norm(): metric-level dispatch needs the chart's own
+
+    """
+    if metric != chart.M.metric:
+        msg = (
+            f"{fname}(): metric-level dispatch needs the chart's own metric; "
+            f"got {metric} for a chart carrying {chart.M.metric}. The metric "
+            f"selects the method; it is not applied in place of the chart's."
+        )
+        raise ValueError(msg)

--- a/src/coordinax/_src/base/checks.py
+++ b/src/coordinax/_src/base/checks.py
@@ -11,11 +11,9 @@ def check_metric_is_charts(
 ) -> None:
     """Refuse a metric that is not the one ``chart`` carries.
 
-    Metric-level dispatch takes a metric for *dispatch* -- to gate on its type
-    -- not as data. Every primitive underneath (`quadratic_form`, `gram`,
-    `metric_matrix`) reads ``chart.M.metric``, so a metric that differs from
-    the chart's cannot be honoured. Answering with the chart's metric anyway
-    would silently answer a question the caller did not ask.
+    The metric gates the dispatch; the primitives underneath all read
+    ``chart.M.metric``, so a differing one cannot be honoured and must not be
+    quietly replaced by the chart's.
 
     Examples
     --------

--- a/src/coordinax/_src/base/checks.py
+++ b/src/coordinax/_src/base/checks.py
@@ -11,9 +11,8 @@ def check_metric_is_charts(
 ) -> None:
     """Refuse a metric that is not the one ``chart`` carries.
 
-    The metric gates the dispatch; the primitives underneath all read
-    ``chart.M.metric``, so a differing one cannot be honoured and must not be
-    quietly replaced by the chart's.
+    The primitives underneath all read ``chart.M.metric``, so a differing one
+    cannot be honoured and must not be quietly swapped for the chart's.
 
     A manifold that leaves its dimension open -- ``Rn(N)``, spelled
     ``ndim is True`` -- pins nothing, so its metric is unbound and equality is

--- a/src/coordinax/_src/base/checks.py
+++ b/src/coordinax/_src/base/checks.py
@@ -15,6 +15,12 @@ def check_metric_is_charts(
     ``chart.M.metric``, so a differing one cannot be honoured and must not be
     quietly replaced by the chart's.
 
+    A manifold that leaves its dimension open -- ``Rn(N)``, spelled
+    ``ndim is True`` -- pins nothing, so its metric is unbound and equality is
+    the wrong test. There the caller's metric supplies the concrete dimension
+    and only the *kind* can be required: `cxc.cartnd` accepts any
+    `FlatMetric`, and still refuses a `MinkowskiMetric`.
+
     Examples
     --------
     >>> import unxt as u
@@ -30,10 +36,16 @@ def check_metric_is_charts(
     norm(): metric-level dispatch needs the chart's own
 
     """
-    if metric != chart.M.metric:
+    chart_metric = chart.M.metric
+    ok = (
+        isinstance(metric, type(chart_metric))
+        if getattr(chart.M, "ndim", None) is True
+        else metric == chart_metric
+    )
+    if not ok:
         msg = (
             f"{fname}(): metric-level dispatch needs the chart's own metric; "
-            f"got {metric} for a chart carrying {chart.M.metric}. The metric "
+            f"got {metric} for a chart carrying {chart_metric}. The metric "
             f"selects the method; it is not applied in place of the chart's."
         )
         raise ValueError(msg)

--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -16,7 +16,11 @@ from unxt.quantity import AllowValue
 import coordinax.angles as cxa
 import coordinaxs.api.manifolds as cxmapi
 from .quadratic_form import gram
-from coordinax._src.base import AbstractChart, AbstractMetricField
+from coordinax._src.base import (
+    AbstractChart,
+    AbstractMetricField,
+    check_metric_is_charts,
+)
 from coordinax._src.custom_types import OptUSys
 from coordinaxs.api.custom_types import CDict
 
@@ -113,6 +117,7 @@ def angle_between(
     angle_between is undefined for two timelike tangent vectors
 
     """
+    check_metric_is_charts(metric, chart, "angle_between")
     chart.check_data(at, keys=True, values=False)
     chart.check_data(uvec, keys=True, values=False)
     chart.check_data(vvec, keys=True, values=False)

--- a/src/coordinax/_src/manifolds/interval.py
+++ b/src/coordinax/_src/manifolds/interval.py
@@ -97,10 +97,6 @@ def interval(
     >>> cxm.interval(cxm.MinkowskiMetric(), cxc.minkowskict, o, ev).round(2)
     Q(24., 'm2')
 
-    ``metric`` is a checked selector, not an override: it must be the chart's own
-    metric, matching the contract of the metric-level `~coordinax.manifolds.norm`
-    overload.
-
     >>> try:
     ...     cxm.interval(cxm.FlatMetric(4), cxc.minkowskict, o, ev)
     ... except ValueError as e:
@@ -108,10 +104,6 @@ def interval(
     interval(): metric-level dispatch needs the chart's own
 
     """
-    # Mirrors `norm`'s metric-level dispatch: the argument is validated against
-    # the chart rather than silently ignored, so a caller who passes a different
-    # metric expecting it to be honoured is told, instead of quietly receiving
-    # the chart's answer.
     check_metric_is_charts(metric, chart, "interval")
 
     chart.check_data(a, keys=True, values=False)

--- a/src/coordinax/_src/manifolds/interval.py
+++ b/src/coordinax/_src/manifolds/interval.py
@@ -30,7 +30,11 @@ import unxt as u
 import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
 from .quadratic_form import quadratic_form
-from coordinax._src.base import AbstractChart, AbstractMetricField
+from coordinax._src.base import (
+    AbstractChart,
+    AbstractMetricField,
+    check_metric_is_charts,
+)
 from coordinax._src.custom_types import OptUSys
 from coordinaxs.api.custom_types import CDict
 
@@ -100,16 +104,15 @@ def interval(
     >>> try:
     ...     cxm.interval(cxm.FlatMetric(4), cxc.minkowskict, o, ev)
     ... except ValueError as e:
-    ...     print(e)
-    Metric-level dispatch: metric must match chart's metric
+    ...     print(str(e)[:56])
+    interval(): metric-level dispatch needs the chart's own
 
     """
     # Mirrors `norm`'s metric-level dispatch: the argument is validated against
     # the chart rather than silently ignored, so a caller who passes a different
     # metric expecting it to be honoured is told, instead of quietly receiving
     # the chart's answer.
-    if metric != chart.M.metric:
-        raise ValueError("Metric-level dispatch: metric must match chart's metric")
+    check_metric_is_charts(metric, chart, "interval")
 
     chart.check_data(a, keys=True, values=False)
     chart.check_data(b, keys=True, values=False)

--- a/src/coordinax/_src/manifolds/norm.py
+++ b/src/coordinax/_src/manifolds/norm.py
@@ -16,7 +16,11 @@ import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
 from ._utils import require_positive_definite
 from .quadratic_form import quadratic_form
-from coordinax._src.base import AbstractChart, AbstractMetricField
+from coordinax._src.base import (
+    AbstractChart,
+    AbstractMetricField,
+    check_metric_is_charts,
+)
 from coordinax._src.charts import Cart0D, Cart1D, Cart2D, Cart3D, CartND
 from coordinax._src.custom_types import OptUSys
 from coordinax._src.euclidean import FlatMetric
@@ -231,8 +235,7 @@ def norm(
     norm() supports only positive-definite metrics, but
 
     """
-    if metric != chart.M.metric:
-        raise ValueError("Metric-level dispatch: metric must match chart's metric")
+    check_metric_is_charts(metric, chart, "norm")
 
     # After the match check, so a mismatched *indefinite* metric still reports the
     # mismatch rather than the definiteness. Guards `chart.M.metric` because that
@@ -289,8 +292,7 @@ def norm(
     # a CDict here only for `quadratic_form` to repack it into a QuantityMatrix
     # was measurable trace-time waste -- and tracing is 30-46% of compile time,
     # so it showed up as slower `jit` compilation, not just slower eager calls.
-    if metric != chart.M.metric:
-        raise ValueError("Metric-level dispatch: metric must match chart's metric")
+    check_metric_is_charts(metric, chart, "norm")
     require_positive_definite(chart.M.metric, "norm")
     return jnp.sqrt(quadratic_form(v, chart, at=at, usys=usys, fname="norm"))
 
@@ -354,6 +356,7 @@ def norm(
     # the matrix from `chart.M` and has no match check, so checking the argument
     # would let `norm(v, FlatMetric(4), minkowskict, ...)` past the guard and
     # straight back to the `nan` this guard exists to prevent.
+    check_metric_is_charts(metric, chart, "norm")
     require_positive_definite(chart.M.metric, "norm")
     mm = cxmapi.metric_matrix(chart.M, at, chart)
     return array_norm(mm.to_dense().matrix, v)  # ty: ignore[unresolved-attribute]
@@ -480,7 +483,8 @@ def norm(
     Array(1., dtype=float64)
 
     """
-    del metric, chart, at, usys  # Unused
+    check_metric_is_charts(metric, chart, "norm")
+    del at, usys  # Unused
     return jnp.linalg.norm(v, axis=-1)
 
 
@@ -515,7 +519,8 @@ def norm(
     Q(5., 'km')
 
     """
-    del metric, at, usys
+    check_metric_is_charts(metric, chart, "norm")
+    del at, usys
     v, unit = pack_uniform_unit(data, chart.components)
     vnorm = jnp.linalg.norm(v, axis=-1)
     return u.Q(vnorm, unit) if unit is not None else vnorm

--- a/src/coordinax/_src/manifolds/scale_factors.py
+++ b/src/coordinax/_src/manifolds/scale_factors.py
@@ -10,7 +10,11 @@ import unxts.linalg as ul
 
 import coordinaxs.api.manifolds as cxmapi
 from ._utils import as_quantity_matrix
-from coordinax._src.base import AbstractChart, AbstractMetricField
+from coordinax._src.base import (
+    AbstractChart,
+    AbstractMetricField,
+    check_metric_is_charts,
+)
 from coordinax._src.custom_types import OptUSys
 from coordinax._src.embedded.manifold import EmbeddedManifold
 from coordinax._src.embedded.metric import PullbackMetric
@@ -65,6 +69,7 @@ def scale_factors(
     QM([1., 1.], '(, )')
 
     """
+    check_metric_is_charts(metric, chart, "scale_factors")
     mm = cxmapi.metric_matrix(chart.M, at, chart)
     if isinstance(mm, DiagonalMetric):
         diag = mm.diagonal

--- a/src/coordinax/_src/manifolds/separation.py
+++ b/src/coordinax/_src/manifolds/separation.py
@@ -22,7 +22,11 @@ import coordinax.distances as cxd
 import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
 from ._utils import require_positive_definite
-from coordinax._src.base import AbstractChart, AbstractMetricField
+from coordinax._src.base import (
+    AbstractChart,
+    AbstractMetricField,
+    check_metric_is_charts,
+)
 from coordinax._src.custom_types import OptUSys
 from coordinaxs.api.custom_types import CDict
 
@@ -84,6 +88,7 @@ def separation(
     """
     # Duplicated with `norm` so the message names the function the caller
     # invoked. Guards `chart.M.metric` -- the metric actually used.
+    check_metric_is_charts(metric, chart, "separation")
     require_positive_definite(chart.M.metric, "separation")
 
     chart.check_data(a, keys=True, values=False)

--- a/src/coordinax/_src/minkowski/rapidity.py
+++ b/src/coordinax/_src/minkowski/rapidity.py
@@ -29,6 +29,7 @@ from coordinax._src.base import (
     AbstractChart,
     AbstractLorentzianMetricField,
     AbstractMetricField,
+    check_metric_is_charts,
 )
 from coordinax._src.custom_types import OptUSys
 from coordinaxs.api.custom_types import CDict
@@ -165,7 +166,7 @@ def rapidity_between(
     rapidity_between is defined only between two timelike tangent vectors
 
     """
-    del metric  # the contraction reads the chart's metric, validated by `gram`
+    check_metric_is_charts(metric, chart, "rapidity_between")
     chart.check_data(at, keys=True, values=False)
     chart.check_data(uvec, keys=True, values=False)
     chart.check_data(vvec, keys=True, values=False)

--- a/src/coordinax/_src/minkowski/scale_factors.py
+++ b/src/coordinax/_src/minkowski/scale_factors.py
@@ -9,6 +9,7 @@ import unxts.linalg as ul
 
 from .charts import MinkowskiCT
 from .metric import MinkowskiMetric
+from coordinax._src.base import check_metric_is_charts
 from coordinax._src.custom_types import OptUSys
 from coordinaxs.api.custom_types import CDict
 
@@ -34,7 +35,8 @@ def scale_factors(
     QM([-1.,  1.,  1.,  1.], '(, , , )')
 
     """
-    del chart, at, usys
+    check_metric_is_charts(metric, chart, "scale_factors")
+    del at, usys
     n = metric.ndim
     value = jnp.array(list(metric.signature), dtype=float)
     units = ul.UnitsMatrix.full(n, "")

--- a/src/coordinax/_src/spherical/scale_factors.py
+++ b/src/coordinax/_src/spherical/scale_factors.py
@@ -15,7 +15,7 @@ import coordinaxs.api.manifolds as cxmapi
 from .chart import LonCosLatSphericalTwoSphere, RelabeledTwoSphere
 from .manifold import HyperSphericalManifold
 from .metric import RoundMetric
-from coordinax._src.base import AbstractChart
+from coordinax._src.base import AbstractChart, check_metric_is_charts
 from coordinax._src.custom_types import OptUSys
 from coordinax._src.metric.matrix import DiagonalMetric
 from coordinaxs.api.custom_types import CDict
@@ -64,6 +64,7 @@ def scale_factors(
     """
     # `metric_matrix` interprets bare angle values as radians, so normalise
     # `at` through the chart's angle unit first (radians when no `usys`).
+    check_metric_is_charts(metric, chart, "scale_factors")
     rad = u.unit("rad")
     ang_unit = usys["angle"] if usys is not None else rad
     at_rad = {k: u.uconvert_value(rad, ang_unit, v) for k, v in at.items()}
@@ -86,7 +87,8 @@ def scale_factors(
     usys: OptUSys = None,
 ) -> ul.QuantityMatrix:
     """`LonCosLat` is non-orthogonal, so it has no scale factors at all."""
-    del metric, at, usys
+    check_metric_is_charts(metric, chart, "scale_factors")
+    del at, usys
     msg = (
         "scale_factors is a diagonal (orthogonal-frame) concept and "
         f"{type(chart).__name__} is non-orthogonal: its round metric has a "
@@ -124,7 +126,7 @@ def scale_factors(
     QM([1., 1.], '(, )')
 
     """
-    del metric
+    check_metric_is_charts(metric, chart, "scale_factors")
     components = chart.components
     ang_unit = usys["angle"] if usys is not None else u.unit("rad")
     angles = jnp.stack(

--- a/tests/unit/manifolds/test_interval.py
+++ b/tests/unit/manifolds/test_interval.py
@@ -78,7 +78,7 @@ class TestInterval:
         ``chart.M``, so passing a different metric silently returned the
         chart's answer. Matches `norm`'s metric-level contract.
         """
-        with pytest.raises(ValueError, match="must match chart"):
+        with pytest.raises(ValueError, match="needs the chart's own metric"):
             cxm.interval(cxm.FlatMetric(4), cxc.minkowskict, ORIGIN, event(1.0, 5.0))
 
     def test_bare_arrays_require_usys_like_norm_does(self):
@@ -358,7 +358,7 @@ class TestCausalVerbsValidateTheirMetricArgument:
     )
     def test_lorentzian_metric_with_riemannian_chart_is_rejected(self, verb):
         """The mismatch must be reported, not silently resolved to the chart."""
-        with pytest.raises(ValueError, match="must match chart"):
+        with pytest.raises(ValueError, match="needs the chart's own metric"):
             getattr(cxmapi, verb)(cxm.MinkowskiMetric(), cxc.cart3d, self.A3, self.B3)
 
     @pytest.mark.parametrize(

--- a/tests/unit/manifolds/test_metric_arg_is_honoured.py
+++ b/tests/unit/manifolds/test_metric_arg_is_honoured.py
@@ -1,0 +1,182 @@
+"""Every metric-level dispatch must honour the metric it is handed.
+
+A metric-level overload takes ``(metric, chart, ...)``, but every primitive
+underneath -- `quadratic_form`, `gram`, `metric_matrix` -- reads
+``chart.M.metric``. So the argument can never be *used*; it selects the method
+and must otherwise be checked. Skipping the check is silent: the tests all pass
+the matching metric, so the ignored argument never differs from the one
+actually applied, and nothing fails.
+
+That is why this defect recurred four times (#674, #680, #695, and again in
+`angle_between`/`norm` here). These tests target the *shape* of the mistake
+rather than the instances: `test_no_unguarded_metric_overloads` reads the
+source, so a newly added overload that forgets is caught without anyone
+remembering to add a case for it.
+"""
+
+__all__: tuple[str, ...] = ()
+
+import ast
+import pathlib
+
+import pytest
+
+import quaxed.numpy as jnp
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+
+USYS = u.unitsystem("m", "s", "kg", "rad")
+Z3 = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+P3 = {"x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+Z4 = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+X4 = {"ct": u.Q(0.0, "m"), "x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+Y4 = {"ct": u.Q(0.0, "m"), "x": u.Q(0.0, "m"), "y": u.Q(1.0, "m"), "z": u.Q(0.0, "m")}
+
+
+def _four_velocity(beta: float) -> dict[str, u.AbstractQuantity]:
+    gamma = 1.0 / jnp.sqrt(1.0 - beta**2)
+    return {
+        "ct": u.Q(gamma, ""),
+        "x": u.Q(gamma * beta, ""),
+        "y": u.Q(0.0, ""),
+        "z": u.Q(0.0, ""),
+    }
+
+
+#: ``(id, call)`` where ``call`` takes the *wrong* metric and must refuse it.
+#: One row per metric-level overload reachable with a mismatched metric.
+WRONG_METRIC_CALLS = [
+    ("norm-cdict", lambda m: cxm.norm(P3, m, cxc.cart3d, at=Z3)),
+    (
+        "norm-bare-array",
+        lambda m: cxm.norm(
+            jnp.asarray([1.0, 0.0, 0.0]), m, cxc.cart3d, at=Z3, usys=USYS
+        ),
+    ),
+    ("separation", lambda m: cxm.separation(m, cxc.cart3d, Z3, P3)),
+    ("angle_between-3d", lambda m: cxm.angle_between(m, cxc.cart3d, P3, P3, at=Z3)),
+    ("interval", lambda m: cxm.interval(m, cxc.minkowskict, Z4, X4)),
+    (
+        "angle_between-4d",
+        lambda m: cxm.angle_between(m, cxc.minkowskict, X4, Y4, at=Z4),
+    ),
+    ("scale_factors", lambda m: cxm.scale_factors(m, cxc.cart3d, at=P3)),
+]
+
+#: A metric that is *not* the chart's, per chart dimension.
+WRONG = {3: cxm.MinkowskiMetric(), 4: cxm.FlatMetric(4)}
+
+
+@pytest.mark.parametrize(
+    ("name", "call"), WRONG_METRIC_CALLS, ids=[c[0] for c in WRONG_METRIC_CALLS]
+)
+def test_mismatched_metric_is_refused(name: str, call) -> None:
+    """A metric that is not the chart's must raise, not be quietly dropped."""
+    wrong = WRONG[4] if "4d" in name or name == "interval" else WRONG[3]
+    with pytest.raises(ValueError, match="metric-level dispatch needs the chart's own"):
+        call(wrong)
+
+
+def test_flat_metric_fast_path_checks_dimension() -> None:
+    """The Cartesian short-circuit is dispatch-gated but still not exempt.
+
+    ``FlatMetric(2)`` and ``FlatMetric(3)`` both satisfy the ``FlatMetric``
+    annotation, so dispatch alone does not pin the dimension.
+    """
+    with pytest.raises(ValueError, match="metric-level dispatch needs the chart's own"):
+        cxm.norm(
+            jnp.asarray([1.0, 0.0, 0.0]),
+            cxm.FlatMetric(2),
+            cxc.cart3d,
+            at=Z3,
+            usys=USYS,
+        )
+
+
+def test_matching_metric_still_works() -> None:
+    """The guard must not reject the legitimate call."""
+    assert (
+        float(cxm.norm(P3, cxc.cart3d.M.metric, cxc.cart3d, at=Z3).ustrip("m")) == 1.0
+    )
+    assert cxm.interval(cxc.minkowskict.M.metric, cxc.minkowskict, Z4, X4) is not None
+    phi = cxm.lorentzian.rapidity_between(
+        cxc.minkowskict.M.metric,
+        cxc.minkowskict,
+        _four_velocity(0.0),
+        _four_velocity(0.6),
+        at=Z4,
+    )
+    assert float(phi) == pytest.approx(float(jnp.arctanh(0.6)), abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# The completeness check: the reason this closes the class and not the cases.
+
+_SRC = pathlib.Path(cxm.__file__).parent.parent / "_src"
+
+
+def _forwards_metric(node: ast.FunctionDef) -> bool:
+    """Report whether the body passes its own ``metric`` to another verb.
+
+    Checked structurally, not by substring: a body that merely mentions
+    ``cxmapi`` while forwarding ``chart.M`` is *not* forwarding the metric, and
+    that is exactly the bug this file exists to catch.
+    """
+    return any(
+        isinstance(n, ast.Call)
+        and any(isinstance(a, ast.Name) and a.id == "metric" for a in n.args)
+        for n in ast.walk(node)
+    )
+
+
+def _is_refusal(node: ast.FunctionDef) -> bool:
+    """Report whether the body raises instead of ever reaching a metric."""
+    return any(
+        isinstance(n, ast.Raise)
+        and isinstance(n.exc, ast.Call)
+        and isinstance(n.exc.func, ast.Name)
+        and n.exc.func.id == "NotImplementedError"
+        for n in ast.walk(node)
+    )
+
+
+def _metric_level_overloads() -> list[tuple[str, int, ast.FunctionDef]]:
+    """Every ``def f(..., metric, chart, ...)`` under ``_src``, found by source."""
+    found = []
+    for path in sorted(_SRC.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            names = {a.arg for a in node.args.posonlyargs + node.args.args}
+            if {"metric", "chart"} <= names:
+                found.append((str(path.relative_to(_SRC)), node.lineno, node))
+    return found
+
+
+def test_no_unguarded_metric_overloads() -> None:
+    """No metric-level overload may silently ignore its metric.
+
+    Source-level rather than behavioural on purpose: a new overload added later
+    is covered the moment it is written, without anyone remembering to extend
+    `WRONG_METRIC_CALLS` above.
+    """
+    overloads = _metric_level_overloads()
+    assert overloads, "introspection found nothing -- the check would vacuously pass"
+
+    unguarded = [
+        f"{path}:{line}"
+        for path, line, node in overloads
+        if "check_metric_is_charts" not in ast.unparse(node)
+        and not _forwards_metric(node)
+        and not _is_refusal(node)
+    ]
+    assert not unguarded, (
+        "these take a `metric` but neither check it against the chart nor "
+        f"forward it to a verb that does: {unguarded}"
+    )

--- a/tests/unit/manifolds/test_metric_arg_is_honoured.py
+++ b/tests/unit/manifolds/test_metric_arg_is_honoured.py
@@ -37,6 +37,9 @@ Y4 = {"ct": u.Q(0.0, "m"), "x": u.Q(0.0, "m"), "y": u.Q(1.0, "m"), "z": u.Q(0.0,
 MINK = cxm.MinkowskiMetric()
 FLAT4 = cxm.FlatMetric(4)
 
+#: A point on `cartnd`, whose manifold `Rn(N)` leaves its dimension open.
+QN = {"q": u.Q(jnp.asarray([1.0, 2.0, 3.0]), "m")}
+
 
 #: ``(id, thunk)`` where the thunk passes a metric the chart does not carry.
 #: One row per metric-level overload reachable with a mismatched metric.
@@ -69,6 +72,11 @@ MISMATCHED_CALLS = [
         "angle_between-4d",
         lambda: cxm.angle_between(FLAT4, cxc.minkowskict, X4, Y4, at=Z4),
     ),
+    # `Rn(N)` relaxes to a kind check, but a kind check is still a check.
+    (
+        "scale_factors-open-ndim-wrong-kind",
+        lambda: cxm.scale_factors(MINK, cxc.cartnd, at=QN),
+    ),
 ]
 
 
@@ -80,6 +88,18 @@ def test_mismatched_metric_is_refused(name: str, call) -> None:
     del name
     with pytest.raises(ValueError, match="metric-level dispatch needs the chart's own"):
         call()
+
+
+def test_open_dimension_chart_accepts_any_metric_of_its_kind() -> None:
+    """`Rn(N)` pins no dimension, so the caller's metric supplies it.
+
+    The premise "the metric argument is never data" holds only for a chart
+    whose manifold fixes its dimension. `cxc.cartnd` does not, so demanding
+    equality against its unbound `FlatMetric(ndim=True)` would reject the
+    legitimate call that #708 relies on.
+    """
+    got = cxm.scale_factors(cxm.FlatMetric(3), cxc.cartnd, at=QN)
+    assert got.shape[-1] == 3
 
 
 def test_matching_metric_still_works() -> None:

--- a/tests/unit/manifolds/test_metric_arg_is_honoured.py
+++ b/tests/unit/manifolds/test_metric_arg_is_honoured.py
@@ -7,11 +7,9 @@ and must otherwise be checked. Skipping the check is silent: the tests all pass
 the matching metric, so the ignored argument never differs from the one
 actually applied, and nothing fails.
 
-That is why this defect recurred four times (#674, #680, #695, and again in
-`angle_between`/`norm` here). These tests target the *shape* of the mistake
-rather than the instances: `test_no_unguarded_metric_overloads` reads the
-source, so a newly added overload that forgets is caught without anyone
-remembering to add a case for it.
+Hence #674, #680, #695 -- and `angle_between`/`norm` here.
+`test_no_unguarded_metric_overloads` reads the source, so a new overload that
+forgets is caught without anyone remembering to add a case.
 """
 
 __all__: tuple[str, ...] = ()
@@ -34,65 +32,54 @@ Z4 = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
 X4 = {"ct": u.Q(0.0, "m"), "x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
 Y4 = {"ct": u.Q(0.0, "m"), "x": u.Q(0.0, "m"), "y": u.Q(1.0, "m"), "z": u.Q(0.0, "m")}
 
-
-def _four_velocity(beta: float) -> dict[str, u.AbstractQuantity]:
-    gamma = 1.0 / jnp.sqrt(1.0 - beta**2)
-    return {
-        "ct": u.Q(gamma, ""),
-        "x": u.Q(gamma * beta, ""),
-        "y": u.Q(0.0, ""),
-        "z": u.Q(0.0, ""),
-    }
+#: Metrics no chart below carries: Minkowski against the 3-D charts, flat
+#: against the Minkowski one.
+MINK = cxm.MinkowskiMetric()
+FLAT4 = cxm.FlatMetric(4)
 
 
-#: ``(id, call)`` where ``call`` takes the *wrong* metric and must refuse it.
+#: ``(id, thunk)`` where the thunk passes a metric the chart does not carry.
 #: One row per metric-level overload reachable with a mismatched metric.
-WRONG_METRIC_CALLS = [
-    ("norm-cdict", lambda m: cxm.norm(P3, m, cxc.cart3d, at=Z3)),
+MISMATCHED_CALLS = [
+    ("norm-cdict", lambda: cxm.norm(P3, MINK, cxc.cart3d, at=Z3)),
     (
         "norm-bare-array",
-        lambda m: cxm.norm(
-            jnp.asarray([1.0, 0.0, 0.0]), m, cxc.cart3d, at=Z3, usys=USYS
+        lambda: cxm.norm(
+            jnp.asarray([1.0, 0.0, 0.0]), MINK, cxc.cart3d, at=Z3, usys=USYS
         ),
     ),
-    ("separation", lambda m: cxm.separation(m, cxc.cart3d, Z3, P3)),
-    ("angle_between-3d", lambda m: cxm.angle_between(m, cxc.cart3d, P3, P3, at=Z3)),
-    ("interval", lambda m: cxm.interval(m, cxc.minkowskict, Z4, X4)),
+    # `FlatMetric(2)` and `FlatMetric(3)` both satisfy the `FlatMetric`
+    # annotation, so the Cartesian short-circuit's dispatch does not pin the
+    # dimension and the guard is what catches it.
     (
-        "angle_between-4d",
-        lambda m: cxm.angle_between(m, cxc.minkowskict, X4, Y4, at=Z4),
-    ),
-    ("scale_factors", lambda m: cxm.scale_factors(m, cxc.cart3d, at=P3)),
-]
-
-#: A metric that is *not* the chart's, per chart dimension.
-WRONG = {3: cxm.MinkowskiMetric(), 4: cxm.FlatMetric(4)}
-
-
-@pytest.mark.parametrize(
-    ("name", "call"), WRONG_METRIC_CALLS, ids=[c[0] for c in WRONG_METRIC_CALLS]
-)
-def test_mismatched_metric_is_refused(name: str, call) -> None:
-    """A metric that is not the chart's must raise, not be quietly dropped."""
-    wrong = WRONG[4] if "4d" in name or name == "interval" else WRONG[3]
-    with pytest.raises(ValueError, match="metric-level dispatch needs the chart's own"):
-        call(wrong)
-
-
-def test_flat_metric_fast_path_checks_dimension() -> None:
-    """The Cartesian short-circuit is dispatch-gated but still not exempt.
-
-    ``FlatMetric(2)`` and ``FlatMetric(3)`` both satisfy the ``FlatMetric``
-    annotation, so dispatch alone does not pin the dimension.
-    """
-    with pytest.raises(ValueError, match="metric-level dispatch needs the chart's own"):
-        cxm.norm(
+        "norm-flat-wrong-ndim",
+        lambda: cxm.norm(
             jnp.asarray([1.0, 0.0, 0.0]),
             cxm.FlatMetric(2),
             cxc.cart3d,
             at=Z3,
             usys=USYS,
-        )
+        ),
+    ),
+    ("separation", lambda: cxm.separation(MINK, cxc.cart3d, Z3, P3)),
+    ("angle_between-3d", lambda: cxm.angle_between(MINK, cxc.cart3d, P3, P3, at=Z3)),
+    ("scale_factors", lambda: cxm.scale_factors(MINK, cxc.cart3d, at=P3)),
+    ("interval", lambda: cxm.interval(FLAT4, cxc.minkowskict, Z4, X4)),
+    (
+        "angle_between-4d",
+        lambda: cxm.angle_between(FLAT4, cxc.minkowskict, X4, Y4, at=Z4),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("name", "call"), MISMATCHED_CALLS, ids=[c[0] for c in MISMATCHED_CALLS]
+)
+def test_mismatched_metric_is_refused(name: str, call) -> None:
+    """A metric that is not the chart's must raise, not be quietly dropped."""
+    del name
+    with pytest.raises(ValueError, match="metric-level dispatch needs the chart's own"):
+        call()
 
 
 def test_matching_metric_still_works() -> None:
@@ -101,14 +88,6 @@ def test_matching_metric_still_works() -> None:
         float(cxm.norm(P3, cxc.cart3d.M.metric, cxc.cart3d, at=Z3).ustrip("m")) == 1.0
     )
     assert cxm.interval(cxc.minkowskict.M.metric, cxc.minkowskict, Z4, X4) is not None
-    phi = cxm.lorentzian.rapidity_between(
-        cxc.minkowskict.M.metric,
-        cxc.minkowskict,
-        _four_velocity(0.0),
-        _four_velocity(0.6),
-        at=Z4,
-    )
-    assert float(phi) == pytest.approx(float(jnp.arctanh(0.6)), abs=1e-6)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/manifolds/test_metric_arg_is_honoured.py
+++ b/tests/unit/manifolds/test_metric_arg_is_honoured.py
@@ -1,11 +1,9 @@
 """Every metric-level dispatch must honour the metric it is handed.
 
-A metric-level overload takes ``(metric, chart, ...)``, but every primitive
-underneath -- `quadratic_form`, `gram`, `metric_matrix` -- reads
-``chart.M.metric``. So the argument can never be *used*; it selects the method
-and must otherwise be checked. Skipping the check is silent: the tests all pass
-the matching metric, so the ignored argument never differs from the one
-actually applied, and nothing fails.
+The primitives underneath a metric-level overload all read ``chart.M.metric``,
+so its ``metric`` argument selects the method and must otherwise be checked.
+Forgetting is silent: every test passes the matching metric, so the ignored
+argument never differs from the one applied.
 
 Hence #674, #680, #695 -- and `angle_between`/`norm` here.
 `test_no_unguarded_metric_overloads` reads the source, so a new overload that
@@ -81,23 +79,16 @@ MISMATCHED_CALLS = [
 
 
 @pytest.mark.parametrize(
-    ("name", "call"), MISMATCHED_CALLS, ids=[c[0] for c in MISMATCHED_CALLS]
+    "call", [c[1] for c in MISMATCHED_CALLS], ids=[c[0] for c in MISMATCHED_CALLS]
 )
-def test_mismatched_metric_is_refused(name: str, call) -> None:
+def test_mismatched_metric_is_refused(call) -> None:
     """A metric that is not the chart's must raise, not be quietly dropped."""
-    del name
     with pytest.raises(ValueError, match="metric-level dispatch needs the chart's own"):
         call()
 
 
 def test_open_dimension_chart_accepts_any_metric_of_its_kind() -> None:
-    """`Rn(N)` pins no dimension, so the caller's metric supplies it.
-
-    The premise "the metric argument is never data" holds only for a chart
-    whose manifold fixes its dimension. `cxc.cartnd` does not, so demanding
-    equality against its unbound `FlatMetric(ndim=True)` would reject the
-    legitimate call that #708 relies on.
-    """
+    """`cartnd`'s `Rn(N)` fixes no dimension, so #708's call is legitimate."""
     got = cxm.scale_factors(cxm.FlatMetric(3), cxc.cartnd, at=QN)
     assert got.shape[-1] == 3
 
@@ -111,7 +102,6 @@ def test_matching_metric_still_works() -> None:
 
 
 # ---------------------------------------------------------------------------
-# The completeness check: the reason this closes the class and not the cases.
 
 _SRC = pathlib.Path(cxm.__file__).parent.parent / "_src"
 
@@ -133,11 +123,8 @@ def _calls_guard(node: ast.FunctionDef) -> bool:
 def _forwards_metric(node: ast.FunctionDef) -> bool:
     """Report whether the body passes its own ``metric`` to another verb.
 
-    Only a dispatched verb counts -- an attribute call such as
-    ``cxmapi.interval(metric, ...)``. A bare-name call taking ``metric`` (the
-    guard itself, or a local helper) is not forwarding, and a body that merely
-    mentions ``cxmapi`` while passing ``chart.M`` is not either. Both are
-    exactly the shapes this file exists to catch.
+    Attribute calls only (``cxmapi.interval(metric, ...)``): a bare-name call
+    taking ``metric`` is the guard itself or a local helper, not a forward.
     """
     return any(
         isinstance(n, ast.Call)

--- a/tests/unit/manifolds/test_metric_arg_is_honoured.py
+++ b/tests/unit/manifolds/test_metric_arg_is_honoured.py
@@ -117,15 +117,32 @@ def test_matching_metric_still_works() -> None:
 _SRC = pathlib.Path(cxm.__file__).parent.parent / "_src"
 
 
-def _forwards_metric(node: ast.FunctionDef) -> bool:
-    """Report whether the body passes its own ``metric`` to another verb.
+def _calls_guard(node: ast.FunctionDef) -> bool:
+    """Report whether the body actually *calls* the guard.
 
-    Checked structurally, not by substring: a body that merely mentions
-    ``cxmapi`` while forwarding ``chart.M`` is *not* forwarding the metric, and
-    that is exactly the bug this file exists to catch.
+    A call node, not a substring of the unparsed source: a docstring or comment
+    naming `check_metric_is_charts` must not be able to satisfy this.
     """
     return any(
         isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "check_metric_is_charts"
+        for n in ast.walk(node)
+    )
+
+
+def _forwards_metric(node: ast.FunctionDef) -> bool:
+    """Report whether the body passes its own ``metric`` to another verb.
+
+    Only a dispatched verb counts -- an attribute call such as
+    ``cxmapi.interval(metric, ...)``. A bare-name call taking ``metric`` (the
+    guard itself, or a local helper) is not forwarding, and a body that merely
+    mentions ``cxmapi`` while passing ``chart.M`` is not either. Both are
+    exactly the shapes this file exists to catch.
+    """
+    return any(
+        isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
         and any(isinstance(a, ast.Name) and a.id == "metric" for a in n.args)
         for n in ast.walk(node)
     )
@@ -147,12 +164,14 @@ def _metric_level_overloads() -> list[tuple[str, int, ast.FunctionDef]]:
     found = []
     for path in sorted(_SRC.rglob("*.py")):
         try:
-            tree = ast.parse(path.read_text())
+            tree = ast.parse(path.read_text(encoding="utf-8"))
         except SyntaxError:  # pragma: no cover
             continue
         for node in ast.walk(tree):
             if not isinstance(node, ast.FunctionDef):
                 continue
+            if node.name == "check_metric_is_charts":
+                continue  # the guard itself, not a dispatch that needs guarding
             names = {a.arg for a in node.args.posonlyargs + node.args.args}
             if {"metric", "chart"} <= names:
                 found.append((str(path.relative_to(_SRC)), node.lineno, node))
@@ -172,7 +191,7 @@ def test_no_unguarded_metric_overloads() -> None:
     unguarded = [
         f"{path}:{line}"
         for path, line, node in overloads
-        if "check_metric_is_charts" not in ast.unparse(node)
+        if not _calls_guard(node)
         and not _forwards_metric(node)
         and not _is_refusal(node)
     ]

--- a/tests/unit/manifolds/test_norm.py
+++ b/tests/unit/manifolds/test_norm.py
@@ -678,21 +678,39 @@ class TestIndefiniteMetricsAreRejected:
         """
         v = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
         at = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
-        with pytest.raises(ValueError, match="must match chart"):
+        with pytest.raises(ValueError, match="needs the chart's own metric"):
             cxm.norm(v, cxm.MinkowskiMetric(), cxc.cart3d, at=at)
 
     def test_guard_follows_the_metric_actually_used(self):
         """A positive-definite *argument* cannot smuggle an indefinite chart past.
 
-        The packed-array overload builds its matrix from ``chart.M`` and has no
-        match check, so guarding the ``metric`` argument would let this call
-        through to the very ``nan`` the guard exists to prevent.
+        Originally this reached the definiteness guard, which had to read
+        ``chart.M.metric`` rather than the argument or it would hand back the
+        very ``nan`` it exists to prevent. The packed-array overload now also
+        checks the metric against the chart, so the call is refused one step
+        earlier -- but the property is the same one, and still holds.
+        """
+        at = {k: jnp.array(0.0) for k in ("ct", "x", "y", "z")}
+        with pytest.raises(ValueError, match="needs the chart's own metric"):
+            cxm.norm(
+                jnp.array([5.0, 1.0, 0.0, 0.0]),
+                cxm.FlatMetric(4),
+                cxc.minkowskict,
+                at=at,
+                usys=u.unitsystems.si,
+            )
+
+    def test_definiteness_guard_reads_the_charts_metric(self):
+        """With the metric matching, the indefinite chart is still refused.
+
+        The companion to the above: now that a mismatch cannot get this far,
+        this is what keeps the definiteness guard honest.
         """
         at = {k: jnp.array(0.0) for k in ("ct", "x", "y", "z")}
         with pytest.raises(NotImplementedError, match=r"pseudo.*indefinite"):
             cxm.norm(
                 jnp.array([5.0, 1.0, 0.0, 0.0]),
-                cxm.FlatMetric(4),
+                cxc.minkowskict.M.metric,
                 cxc.minkowskict,
                 at=at,
                 usys=u.unitsystems.si,


### PR DESCRIPTION
Fixes the defect class that recurred through #674, #680 and #695 — caught by review each time, never by a test.

## What is happening

A metric-level overload is `f(metric, chart, ...)`. But every primitive beneath it — `quadratic_form`, `gram`, `metric_matrix(chart.M, ...)` — takes a **chart** and reads `chart.M.metric`. None of them accepts a metric.

So the `metric` argument can never actually be *used*. It selects the plum method and is otherwise a **precondition to assert**. Asserting it is a separate line that is easy to omit — and omitting it is completely silent, because every test passes the *matching* metric. The ignored argument never differs from the one applied, so nothing fails.

The guard was also copy-pasted verbatim in three places, so there was no single point a new overload would naturally route through.

## What was broken

`angle_between` was returning wrong answers on `main`:

```pycon
>>> cxm.angle_between(cxm.FlatMetric(4), cxc.minkowskict, xhat, yhat, at=at4)
Angle(1.5707964, 'rad')   # computed with the *Minkowski* metric
```

Nine overloads were unguarded in total:

| site | status |
| --- | --- |
| `angle_between` | silent, reachable |
| `norm` bare-array overload | silent, reachable |
| `norm` Cartesian fast paths ×2 | accepted `FlatMetric(2)` on a 3-D chart |
| `scale_factors` ×5 | same dimension hole |
| `rapidity_between` | latent, hidden by its Lorentzian type gate |

## The fix

One `check_metric_is_charts(metric, chart, fname)`, replacing the three copies and filling the nine gaps. It lives in **`_src/base`**, not `_src/manifolds/_utils`, because `charts/` and `euclidean/` also need it and importing `manifolds` from them is a circular import.

The error names both metrics by value, since a dimension mismatch prints identically by type:

```
norm(): metric-level dispatch needs the chart's own metric; got
FlatMetric(ndim=2) for a chart carrying FlatMetric(ndim=3). The metric
selects the method; it is not applied in place of the chart's.
```

## What closes the class

`test_no_unguarded_metric_overloads` parses `_src`, finds every `def f(..., metric, chart, ...)`, and requires each to call the guard, forward `metric` to a verb that does, or be a refusal overload. A new verb is covered the moment it is written, with no one having to remember.

It earned itself twice while being written:

- It found the **five `scale_factors` overloads** that manual enumeration missed.
- When the "forwards it onward" exemption was first written as a substring check for `cxmapi.`, it wrongly excused two overloads that call the API while forwarding `chart.M` rather than `metric`. Making the check AST-based — *does a call actually receive the `metric` name?* — exposed both.

## Note on an existing test

`test_guard_follows_the_metric_actually_used` (from #674) documented that the packed-array overload *has no match check*, so the definiteness guard had to read `chart.M.metric`. That overload now has one, and the call is refused a step earlier. Rather than loosen the assertion, it is split in two: the mismatch case, and a new `test_definiteness_guard_reads_the_charts_metric` that passes a **matching** indefinite metric — which is what keeps #674's actual property under test now that a mismatch cannot reach it.

## Verification

- Full suite: **9941 passed**, 8 skipped, 1 xfailed
- ruff and ty unchanged from baseline (the one remaining ruff error and all 6 ty diagnostics are pre-existing, in untouched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
