### PR TITLE
🐛 fix(spherical): return the intrinsic metric as a dimensionless QuantityMatrix

### DIFF
--- a/src/coordinax/_src/manifolds/norm.py
+++ b/src/coordinax/_src/manifolds/norm.py
@@ -366,7 +366,9 @@ def norm(
     # here -- checking the units really are empty rather than assuming so.
     gm = mm.to_dense().matrix  # ty: ignore[unresolved-attribute]
     if isinstance(gm, ul.QuantityMatrix):
-        if gm.unit != ul.UnitsMatrix.full(gm.shape, ""):
+        # `gm.unit.shape`, not `gm.shape`: the latter carries batch axes the
+        # units do not, so a batched dimensionless metric would be rejected.
+        if gm.unit != ul.UnitsMatrix.full(gm.unit.shape, ""):
             msg = (
                 f"norm(): a bare `jax.Array` cannot carry the unit of this "
                 f"chart's metric ({gm.unit}); pass `v` as a Quantity."

--- a/src/coordinax/_src/manifolds/norm.py
+++ b/src/coordinax/_src/manifolds/norm.py
@@ -359,7 +359,21 @@ def norm(
     check_metric_is_charts(metric, chart, "norm")
     require_positive_definite(chart.M.metric, "norm")
     mm = cxmapi.metric_matrix(chart.M, at, chart)
-    return array_norm(mm.to_dense().matrix, v)  # ty: ignore[unresolved-attribute]
+    # Bare in, bare out. `at` arrives unitless here, so the metric comes back
+    # bare (Cartesian charts) or as a *dimensionless* `QuantityMatrix` (the
+    # sphere charts). `array_norm` has no `(QuantityMatrix, Array)` overload,
+    # and `QuantityMatrix.ustrip` will not take a `UnitsMatrix`, so unwrap it
+    # here -- checking the units really are empty rather than assuming so.
+    gm = mm.to_dense().matrix  # ty: ignore[unresolved-attribute]
+    if isinstance(gm, ul.QuantityMatrix):
+        if gm.unit != ul.UnitsMatrix.full(gm.shape, ""):
+            msg = (
+                f"norm(): a bare `jax.Array` cannot carry the unit of this "
+                f"chart's metric ({gm.unit}); pass `v` as a Quantity."
+            )
+            raise ValueError(msg)
+        gm = gm.value
+    return array_norm(gm, v)
 
 
 # ===========================================================================

--- a/src/coordinax/_src/manifolds/norm.py
+++ b/src/coordinax/_src/manifolds/norm.py
@@ -368,7 +368,15 @@ def norm(
     if isinstance(gm, ul.QuantityMatrix):
         # `gm.unit.shape`, not `gm.shape`: the latter carries batch axes the
         # units do not, so a batched dimensionless metric would be rejected.
-        if gm.unit != ul.UnitsMatrix.full(gm.unit.shape, ""):
+        if gm.unit != ul.UnitsMatrix.full(gm.unit.shape, ""):  # pragma: no cover
+            # Unreachable through any public route today, hence the pragma: a
+            # bare `at` yields a dimensionless metric, and the unitful ones
+            # that exist (an embedded sphere's pullback, m2) belong to charts
+            # `check_metric_is_charts` rejects further up. Kept rather than
+            # deleted for the number it protects: dropping a metric's unit here
+            # would return a norm in the wrong dimension and look fine. A chart
+            # whose metric carries units at a bare base point is a supportable
+            # thing to add; this is what would catch it on the first call.
             msg = (
                 f"norm(): a bare `jax.Array` cannot carry the unit of this "
                 f"chart's metric ({gm.unit}); pass `v` as a Quantity."

--- a/src/coordinax/_src/manifolds/quadratic_form.py
+++ b/src/coordinax/_src/manifolds/quadratic_form.py
@@ -401,8 +401,15 @@ def _contract(mm: DiagonalMetric, uvec: Array, vvec: Array, /) -> Any:
     the per-component units cannot be factored out of a sum against unitless
     vectors. That combination does not work on the dense path either, so this
     keeps the pre-existing failure rather than substituting a different one.
+
+    A *dimensionless* one is unwrapped instead. The intrinsic sphere's metric
+    is a dimensionless `QuantityMatrix` -- angles over angles -- so sending it
+    to the dense path would both drop this $O(n)$ route and return a
+    `Quantity` from bare inputs.
     """
     d = mm.diagonal
     if isinstance(d, ul.QM):
-        return jnp.einsum("...i,...ij,...j->...", uvec, mm.to_dense().matrix, vvec)
+        if d.unit != ul.UnitsMatrix.full(d.shape, ""):
+            return jnp.einsum("...i,...ij,...j->...", uvec, mm.to_dense().matrix, vvec)
+        d = d.value
     return jnp.sum(d * uvec * vvec, axis=-1)

--- a/src/coordinax/_src/manifolds/quadratic_form.py
+++ b/src/coordinax/_src/manifolds/quadratic_form.py
@@ -409,7 +409,11 @@ def _contract(mm: DiagonalMetric, uvec: Array, vvec: Array, /) -> Any:
     """
     d = mm.diagonal
     if isinstance(d, ul.QM):
-        if d.unit != ul.UnitsMatrix.full(d.shape, ""):
+        # `d.unit.shape`, not `d.shape`: a batched diagonal carries units on
+        # the component axis only, so comparing against the *value* shape never
+        # matches and would send every batched dimensionless metric to the
+        # dense path.
+        if d.unit != ul.UnitsMatrix.full(d.unit.shape, ""):
             return jnp.einsum("...i,...ij,...j->...", uvec, mm.to_dense().matrix, vvec)
         d = d.value
     return jnp.sum(d * uvec * vvec, axis=-1)

--- a/src/coordinax/_src/spherical/metric.py
+++ b/src/coordinax/_src/spherical/metric.py
@@ -42,8 +42,9 @@ class RoundMetric(AbstractDiagonalMetricField):
     The metric matrix is obtained via the dispatch API on the associated manifold:
 
     >>> at = {"theta": jnp.array(jnp.pi / 2), "phi": jnp.array(0.0)}
-    >>> cxmapi.metric_matrix(cxm.S2, at, cxc.sph2).diagonal
-    QM([1., 1.], '(, )')
+    >>> d = cxmapi.metric_matrix(cxm.S2, at, cxc.sph2).diagonal
+    >>> bool(jnp.allclose(d.value, jnp.array([1.0, 1.0])))
+    True
 
     """
 

--- a/src/coordinax/_src/spherical/metric.py
+++ b/src/coordinax/_src/spherical/metric.py
@@ -43,7 +43,7 @@ class RoundMetric(AbstractDiagonalMetricField):
 
     >>> at = {"theta": jnp.array(jnp.pi / 2), "phi": jnp.array(0.0)}
     >>> cxmapi.metric_matrix(cxm.S2, at, cxc.sph2).diagonal
-    Array([1., 1.], dtype=float64)
+    QM([1., 1.], '(, )')
 
     """
 

--- a/src/coordinax/_src/spherical/register_metric.py
+++ b/src/coordinax/_src/spherical/register_metric.py
@@ -110,7 +110,14 @@ def metric_matrix(
         # empty stack decides the result dtype for S¹.
         else jnp.zeros((0, *vals[-1].shape), dtype=vals[-1].dtype)
     )
-    return DiagonalMetric(_sine_product_diagonal(thetas, 1.0))
+    # Dimensionless, but a `QuantityMatrix` all the same: the sibling rules
+    # below already return one, and a generic consumer should not have to ask
+    # which dispatch produced its metric. `angles -> angles`, so the unit is
+    # empty -- unlike the *embedded* sphere, whose induced metric measures
+    # ambient length and correctly carries `L**2/rad**2`.
+    diag = _sine_product_diagonal(thetas, 1.0)
+    n = len(components)
+    return DiagonalMetric(ul.QM(diag, unit=ul.UnitsMatrix.full(n, "")))
 
 
 @plum.dispatch

--- a/src/coordinax/_src/spherical/register_metric.py
+++ b/src/coordinax/_src/spherical/register_metric.py
@@ -84,7 +84,7 @@ def metric_matrix(
     >>> isinstance(g, DiagonalMetric)
     True
     >>> g.diagonal
-    Array([1., 1.], dtype=float64)
+    QM([1., 1.], '(, )')
 
     $S^2$ at $\theta = \pi/6$:
 

--- a/src/coordinax/_src/spherical/register_metric.py
+++ b/src/coordinax/_src/spherical/register_metric.py
@@ -83,8 +83,8 @@ def metric_matrix(
     >>> g = metric_matrix(M, at, cxc.sph2)
     >>> isinstance(g, DiagonalMetric)
     True
-    >>> g.diagonal
-    QM([1., 1.], '(, )')
+    >>> bool(jnp.allclose(g.diagonal.value, jnp.array([1.0, 1.0])))
+    True
 
     $S^2$ at $\theta = \pi/6$:
 

--- a/tests/unit/manifolds/test_metric_matrix_batch_invariant.py
+++ b/tests/unit/manifolds/test_metric_matrix_batch_invariant.py
@@ -63,7 +63,8 @@ def test_curvilinear_metric_batches_like_elementwise(data):
     for idx in np.ndindex(shape):
         pt = {k: v[idx] for k, v in point.items()}
         gi = cxmapi.metric_matrix(manifold, pt, chart).diagonal
-        # Same arithmetic on the same values: rows must match, units unchanged.
+        # Same arithmetic on the same values: rows must match. Every chart
+        # here yields a `QuantityMatrix` diagonal, so both sides unwrap.
         np.testing.assert_allclose(gbv[idx], np.asarray(gi.value), rtol=1e-5)
         assert getattr(gb, "unit", None) == getattr(gi, "unit", None)
 

--- a/tests/unit/manifolds/test_metric_matrix_batch_invariant.py
+++ b/tests/unit/manifolds/test_metric_matrix_batch_invariant.py
@@ -59,14 +59,12 @@ def test_curvilinear_metric_batches_like_elementwise(data):
 
     # The Euclidean rules return a united QuantityMatrix; the intrinsic sphere
     # rules return a bare (dimensionless) Array. Compare whichever is carried.
-    gbv = np.asarray(getattr(gb, "value", gb))
+    gbv = np.asarray(gb.value)
     for idx in np.ndindex(shape):
         pt = {k: v[idx] for k, v in point.items()}
         gi = cxmapi.metric_matrix(manifold, pt, chart).diagonal
         # Same arithmetic on the same values: rows must match, units unchanged.
-        np.testing.assert_allclose(
-            gbv[idx], np.asarray(getattr(gi, "value", gi)), rtol=1e-5
-        )
+        np.testing.assert_allclose(gbv[idx], np.asarray(gi.value), rtol=1e-5)
         assert getattr(gb, "unit", None) == getattr(gi, "unit", None)
 
 

--- a/tests/unit/manifolds/test_metric_matrix_dispatch.py
+++ b/tests/unit/manifolds/test_metric_matrix_dispatch.py
@@ -190,7 +190,7 @@ class TestMetricMatrixNumericalValues:
         pt = {"theta": jnp.array(jnp.pi / 2), "phi": jnp.array(0)}
         g = cxmapi.metric_matrix(cxm.S2, pt, cxc.sph2)
         assert isinstance(g, DiagonalMetric)
-        assert jnp.allclose(g.diagonal, jnp.array([1, 1]), atol=1e-6)
+        assert jnp.allclose(g.diagonal.value, jnp.array([1, 1]), atol=1e-6)
 
     def test_hyperspherical_at_off_equator(self):
         """At theta=π/3: diag(S²) = (1, sin²(π/3)) = (1, 3/4)."""
@@ -198,7 +198,7 @@ class TestMetricMatrixNumericalValues:
         g = cxmapi.metric_matrix(cxm.S2, pt, cxc.sph2)
         assert isinstance(g, DiagonalMetric)
         expected = jnp.array([1, jnp.sin(jnp.pi / 3) ** 2])
-        assert jnp.allclose(g.diagonal, expected, atol=1e-6)
+        assert jnp.allclose(g.diagonal.value, expected, atol=1e-6)
 
     def test_euclidean_sph3d_returns_diagonal_metric(self):
         """EuclideanManifold + sph3d uses analytic formula, returning DiagonalMetric."""
@@ -300,7 +300,10 @@ class TestMetricMatrixJIT:
             return cxmapi.metric_matrix(manifold, pt, chart).diagonal
 
         result = compute(*(jnp.asarray(v) for v in point.values()))
-        assert jnp.allclose(result, expected, atol=1e-6)
+        # Parametrized across families: the flat charts' diagonal is a bare
+        # array, the curvilinear ones' a `QuantityMatrix` (dimensionless for
+        # the sphere). Normalise -- `allclose` has no QM overload.
+        assert jnp.allclose(getattr(result, "value", result), expected, atol=1e-6)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/manifolds/test_metric_pullback_consistency.py
+++ b/tests/unit/manifolds/test_metric_pullback_consistency.py
@@ -92,8 +92,10 @@ class TestPullbackConsistencyNumerical:
         g_pullback = cxmapi.metric_matrix(unit_sphere_embedded, pt, cxc.sph2)
 
         # RoundMetric (diagonal) and Jacobian pullback (dense) must agree.
-        expected = g_round.to_dense().matrix  # plain array, shape (2, 2)
-        actual = g_pullback.matrix.value  # QuantityMatrix.value, shape (2, 2)
+        # Both are `QuantityMatrix` now, so both unwrap the same way -- the
+        # round metric dimensionless, the pullback in `1/rad2`.
+        expected = g_round.to_dense().matrix.value
+        actual = g_pullback.matrix.value
 
         assert jnp.allclose(actual, expected, atol=1e-6), (
             f"Mismatch at theta={theta}, phi={phi}:\n"
@@ -115,7 +117,7 @@ class TestPullbackConsistencyNumerical:
         g_round = cxmapi.metric_matrix(cxm.S2, pt, cxc.sph2)
         g_pullback = cxmapi.metric_matrix(unit_sphere_embedded, pt, cxc.sph2)
 
-        expected = g_round.to_dense().matrix
+        expected = g_round.to_dense().matrix.value
         actual = g_pullback.matrix.value
 
         assert jnp.allclose(actual, expected, atol=1e-5), (
@@ -201,7 +203,7 @@ def _dense_values(g):
     non-orthogonal LonCosLat returns a `DenseMetric`.
     """
     m = g.to_dense().matrix
-    return jnp.asarray(getattr(m, "value", m))
+    return jnp.asarray(m.value)
 
 
 def _embedding_metric(chart, coords_rad):

--- a/tests/unit/manifolds/test_metrics.py
+++ b/tests/unit/manifolds/test_metrics.py
@@ -243,13 +243,14 @@ class TestRoundMetric:
         g = mm_dispatch(cxm.S2, p, cxc.sph2)
         assert isinstance(g, DiagonalMetric)
         expected = jnp.array([1, 1])
-        assert jnp.allclose(g.diagonal, expected, atol=1e-6)
+        # dimensionless `QuantityMatrix`; `allclose` has no QM overload
+        assert jnp.allclose(g.diagonal.value, expected, atol=1e-6)
 
     def test_metric_matrix_at_pole_theta_component(self):
         """S^2 metric g_theta_theta = 1 everywhere."""
         p = {"theta": u.Angle(0.1, "rad"), "phi": u.Angle(0, "rad")}
         g = mm_dispatch(cxm.S2, p, cxc.sph2)
-        assert jnp.allclose(g.diagonal[0], 1, atol=1e-6)
+        assert jnp.allclose(g.diagonal.value[0], 1, atol=1e-6)
 
     @pytest.mark.parametrize("theta", [0.1, jnp.pi / 4, jnp.pi / 2, jnp.pi * 3 / 4])
     def test_metric_matrix_phi_component_at_various_latitudes(self, theta):
@@ -257,8 +258,9 @@ class TestRoundMetric:
         p = {"theta": u.Angle(theta, "rad"), "phi": u.Angle(0, "rad")}
         g = mm_dispatch(cxm.S2, p, cxc.sph2)
         exp = jnp.sin(theta) ** 2
-        assert jnp.allclose(g.diagonal[1], exp, atol=1e-6), (
-            f"theta={theta}: g_phi_phi={g.diagonal[1]} != sin^2(theta)={exp}"
+        got = g.diagonal.value[1]
+        assert jnp.allclose(got, exp, atol=1e-6), (
+            f"theta={theta}: g_phi_phi={got} != sin^2(theta)={exp}"
         )
 
     def test_metric_matrix_is_diagonal(self):

--- a/tests/unit/manifolds/test_quadratic_form.py
+++ b/tests/unit/manifolds/test_quadratic_form.py
@@ -30,6 +30,15 @@ from coordinax._src.metric.matrix import DiagonalMetric
 ATOL = 1e-5
 
 
+def _dimensionless(x):
+    """Strip a dimensionless `Quantity` to a bare array, leaving arrays alone.
+
+    `jnp.asarray` would do this on current JAX but raises on the oldest
+    supported version, so the coercion is spelled out.
+    """
+    return u.ustrip("", x) if isinstance(x, u.AbstractQuantity) else jnp.asarray(x)
+
+
 class TestRelationToNorm:
     """`norm` is the square root of the form, for a positive-definite metric."""
 
@@ -224,6 +233,12 @@ class TestDiagonalFastPath:
         ``sph3d`` is excluded: a unitless vector against a unitful (mixed-unit)
         diagonal is unsupported on *both* paths, before this change and after,
         so there is no agreement to assert.
+
+        The two paths agree in *value* but not in *type*: the fast path unwraps
+        a dimensionless diagonal and so returns bare inputs' bare array, while
+        the dense path returns a dimensionless `Quantity`. Each is stripped
+        explicitly rather than passed through `jnp.asarray`, which coerces a
+        `Quantity` only on newer JAX -- the oldest supported version raises.
         """
         del label
         at = {k: u.Q(val, un) for k, (val, un) in at_spec.items()}
@@ -233,7 +248,7 @@ class TestDiagonalFastPath:
 
         fast = _contract(mm, stacked, stacked)
         dense = _contract(mm.to_dense(), stacked, stacked)
-        assert jnp.allclose(jnp.asarray(fast), jnp.asarray(dense), atol=1e-8)
+        assert jnp.allclose(_dimensionless(fast), _dimensionless(dense), atol=1e-8)
 
     def test_batched_arrays_reduce_over_components_not_the_batch(self):
         """``sum(..., axis=-1)`` rather than ``@``, which would eat the batch axis."""


### PR DESCRIPTION
Addresses #628 — but not the way that issue proposes, because its premise is wrong.

## The two families are not the same geometric object

```
dimension of rad         ->  angle          (not dimensionless)

intrinsic S2             ->  [1, sin²θ]     dimensionless
embedded, radius = 1.0   ->  [1, sin²θ]     1 / rad2
embedded, radius = 2.0   ->  [4, 4sin²θ]    1 / rad2
embedded, radius = 2.0 m ->  [4, 4sin²θ]    m2 / rad2
```

- **Embedded** is the *induced* metric: `ds` is an ambient length, so `[g] = L²/rad²`. It scales as `R²`.
- **Intrinsic** is the *angular* metric. `cxm.S2` has no radius parameter; distance on the unit sphere is the great-circle angle, so `[ds] = rad` and `[g]` is dimensionless.

They agree numerically at `R = 1` only because the radius is 1. Since `rad` carries dimension *angle*, forcing `1/rad²` onto the intrinsic metric would leave `g` with dimension `angle⁻²` on a manifold that has no length scale — dimensionally incoherent, not a convention choice. **So the issue's option 1 is unavailable**, and option 2 would discard the `R²` scaling that `m²/rad²` correctly records.

Units are therefore unchanged by this PR.

## What was actually inconsistent: the container

Of the three intrinsic `metric_matrix` rules in `_src/spherical/register_metric.py`, **two already returned a dimensionless `QuantityMatrix`** — one carrying the comment `# angles -> angles, so g is dimensionless`. Only the main hypersphere rule returned a bare array. It now follows its own module.

That fixes the specific asymmetry #628 is about, which was visible in one place in the source:

```python
expected = g_round.to_dense().matrix   # was: plain array
actual   = g_pullback.matrix.value
```

Adjacent lines, one unwrapped and one not. Both are `QuantityMatrix` now, so both unwrap identically, and **both `getattr(g, "value", g)` workarounds the issue cites are removed**.

## Two things this surfaced

**A silent performance regression, nearly shipped.** `_contract`'s bare-array route sends any `QuantityMatrix` diagonal to the dense einsum — right for a *unitful* one, but the intrinsic sphere's is dimensionless, so every sphere chart would have quietly dropped the `O(n)` diagonal path (#686) for `O(n²)` while still returning correct numbers. Only the bare-in/bare-out type error exposed it. The dimensionless case is now unwrapped and keeps the fast path; unitful still goes dense.

**The bare-array contract runs deeper than #628 suggests.** `norm`'s bare-array overload broke too: `array_norm` has no `(QuantityMatrix, Array)` overload, so an `-> Array` function tried to return a `Quantity`.

## Honest scope: the container is still not uniform

```
cart3d       -> ArrayImpl        (bare)
minkowskict  -> ArrayImpl        (bare)
sph3d        -> QuantityMatrix
sph2 (S2)    -> QuantityMatrix   (this PR)
```

The split has moved from *intrinsic-vs-embedded* to *Cartesian-vs-curvilinear*. This PR removes two workarounds and `test_jit`, which is parametrized across both families, still needs one. So this is **not** "one accessor for generic consumers" library-wide; making flat metrics matrix-valued too would be a much larger change.

## `QuantityMatrix` needs upstream work — filed and fixed

Every unwrap in this PR is hand-rolled because `QuantityMatrix` has no working conversion API:

| call | result |
| --- | --- |
| `u.uconvert(UnitsMatrix, qm)` | ✅ registered |
| `u.ustrip(UnitsMatrix, qm)` | ❌ `NotFoundLookupError` |
| `qm.ustrip("")` | ❌ `AttributeError: 'UnitsMatrix' object has no attribute 'to'` |
| `u.unit_of(qm)` | ❌ `TypeError` |
| `jnp.allclose(qm, arr)` / `qnp.allclose(qm, arr)` | ❌ no overload / same `AttributeError` |

`unxts.linalg` registered `uconvert` but not `ustrip`, so everything needing a conversion falls through to the scalar-unit astropy path (`unxt/_interop/unxt_interop_astropy/quantity.py:303`, which calls `x.unit.to(...)`).

Filed as **GalacticDynamics/unxt#879**, fixed in **GalacticDynamics/unxt#880**.

Once that is released, three hand-rolled unwraps here collapse to one call each:

```python
# quadratic_form._contract — currently compares against UnitsMatrix.full(shape, "")
d = u.ustrip(AllowValue, "", mm.diagonal)

# norm's bare-array overload — currently a manual isinstance + unit check + .value
gm = u.ustrip(AllowValue, "", mm.to_dense().matrix)

# tests — currently .value, since allclose rejects a QuantityMatrix
assert qnp.allclose(g.diagonal, expected)
```

`unit_of` ships in unxt#880 too, so generic code can ask a `QuantityMatrix` for its units. (An earlier revision of this description claimed it needed unxt's abstract return type widened — that was wrong; plum enforces each method's own annotation. The real, narrower problem is unxt#881: under a combined pytest session plum resolves `-> UnitsMatrix` to a second class object, so that one test is `xfail`ed upstream.)

## Verification

- Full suite: **9944 passed**, 8 skipped, 1 xfailed
- The `O(n)` diagonal fast path is preserved for dimensionless metrics; unitful still routes dense
- ruff/ty clean via `prek`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

