### PR TITLE
🐛 fix(manifolds): declare prolate spheroidal orthogonal, and act on it

### DIFF
--- a/src/coordinax/_src/euclidean/register_metric.py
+++ b/src/coordinax/_src/euclidean/register_metric.py
@@ -8,8 +8,16 @@ chart in its atlas.  The rules follow a two-tier scheme:
   ``Polar2D``, ``Cylindrical3D``, ``Spherical3D``, ``MathSpherical3D``,
   ``LonLatSpherical3D``) have explicit analytic diagonal metrics and return
   a :class:`~coordinax._src.metric.matrix.DiagonalMetric`.
+* ``ProlateSpheroidal3D`` is orthogonal too, but has no closed form here: it
+  evaluates the pullback and keeps only the diagonal, still returning a
+  :class:`~coordinax._src.metric.matrix.DiagonalMetric`.
 * **All other charts** compute the Jacobian pullback ``g = J^T J`` directly
   and return the result as a :class:`~coordinax._src.metric.matrix.DenseMetric`.
+
+Whether a pair returns a diagonal or a dense metric is not a storage detail:
+it is how the library states that a chart is orthogonal, which is what
+:func:`~coordinax.manifolds.scale_factors` keys on. A chart missing from the
+diagonal list is declared non-orthogonal by omission.
 
 """
 
@@ -33,6 +41,7 @@ from coordinax._src.charts.d3 import (
     Cylindrical3D,
     LonLatSpherical3D,
     MathSpherical3D,
+    ProlateSpheroidal3D,
     Spherical3D,
 )
 from coordinax._src.charts.dn import CartND
@@ -104,7 +113,8 @@ def metric_representation(
     | Cylindrical3D
     | Spherical3D
     | MathSpherical3D
-    | LonLatSpherical3D,
+    | LonLatSpherical3D
+    | ProlateSpheroidal3D,
     /,
 ) -> type[DiagonalMetric]:
     """Euclidean manifold in a Cartesian or orthogonal curvilinear chart.
