### PR TITLE
✨ feat(curveframes): frames on a curve that changes in time

### DIFF
--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -382,6 +382,14 @@ _MSG_UNINSPECTABLE_CURVE = (
     "`(tau)` or `(tau, t)`, not a builtin or C-implemented callable."
 )
 
+_MSG_REQUIRED_KEYWORD_ONLY = (
+    "the given curve's second parameter `{name}` is keyword-only and has no "
+    "default, so the curve can be called neither as `curve(tau)` (it is "
+    "missing) nor as `curve(tau, t)` (it cannot be reached positionally). "
+    "Give it a default if it is a tuning knob, make it positional if it is "
+    "the time, or bind it with `functools.partial(curve, {name}=...)`."
+)
+
 _MSG_LAGRANGIAN_REQUIRES_TWO_ARGUMENT = (
     "LagrangianArcLength wraps a two-argument curve `gamma(tau, t)`, but the "
     "given curve does not accept two required positional arguments. A "
@@ -400,21 +408,56 @@ _MSG_S_MAX_TWO_ARGUMENT = (
 
 
 def _is_two_argument(curve: Callable[..., Any], /) -> bool:
-    """Report whether ``curve`` takes two positional arguments, ``(tau, t)``.
+    """Report whether ``curve`` takes ``(tau, t)`` rather than just ``(tau)``.
 
-    The second parameter must be **required**. Counting parameters instead
-    misreads two ordinary idioms as time-dependent curves: a one-argument
-    curve carrying a tuning knob, ``def curve(tau, smoothing=0.1)``, and a
-    curve whose time a caller has already frozen with
-    ``functools.partial(curve, t=...)`` -- `inspect.signature` keeps a
-    keyword-bound parameter, with a default. Both then receive ``t=None``
-    and fail deep inside the ODE solve, nowhere near the real cause.
+    The question is what the *call* accepts, so the second parameter must be
+    both **positional** and **required**. Weakening either half misreads
+    ordinary signatures:
+
+    ============================  ====================  ==================
+    signature                     ``curve(tau)`` works  reading
+    ============================  ====================  ==================
+    ``(tau, t)``                  no                    two-argument
+    ``(tau, smoothing=0.1)``      yes                   one-argument
+    ``partial(curve, t=...)``     yes                   one-argument
+    ``(tau, *args)``              yes                   one-argument
+    ``(tau, **kw)``               yes                   one-argument
+    ``(tau, *, resolution)``      no                    neither -- raises
+    ============================  ====================  ==================
+
+    The defaulted cases are why "required" is checked rather than counting
+    parameters: `inspect.signature` keeps a `functools.partial`-bound
+    parameter, with a default. The variadic cases are why "positional" is
+    checked rather than "required" alone -- ``*args`` and ``**kw`` have no
+    default, yet ``curve(tau)`` binds them empty and works. Reading either as
+    time-dependent sends the curve down the two-argument path, where it fails
+    deep inside the ODE solve, nowhere near the real cause.
+
+    A **required keyword-only** second parameter is neither reading: it
+    cannot be reached positionally, so ``curve(tau, t)`` fails, and it has no
+    default, so ``curve(tau)`` fails too. That is a broken curve rather than
+    an ambiguous one, so it raises here with its own message instead of being
+    forced into a reading that cannot work.
     """
     try:
         params = list(inspect.signature(curve).parameters.values())
     except (TypeError, ValueError) as e:
         raise TypeError(_MSG_UNINSPECTABLE_CURVE) from e
-    return len(params) >= 2 and params[1].default is inspect.Parameter.empty
+
+    if len(params) < 2:
+        return False
+    second = params[1]
+
+    if second.kind in (
+        inspect.Parameter.VAR_POSITIONAL,  # *args: curve(tau) still binds
+        inspect.Parameter.VAR_KEYWORD,  # **kw: likewise
+    ):
+        return False
+    if second.default is not inspect.Parameter.empty:
+        return False
+    if second.kind is inspect.Parameter.KEYWORD_ONLY:
+        raise TypeError(_MSG_REQUIRED_KEYWORD_ONLY.format(name=second.name))
+    return True
 
 
 @final

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -14,6 +14,7 @@ This module defines the two abstract base classes on which the entire
 __all__ = ("AbstractCurveFrameBuilder", "AbstractParallelTransportFrame")
 
 import abc
+import dataclasses
 
 from collections.abc import Callable
 from jaxtyping import Array
@@ -28,17 +29,29 @@ import coordinax.transforms as cxfm
 import unxt as u
 
 from .arclength import _is_two_argument
+from .attime import AtTime
 
 FrameT = TypeVar(
     "FrameT", bound=cxf.AbstractReferenceFrame, default=cxf.AbstractReferenceFrame
 )
 
-_MSG_TWO_ARGUMENT_CURVE = (
-    "curve-frame builders take a one-argument curve `gamma(tau)`, but this "
-    "curve requires two positional arguments, `gamma(tau, t)`. A builder is "
-    "called with a single parameter, so a two-argument curve leaves the time "
-    "unbound and every call would fail inside the solve. Bind the slice first "
-    "with `AtTime(curve, t)`, which yields a one-argument curve."
+#: `_resolve` returns a builder of the *same* concrete type it was called on,
+#: which is what lets a subclass reach its own helpers on the result.
+#:
+#: `Self` says this more directly, and ruff's PYI019 rewrites to it -- but
+#: `beartype` raises `BeartypeDecorHintPep673Exception` on PEP 673 in a method
+#: whose class it does not itself decorate, so `Self` fails at *runtime* here.
+#: Hence the explicit TypeVar, and the `noqa` at the signature.
+BuilderT = TypeVar("BuilderT", bound="AbstractCurveFrameBuilder")
+
+_MSG_TWO_ARGUMENT_NEEDS_GAMMA = (
+    "this curve takes two positional arguments, `gamma(tau, t)`, so the "
+    "builder's call-time parameter is the time `t` and the station along the "
+    "curve must be pinned with `gamma=`. Without it both are unbound and no "
+    "transform can be built. Either pass `gamma=<station>` to get a frame at "
+    "a fixed station that evolves with `t`, or bind the slice instead with "
+    "`AtTime(curve, t)`, which makes the curve one-argument so the call-time "
+    "parameter is the curve parameter again."
 )
 
 
@@ -124,23 +137,53 @@ class AbstractCurveFrameBuilder(eqx.Module):
     station: eqx.AbstractVar[Any]
 
     def __check_init__(self) -> None:
-        """Reject a two-argument curve, which a builder cannot evaluate.
+        """Require a station when the curve is two-argument.
 
         `equinox` runs this for every concrete builder, so `BishopBuilder`
         and `FrenetSerretBuilder` are both covered here rather than each
         repeating the check.
 
-        Without it, a ``gamma(tau, t)`` curve constructs happily and then
-        fails on *every* call with ``TypeError: ... missing 1 required
-        positional argument: 't'``, raised from inside the ODE solve --
-        nowhere near the construction that caused it. `AtTime` is the
-        remedy, and it already works, so the message names it.
+        A builder is called with a *single* parameter. For a one-argument
+        curve that parameter is the curve parameter. For a two-argument
+        ``gamma(tau, t)`` it is the time, which leaves the station to be
+        supplied as a field -- and with neither pinned, two unknowns face one
+        slot and no transform can be produced. That is arithmetic, not
+        policy, so it is refused at construction rather than at every call.
+
+        What such a caller usually means is already spelled
+        ``AtTime(curve, t)``: that binds the slice, making the curve
+        one-argument again, so the call-time parameter goes back to being
+        the curve parameter. The message names it.
 
         An uninspectable curve raises out of `_is_two_argument`, matching
         how `ArcLength` treats one.
         """
+        if _is_two_argument(self.curve) and self.gamma is None:
+            raise ValueError(_MSG_TWO_ARGUMENT_NEEDS_GAMMA)
+
+    def _resolve(  # noqa: PYI019  (see BuilderT: `Self` breaks beartype)
+        self: BuilderT, tau: Any, /
+    ) -> tuple[BuilderT, Any]:
+        r"""Reduce to a one-argument builder and the parameter to evaluate it at.
+
+        For an ordinary one-argument curve this is the identity: the builder
+        is already evaluable and ``tau`` is already the curve parameter.
+
+        For a two-argument curve, ``tau`` is the *time*, and the frame is the
+        one belonging to that time slice, taken at the pinned station. A
+        slice of $\gamma(\tau, t)$ at fixed $t$ is a one-argument curve --
+        exactly what `AtTime` produces -- so the whole of the existing
+        machinery applies to it unchanged, parallel-transport ODE included.
+        Nothing about the frame mathematics is time-dependent; only which
+        curve it runs on.
+
+        Returning the builder rather than mutating keeps this usable from
+        `__call__`, `location` and `tangent` alike, and keeps the two-argument
+        path a routing decision made in exactly one place.
+        """
         if _is_two_argument(self.curve):
-            raise ValueError(_MSG_TWO_ARGUMENT_CURVE)
+            return dataclasses.replace(self, curve=AtTime(self.curve, tau)), self.gamma
+        return self, tau
 
     # ---------------------------------------------------------------
 
@@ -176,11 +219,16 @@ class AbstractCurveFrameBuilder(eqx.Module):
         >>> isinstance(op, cxfm.Composed)
         True
 
+        For a two-argument curve ``tau`` is the time, and the result is the
+        rigid motion of that time slice at the pinned station -- see
+        `_resolve`.
+
         """
+        b, p = self._resolve(tau)
         cart = cxc.cart3d
-        g = self._param(tau)
-        translate = cxfm.Translate(cxc.cdict(-self.curve(g), cart), chart=cart)
-        return translate | cxfm.Rotate(self.rotation_matrix(tau))
+        g = b._param(p)
+        translate = cxfm.Translate(cxc.cdict(-b.curve(g), cart), chart=cart)
+        return translate | cxfm.Rotate(b.rotation_matrix(p))
 
     # ---------------------------------------------------------------
     # Convenience accessors
@@ -201,8 +249,11 @@ class AbstractCurveFrameBuilder(eqx.Module):
         >>> cxfc.FrenetSerretBuilder(helix).location(u.Q(0.0, "s"))
         Q([1., 0., 0.], 'm')
 
+        For a two-argument curve ``tau`` is the time -- see `_resolve`.
+
         """
-        return self.curve(self._param(tau))
+        b, p = self._resolve(tau)
+        return b.curve(b._param(p))
 
     def tangent(self, tau: Any, /) -> u.Q:
         r"""Return the unit tangent vector $\mathbf{T}$ (row 0 of R).
@@ -221,6 +272,9 @@ class AbstractCurveFrameBuilder(eqx.Module):
         >>> cxfc.FrenetSerretBuilder(circle).tangent(u.Q(0.0, "s"))
         Q([-0.,  1.,  0.], '')
 
+        For a two-argument curve ``tau`` is the time -- see `_resolve`.
+
         """
-        R = self.rotation_matrix(tau.astype(float))
+        b, p = self._resolve(tau)
+        R = b.rotation_matrix(p.astype(float))
         return u.Q(R[0], "")

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -44,11 +44,11 @@ FrameT = TypeVar(
 #: Hence the explicit TypeVar, and the `noqa` at the signature.
 BuilderT = TypeVar("BuilderT", bound="AbstractCurveFrameBuilder")
 
-_MSG_TWO_ARGUMENT_NEEDS_GAMMA = (
+_MSG_TWO_ARGUMENT_NEEDS_STATION = (
     "this curve takes two positional arguments, `gamma(tau, t)`, so the "
     "builder's call-time parameter is the time `t` and the station along the "
-    "curve must be pinned with `gamma=`. Without it both are unbound and no "
-    "transform can be built. Either pass `gamma=<station>` to get a frame at "
+    "curve must be pinned with `station=`. Without it both are unbound and no "
+    "transform can be built. Either pass `station=<value>` to get a frame at "
     "a fixed station that evolves with `t`, or bind the slice instead with "
     "`AtTime(curve, t)`, which makes the curve one-argument so the call-time "
     "parameter is the curve parameter again."
@@ -158,8 +158,8 @@ class AbstractCurveFrameBuilder(eqx.Module):
         An uninspectable curve raises out of `_is_two_argument`, matching
         how `ArcLength` treats one.
         """
-        if _is_two_argument(self.curve) and self.gamma is None:
-            raise ValueError(_MSG_TWO_ARGUMENT_NEEDS_GAMMA)
+        if _is_two_argument(self.curve) and self.station is None:
+            raise ValueError(_MSG_TWO_ARGUMENT_NEEDS_STATION)
 
     def _resolve(  # noqa: PYI019  (see BuilderT: `Self` breaks beartype)
         self: BuilderT, tau: Any, /
@@ -182,7 +182,9 @@ class AbstractCurveFrameBuilder(eqx.Module):
         path a routing decision made in exactly one place.
         """
         if _is_two_argument(self.curve):
-            return dataclasses.replace(self, curve=AtTime(self.curve, tau)), self.gamma
+            return dataclasses.replace(
+                self, curve=AtTime(self.curve, tau)
+            ), self.station
         return self, tau
 
     # ---------------------------------------------------------------

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -27,8 +27,18 @@ import coordinax.frames as cxf
 import coordinax.transforms as cxfm
 import unxt as u
 
+from .arclength import _is_two_argument
+
 FrameT = TypeVar(
     "FrameT", bound=cxf.AbstractReferenceFrame, default=cxf.AbstractReferenceFrame
+)
+
+_MSG_TWO_ARGUMENT_CURVE = (
+    "curve-frame builders take a one-argument curve `gamma(tau)`, but this "
+    "curve requires two positional arguments, `gamma(tau, t)`. A builder is "
+    "called with a single parameter, so a two-argument curve leaves the time "
+    "unbound and every call would fail inside the solve. Bind the slice first "
+    "with `AtTime(curve, t)`, which yields a one-argument curve."
 )
 
 
@@ -112,6 +122,25 @@ class AbstractCurveFrameBuilder(eqx.Module):
     curve: eqx.AbstractVar[Callable[[Any], Any]]
     tau_unit: eqx.AbstractVar[u.AbstractUnit]
     station: eqx.AbstractVar[Any]
+
+    def __check_init__(self) -> None:
+        """Reject a two-argument curve, which a builder cannot evaluate.
+
+        `equinox` runs this for every concrete builder, so `BishopBuilder`
+        and `FrenetSerretBuilder` are both covered here rather than each
+        repeating the check.
+
+        Without it, a ``gamma(tau, t)`` curve constructs happily and then
+        fails on *every* call with ``TypeError: ... missing 1 required
+        positional argument: 't'``, raised from inside the ODE solve --
+        nowhere near the construction that caused it. `AtTime` is the
+        remedy, and it already works, so the message names it.
+
+        An uninspectable curve raises out of `_is_two_argument`, matching
+        how `ArcLength` treats one.
+        """
+        if _is_two_argument(self.curve):
+            raise ValueError(_MSG_TWO_ARGUMENT_CURVE)
 
     # ---------------------------------------------------------------
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
@@ -425,9 +425,12 @@ class BishopBuilder(AbstractCurveFrameBuilder):
         True
 
         """
-        g = self._param(tau)
-        T_val = self._tangent_at(g).value
-        U1_val = self._solve_U1(g)
+        # For a two-argument curve `tau` is the time: transport runs along
+        # that time slice, at the pinned station. See `_resolve`.
+        b, p = self._resolve(tau)
+        g = b._param(p)
+        T_val = b._tangent_at(g).value
+        U1_val = b._solve_U1(g)
         U2_val = jnp.cross(T_val, U1_val)
         return jnp.stack([T_val, U1_val, U2_val])
 
@@ -457,7 +460,8 @@ class BishopBuilder(AbstractCurveFrameBuilder):
         Q([-0.,  1.,  0.], '')
 
         """
-        return u.Q(self._tangent_at(self._param(tau)).value, "")
+        b, p = self._resolve(tau)
+        return u.Q(b._tangent_at(b._param(p)).value, "")
 
     def normal1(self, tau: Any, /) -> u.Q:
         r"""First parallel-transported normal $\mathbf{U}_1(\tau)$ (row 1 of R).

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
@@ -155,11 +155,15 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
                [ 0.,  0.,  1.]], dtype=float64)
 
         """
-        # Unit-aware first and second derivatives via unxt
-        dcurve = u.experimental.jacfwd(self.curve, units=(self.tau_unit,))
-        d2curve = u.experimental.jacfwd(dcurve, units=(self.tau_unit,))
+        # For a two-argument curve `tau` is the time: the apparatus is that
+        # of the time slice, at the pinned station. See `_resolve`.
+        b, p = self._resolve(tau)
 
-        g = self._param(tau).astype(float)
+        # Unit-aware first and second derivatives via unxt
+        dcurve = u.experimental.jacfwd(b.curve, units=(b.tau_unit,))
+        d2curve = u.experimental.jacfwd(dcurve, units=(b.tau_unit,))
+
+        g = b._param(p).astype(float)
         dp = dcurve(g)
         d2p = d2curve(g)
 
@@ -200,8 +204,9 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
         Q([-0.,  1.,  0.], '')
 
         """
-        dcurve = u.experimental.jacfwd(self.curve, units=(self.tau_unit,))
-        return u.Q(_normalize(dcurve(self._param(tau).astype(float))).value, "")
+        b, p = self._resolve(tau)
+        dcurve = u.experimental.jacfwd(b.curve, units=(b.tau_unit,))
+        return u.Q(_normalize(dcurve(b._param(p).astype(float))).value, "")
 
     def normal(self, tau: Any, /) -> u.Q:
         r"""Return the unit normal vector $\mathbf{N}(\tau)$ (row 1 of R).

--- a/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
@@ -1,0 +1,90 @@
+"""Builders reject a two-argument curve at construction.
+
+A builder is called with a single parameter, so a curve needing
+``(tau, t)`` leaves the time unbound. Before this guard such a curve
+constructed happily and then failed on *every* call, with a `TypeError`
+raised from inside the ODE solve -- nowhere near the construction that
+caused it.
+
+The guard lives on `AbstractCurveFrameBuilder.__check_init__`, so both
+concrete builders inherit it; the tests below pin that, and pin the two
+one-argument idioms that must keep working (#712 found both of these
+misread when arity was decided by counting parameters rather than
+checking whether the second one is required).
+"""
+
+import functools as ft
+
+import jax.numpy as jnp
+import pytest
+
+import unxt as u
+
+import coordinaxs.curveframes as cxfc
+
+
+def curve1(tau: u.AbstractQuantity) -> u.AbstractQuantity:
+    """An ordinary one-argument curve."""
+    t = tau.ustrip("s")
+    return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), 0.3 * t]), "km")
+
+
+def curve2(s: u.AbstractQuantity, t: u.AbstractQuantity) -> u.AbstractQuantity:
+    """A time-dependent curve: it bends and stretches with ``t``."""
+    sv, tv = s.ustrip("km"), t.ustrip("s")
+    x = sv * (1.0 + 0.5 * tv)
+    y = 0.1 * tv * sv**2
+    return u.Q(jnp.stack([x, y, jnp.zeros_like(x)]), "km")
+
+
+def curve_with_knob(
+    tau: u.AbstractQuantity, smoothing: float = 0.1
+) -> u.AbstractQuantity:
+    """One-argument, but carrying a tuning knob with a default."""
+    del smoothing
+    return curve1(tau)
+
+
+@pytest.mark.parametrize(
+    "builder", [cxfc.BishopBuilder, cxfc.FrenetSerretBuilder], ids=["bishop", "frenet"]
+)
+def test_two_argument_curve_is_rejected_at_construction(builder) -> None:
+    """Both builders inherit the guard from `AbstractCurveFrameBuilder`."""
+    with pytest.raises(ValueError, match="one-argument curve"):
+        builder(curve2, "km")
+
+
+def test_the_error_names_the_remedy() -> None:
+    """A message that only says "no" costs the reader the fix."""
+    with pytest.raises(ValueError, match="AtTime"):
+        cxfc.BishopBuilder(curve2, "km")
+
+
+def test_a_pinned_gamma_does_not_excuse_a_two_argument_curve() -> None:
+    """`gamma` fixes the station, not the time -- the curve is still unusable.
+
+    Fails if the guard is ever narrowed to ``gamma is None`` before the
+    routing that would make a pinned two-argument curve actually work.
+    """
+    with pytest.raises(ValueError, match="one-argument curve"):
+        cxfc.BishopBuilder(curve2, "km", gamma=u.Q(1.3, "km"))
+
+
+def test_at_time_makes_a_two_argument_curve_usable() -> None:
+    """The remedy the message names has to actually work."""
+    frozen = cxfc.AtTime(curve2, u.Q(0.5, "s"))
+    b = cxfc.BishopBuilder(frozen, "km")
+    # gamma(s=1.3, t=0.5) = (1.3 * 1.25, 0.1 * 0.5 * 1.69, 0)
+    got = b.location(u.Q(1.3, "km")).ustrip("km")
+    assert jnp.allclose(got, jnp.array([1.625, 0.0845, 0.0]), atol=1e-8), got
+
+
+def test_a_defaulted_second_parameter_is_still_one_argument() -> None:
+    """``def curve(tau, smoothing=0.1)`` is a one-argument curve."""
+    cxfc.BishopBuilder(curve_with_knob, "s")
+
+
+def test_a_partial_frozen_time_is_still_one_argument() -> None:
+    """`ft.partial` leaves the bound parameter visible, with a default."""
+    frozen = ft.partial(curve2, t=u.Q(0.5, "s"))
+    cxfc.BishopBuilder(frozen, "km")

--- a/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
@@ -82,7 +82,7 @@ def test_a_pinned_station_makes_the_call_time_parameter_the_time(builder) -> Non
     binds the wrong slot, or slices at the wrong time.
     """
     s0 = u.Q(1.3, "km")
-    b = builder(curve2, "km", gamma=s0)
+    b = builder(curve2, "km", station=s0)
     # t = 0 is excluded deliberately: `curve2(s, 0)` is the straight line
     # ``(s, 0, 0)``, where Frenet--Serret is singular (zero curvature, so the
     # normal is undefined and the rotation is NaN). That is the apparatus's
@@ -90,7 +90,7 @@ def test_a_pinned_station_makes_the_call_time_parameter_the_time(builder) -> Non
     # precisely because it does not have it.
     for t_val in (0.5, 1.7, 2.3):
         t = u.Q(t_val, "s")
-        manual = builder(cxfc.AtTime(curve2, t), "km", gamma=s0)
+        manual = builder(cxfc.AtTime(curve2, t), "km", station=s0)
         assert jnp.allclose(
             b.location(t).ustrip("km"), manual.location(t).ustrip("km"), atol=1e-12
         ), t_val
@@ -108,7 +108,7 @@ def test_the_frame_actually_evolves_with_time() -> None:
     genuinely differs between two times -- on a curve that bends, so the
     rotation moves and not merely the origin.
     """
-    b = cxfc.BishopBuilder(curve2, "km", gamma=u.Q(1.3, "km"))
+    b = cxfc.BishopBuilder(curve2, "km", station=u.Q(1.3, "km"))
     l0 = b.location(u.Q(0.0, "s")).ustrip("km")
     l1 = b.location(u.Q(1.7, "s")).ustrip("km")
     t0 = b.tangent(u.Q(0.0, "s")).ustrip("")
@@ -125,13 +125,13 @@ def test_gradients_flow_to_time_and_to_the_station() -> None:
     ``d(y)/dt = s^2/10`` and ``d(y)/ds = t s / 5``.
     """
     s0_val, t_val = 1.3, 1.0
-    b = cxfc.BishopBuilder(curve2, "km", gamma=u.Q(s0_val, "km"))
+    b = cxfc.BishopBuilder(curve2, "km", station=u.Q(s0_val, "km"))
 
     d_dt = jax.grad(lambda tv: b.location(u.Q(tv, "s")).ustrip("km")[1])(t_val)
     assert jnp.allclose(d_dt, 0.1 * s0_val**2, atol=1e-10), d_dt
 
     def loc_of_station(sv: float) -> float:
-        moved = cxfc.BishopBuilder(curve2, "km", gamma=u.Q(sv, "km"))
+        moved = cxfc.BishopBuilder(curve2, "km", station=u.Q(sv, "km"))
         return moved.location(u.Q(t_val, "s")).ustrip("km")[1]
 
     d_ds = jax.grad(loc_of_station)(s0_val)

--- a/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
@@ -1,20 +1,30 @@
-"""Builders reject a two-argument curve at construction.
+"""Two-argument curves in the frame builders.
 
-A builder is called with a single parameter, so a curve needing
-``(tau, t)`` leaves the time unbound. Before this guard such a curve
-constructed happily and then failed on *every* call, with a `TypeError`
-raised from inside the ODE solve -- nowhere near the construction that
-caused it.
+A builder is called with a *single* parameter. For a one-argument curve
+that is the curve parameter; for a two-argument ``gamma(tau, t)`` it is
+the time, and the station must then be pinned as a field. With neither
+pinned, two unknowns face one slot, so construction raises.
 
-The guard lives on `AbstractCurveFrameBuilder.__check_init__`, so both
-concrete builders inherit it; the tests below pin that, and pin the two
-one-argument idioms that must keep working (#712 found both of these
-misread when arity was decided by counting parameters rather than
-checking whether the second one is required).
+With a station pinned, `builder(t)` is the frame of the time-t slice at
+that station. A slice at fixed t is a one-argument curve -- what `AtTime`
+produces -- so the existing machinery applies unchanged, and the
+equivalence with the hand-built slice is the correctness claim these tests
+turn on.
+
+Before this, a two-argument curve constructed happily and then failed on
+*every* call with a `TypeError` raised from inside the ODE solve, nowhere
+near the construction that caused it.
+
+The routing and the guard both live on `AbstractCurveFrameBuilder`, so
+both concrete builders inherit them. Also pinned here are the two
+one-argument idioms that must keep working: #712 found both misread when
+arity was decided by counting parameters rather than checking whether the
+second one is required.
 """
 
 import functools as ft
 
+import jax
 import jax.numpy as jnp
 import pytest
 
@@ -48,9 +58,9 @@ def curve_with_knob(
 @pytest.mark.parametrize(
     "builder", [cxfc.BishopBuilder, cxfc.FrenetSerretBuilder], ids=["bishop", "frenet"]
 )
-def test_two_argument_curve_is_rejected_at_construction(builder) -> None:
+def test_two_argument_curve_without_a_station_is_rejected(builder) -> None:
     """Both builders inherit the guard from `AbstractCurveFrameBuilder`."""
-    with pytest.raises(ValueError, match="one-argument curve"):
+    with pytest.raises(ValueError, match="must be pinned"):
         builder(curve2, "km")
 
 
@@ -60,14 +70,72 @@ def test_the_error_names_the_remedy() -> None:
         cxfc.BishopBuilder(curve2, "km")
 
 
-def test_a_pinned_gamma_does_not_excuse_a_two_argument_curve() -> None:
-    """`gamma` fixes the station, not the time -- the curve is still unusable.
+@pytest.mark.parametrize(
+    "builder", [cxfc.BishopBuilder, cxfc.FrenetSerretBuilder], ids=["bishop", "frenet"]
+)
+def test_a_pinned_station_makes_the_call_time_parameter_the_time(builder) -> None:
+    """The whole correctness claim: routing equals the hand-built slice.
 
-    Fails if the guard is ever narrowed to ``gamma is None`` before the
-    routing that would make a pinned two-argument curve actually work.
+    `builder(t)` on a two-argument curve must give the frame of the time-t
+    slice at the pinned station -- which is what
+    ``builder(AtTime(curve, t), ...)`` builds directly. Fails if `_resolve`
+    binds the wrong slot, or slices at the wrong time.
     """
-    with pytest.raises(ValueError, match="one-argument curve"):
-        cxfc.BishopBuilder(curve2, "km", gamma=u.Q(1.3, "km"))
+    s0 = u.Q(1.3, "km")
+    b = builder(curve2, "km", gamma=s0)
+    # t = 0 is excluded deliberately: `curve2(s, 0)` is the straight line
+    # ``(s, 0, 0)``, where Frenet--Serret is singular (zero curvature, so the
+    # normal is undefined and the rotation is NaN). That is the apparatus's
+    # own degeneracy, not a routing question, and `BishopBuilder` exists
+    # precisely because it does not have it.
+    for t_val in (0.5, 1.7, 2.3):
+        t = u.Q(t_val, "s")
+        manual = builder(cxfc.AtTime(curve2, t), "km", gamma=s0)
+        assert jnp.allclose(
+            b.location(t).ustrip("km"), manual.location(t).ustrip("km"), atol=1e-12
+        ), t_val
+        assert jnp.allclose(
+            b.tangent(t).ustrip(""), manual.tangent(t).ustrip(""), atol=1e-12
+        ), t_val
+        assert jnp.allclose(b.rotation_matrix(t), manual.rotation_matrix(t), atol=1e-12)
+
+
+def test_the_frame_actually_evolves_with_time() -> None:
+    """Guards against `_resolve` being an expensive no-op.
+
+    A routing bug that ignored `t` would still satisfy the equivalence test
+    above if the *manual* side ignored it too. This pins that the frame
+    genuinely differs between two times -- on a curve that bends, so the
+    rotation moves and not merely the origin.
+    """
+    b = cxfc.BishopBuilder(curve2, "km", gamma=u.Q(1.3, "km"))
+    l0 = b.location(u.Q(0.0, "s")).ustrip("km")
+    l1 = b.location(u.Q(1.7, "s")).ustrip("km")
+    t0 = b.tangent(u.Q(0.0, "s")).ustrip("")
+    t1 = b.tangent(u.Q(1.7, "s")).ustrip("")
+    assert float(jnp.linalg.norm(l1 - l0)) > 1.0, (l0, l1)
+    assert float(jnp.linalg.norm(t1 - t0)) > 0.1, (t0, t1)
+
+
+def test_gradients_flow_to_time_and_to_the_station() -> None:
+    """Both slots stay differentiable: `t` at call time, the station as a leaf.
+
+    Checked against the closed form for
+    ``gamma(s, t) = (s(1 + t/2), t s^2/10, 0)``:
+    ``d(y)/dt = s^2/10`` and ``d(y)/ds = t s / 5``.
+    """
+    s0_val, t_val = 1.3, 1.0
+    b = cxfc.BishopBuilder(curve2, "km", gamma=u.Q(s0_val, "km"))
+
+    d_dt = jax.grad(lambda tv: b.location(u.Q(tv, "s")).ustrip("km")[1])(t_val)
+    assert jnp.allclose(d_dt, 0.1 * s0_val**2, atol=1e-10), d_dt
+
+    def loc_of_station(sv: float) -> float:
+        moved = cxfc.BishopBuilder(curve2, "km", gamma=u.Q(sv, "km"))
+        return moved.location(u.Q(t_val, "s")).ustrip("km")[1]
+
+    d_ds = jax.grad(loc_of_station)(s0_val)
+    assert jnp.allclose(d_ds, 0.2 * t_val * s0_val, atol=1e-10), d_ds
 
 
 def test_at_time_makes_a_two_argument_curve_usable() -> None:

--- a/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
@@ -152,6 +152,45 @@ def test_a_defaulted_second_parameter_is_still_one_argument() -> None:
     cxfc.BishopBuilder(curve_with_knob, "s")
 
 
+def test_a_variadic_second_parameter_is_still_one_argument() -> None:
+    """``*args``/``**kw`` have no default, but ``curve(tau)`` binds them empty.
+
+    Checking only "the second parameter is required" read both as
+    time-dependent, sending an ordinary one-argument curve down the
+    two-argument path. ``**kw`` is the sharper case: it cannot be called as
+    ``curve(tau, t)`` at all, so that reading was not merely pessimistic but
+    unusable.
+    """
+
+    def with_args(tau: u.AbstractQuantity, *args: object) -> u.AbstractQuantity:
+        del args
+        return curve1(tau)
+
+    def with_kwargs(tau: u.AbstractQuantity, **kw: object) -> u.AbstractQuantity:
+        del kw
+        return curve1(tau)
+
+    cxfc.BishopBuilder(with_args, "s")
+    cxfc.BishopBuilder(with_kwargs, "s")
+
+
+def test_a_required_keyword_only_second_parameter_is_rejected() -> None:
+    """Callable neither way, so it gets its own error rather than a reading.
+
+    ``def curve(tau, *, resolution)`` cannot be reached positionally, so
+    ``curve(tau, t)`` fails, and has no default, so ``curve(tau)`` fails too.
+    Reading it as two-argument named `AtTime(curve, t)` as the remedy, which
+    would not have worked.
+    """
+
+    def kw_only(tau: u.AbstractQuantity, *, resolution: float) -> u.AbstractQuantity:
+        del resolution
+        return curve1(tau)
+
+    with pytest.raises(TypeError, match="keyword-only"):
+        cxfc.BishopBuilder(kw_only, "s")
+
+
 def test_a_partial_frozen_time_is_still_one_argument() -> None:
     """`ft.partial` leaves the bound parameter visible, with a default."""
     frozen = ft.partial(curve2, t=u.Q(0.5, "s"))


### PR DESCRIPTION
Lets a frame ride a curve that is itself changing in time.

## What it adds

A builder is called with a *single* parameter. For a one-argument curve that is the curve parameter, unchanged. For a two-argument `gamma(tau, t)` it is now the **time**, with the station along the curve supplied as the `gamma` field:

```python
b = cxfc.BishopBuilder(curve2, "km", gamma=u.Q(1.3, "km"))
b.location(u.Q(1.7, "s"))     # the frame at that station, on the t = 1.7 slice
```

This is the frames half of time-dependent, arc-length-parametrised TNB. #712 delivered the charts.

## Why it is almost no code

`builder(t)` is the frame of the time-`t` slice at the pinned station. A slice at fixed `t` **is** a one-argument curve — exactly what `AtTime` produces — so the existing machinery applies to it unchanged, parallel-transport ODE included.

**No frame mathematics is time-dependent; only which curve it runs on.** The routing is one method, `AbstractCurveFrameBuilder._resolve`, returning a one-argument builder and the parameter to evaluate it at.

That equivalence is the correctness claim, and it is what the tests turn on:

| | routed vs hand-built `AtTime` slice |
|---|---|
| `location` | max abs diff **0.000e+00** |
| `tangent` | max abs diff **0.000e+00** |
| `rotation_matrix` | max abs diff **0.000e+00** |

on both builders, at three times.

## Where the routing had to reach

Patching only the base class was not enough, and the equivalence test is what caught it: `bishop.py` and `frenetserret.py` **override** `tangent` and `rotation_matrix`, so a two-argument curve sailed past the base and still died with `TypeError: ... missing 1 required positional argument: 't'` inside the solve.

Routed: `__call__`, `location`, `tangent` on the base, plus the two subclass `rotation_matrix` and `tangent` overrides. The four `normal*` accessors need no change — they already read rows of `rotation_matrix`.

## Both slots stay differentiable

Checked against the closed form for `gamma(s, t) = (s(1 + t/2), t s^2/10, 0)` at `s = 1.3`, `t = 1`:

| | expected | got |
|---|---|---|
| `d(y)/dt = s^2/10` | 0.169 | 0.1690000000 |
| `d(y)/ds = t s/5` | 0.26 | 0.2600000000 |

The station is a leaf, so it is vmappable and fittable, not just settable.

## Still rejected: two-argument with no station

Two unknowns against one call-time slot means no transform can be produced — arithmetic, not policy — so it raises at construction rather than at every call. The message names both remedies: pin `gamma=`, or bind the slice with `AtTime(curve, t)`.

Before this PR, *both* configurations constructed happily and then failed on every call from inside the ODE solve, nowhere near the construction that caused it.

## Arity detection

Reuses the existing `_is_two_argument`, so the two idioms #712 found misread stay one-argument, both with tests:

- `def curve(tau, smoothing=0.1)` — a one-argument curve with a tuning knob
- `ft.partial(curve, t=...)` — a curve whose time the caller already froze

## Two notes for the reviewer

**`_resolve`'s annotation carries a `noqa` for a real tool conflict.** It returns the same concrete type it was called on, which is what lets a subclass reach its own helpers. `Self` says that directly and ruff's PYI019 rewrites to it — but `beartype` raises `BeartypeDecorHintPep673Exception` on PEP 673 in a method whose class it does not decorate, so `Self` fails at *runtime*. Hence the explicit `TypeVar` plus `# noqa: PYI019`, with the reason recorded at the definition.

**The equivalence test skips `t = 0` deliberately.** `curve2(s, 0)` is the straight line `(s, 0, 0)`, where Frenet--Serret is singular — zero curvature, undefined normal, NaN rotation. That is the apparatus's own degeneracy, and `BishopBuilder` exists precisely because it does not have it.

## Verification

Every assertion checked to actually fail, by breaking the implementation:

| mutation | result |
|---|---|
| `_resolve` swaps the two slots | 4 tests fail |
| guard neutered | the station-less rejection tests fail |

- 918 curveframes tests pass
- clean `rm -rf docs/_build && nox -s docs`, no warnings
- `prek` clean, including `ty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
