### PR TITLE
⚡️ perf(transforms): fuse adjacent `Scale`s in `simplify`

### DIFF
--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -102,3 +102,9 @@ def simplify(op: Scale, /, *, approx: bool = True, **kw: Any) -> AbstractTransfo
     if approx and jnp.allclose(op.S, jnp.eye(op.S.shape[0], dtype=op.S.dtype), **kw):
         return identity
     return op
+
+
+@plum.dispatch
+def _merge(a: Scale, b: Scale, /) -> AbstractTransform | None:
+    """Merge two adjacent scalings (``a`` applied first) into one, as ``b.S @ a.S``."""
+    return Scale(b.S @ a.S)

--- a/tests/unit/transforms/test_simplify.py
+++ b/tests/unit/transforms/test_simplify.py
@@ -11,6 +11,7 @@ import quaxed.numpy as jnp
 import unxt as u
 from dataclassish import replace
 
+import coordinax as cx
 import coordinax.charts as cxc
 import coordinax.representations as cxr
 import coordinax.transforms as cxfm
@@ -209,3 +210,29 @@ class TestLorentzBoostSimplify:
         """Simplifying must not quietly change what the boost does."""
         op = cxfm.LorentzBoost([0.6, 0.0, 0.0])
         assert jnp.allclose(cxfm.simplify(op).matrix, op.matrix)
+
+
+class TestScaleMerge:
+    """Adjacent `Scale`s fuse, as adjacent `Rotate`s already did."""
+
+    def test_two_scalings_merge_into_one(self):
+        s1 = cxfm.Scale.from_factors(jnp.asarray([2.0, 3.0, 4.0]))
+        s2 = cxfm.Scale.from_factors(jnp.asarray([5.0, 7.0, 11.0]))
+        got = cxfm.simplify(s1 | s2)
+        assert isinstance(got, cxfm.Scale)
+        assert jnp.allclose(jnp.diag(got.matrix), jnp.asarray([10.0, 21.0, 44.0]))
+
+    def test_merge_matches_sequential_application(self):
+        s1 = cxfm.Scale.from_factors(jnp.asarray([2.0, 3.0, 4.0]))
+        s2 = cxfm.Scale.from_factors(jnp.asarray([5.0, 7.0, 11.0]))
+        p = cx.Point.from_([1.0, 2.0, 3.0], "m")
+        merged = cxfm.simplify(s1 | s2)(p)
+        sequential = s2(s1(p))
+        for k in "xyz":
+            assert jnp.allclose(merged[k].value, sequential[k].value)
+
+    def test_chain_collapses_to_a_single_op(self):
+        s = [cxfm.Scale.from_factors(jnp.asarray([f, f, f])) for f in (2.0, 3.0, 5.0)]
+        got = cxfm.simplify(s[0] | s[1] | s[2])
+        assert isinstance(got, cxfm.Scale)
+        assert jnp.allclose(jnp.diag(got.matrix), jnp.asarray([30.0, 30.0, 30.0]))


### PR DESCRIPTION
From the `coordinax.transforms` audit. One rule, exact, additive.

## The gap

`simplify` merges adjacent operators through `_merge`, which is dispatched on the pair's types. Rules existed for `Rotate` and `AbstractAdd` — but not `Scale`, so:

```
Rotate|Rotate  -> Rotate     (1 op)
Scale|Scale    -> Composed   (2 ops)   <- no rule
```

A chain of scalings stayed a chain, paying one full `act` dispatch per element.

## The fix

```python
@plum.dispatch
def _merge(a: Scale, b: Scale, /) -> AbstractTransform | None:
    return Scale(b.S @ a.S)
```

Mirrors the `Rotate` rule exactly, including the argument order — `a` is applied first, so the product is `b @ a`. I checked that convention against the existing rule rather than assuming it: `simplify(A | B).matrix` equals `B.matrix @ A.matrix` to 0.0, and matches `B(A(p))` to 0.0.

## Verification

```
3-scaling chain, eager unfused    8822 us
3-scaling chain, fused            3953 us    <- 2.2x
merged vs sequential              0.0        <- exact, not a tolerance
diag(S1|S2)                       [10, 21, 44]   (2,3,4) x (5,7,11)
```

Exact because it is a matrix product, so like the `Rotate` rule it runs regardless of `approx` — no value inspection, safe inside `jit`.

- Full suite: **10369 passed**, 10 skipped, 1 xfailed
- `prek run --all-files` clean
- Three tests added: the merge, agreement with sequential application, and a 3-chain collapsing to one op

## What this does not do

Mixed linear chains (`Rotate | Scale`) still do not fuse — that is a further 4.9x and needs a return type the library does not have. Design options are in #726; a `Linear` class implementing it is in progress as a follow-up.

Also found while auditing, both in #726 rather than here:

- `Scale.inverse` reads `self.S` directly, bypassing the `.matrix` shape check, so a bad shape surfaces a raw `jnp.linalg.inv` error rather than the clear one `.matrix` gives.
- Separately: `simplify` has **no rule registered for `LorentzBoost`**, so any `Composed` containing a boost raises `NotFoundLookupError`. Pre-existing (confirmed with this change stashed); will be its own fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)