### PR TITLE
🐛 fix(pdoc): correct four misspelled `__pdoc__` kwargs

### DIFF
--- a/packages/coordinaxs.interop.astropy/src/coordinaxs/interop/astropy/_src/frames.py
+++ b/packages/coordinaxs.interop.astropy/src/coordinaxs/interop/astropy/_src/frames.py
@@ -315,7 +315,7 @@ def from_(
         frame=ICRS()
       ),
       roll=Angle(f64[], 'deg'),
-      z_sun=Quantity(f64[], 'pc'),
+      z_sun=Q(f64[], 'pc'),
       galcen_v_sun=Tangent(
         {'x': Q(f64[], 'km / s'), 'y': Q(f64[], 'km / s'), 'z': Q(f64[], 'km / s')},
         chart=Cart3D(M=Rn(3)),
@@ -397,7 +397,7 @@ def astropy_galactocentric_to_coordinax_galactocentric(
         frame=ICRS()
       ),
       roll=Angle(f64[], 'deg'),
-      z_sun=Quantity(f64[], 'pc'),
+      z_sun=Q(f64[], 'pc'),
       galcen_v_sun=Tangent(
         {'x': Q(f64[], 'km / s'), 'y': Q(f64[], 'km / s'), 'z': Q(f64[], 'km / s')},
         chart=Cart3D(M=Rn(3)),

--- a/src/coordinax/_src/base/charts.py
+++ b/src/coordinax/_src/base/charts.py
@@ -242,19 +242,19 @@ class AbstractChart(Generic[MT, Ks, Ds], metaclass=abc.ABCMeta):
 
         >>> wl.pprint(cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(20, "km")))
         ProlateSpheroidal3D[('mu', 'nu', 'phi'), ('area', 'area', 'angle')](
-            Delta=StaticQuantity(i64[](numpy), unit='km'), M=Rn(3)
+            Delta=StaticQuantity(i64[](numpy), 'km'), M=Rn(3)
         )
 
         >>> wl.pprint(cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(20, "km")),
         ... short_arrays=False)
         ProlateSpheroidal3D[('mu', 'nu', 'phi'), ('area', 'area', 'angle')](
-            Delta=StaticQuantity(array(20), unit='km'), M=Rn(3)
+            Delta=StaticQuantity(array(20), 'km'), M=Rn(3)
         )
 
         """
         kw.setdefault("short_arrays", "compact")
-        kw.setdefault("use_short_names", True)
-        kw.setdefault("named_units", False)
+        kw.setdefault("use_short_name", True)
+        kw.setdefault("named_unit", False)
         kw.setdefault("hide_defaults", True)
 
         if include_params:

--- a/src/coordinax/frames/_src/base.py
+++ b/src/coordinax/frames/_src/base.py
@@ -76,7 +76,7 @@ class AbstractReferenceFrame(eqx.Module):
         # Set defaults for pdoc kwargs
         kw.setdefault("include_params", False)
         kw.setdefault("short_arrays", "compact")
-        kw.setdefault("use_short_names", True)
+        kw.setdefault("use_short_name", True)
         kw.setdefault("named_unit", False)
 
         # Include only fields that differ from their default values.

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -134,7 +134,7 @@ class AbstractAdd(AbstractTransform):
         # Set pdoc option defaults
         kw.setdefault("include_params", False)
         kw.setdefault("short_arrays", "compact")
-        kw.setdefault("use_short_names", True)
+        kw.setdefault("use_short_name", True)
         kw.setdefault("named_unit", False)
 
         # Build the fields


### PR DESCRIPTION
`use_short_names` and `named_units` are not parameters of `unxt`'s `__pdoc__` —
the real names are singular, `use_short_name` and `named_unit`.
`wadler_lindig` forwards unrecognised kwargs untouched, so these were swallowed
by `**kwargs` and did nothing at all.

Verified before changing anything:

```pycon
>>> wl.pformat(u.Q(10.0, "m"), short_arrays="compact",
...            use_short_names=True, named_units=False)   # misspelled
"Quantity(10., unit='m')"
>>> wl.pformat(u.Q(10.0, "m"), short_arrays="compact",
...            use_short_name=True, named_unit=False)     # correct
"Q(10., 'm')"
```

## Sites

| file | was | |
|---|---|---|
| `_src/base/charts.py` | `use_short_names`, `named_units` | both wrong |
| `frames/_src/base.py` | `use_short_names` | `named_unit` already correct |
| `transforms/_src/actions/add.py` | `use_short_names` | `named_unit` already correct |

The latter two were *half*-working: units printed positionally while the class
name stayed long. `charts.py` was the only fully-broken one.

## Output change

Small, and confined to `charts.py` — two doctests move from `unit='km'` to
`'km'`, which is exactly what `named_unit=False` was asking for:

```diff
  ProlateSpheroidal3D[('mu', 'nu', 'phi'), ('area', 'area', 'angle')](
-     Delta=StaticQuantity(array(20), unit='km'), M=Rn(3)
+     Delta=StaticQuantity(array(20), 'km'), M=Rn(3)
  )
```

`StaticQuantity` has no `short_name`, so `use_short_name=True` has no visible
effect there. Nothing else in the suite changes.

## Verification

`pytest src docs tests README.md` — the only failures were those two doctests
(now updated) and one `hypothesis` DeadlineExceeded in
`tests/unit/charts/test_cdict.py` that passes on re-run and is unrelated.
`ruff check` and `ruff format --check` clean.

Found while tracing `__pdoc__` kwargs for GalacticDynamics/unxt#855.
