### PR TITLE
♻️ refactor(curveframes): rename the builders' gamma field to station

### DIFF
--- a/packages/coordinaxs.curveframes/docs/guide.md
+++ b/packages/coordinaxs.curveframes/docs/guide.md
@@ -188,7 +188,7 @@ def transform_point(tau, p):
     return cxfm.act(op_to_curve, tau, p)
 ```
 
-This works because `op_to_curve` never becomes a traced argument of `transform_point` — it's baked in at trace time. Passing a builder holding **array leaves** — `BishopBuilder`'s `tau_0`, a `gamma`, or any curve that is itself an `equinox.Module` with array fields — as an _argument_ to a plain `jax.jit` is a different story: `jax.jit` treats a bound-method argument as a static, hashable value, and JAX cannot hash an array leaf:
+This works because `op_to_curve` never becomes a traced argument of `transform_point` — it's baked in at trace time. Passing a builder holding **array leaves** — `BishopBuilder`'s `tau_0`, a `station`, or any curve that is itself an `equinox.Module` with array fields — as an _argument_ to a plain `jax.jit` is a different story: `jax.jit` treats a bound-method argument as a static, hashable value, and JAX cannot hash an array leaf:
 
 ```python
 class Helix(eqx.Module):
@@ -237,7 +237,7 @@ trajectory = jax.jit(jax.vmap(lambda t: cxfm.act(op_to_curve, t, p)))(taus)
 
 The **Bishop transform** (also called rotation-minimising or parallel-transport frame) provides an alternative to the Frenet–Serret frame. Its key advantage is that it is **well-defined even when the curvature vanishes** ($\kappa = 0$), where the Frenet–Serret normal is singular.
 
-`BishopBuilder` extends `AbstractCurveFrameBuilder` with two more fields, in addition to `curve`, `tau_unit`, `gamma`:
+`BishopBuilder` extends `AbstractCurveFrameBuilder` with two more fields, in addition to `curve`, `tau_unit`, `station`:
 
 | Field | Meaning |
 | --- | --- |
@@ -459,7 +459,7 @@ For the different shapes an arc-length curve can arrive in — including a user'
 
 ### Builder Evaluation
 
