### PR TITLE
ci: bump pypa/gh-action-pypi-publish to v1.14.2

### DIFF
--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -227,7 +227,7 @@ jobs:
           name: ${{ needs.validate.outputs.packages_artifact }}
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -258,4 +258,4 @@ jobs:
         with:
           subject-path: dist/*
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
## Summary

CD Publish was failing at the `pypa/gh-action-pypi-publish` step for every package with:

```
Checking dist/coordinax-0.1.dev653-py3-none-any.whl: ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

([failing run](https://github.com/GalacticDynamics/coordinax/actions/runs/31790252345/job/94735337772))

**Root cause:** `hatchling` 1.32.0 (released 2026-08-11) bumped its default core metadata version from 2.4 to 2.5 ([PEP 794](https://peps.python.org/pep-0794/) support). The *build* job already tolerates this — `hynek/build-and-inspect-python-package` was bumped to v3.0.1 in #697. But the privileged *publish* job in `cd-publish.yml` still pinned `pypa/gh-action-pypi-publish@cef221092...` (`v1.14.0`), which bundles `packaging==25.0` / `twine==6.1.0` — neither of which recognize metadata version `2.5`, so `verify-metadata` rejects every artifact downstream of an otherwise-successful build.

**Fix:** bump the pin to `v1.14.2` (`packaging==26.2` / `twine==7.0.0`, which supports 2.5) in both `publish-testpypi` and `publish-pypi` jobs. `cd-publish.yml` is the single shared workflow that publishes all six packages, so this one change fixes every package's publish path.

This is the same class of fix as [GalacticDynamics/unxt#867](https://github.com/GalacticDynamics/unxt/pull/867) and [GalacticDynamics/galax#801](https://github.com/GalacticDynamics/galax/pull/801), which bumped the same stale dependency on the *build*-side action. Those two PRs didn't touch the *publish*-side `pypa/gh-action-pypi-publish` pin, so their `cd-publish-*.yml` workflows are still carrying this same latent bug — they just haven't hit it yet because neither repo has had a push to `main` (which triggers TestPyPI publish) since hatchling 1.32.0 shipped. Worth porting this same bump there too.

## Test plan

- [x] `prek run` passes on the changed workflow file (`Validate GitHub Workflows` hook included)
- [x] Verified `v1.14.2`'s `requirements/runtime.txt` pins `packaging==26.2`/`twine==7.0.0` vs. `v1.14.0`'s `packaging==25.0`/`twine==6.1.0`
- [x] Verified the pinned commit SHA (`dc37677b2e1c63e2034f94d8a5b11f265b73ba33`) resolves to the `v1.14.2` tag in `pypa/gh-action-pypi-publish`
- [ ] CD Publish workflow succeeds end-to-end on merge to `main` (can't run the privileged publish workflow from here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