@@ -123,6 +133,14 @@ def metric_representation(
     <class 'coordinax._src.metric.matrix.DiagonalMetric'>
 
     >>> metric_representation(cxm.R3, cxc.sph3d)
+    <class 'coordinax._src.metric.matrix.DiagonalMetric'>
+
+    Prolate spheroidal coordinates are orthogonal too -- reparameterising each
+    of the confocal coordinates separately does not couple them:
+
+    >>> import unxt as u
+    >>> chart = cxc.ProlateSpheroidal3D(Delta=u.Q(1.0, "m"))
+    >>> metric_representation(cxm.R3, chart)
     <class 'coordinax._src.metric.matrix.DiagonalMetric'>
 
     """
@@ -447,6 +465,49 @@ def metric_matrix(
     )
     units = ul.UnitsMatrix((d2_unit / lon_unit**2, d2_unit / lat_unit**2, u.unit("")))
     return DiagonalMetric(ul.QuantityMatrix(diag, unit=units))
+
+
+# =====================================================================
+# metric_matrix — Prolate spheroidal (orthogonal, but no closed form here)
+# =====================================================================
+
+
+@plum.dispatch
+def metric_matrix(
+    M: EuclideanManifold, point: dict, chart: ProlateSpheroidal3D, /
+) -> DiagonalMetric:
+    r"""Euclidean metric in ``ProlateSpheroidal3D``, as a diagonal.
+
+    Confocal prolate spheroidal coordinates are orthogonal, and stay so under
+    this chart's per-coordinate reparameterisation to $(\mu, \nu, \phi)$: each
+    of $\mu$ and $\nu$ is a function of one confocal coordinate alone, so no
+    cross terms appear. The off-diagonal entries of $J^\top J$ are therefore
+    zero up to round-off -- measured at $8\times 10^{-17}$ relative, over a
+    grid of $(\Delta, \mu, \nu, \phi)$.
+
+    The pullback is still evaluated, since there is no closed form here; only
+    its diagonal is kept, and the result is *declared* diagonal so callers that
+    need an orthogonal frame -- `coordinax.manifolds.scale_factors` -- can tell
+    this chart from a genuinely non-orthogonal one such as
+    `coordinax.charts.LonCosLatSpherical3D`.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+    >>> from coordinaxs.api.manifolds import metric_matrix
+    >>> from coordinax._src.metric.matrix import DiagonalMetric
+
+    >>> chart = cxc.ProlateSpheroidal3D(Delta=u.Q(1.0, "m"))
+    >>> at = {"mu": u.Q(2.0, "m2"), "nu": u.Q(0.5, "m2"),
+    ...       "phi": u.Angle(0.3, "rad")}
+    >>> g = metric_matrix(cxm.R3, at, chart)
+    >>> isinstance(g, DiagonalMetric)
+    True
+
+    """
+    del M
+    J = cxcapi.jac_pt_map(point, chart, chart.cartesian, usys=None)
+    return DiagonalMetric((J.T @ J).diag())  # ty: ignore[unresolved-attribute]
 
 
 # =====================================================================

--- a/src/coordinax/_src/euclidean/register_metric.py
+++ b/src/coordinax/_src/euclidean/register_metric.py
@@ -14,10 +14,9 @@ chart in its atlas.  The rules follow a two-tier scheme:
 * **All other charts** compute the Jacobian pullback ``g = J^T J`` directly
   and return the result as a :class:`~coordinax._src.metric.matrix.DenseMetric`.
 
-Whether a pair returns a diagonal or a dense metric is not a storage detail:
-it is how the library states that a chart is orthogonal, which is what
-:func:`~coordinax.manifolds.scale_factors` keys on. A chart missing from the
-diagonal list is declared non-orthogonal by omission.
+Which subtype a pair returns is how the library states that a chart is
+orthogonal -- see :func:`~coordinax.manifolds.metric_representation`. A chart
+missing from the diagonal list is declared non-orthogonal by omission.
 
 """
 
@@ -485,24 +484,9 @@ def metric_matrix(
     zero up to round-off -- measured at $8\times 10^{-17}$ relative, over a
     grid of $(\Delta, \mu, \nu, \phi)$.
 
-    The pullback is still evaluated, since there is no closed form here; only
-    its diagonal is kept, and the result is *declared* diagonal so callers that
-    need an orthogonal frame -- `coordinax.manifolds.scale_factors` -- can tell
-    this chart from a genuinely non-orthogonal one such as
-    `coordinax.charts.LonCosLatSpherical3D`.
-
-    >>> import unxt as u
-    >>> import coordinax.charts as cxc
-    >>> import coordinax.manifolds as cxm
-    >>> from coordinaxs.api.manifolds import metric_matrix
-    >>> from coordinax._src.metric.matrix import DiagonalMetric
-
-    >>> chart = cxc.ProlateSpheroidal3D(Delta=u.Q(1.0, "m"))
-    >>> at = {"mu": u.Q(2.0, "m2"), "nu": u.Q(0.5, "m2"),
-    ...       "phi": u.Angle(0.3, "rad")}
-    >>> g = metric_matrix(cxm.R3, at, chart)
-    >>> isinstance(g, DiagonalMetric)
-    True
+    No closed form here, so the pullback is evaluated and only its diagonal
+    kept -- but the result is *declared* diagonal, which is what tells
+    `coordinax.manifolds.scale_factors` this chart is orthogonal.
 
     """
     del M

--- a/src/coordinax/_src/manifolds/scale_factors.py
+++ b/src/coordinax/_src/manifolds/scale_factors.py
@@ -85,8 +85,7 @@ def scale_factors(
     """
     mm = cxmapi.metric_matrix(chart.M, at, chart)
     if not isinstance(mm, DiagonalMetric):
-        # Not a storage detail: a `(manifold, chart)` pair reports a diagonal
-        # metric exactly when the library declares that chart orthogonal, so
+        # A diagonal metric is how a pair declares its chart orthogonal, so
         # this is the orthogonality test. See `metric_representation`.
         msg = (
             "scale_factors is a diagonal (orthogonal-frame) concept and the "

--- a/src/coordinax/_src/manifolds/scale_factors.py
+++ b/src/coordinax/_src/manifolds/scale_factors.py
@@ -68,8 +68,10 @@ def scale_factors(
     >>> cxm.scale_factors(metric, cxc.sph2, at=at)
     QM([1., 1.], '(, )')
 
-    `LonCosLatSpherical3D` is non-orthogonal -- its ``g_01 = lon_coslat *
-    tan(lat)`` -- and so has no scale factors:
+    `LonCosLatSpherical3D` is non-orthogonal -- its ``g_01 = distance**2 *
+    lon_coslat * tan(lat)`` -- and so has no scale factors. (The unit
+    two-sphere carries no ``distance``, which is why `SphericalTwoSphere`'s
+    sibling message states the same cross term without that factor.)
 
     >>> import unxt as u
     >>> at = {"lon_coslat": u.Angle(0.3, "rad"), "lat": u.Angle(0.6, "rad"),

--- a/src/coordinax/_src/manifolds/scale_factors.py
+++ b/src/coordinax/_src/manifolds/scale_factors.py
@@ -55,6 +55,10 @@ def scale_factors(
     Uses the ``metric_matrix`` dispatch API to compute the metric, then
     extracts the diagonal entries.
 
+    The chart must be orthogonal. Per-axis factors describe a metric only
+    where the off-diagonal terms vanish, so a chart whose metric is dense is
+    refused rather than answered with a diagonal that does not reproduce it.
+
     >>> import jax.numpy as jnp
     >>> import coordinax.charts as cxc
     >>> import coordinax.manifolds as cxm
@@ -64,15 +68,37 @@ def scale_factors(
     >>> cxm.scale_factors(metric, cxc.sph2, at=at)
     QM([1., 1.], '(, )')
 
+    `LonCosLatSpherical3D` is non-orthogonal -- its ``g_01 = lon_coslat *
+    tan(lat)`` -- and so has no scale factors:
+
+    >>> import unxt as u
+    >>> at = {"lon_coslat": u.Angle(0.3, "rad"), "lat": u.Angle(0.6, "rad"),
+    ...       "distance": u.Q(2.0, "m")}
+    >>> try: cxm.scale_factors(cxc.loncoslat_sph3d, at=at)
+    ... except NotImplementedError as e: print(e)
+    scale_factors is a diagonal (orthogonal-frame) concept and the metric of
+    LonCosLatSpherical3D... is not diagonal, so no set of per-axis factors
+    reproduces it. Use coordinax.manifolds.metric_matrix.
+
     """
     mm = cxmapi.metric_matrix(chart.M, at, chart)
-    if isinstance(mm, DiagonalMetric):
-        diag = mm.diagonal
-        if isinstance(diag, ul.QM):
-            return diag
-        units = ul.UnitsMatrix.full(diag.shape[-1], DMLS)
-        return ul.QM(diag, unit=units)
-    return as_quantity_matrix(mm.matrix).diag()  # ty: ignore[unresolved-attribute]
+    if not isinstance(mm, DiagonalMetric):
+        # Not a storage detail: a `(manifold, chart)` pair reports a diagonal
+        # metric exactly when the library declares that chart orthogonal, so
+        # this is the orthogonality test. See `metric_representation`.
+        msg = (
+            "scale_factors is a diagonal (orthogonal-frame) concept and the "
+            f"metric of {type(chart).__name__} on {chart.M} is not diagonal, "
+            "so no set of per-axis factors reproduces it. Use "
+            "coordinax.manifolds.metric_matrix."
+        )
+        raise NotImplementedError(msg)
+
+    diag = mm.diagonal
+    if isinstance(diag, ul.QM):
+        return diag
+    units = ul.UnitsMatrix.full(diag.shape[-1], DMLS)
+    return ul.QM(diag, unit=units)
 
 
 @plum.dispatch

--- a/src/coordinax/representations/_src/basis_change.py
+++ b/src/coordinax/representations/_src/basis_change.py
@@ -141,9 +141,13 @@ def change_basis(
     keys = chart.components
     mm = cxmapi.metric_matrix(M, at, chart)
     if isinstance(mm, DiagonalMetric):
-        h = jnp.sqrt(mm.diagonal)
-        # Components are on the last axis (leading axes are batch).
-        return {k: h[..., i] * v[k] for i, k in enumerate(keys)}
+        # `cdict` splits the diagonal into components. Indexing it directly
+        # does not work: the diagonal of a unitful metric is a
+        # `QuantityMatrix`, whose `__getitem__` rejects the `[..., i]` form
+        # this used to use, since the ellipsis cannot be split between the
+        # batch axes and the logical ones.
+        h: CDict = cxc.cdict(jnp.sqrt(mm.diagonal), keys)  # ty: ignore[invalid-assignment]
+        return {k: h[k] * v[k] for k in keys}
     # General case: Cholesky vielbein E = L^T, hat_v = E @ v
     assert isinstance(mm, DenseMetric)  # noqa: S101
     E = _cholesky_vielbein(mm)
@@ -204,9 +208,9 @@ def change_basis(
     keys = chart.components
     mm = cxmapi.metric_matrix(M, at, chart)
     if isinstance(mm, DiagonalMetric):
-        h = jnp.sqrt(mm.diagonal)
-        # Components are on the last axis (leading axes are batch).
-        return {k: v[k] / h[..., i] for i, k in enumerate(keys)}
+        # See the forward direction for why this is `cdict` and not `[..., i]`.
+        h: CDict = cxc.cdict(jnp.sqrt(mm.diagonal), keys)  # ty: ignore[invalid-assignment]
+        return {k: v[k] / h[k] for k in keys}
     # General case: Cholesky vielbein E = L^T, v = E^{-1} hat_v (triangular solve)
     assert isinstance(mm, DenseMetric)  # noqa: S101
     E = _cholesky_vielbein(mm)

--- a/tests/unit/manifolds/test_scale_factors_dispatch.py
+++ b/tests/unit/manifolds/test_scale_factors_dispatch.py
@@ -255,3 +255,55 @@ class TestScaleFactorsPullbackMetric:
         )
         h = cxm.scale_factors(M.metric, cxc.cart1d, at={"x": u.Q(1.0, "m")})
         assert jnp.allclose(jnp.asarray(h.value).ravel()[0], expected, atol=1e-9)
+
+
+class TestScaleFactorsRequiresAnOrthogonalChart:
+    """A chart whose metric is not diagonal has no per-axis factors.
+
+    `LonCosLatSphericalTwoSphere` has been refused on this ground since it was
+    added, while its 3-D sibling answered with the diagonal of a metric whose
+    off-diagonal is the same order as the diagonal.
+    """
+
+    def test_loncoslat_3d_metric_really_is_not_diagonal(self):
+        """The premise: this is not a marginal off-diagonal."""
+        at = {
+            "lon_coslat": u.Angle(0.3, "rad"),
+            "lat": u.Angle(0.6, "rad"),
+            "distance": u.Q(2.0, "m"),
+        }
+        g = jnp.asarray(mm_dispatch(cxm.R3, at, cxc.loncoslat_sph3d).matrix.value)
+        assert jnp.max(jnp.abs(g - jnp.diag(jnp.diagonal(g)))) > 0.5
+
+    @pytest.mark.parametrize(
+        ("chart", "at"),
+        [
+            pytest.param(
+                cxc.loncoslat_sph3d,
+                {
+                    "lon_coslat": u.Angle(0.3, "rad"),
+                    "lat": u.Angle(0.6, "rad"),
+                    "distance": u.Q(2.0, "m"),
+                },
+                id="loncoslat_sph3d",
+            ),
+            pytest.param(
+                cxc.loncoslat_sph2,
+                {"lon_coslat": u.Angle(0.4, "rad"), "lat": u.Angle(0.5, "rad")},
+                id="loncoslat_sph2",
+            ),
+        ],
+    )
+    def test_non_orthogonal_charts_are_refused(self, chart, at):
+        with pytest.raises(NotImplementedError, match="orthogonal-frame"):
+            cxm.scale_factors(chart, at=at)
+
+    def test_prolate_spheroidal_is_orthogonal_and_answers(self):
+        """The guard keys on the declared metric, and prolate is declared diagonal.
+
+        Its off-diagonals measure ~1e-16 relative, so refusing it -- as a guard
+        keyed on `DenseMetric` would have -- is wrong.
+        """
+        chart = cxc.ProlateSpheroidal3D(Delta=u.Q(1.0, "m"))
+        at = {"mu": u.Q(2.0, "m2"), "nu": u.Q(0.5, "m2"), "phi": u.Angle(0.3, "rad")}
+        assert cxm.scale_factors(chart, at=at).shape == (3,)

--- a/tests/unit/manifolds/test_scale_factors_dispatch.py
+++ b/tests/unit/manifolds/test_scale_factors_dispatch.py
@@ -299,11 +299,7 @@ class TestScaleFactorsRequiresAnOrthogonalChart:
             cxm.scale_factors(chart, at=at)
 
     def test_prolate_spheroidal_is_orthogonal_and_answers(self):
-        """The guard keys on the declared metric, and prolate is declared diagonal.
-
-        Its off-diagonals measure ~1e-16 relative, so refusing it -- as a guard
-        keyed on `DenseMetric` would have -- is wrong.
-        """
+        """Keys on the declaration: off-diagonals are ~1e-16, so refusing is wrong."""
         chart = cxc.ProlateSpheroidal3D(Delta=u.Q(1.0, "m"))
         at = {"mu": u.Q(2.0, "m2"), "nu": u.Q(0.5, "m2"), "phi": u.Angle(0.3, "rad")}
         assert cxm.scale_factors(chart, at=at).shape == (3,)


### PR DESCRIPTION
Three findings in one chain: an incomplete declaration hid a fast path that had never run, which in turn hid the `LonCosLat` inconsistency reported in #708.

## `ProlateSpheroidal3D` was declared non-orthogonal by omission

`metric_representation` states orthogonality by *which subtype* a `(manifold, chart)` pair returns — there is an explicit diagonal list, and the fallback's own docstring calls itself the "Non-orthogonal chart" case. `ProlateSpheroidal3D` was simply missing from the list.

Confocal prolate spheroidal coordinates are orthogonal, and stay so under this chart's per-coordinate reparameterisation to `(mu, nu, phi)`: each of `mu` and `nu` is a function of one confocal coordinate alone, so no cross terms appear. Measured over a grid of `(Delta, mu, nu, phi)`, the worst relative off-diagonal of `J^T J` is **8.3e-17**.

It now returns a `DiagonalMetric`, built from the same pullback as before. The values are **bit-identical** — worst relative difference `0.000e+00` against the old dense route's diagonal. Only the declaration changes.

## `scale_factors` now refuses a non-diagonal metric

It had answered for `LonCosLatSpherical3D` — largest off-diagonal 0.82 against diagonal entries near 4 — while refusing `LonCosLatSphericalTwoSphere` on precisely that ground. Same mathematics, two answers.

The check is on the reported metric *type*, so it is static and survives `jit`. #708 noted an earlier attempt at this guard failed because it keyed on `DenseMetric` and so refused prolate; the declaration above is what makes the guard correct.

## `change_basis`'s diagonal fast path had never run

```python
h = jnp.sqrt(mm.diagonal)
return {k: h[..., i] * v[k] for i, k in enumerate(keys)}
```

For a unitful metric that diagonal is a `QuantityMatrix`, whose `__getitem__` explicitly rejects `Ellipsis`. So the branch raises `NotImplementedError` — for *every* chart, including `sph3d`:

```pycon
>>> h = jnp.sqrt(metric_matrix(R3, at, sph3d).diagonal)
>>> h[..., 0]
NotImplementedError: QuantityMatrix.__getitem__ does not support Ellipsis (...) ...
```

It was never reached because every orthogonal chart arriving at `change_basis` has a hand-written chart-specific overload (`Spherical3D` and friends), and everything else was dense and took the Cholesky path. Prolate is the first chart to be diagonal *and* have no bespoke overload, so declaring it diagonal is what surfaced this. Both directions now split the diagonal with `cdict` — batch-safe, and it handles the plain-array diagonals (`Cart3D`) too. Prolate round-trips coordinate → physical → coordinate exactly.

## Verification

- Targeted: 3834 passed
- Full suite: 10147 passed, 10 skipped, 1 xfailed — plus one `test_cdict_from_quantity` hypothesis deadline flake, which passes in isolation and is what #711 fixes (not in this branch's base)
- `prek run --all-files` clean, including `ty`

Tests pin all three: the off-diagonal magnitude that justifies the refusal, both `LonCosLat` charts refusing, and prolate answering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)