-A curve-frame builder is an `equinox.Module`: `curve`, `gamma` (and, for `BishopBuilder`, `tau_0`, `initial_normal`) are pytree **leaves**, not lazy callables stashed on the instance. Nothing is pre-computed at construction time — `rotation_matrix(tau)` and `__call__(tau)` are ordinary methods that derive the tangent/normal/binormal (or Bishop's parallel-transported normals) from `curve` afresh, on every call, via `unxt.experimental.jacfwd`. This means:
+A curve-frame builder is an `equinox.Module`: `curve`, `station` (and, for `BishopBuilder`, `tau_0`, `initial_normal`) are pytree **leaves**, not lazy callables stashed on the instance. Nothing is pre-computed at construction time — `rotation_matrix(tau)` and `__call__(tau)` are ordinary methods that derive the tangent/normal/binormal (or Bishop's parallel-transported normals) from `curve` afresh, on every call, via `unxt.experimental.jacfwd`. This means:
 
 - **Structural, not procedural, JAX integration**: because the parameters are real pytree data, `jit`, `vmap`, and `grad` operate on a builder — or a whole frame — the same way they operate on any other pytree; there's no separate "make it JAX-compatible" step.
 - **Differentiable curve parameters**: if `curve` is itself an `equinox.Module` with leaf fields, gradients flow through curve construction and into the frame (see "Differentiating the Curve" below) — not possible when a curve was a bare Python closure.
@@ -497,9 +497,9 @@ assert abs(float(grad_radius)) > 1e-3
 
 `jax.grad` differentiates through the Gram–Schmidt tangent/normal construction and the rigid-body transform, all the way back to the helix radius. This is the capability the old closure-based `curve` fields could not offer: whatever a plain Python closure captured was a trace-time constant, invisible to `jax.grad`.
 
-#### A Frame Field via `vmap` over `gamma`
+#### A Frame Field via `vmap` over `station`
 
-With `gamma` set, a builder produces a fixed, $\tau$-independent frame anchored at $\boldsymbol{\gamma}(\gamma)$ — a frame _field_ rather than a moving frame. Because `gamma` is a pytree leaf, `jax.vmap` over a batch of `gamma` values builds a batch of frames in a single call — the frame field along the whole curve, not a Python loop over frames:
+With `station` set, a builder produces a fixed, $\tau$-independent frame anchored at $\boldsymbol{\gamma}(\text{station})$ — a frame _field_ rather than a moving frame. Because `station` is a pytree leaf, `jax.vmap` over a batch of `station` values builds a batch of frames in a single call — the frame field along the whole curve, not a Python loop over frames:
 
 ```python
 def circle(tau):
@@ -508,19 +508,19 @@ def circle(tau):
 
 
 p = u.Q(jnp.array([2.0, 1.0, -0.5]), "km")
-gammas = u.Q(jnp.linspace(0.0, 1.5, 5), "s")
+stations = u.Q(jnp.linspace(0.0, 1.5, 5), "s")
 
 
-def at_gamma(g):
+def at_station(g):
     op = cxfm.TimeDep(cxfc.FrenetSerretBuilder(circle, "s", g))
     return cxfm.act(op, u.Q(0.0, "s"), p)
 
 
-field = jax.vmap(at_gamma)(gammas)
+field = jax.vmap(at_station)(stations)
 assert field.ustrip("km").shape == (5, 3)
 ```
 
-Each row of `field` is the same point `p` expressed in the frame anchored at the corresponding `gamma` value.
+Each row of `field` is the same point `p` expressed in the frame anchored at the corresponding `station` value.
 
 ### Active Semantics
 
@@ -528,4 +528,4 @@ Curve frames follow coordinax's **active transformation** convention. `act(op, t
 
 ### Scalar-First Design
 
-`rotation_matrix`, `__call__`, and the convenience accessors operate on scalar $\tau$ and scalar-component vectors — a builder's fields hold a single curve, not a batch of curves. Batching over $\tau$, over `gamma`, or over a curve's own parameters is achieved by `jax.vmap`-ing the builder or the `TimeDep` operator, not by passing shaped arrays into the builder's fields. This keeps the builder implementation simple and composes cleanly with all JAX transformations.
+`rotation_matrix`, `__call__`, and the convenience accessors operate on scalar $\tau$ and scalar-component vectors — a builder's fields hold a single curve, not a batch of curves. Batching over $\tau$, over `station`, or over a curve's own parameters is achieved by `jax.vmap`-ing the builder or the `TimeDep` operator, not by passing shaped arrays into the builder's fields. This keeps the builder implementation simple and composes cleanly with all JAX transformations.

--- a/packages/coordinaxs.curveframes/docs/spec.md
+++ b/packages/coordinaxs.curveframes/docs/spec.md
@@ -351,7 +351,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
 
     Convenience accessors: `normal(tau)` (row 1), `binormal(tau)` (row 2); `location(tau)`, `tangent(tau)` are inherited from `AbstractCurveFrameBuilder`.
 
-    Constructed directly — `FrenetSerretBuilder(curve, tau_unit="s", gamma=None)` — there is no `from_curve`/`from_` classmethod on the builder; that convenience lives on `FrenetSerretFrame`.
+    Constructed directly — `FrenetSerretBuilder(curve, tau_unit="s", station=None)` — there is no `from_curve`/`from_` classmethod on the builder; that convenience lives on `FrenetSerretFrame`.
 
     JAX compatibility: `FrenetSerretBuilder` is an `equinox.Module`, so it is a valid pytree. `curve`, `gamma` are dynamic leaves (differentiable, `vmap`-able); `tau_unit` is static. `rotation_matrix` and `__call__` operate on scalar $\tau$; batching is via `jax.vmap`. A plain `jax.jit` cannot hash a builder holding array leaves (e.g. an `equinox.Module` curve with array fields, or a `gamma`); use `eqx.filter_jit` in that case.
 
@@ -374,7 +374,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
     Constructors:
 
     - `FrenetSerretFrame(base_frame, xop, xop_inv)` — direct construction from a base frame and a `TimeDep`-wrapped `FrenetSerretBuilder` (forward and inverse).
-    - `from_curve(base_frame, curve, /, tau_unit="s", *, gamma=None)` — convenience constructor that builds `FrenetSerretBuilder(curve, tau_unit, gamma)`, wraps it in `TimeDep`, and sets `xop_inv = xop.inverse`.
+    - `from_curve(base_frame, curve, /, tau_unit="s", *, station=None)` — convenience constructor that builds `FrenetSerretBuilder(curve, tau_unit, station)`, wraps it in `TimeDep`, and sets `xop_inv = xop.inverse`.
 
     Frame transitions:
 
@@ -426,7 +426,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
 
     Convenience accessors: `normal1(tau)` (row 1), `normal2(tau)` (row 2); `location(tau)`, `tangent(tau)` inherited.
 
-    Constructed directly — `BishopBuilder(curve, tau_unit="s", gamma=None, tau_0=None, initial_normal=None, diffeqsolver=DiffEqSolver(Tsit5(), PIDController(1e-10, 1e-10), DirectAdjoint(), max_steps=16384))` — there is no `from_curve`/`from_` classmethod on the builder; that convenience lives on `BishopFrame`.
+    Constructed directly — `BishopBuilder(curve, tau_unit="s", station=None, tau_0=None, initial_normal=None, diffeqsolver=DiffEqSolver(Tsit5(), PIDController(1e-10, 1e-10), DirectAdjoint(), max_steps=16384))` — there is no `from_curve`/`from_` classmethod on the builder; that convenience lives on `BishopFrame`.
 
     JAX compatibility: same as `FrenetSerretBuilder` — `curve`, `gamma`, `tau_0`, `initial_normal` are dynamic leaves; `tau_unit` and `diffeqsolver` are static. A plain `jax.jit` cannot hash a builder holding array leaves; use `eqx.filter_jit`.
 
@@ -447,7 +447,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
     Constructors:
 
     - `BishopFrame(base_frame, xop, xop_inv)` — direct construction.
-    - `from_curve(base_frame, curve, /, tau_unit="s", *, gamma=None, tau_0=None, initial_normal=None)` — convenience constructor that builds `BishopBuilder(curve, tau_unit, gamma, tau_0, initial_normal)`, wraps it in `TimeDep`, and sets `xop_inv = xop.inverse`.
+    - `from_curve(base_frame, curve, /, tau_unit="s", *, station=None, tau_0=None, initial_normal=None)` — convenience constructor that builds `BishopBuilder(curve, tau_unit, station, tau_0, initial_normal)`, wraps it in `TimeDep`, and sets `xop_inv = xop.inverse`.
 
     Frame transitions:
 

--- a/packages/coordinaxs.curveframes/docs/spec.md
+++ b/packages/coordinaxs.curveframes/docs/spec.md
@@ -332,7 +332,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
     Methods:
 
     - `rotation_matrix(tau) -> Array` — **abstract**, implemented by concrete subclasses; the $3\times3$ rotation matrix $R$ whose rows are the frame vectors.
-    - `__call__(tau) -> Composed` — builds `Translate(-gamma(param)) | Rotate(rotation_matrix(tau))`, where `param` is `tau` or the fixed `gamma`.
+    - `__call__(tau) -> Composed` — builds `Translate(-gamma(param)) | Rotate(rotation_matrix(tau))`, where `param` is `tau` or the fixed `station`.
     - `location(tau)`, `tangent(tau)` — convenience accessors; `location` evaluates $\boldsymbol{\gamma}$ at the resolved parameter, `tangent` returns row 0 of `rotation_matrix(tau)`.
 
 (curveframes-sw-frenet-transform)=
@@ -341,11 +341,11 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
 
     A `@final` subclass of `AbstractCurveFrameBuilder` computing the $(\mathbf{T}, \mathbf{N}, \mathbf{B})$ triad.
 
-    Fields (in addition to the ABC's `curve`, `tau_unit`, `gamma`): none — `FrenetSerretBuilder` adds no fields beyond the base class.
+    Fields (in addition to the ABC's `curve`, `tau_unit`, `station`): none — `FrenetSerretBuilder` adds no fields beyond the base class.
 
     - `curve : Callable[[Any], Any]` — the constructing curve.
     - `tau_unit : unxt.AbstractUnit` — unit of the curve parameter, used by `unxt.experimental.jacfwd` to compute unit-correct derivatives. Defaults to `"s"`. Static.
-    - `gamma : Any` — optional fixed curve parameter (a leaf); see `AbstractCurveFrameBuilder`.
+    - `station : Any` — optional fixed curve parameter (a leaf); see `AbstractCurveFrameBuilder`.
 
     `rotation_matrix(tau)` computes $R = [\mathbf{T}; \mathbf{N}; \mathbf{B}]$: unit-aware first and second derivatives of `curve` via `unxt.experimental.jacfwd`, then $\mathbf{T} = \gamma'/\lVert\gamma'\rVert$, Gram–Schmidt rejection of $\gamma''$ onto $\mathbf{T}$ normalised to give $\mathbf{N}$, and $\mathbf{B} = \mathbf{T}\times\mathbf{N}$.
 
@@ -353,7 +353,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
 
     Constructed directly — `FrenetSerretBuilder(curve, tau_unit="s", station=None)` — there is no `from_curve`/`from_` classmethod on the builder; that convenience lives on `FrenetSerretFrame`.
 
-    JAX compatibility: `FrenetSerretBuilder` is an `equinox.Module`, so it is a valid pytree. `curve`, `gamma` are dynamic leaves (differentiable, `vmap`-able); `tau_unit` is static. `rotation_matrix` and `__call__` operate on scalar $\tau$; batching is via `jax.vmap`. A plain `jax.jit` cannot hash a builder holding array leaves (e.g. an `equinox.Module` curve with array fields, or a `gamma`); use `eqx.filter_jit` in that case.
+    JAX compatibility: `FrenetSerretBuilder` is an `equinox.Module`, so it is a valid pytree. `curve`, `station` are dynamic leaves (differentiable, `vmap`-able); `tau_unit` is static. `rotation_matrix` and `__call__` operate on scalar $\tau$; batching is via `jax.vmap`. A plain `jax.jit` cannot hash a builder holding array leaves (e.g. an `equinox.Module` curve with array fields, or a `station`); use `eqx.filter_jit` in that case.
 
     `act` dispatches on `TimeDep(FrenetSerretBuilder(...))`, not on the builder directly — see {ref}`TimeDep <software-spec-transforms-timedep>` in the root spec. `act(TimeDep(F), tau, x)` evaluates `F(tau)` and applies the resulting `Composed` transform.
 
@@ -411,11 +411,11 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
 
     A `@final` subclass of `AbstractCurveFrameBuilder` computing the $(\mathbf{T}, \mathbf{U}_1, \mathbf{U}_2)$ triad via parallel transport.
 
-    Fields (the ABC's `curve`, `tau_unit`, `gamma`, plus two more):
+    Fields (the ABC's `curve`, `tau_unit`, `station`, plus two more):
 
     - `curve : Callable[[Any], Any]` — the constructing curve.
     - `tau_unit : unxt.AbstractUnit` — unit of the curve parameter. Defaults to `"s"`. Static.
-    - `gamma : Any` — optional fixed curve parameter (a leaf); see `AbstractCurveFrameBuilder`.
+    - `station : Any` — optional fixed curve parameter (a leaf); see `AbstractCurveFrameBuilder`.
     - `tau_0 : unxt.AbstractQuantity | None` — reference parameter where the initial frame is defined (a leaf). `None` is resolved to `Q(0.0, tau_unit)` by `__post_init__`.
     - `initial_normal : Any` — initial $\mathbf{U}_{1,0}$ (dimensionless 3-vector, a leaf), or `None` for auto-selection via Gram–Schmidt.
     - `diffeqsolver : diffraxtra.DiffEqSolver` — the whole `diffrax` configuration (solver, step-size controller, adjoint, step budget) in one **static** field (hashable, contributes no array leaves, so the builder's pytree stays about the curve). Defaults below.
@@ -428,7 +428,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
 
     Constructed directly — `BishopBuilder(curve, tau_unit="s", station=None, tau_0=None, initial_normal=None, diffeqsolver=DiffEqSolver(Tsit5(), PIDController(1e-10, 1e-10), DirectAdjoint(), max_steps=16384))` — there is no `from_curve`/`from_` classmethod on the builder; that convenience lives on `BishopFrame`.
 
-    JAX compatibility: same as `FrenetSerretBuilder` — `curve`, `gamma`, `tau_0`, `initial_normal` are dynamic leaves; `tau_unit` and `diffeqsolver` are static. A plain `jax.jit` cannot hash a builder holding array leaves; use `eqx.filter_jit`.
+    JAX compatibility: same as `FrenetSerretBuilder` — `curve`, `station`, `tau_0`, `initial_normal` are dynamic leaves; `tau_unit` and `diffeqsolver` are static. A plain `jax.jit` cannot hash a builder holding array leaves; use `eqx.filter_jit`.
 
     `act` dispatches on `TimeDep(BishopBuilder(...))`, identically to `FrenetSerretBuilder`.
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -88,36 +88,36 @@ class AbstractCurveFrameBuilder(eqx.Module):
     decomposed into ``Translate(-gamma) | Rotate(R)``.
 
     Being an `equinox.Module`, every field is a pytree leaf: the curve's own
-    parameters (when ``curve`` is itself an `equinox.Module`) and ``gamma`` are
-    differentiable and vmappable.  A bare function passed as ``curve`` still
+    parameters (when ``curve`` is itself an `equinox.Module`) and ``station``
+    are differentiable and vmappable.  A bare function passed as ``curve`` still
     works, but whatever it closes over is a trace-time constant.
 
     Fields
     ------
     curve : Callable
-        The curve $\gamma \mapsto \boldsymbol{\gamma}(\gamma)$, mapping a
+        The curve $\tau \mapsto \boldsymbol{\gamma}(\tau)$, mapping a
         parameter `Quantity` to a Cartesian 3-vector `Quantity`.
     tau_unit : AbstractUnit
         Physical unit of the curve parameter (e.g. ``"s"``).  Static: it selects
         the differentiation units, not a numeric value.
-    gamma : Any, optional
-        A *fixed* curve parameter.  When `None` (the default) $\tau$ itself is
-        the curve parameter — the classic moving-frame usage.  When set, the
-        frame sits at a fixed point of the curve and is $\tau$-independent: a
-        frame *field* along the curve, differentiable and vmappable in
-        ``gamma``.
+    station : Any, optional
+        A *fixed* curve parameter — a station along the curve.  When `None`
+        (the default) $\tau$ itself is the curve parameter — the classic
+        moving-frame usage.  When set, the frame sits at that station and is
+        $\tau$-independent: a frame *field* along the curve, differentiable and
+        vmappable in ``station``.
 
     """
 
     curve: eqx.AbstractVar[Callable[[Any], Any]]
     tau_unit: eqx.AbstractVar[u.AbstractUnit]
-    gamma: eqx.AbstractVar[Any]
+    station: eqx.AbstractVar[Any]
 
     # ---------------------------------------------------------------
 
     def _param(self, tau: Any, /) -> Any:
-        """Return the curve parameter: ``tau``, or the fixed ``gamma``."""
-        return tau if self.gamma is None else self.gamma
+        """Return the curve parameter: ``tau``, or the fixed ``station``."""
+        return tau if self.station is None else self.station
 
     @abc.abstractmethod
     def rotation_matrix(self, tau: Any, /) -> Array:

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
@@ -182,8 +182,8 @@ class BishopBuilder(AbstractCurveFrameBuilder):
         `equinox.Module` for differentiable curve parameters.
     tau_unit : AbstractUnit or str, optional
         Unit of the curve parameter.  Defaults to ``"s"``.
-    gamma : optional
-        A fixed curve parameter; see `AbstractCurveFrameBuilder`.
+    station : optional
+        A fixed station along the curve; see `AbstractCurveFrameBuilder`.
     tau_0 : Quantity, optional
         Reference parameter where the initial frame is defined.  Defaults to
         ``Q(0.0, tau_unit)``.
@@ -286,8 +286,8 @@ class BishopBuilder(AbstractCurveFrameBuilder):
     )
     """The unit of the curve parameter tau."""
 
-    gamma: Any = None
-    """Optional fixed curve parameter (a leaf); `None` means "use tau"."""
+    station: Any = None
+    """Optional fixed station along the curve (a leaf); `None` means "use tau"."""
 
     tau_0: u.AbstractQuantity | None = None
     """Reference parameter value where the initial frame is defined (a leaf).
@@ -593,7 +593,7 @@ class BishopFrame(AbstractParallelTransportFrame[FrameT]):
         /,
         tau_unit: u.AbstractUnit | str = "s",
         *,
-        gamma: Any = None,
+        station: Any = None,
         tau_0: u.AbstractQuantity | None = None,
         initial_normal: Any | None = None,
         diffeqsolver: DiffEqSolver = _DIFFEQSOLVER,
@@ -608,9 +608,9 @@ class BishopFrame(AbstractParallelTransportFrame[FrameT]):
             A function ``tau -> Quantity[float, (3,)]``.
         tau_unit : str, optional
             Unit of the curve parameter for differentiation.
-        gamma : optional
-            A fixed curve parameter; when given the frame is a fixed frame
-            *field* along the curve rather than a moving frame.
+        station : optional
+            A fixed station along the curve; when given the frame is a fixed
+            frame *field* along the curve rather than a moving frame.
         tau_0 : Quantity, optional
             Reference parameter.  Defaults to ``Q(0.0, tau_unit)``.
         initial_normal : array-like, optional
@@ -645,7 +645,7 @@ class BishopFrame(AbstractParallelTransportFrame[FrameT]):
 
         """
         builder = BishopBuilder(
-            curve, tau_unit, gamma, tau_0, initial_normal, diffeqsolver
+            curve, tau_unit, station, tau_0, initial_normal, diffeqsolver
         )
         xop = cxfm.TimeDep(builder)
         return cls(base_frame=base_frame, xop=xop, xop_inv=xop.inverse)

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
@@ -124,7 +124,7 @@ class TubularChart(AbstractParameterizedChart):
             # global self-approach distance (see the curve-charts guide's
             # Limitations section).
             #
-            # `~(f > 0)`, not `f <= 0`: a pinned-gamma builder makes the
+            # `~(f > 0)`, not `f <= 0`: a pinned-station builder makes the
             # on-curve speed (and factor) `0/0 = nan`, and `nan <= 0` is
             # False too -- negating `nan > 0` (also False) catches it.
             #

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
@@ -95,8 +95,8 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
     tau_unit : AbstractUnit or str, optional
         Unit of the curve parameter, used by {func}`unxt.experimental.jacfwd` to
         compute unit-correct derivatives.  Defaults to ``"s"``.
-    gamma : optional
-        A fixed curve parameter; see `AbstractCurveFrameBuilder`.
+    station : optional
+        A fixed station along the curve; see `AbstractCurveFrameBuilder`.
 
     Examples
     --------
@@ -124,8 +124,8 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
     )
     """The unit of the curve parameter tau."""
 
-    gamma: Any = None
-    """Optional fixed curve parameter (a leaf); `None` means "use tau"."""
+    station: Any = None
+    """Optional fixed station along the curve (a leaf); `None` means "use tau"."""
 
     def rotation_matrix(self, tau: Any, /) -> Array:
         r"""Compute the full rotation matrix $R = [T; N; B]$.
@@ -326,7 +326,7 @@ class FrenetSerretFrame(AbstractParallelTransportFrame[FrameT]):
         /,
         tau_unit: u.AbstractUnit | str = "s",
         *,
-        gamma: Any = None,
+        station: Any = None,
     ) -> "FrenetSerretFrame[FrameT]":
         """Construct a FrenetSerretFrame from a base frame and curve.
 
@@ -339,9 +339,9 @@ class FrenetSerretFrame(AbstractParallelTransportFrame[FrameT]):
             a smooth space curve.
         tau_unit : str, optional
             Unit of the curve parameter for differentiation.
-        gamma : optional
-            A fixed curve parameter; when given the frame is a fixed frame
-            *field* along the curve rather than a moving frame.
+        station : optional
+            A fixed station along the curve; when given the frame is a fixed
+            frame *field* along the curve rather than a moving frame.
 
         Returns
         -------
@@ -365,6 +365,6 @@ class FrenetSerretFrame(AbstractParallelTransportFrame[FrameT]):
         Alice()
 
         """
-        builder = FrenetSerretBuilder(curve, tau_unit, gamma)
+        builder = FrenetSerretBuilder(curve, tau_unit, station)
         xop = cxfm.TimeDep(builder)
         return cls(base_frame=base_frame, xop=xop, xop_inv=xop.inverse)

--- a/packages/coordinaxs.curveframes/tests/test_capabilities.py
+++ b/packages/coordinaxs.curveframes/tests/test_capabilities.py
@@ -131,7 +131,7 @@ class TestGradThroughCurveParameter:
 class TestFixedStation:
     """With ``station`` set, the frame sits at a fixed point of the curve."""
 
-    def test_gamma_frame_is_tau_independent(self):
+    def test_station_frame_is_tau_independent(self):
         station = u.Q(0.7, "s")
         op = cxfm.TimeDep(cxfc.FrenetSerretBuilder(circle, "s", station))
 
@@ -146,7 +146,7 @@ class TestFixedStation:
             (cxfc.BishopBuilder, 2.0, 1e-6),  # ODE, so looser
         ],
     )
-    def test_gamma_frame_matches_the_moving_frame_at_gamma(
+    def test_station_frame_matches_the_moving_frame_at_station(
         self, builder_cls, tau_val, atol
     ):
         station = u.Q(0.7, "s")
@@ -159,7 +159,7 @@ class TestFixedStation:
             atol=atol,
         )
 
-    def test_vmap_over_gamma(self):
+    def test_vmap_over_station(self):
         """A frame field: vmap the fixed curve parameter, not tau."""
         stations = u.Q(jnp.linspace(0.0, 1.5, 5), "s")
 
@@ -174,7 +174,7 @@ class TestFixedStation:
             expected = at_station(stations[i]).ustrip("km")
             assert jnp.allclose(batched[i], expected, atol=1e-6)
 
-    def test_grad_w_r_t_gamma(self):
+    def test_grad_w_r_t_station(self):
         """``station`` is a leaf, so the frame field is differentiable in it."""
 
         def loss(g):
@@ -189,7 +189,7 @@ class TestFixedStation:
         fd = (loss(g0 + h) - loss(g0 - h)) / (2 * h)
         assert jnp.allclose(grad, fd, rtol=1e-5, atol=1e-7)
 
-    def test_frame_from_curve_accepts_gamma(self):
+    def test_frame_from_curve_accepts_station(self):
         station = u.Q(0.7, "s")
         frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle, station=station)
         assert frame.xop.builder.station is station

--- a/packages/coordinaxs.curveframes/tests/test_capabilities.py
+++ b/packages/coordinaxs.curveframes/tests/test_capabilities.py
@@ -4,8 +4,8 @@ These exercise what the old closure-based design could not express:
 
 (a) gradients with respect to a *curve parameter* — a field of an
     `equinox.Module` curve, hence a real pytree leaf;
-(b) a fixed-``gamma`` frame *field* along the curve, and ``vmap`` over
-    ``gamma``.
+(b) a fixed-``station`` frame *field* along the curve, and ``vmap`` over
+    ``station``.
 """
 
 from typing import Any
@@ -125,15 +125,15 @@ class TestGradThroughCurveParameter:
 
 
 # ===================================================================
-# (b) Fixed gamma: a frame *field* along the curve
+# (b) Fixed station: a frame *field* along the curve
 
 
-class TestFixedGamma:
-    """With ``gamma`` set, the frame sits at a fixed point of the curve."""
+class TestFixedStation:
+    """With ``station`` set, the frame sits at a fixed point of the curve."""
 
     def test_gamma_frame_is_tau_independent(self):
-        gamma = u.Q(0.7, "s")
-        op = cxfm.TimeDep(cxfc.FrenetSerretBuilder(circle, "s", gamma))
+        station = u.Q(0.7, "s")
+        op = cxfm.TimeDep(cxfc.FrenetSerretBuilder(circle, "s", station))
 
         a = cxfm.act(op, u.Q(0.0, "s"), P).ustrip("km")
         b = cxfm.act(op, u.Q(3.1, "s"), P).ustrip("km")
@@ -149,33 +149,33 @@ class TestFixedGamma:
     def test_gamma_frame_matches_the_moving_frame_at_gamma(
         self, builder_cls, tau_val, atol
     ):
-        gamma = u.Q(0.7, "s")
-        fixed = cxfm.TimeDep(builder_cls(circle, "s", gamma))
+        station = u.Q(0.7, "s")
+        fixed = cxfm.TimeDep(builder_cls(circle, "s", station))
         moving = cxfm.TimeDep(builder_cls(circle))
 
         assert jnp.allclose(
             cxfm.act(fixed, u.Q(tau_val, "s"), P).ustrip("km"),
-            cxfm.act(moving, gamma, P).ustrip("km"),
+            cxfm.act(moving, station, P).ustrip("km"),
             atol=atol,
         )
 
     def test_vmap_over_gamma(self):
         """A frame field: vmap the fixed curve parameter, not tau."""
-        gammas = u.Q(jnp.linspace(0.0, 1.5, 5), "s")
+        stations = u.Q(jnp.linspace(0.0, 1.5, 5), "s")
 
-        def at_gamma(g):
+        def at_station(g):
             op = cxfm.TimeDep(cxfc.FrenetSerretBuilder(circle, "s", g))
             return cxfm.act(op, u.Q(0.0, "s"), P)
 
-        batched = jax.vmap(at_gamma)(gammas).ustrip("km")
+        batched = jax.vmap(at_station)(stations).ustrip("km")
         assert batched.shape == (5, 3)
 
         for i in range(5):
-            expected = at_gamma(gammas[i]).ustrip("km")
+            expected = at_station(stations[i]).ustrip("km")
             assert jnp.allclose(batched[i], expected, atol=1e-6)
 
     def test_grad_w_r_t_gamma(self):
-        """``gamma`` is a leaf, so the frame field is differentiable in it."""
+        """``station`` is a leaf, so the frame field is differentiable in it."""
 
         def loss(g):
             builder = cxfc.FrenetSerretBuilder(circle, "s", u.Q(g, "s"))
@@ -190,9 +190,9 @@ class TestFixedGamma:
         assert jnp.allclose(grad, fd, rtol=1e-5, atol=1e-7)
 
     def test_frame_from_curve_accepts_gamma(self):
-        gamma = u.Q(0.7, "s")
-        frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle, gamma=gamma)
-        assert frame.xop.builder.gamma is gamma
+        station = u.Q(0.7, "s")
+        frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle, station=station)
+        assert frame.xop.builder.station is station
 
         op = cxf.frame_transition(cxf.Alice(), frame)
         assert jnp.allclose(

--- a/packages/coordinaxs.curveframes/tests/unit/test_tubular_chart.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_tubular_chart.py
@@ -130,13 +130,13 @@ def test_the_reach_guard_also_fires_under_jit() -> None:
         run(-1.6)
 
 
-def test_the_reach_guard_fires_on_a_nan_factor_from_a_pinned_gamma() -> None:
+def test_the_reach_guard_fires_on_a_nan_factor_from_a_pinned_station() -> None:
     """See the `~(f > 0)` vs `f <= 0` comment in `TubularChart.check_data`.
 
-    Reachable via public API: `FrenetSerretBuilder(curve, gamma=...)`.
+    Reachable via public API: `FrenetSerretBuilder(curve, station=...)`.
     """
     ch = cxfc.TubularChart(
-        cxfc.FrenetSerretBuilder(circle, gamma=u.Q(0.5, "s")), tau_bounds=BOUNDS
+        cxfc.FrenetSerretBuilder(circle, station=u.Q(0.5, "s")), tau_bounds=BOUNDS
     )
     at = {"tau": u.Q(0.7, "s"), "n1": u.Q(0.2, "km"), "n2": u.Q(0.0, "km")}
     assert jnp.isnan(ch.jacobian_factor(at))


### PR DESCRIPTION
Renames the curve-frame builders' `gamma` field to `station`.

## Why

`gamma` is the conventional symbol for the curve itself, so using it for a *fixed parameter along* that curve collided with the thing it indexes. `base.py` documented the curve as:

```
The curve $\gamma \mapsto \boldsymbol{\gamma}(\gamma)$
```

— the same symbol for the parameter and the curve. That is the confusion in miniature, and it is fixed here too.

The collision gets worse with the two-argument curves coming in the time-dependent frames work, where a curve is written `gamma(tau, t)` and `station` needs to name a point on it.

## Breaking change

`FrenetSerretBuilder(curve, tau_unit, gamma=...)` and `BishopBuilder(...)`, plus both `from_curve` classmethods, now take `station`. No deprecation alias — matching how #712 made `tau_unit` required. Happy to add one if preferred.

## What was deliberately not renamed

The word means two different things in this package, and only one of them is the field:

| stays `gamma` | reason |
|---|---|
| `Translate(-gamma) \| Rotate(R)` | the curve position gamma(tau) |
| `chart.py`'s `gamma_v` | the curve, vectorised |
| `arclength.py`'s `gamma(tau, t)` messages | the curve |
| test docstrings (`p - gamma`, `\|d(gamma)/ds\|`) | the curve |

Also untouched: `lorentz.py` and `semantics.py`, whose `gamma` is the **Lorentz factor** — an unrelated concept that a repo-wide rename would have silently corrupted.

## Scope

7 files, 56 lines, confined to `packages/coordinaxs.curveframes/`.

An earlier draft also renamed the generic example in `docs/guides/transforms.md` and `TimeDep`'s docstring, for consistency. That was reverted: the example's `gamma` is an angle in radians with a companion `gamma_rate` in rad/s, so it is not a station, and renaming it would have cascaded into core tests as `station_rate`.

## Verification

- 944 tests pass (curveframes suite plus the transforms guide's doctests)
- clean `rm -rf docs/_build && nox -s docs`, no warnings
- `prek run --all-files` clean, including `ty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
