### PR TITLE
💥 refactor(transforms): `Scale` is diagonal, and its inverse is O(n)

### DIFF
--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -23,6 +23,10 @@ from coordinax.transforms._src import groups
 SMatrix: TypeAlias = Shaped[Array, " N N"]
 
 _MSG_SINGULAR: Final = "Scale matrix must be invertible."
+_MSG_NOT_DIAGONAL: Final = (
+    "Scale requires a diagonal matrix -- it scales the axes, and nothing else. "
+    "For a general linear map use `Linear`."
+)
 
 
 @final
@@ -35,8 +39,34 @@ class Scale(AbstractLinearTransform):
     x \mapsto Sx,
     $$
 
-    where ``S`` is an invertible scaling matrix. The common case is diagonal
-    anisotropic scaling with per-axis factors.
+    where ``S`` is an invertible **diagonal** matrix: anisotropic scaling with
+    one factor per axis.
+
+    Diagonality is the whole content of the type. A `Scale` holding an
+    off-diagonal matrix would be a general linear map wearing a name that
+    promises otherwise, and `isinstance(op, Scale)` would stop meaning
+    anything. `~coordinax.transforms.Linear` is the type for a general matrix.
+
+    Examples
+    --------
+    >>> import quaxed.numpy as jnp
+    >>> import coordinax.transforms as cxfm
+
+    >>> jnp.diagonal(cxfm.Scale.from_factors(jnp.asarray([2.0, 3.0, 4.0])).matrix)
+    Array([2., 3., 4.], dtype=float64)
+
+    A matrix that is already diagonal is accepted:
+
+    >>> jnp.diagonal(cxfm.Scale(jnp.diag(jnp.asarray([2.0, 1.0, 0.5]))).matrix)
+    Array([2. , 1. , 0.5], dtype=float64)
+
+    One that is not is refused, and points at the type that fits:
+
+    >>> try:
+    ...     cxfm.Scale(jnp.asarray([[1.0, 0.5], [0.0, 1.0]])).matrix
+    ... except Exception as e:
+    ...     print("Scale requires a diagonal matrix" in str(e))
+    True
 
     """
 
@@ -66,12 +96,30 @@ class Scale(AbstractLinearTransform):
 
     @property
     def inverse(self) -> "Scale":
-        """Return the inverse scaling transform."""
-        return type(self)(jnp.linalg.inv(self.S))
+        """Return the inverse scaling transform.
+
+        Reciprocals of the diagonal, not `jnp.linalg.inv`: O(n) rather than
+        O(n^3), and exact where the general solve is not. Going through
+        `matrix` rather than the raw field also means a malformed `S` is caught
+        here with the same message as everywhere else, instead of surfacing as
+        a raw LAPACK shape error.
+        """
+        return type(self)(jnp.diag(1.0 / jnp.diagonal(self.matrix)))
 
     @property
     def _raw_matrix(self) -> Any:
-        return self.S
+        return self._validate_diagonal(self.S)
+
+    def _validate_diagonal(self, matrix: Any, /) -> Any:
+        """Check the matrix has no off-diagonal entries.
+
+        Deferred like the singular check so it survives `jit`: a plain `bool`
+        on a traced value raises `TracerBoolConversionError`.
+        """
+        if matrix.ndim != 2:  # let the base's square check produce the message
+            return matrix
+        off = matrix - jnp.diag(jnp.diagonal(matrix))
+        return eqx.error_if(matrix, jnp.any(off != 0), _MSG_NOT_DIAGONAL)
 
 
 @Scale.from_.dispatch  # ty: ignore[unresolved-attribute]

--- a/tests/unit/transforms/test_simplify.py
+++ b/tests/unit/transforms/test_simplify.py
@@ -312,3 +312,52 @@ class TestLinearFusion:
         got = cxfm.Linear.from_(jnp.eye(3) * 2.0)
         assert isinstance(got, cxfm.Linear)
         assert jnp.allclose(got.matrix, jnp.eye(3) * 2.0)
+
+
+class TestScaleIsDiagonal:
+    """`Scale` scales the axes; an off-diagonal matrix belongs to `Linear`.
+
+    Before `Linear` existed there was nowhere else to put a general matrix, so
+    `Scale` accepted one and its name over-promised.
+    """
+
+    def test_from_factors_is_accepted(self):
+        op = cxfm.Scale.from_factors(jnp.asarray([2.0, 3.0, 4.0]))
+        assert jnp.allclose(jnp.diagonal(op.matrix), jnp.asarray([2.0, 3.0, 4.0]))
+
+    def test_an_already_diagonal_matrix_is_accepted(self):
+        op = cxfm.Scale(jnp.diag(jnp.asarray([2.0, 1.0, 0.5])))
+        assert jnp.allclose(jnp.diagonal(op.matrix), jnp.asarray([2.0, 1.0, 0.5]))
+
+    def test_an_off_diagonal_matrix_is_refused(self):
+        shear = jnp.asarray([[1.0, 0.5, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+        with pytest.raises(Exception, match="diagonal"):
+            _ = cxfm.Scale(shear).matrix
+
+    def test_a_rotation_is_refused(self):
+        """The case that motivated the narrowing: a rotation is not a scaling."""
+        rot = cxfm.Rotate.from_euler("z", u.Q(30, "deg"))
+        with pytest.raises(Exception, match="diagonal"):
+            _ = cxfm.Scale(rot.matrix).matrix
+
+    def test_inverse_is_reciprocals_and_round_trips(self):
+        op = cxfm.Scale.from_factors(jnp.asarray([2.0, 4.0, 5.0]))
+        assert jnp.allclose(
+            jnp.diagonal(op.inverse.matrix), jnp.asarray([0.5, 0.25, 0.2])
+        )
+        p = cx.Point.from_([1.0, 2.0, 3.0], "m")
+        back = op.inverse(op(p))
+        for k, want in zip(("x", "y", "z"), (1.0, 2.0, 3.0), strict=True):
+            assert jnp.allclose(back[k].value, want, atol=1e-12)
+
+    def test_inverse_of_a_malformed_scale_reports_the_real_problem(self):
+        """It used to surface a raw `jnp.linalg.inv` shape error (see #726)."""
+        with pytest.raises(Exception, match="square"):
+            _ = cxfm.Scale(jnp.asarray([2.0, 3.0, 4.0])).inverse
+
+    def test_merged_scales_stay_diagonal(self):
+        s1 = cxfm.Scale.from_factors(jnp.asarray([2.0, 3.0, 4.0]))
+        s2 = cxfm.Scale.from_factors(jnp.asarray([5.0, 7.0, 11.0]))
+        got = cxfm.simplify(s1 | s2)
+        assert isinstance(got, cxfm.Scale)
+        assert jnp.allclose(jnp.diagonal(got.matrix), jnp.asarray([10.0, 21.0, 44.0]))


### PR DESCRIPTION
**Stacks on #728** — review the top commit only, or merge #728 first. Sibling of #730, independent of it.

Breaking, as discussed in #726.

## Why `Scale` was general

`Scale` accepted any square matrix. So `Scale(rotation_matrix)` was a rotation wearing a name that promises axis scaling, and `isinstance(op, Scale)` implied nothing about the operator.

It was general because it had to be: before `Linear` (#728) there was nowhere else for a general matrix to go. There is now, so `Scale` can mean what it says.

## What changes

Off-diagonal entries are refused, with a message naming the type that fits:

```
Scale requires a diagonal matrix -- it scales the axes, and nothing else.
For a general linear map use `Linear`.
```

Deferred through `eqx.error_if`, like the existing singular check, so it survives `jit`.

**The inverse becomes O(n).** Reciprocals of the diagonal rather than `jnp.linalg.inv` — O(n) instead of O(n³), and exact where the general solve is not.

It also now reads through `matrix` rather than the raw `S` field, which fixes the bypass reported in #726: a malformed `S` surfaced a raw LAPACK error

```
Argument to inv must have shape [..., n, n], got (3,).
```

where `.matrix` already had a clear message. Both now say the same thing.

## Breaking surface

Narrow. I checked every `Scale(...)` construction in the tree; the only one not going through `from_factors` is in the transforms guide:

```python
stretch_matrix = cxfm.Scale(jnp.diag(jnp.array([2.0, 1.0, 0.5])))
```

— already diagonal, still valid. Code that breaks was passing a genuinely non-diagonal matrix, i.e. relying on `Scale` not meaning scaling; the error tells it to use `Linear`.

## Verification

- Full suite: **10401 passed**, 10 skipped, 1 xfailed
- `prek run --all-files` clean, including `ty`
- Seven tests: `from_factors`, an already-diagonal matrix, a shear refused, a rotation refused, the O(n) inverse and its round-trip, the malformed-`S` message, and merged scalings staying diagonal

🤖 Generated with [Claude Code](https://claude.com/claude-code)