### PR TITLE
🐛 fix(transforms): register `simplify` for `LorentzBoost`

### DIFF
--- a/src/coordinax/transforms/_src/actions/lorentz.py
+++ b/src/coordinax/transforms/_src/actions/lorentz.py
@@ -8,10 +8,13 @@ from jaxtyping import Array, Shaped
 from typing import Any, final
 
 import equinox as eqx
+import plum
 
 import quaxed.numpy as jnp
 import unxt as u
 
+from .base import AbstractTransform
+from .identity import identity
 from .linear import AbstractLinearTransform
 from coordinax.transforms._src import groups
 
@@ -320,3 +323,39 @@ class LorentzBoost(AbstractLinearTransform):
         top_row = jnp.concatenate([gamma[None], gamma * beta])
         bottom = jnp.concatenate([(gamma * beta)[:, None], spatial], axis=1)
         return jnp.concatenate([top_row[None, :], bottom], axis=0)
+
+
+@plum.dispatch
+def simplify(
+    op: LorentzBoost, /, *, approx: bool = True, **kw: Any
+) -> AbstractTransform:
+    """Simplify a Lorentz boost to identity when its velocity is zero.
+
+    Every other transform has had this rule; `LorentzBoost` did not, and
+    `simplify` dispatches per operator with no generic fallback -- so
+    ``simplify`` of a boost, or of any `~coordinax.transforms.Composed`
+    containing one, raised `NotFoundLookupError` rather than returning the
+    operator unchanged.
+
+    The zero-velocity check inspects values, so it is skipped when
+    ``approx=False``; the point of the rule is that the ``approx=False`` path
+    now returns ``op`` instead of raising.
+
+    Examples
+    --------
+    >>> import coordinax.transforms as cxfm
+
+    A boost with velocity is left alone:
+
+    >>> cxfm.simplify(cxfm.LorentzBoost([0.6, 0.0, 0.0]))
+    LorentzBoost(...)
+
+    A zero boost is the identity:
+
+    >>> cxfm.simplify(cxfm.LorentzBoost([0.0, 0.0, 0.0]))
+    Identity()
+
+    """
+    if approx and jnp.allclose(op.beta, jnp.zeros_like(op.beta), **kw):
+        return identity
+    return op

--- a/tests/unit/transforms/test_simplify.py
+++ b/tests/unit/transforms/test_simplify.py
@@ -176,3 +176,36 @@ def test_approx_false_works_under_jit() -> None:
 def test_default_simplify_is_not_jit_safe() -> None:
     with pytest.raises(jax.errors.TracerBoolConversionError):
         jax.jit(lambda op: cxfm.simplify(op))(cxfm.Rotate(jnp.eye(3)))
+
+
+class TestLorentzBoostSimplify:
+    """`simplify` dispatches per operator and has no generic fallback.
+
+    So a missing rule is not a missed optimisation -- it is a crash. Every
+    other transform had one; `LorentzBoost` did not, which took out any
+    `Composed` containing a boost as well.
+    """
+
+    def test_boost_with_velocity_is_returned_unchanged(self):
+        op = cxfm.LorentzBoost([0.6, 0.0, 0.0])
+        assert isinstance(cxfm.simplify(op), cxfm.LorentzBoost)
+
+    def test_zero_boost_collapses_to_identity(self):
+        assert cxfm.simplify(cxfm.LorentzBoost([0.0, 0.0, 0.0])) is cxfm.identity
+
+    def test_zero_boost_is_kept_when_not_approx(self):
+        """The zero check inspects values, so `approx=False` must skip it."""
+        op = cxfm.LorentzBoost([0.0, 0.0, 0.0])
+        assert isinstance(cxfm.simplify(op, approx=False), cxfm.LorentzBoost)
+
+    def test_composed_containing_a_boost_simplifies(self):
+        """The regression: this raised `NotFoundLookupError`."""
+        rot = cxfm.Rotate.from_euler("z", u.Q(30, "deg"))
+        got = cxfm.simplify(rot | cxfm.LorentzBoost([0.6, 0.0, 0.0]))
+        assert isinstance(got, cxfm.Composed)
+        assert len(got.transforms) == 2
+
+    def test_boost_is_preserved_through_simplification(self):
+        """Simplifying must not quietly change what the boost does."""
+        op = cxfm.LorentzBoost([0.6, 0.0, 0.0])
+        assert jnp.allclose(cxfm.simplify(op).matrix, op.matrix)


### PR DESCRIPTION
Found while auditing `coordinax.transforms`. Independent of #727/#728 — branched off `main` so it can merge on its own.

## The bug

`simplify` dispatches per operator and has no generic fallback, so a missing rule is not a missed optimisation — it raises:

```
simplify(LorentzBoost([0.6, 0, 0]))         -> NotFoundLookupError
simplify(Rotate(...) | LorentzBoost(...))   -> NotFoundLookupError
```

The second is the wider blast radius: `simplify(Composed)` recurses into every element, so *any* composition containing a boost fails, however incidental the boost.

I swept the whole family rather than assuming the one I tripped over was the only gap:

```
Rotate OK   Scale OK   Reflect OK   Identity OK   Translate OK   Boost OK
LorentzBoost  NotFoundLookupError
```

`Boost` is fine because it derives from `AbstractAdd` and inherits that rule. `LorentzBoost` derives from `AbstractLinearTransform`, which has none — so it was the single orphan.

## The fix

Mirrors the sibling rules: collapse to `Identity` when the velocity is zero, otherwise return the operator unchanged. The zero check inspects values, so it is gated on `approx` — the point being that `approx=False` now returns the operator rather than raising.

| call | before | after |
|---|---|---|
| `simplify(boost)` | raise | `LorentzBoost` |
| `simplify(zero boost)` | raise | `Identity` |
| `simplify(zero, approx=False)` | raise | `LorentzBoost` |
| `simplify(Rotate \| boost)` | raise | `Composed` (2 ops) |

## Verification

- Full suite: **10374 passed**, 10 skipped, 1 xfailed
- `prek run --all-files` clean, including `ty`
- Five tests: the boost preserved, the zero collapse, the `approx=False` path, a `Composed` containing a boost (the regression), and that the matrix is unchanged through simplification — a rule that quietly altered the boost would be worse than one that raised

## Interaction with #728

`Rotate | LorentzBoost` is 3x3 beside 4x4, so there is no product to take. #728's generic `_merge` returns `None` for mismatched dimensions and the pair stays a two-element `Composed` — the same answer this PR now produces. #728 had to test that guard by calling `_merge` directly, because `simplify` raised first; once both land, that test can move up to `simplify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)