### PR TITLE
📝 docs(spec): specify the `lorentzian` verbs

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3236,6 +3236,13 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
     `interval` itself is canonical in `coordinax.manifolds` and re-exported here,
     since the signed quadratic form is defined for every metric.
 
+    **Tracing.** The three causal verbs return, or branch on, a Python value --
+    `causal_character` a `str`, the other two an exception chosen by the class --
+    so they are eager-only and raise `ConcretizationTypeError` under `jax.jit`.
+    Classify outside the traced region, or use `interval` inside it and branch on
+    its sign yourself. `rapidity_between` is the exception: it is traceable, and
+    substitutes `nan` for the refusal it would raise eagerly.
+
 (software-spec-causal_character)=
 
 !!! info `causal_character`
@@ -3272,7 +3279,7 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
 
     **Dispatch behavior:**
 
-    - It is the sign of `interval`, and inherits that verb's symmetry properties: the *classification* is symmetric in `a` and `b` even though the underlying magnitude need not be, since flipping the pair negates neither the sign of $\Delta s^2$ on a flat metric nor the class it names.
+    - It is the sign of `interval`, which evaluates the metric **at the first point**. Where the metric is constant along the path the classification is therefore symmetric in `a` and `b` -- true of every Lorentzian metric currently shipped, `MinkowskiMetric` being flat. It is *not* guaranteed for a position-dependent one: $\Delta x^\top G(a)\, \Delta x$ and $\Delta x^\top G(b)\, \Delta x$ can differ, and near a null separation they can differ in sign. Do not rely on symmetry on a curved spacetime metric.
     - The metric-level overload delegates to metric-level `interval`, which validates that `metric` is the chart's own. Going via the chart would ignore the argument, so a Lorentzian metric passed with a Riemannian chart would classify using the chart's metric and slip the precondition.
     - A non-Lorentzian metric raises `NotImplementedError`.
 
@@ -3331,8 +3338,8 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
     **Signatures:**
 
     ```
-    cxm.lorentzian.proper_time(chart, a, b, /, *, usys=None)
-    cxm.lorentzian.proper_time(metric, chart, a, b, /, *, usys=None)
+    cxm.lorentzian.proper_time(chart, a, b, /, *, atol=..., usys=None)
+    cxm.lorentzian.proper_time(metric, chart, a, b, /, *, atol=..., usys=None)
     ```
 
     **Return:**
@@ -3342,6 +3349,7 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
     **Dispatch behavior:**
 
     - Raises `ValueError` on a spacelike or null pair rather than returning `nan`: there is no clock that travels between spacelike-separated events, so the answer is not "undefined", it is "the question does not apply". Use `proper_distance` there.
+    - `atol` is forwarded to the same classification `causal_character` performs, so it is what decides how near null a pair may be before being refused.
     - A non-Lorentzian metric raises `NotImplementedError`.
 
     **Examples**
@@ -3382,8 +3390,8 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
     **Signatures:**
 
     ```
-    cxm.lorentzian.proper_distance(chart, a, b, /, *, usys=None)
-    cxm.lorentzian.proper_distance(metric, chart, a, b, /, *, usys=None)
+    cxm.lorentzian.proper_distance(chart, a, b, /, *, atol=..., usys=None)
+    cxm.lorentzian.proper_distance(metric, chart, a, b, /, *, atol=..., usys=None)
     ```
 
     **Return:**
@@ -3393,6 +3401,7 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
     **Dispatch behavior:**
 
     - The mirror of `proper_time`: raises `ValueError` on a timelike or null pair, since no frame makes timelike-separated events simultaneous.
+    - `atol` is forwarded to the same classification, as for `proper_time`.
     - A non-Lorentzian metric raises `NotImplementedError`.
 
     **Examples**
@@ -3447,7 +3456,7 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
 
     **Dispatch behavior:**
 
-    - Raises `ValueError` unless **both** operands are timelike.
+    - Eagerly, raises `ValueError` unless **both** operands are timelike. Under `jax.jit` it cannot: the condition is a traced value, so the same test becomes a mask and the result is `nan`. Check the output rather than relying on the exception inside a traced function.
     - Calls `check_metric_is_charts` directly, where the causal verbs inherit the same guard through metric-level `interval`.
     - A non-Lorentzian metric raises `NotImplementedError`.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3219,12 +3219,10 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
     spacetime metric (Schwarzschild, FLRW) carries the marker and acquires all
     of them.
 
-    Without exactly one timelike direction there is nothing to classify: a
-    positive-definite metric gives the interval one sign for every pair, and an
-    indefinite metric with several timelike directions gives varying signs that
-    do not partition pairs into past, future and elsewhere. Each verb raises
-    `NotImplementedError` rather than returning a value that could be read as a
-    classification.
+    Neither a definite metric nor one with several timelike directions
+    partitions pairs into past, future and elsewhere, so **every verb here
+    raises `NotImplementedError`** on one rather than returning a value that
+    could be read as a classification.
 
     | verb | reads | defined for |
     |---|---|---|
@@ -3279,9 +3277,8 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
 
     **Dispatch behavior:**
 
-    - It is the sign of `interval`, which evaluates the metric **at the first point**. Where the metric is constant along the path the classification is therefore symmetric in `a` and `b` -- true of every Lorentzian metric currently shipped, `MinkowskiMetric` being flat. It is *not* guaranteed for a position-dependent one: $\Delta x^\top G(a)\, \Delta x$ and $\Delta x^\top G(b)\, \Delta x$ can differ, and near a null separation they can differ in sign. Do not rely on symmetry on a curved spacetime metric.
-    - The metric-level overload delegates to metric-level `interval`, which validates that `metric` is the chart's own. Going via the chart would ignore the argument, so a Lorentzian metric passed with a Riemannian chart would classify using the chart's metric and slip the precondition.
-    - A non-Lorentzian metric raises `NotImplementedError`.
+    - It is the sign of `interval`, which evaluates the metric **at the first point**. The classification is therefore symmetric in `a` and `b` only where the metric is constant along the path -- true of `MinkowskiMetric`, the only Lorentzian metric shipped. On a position-dependent one the two orderings can differ in sign near a null separation; do not rely on symmetry there.
+    - The metric-level overload delegates to metric-level `interval`, which validates that `metric` is the chart's own; the chart-level path would ignore the argument entirely.
 
     **Examples**
 
@@ -3344,13 +3341,12 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
 
     **Return:**
 
-    - A `unxt.Quantity` with dimensions of **time**. The interval is a length-squared in a chart whose time axis is `ct`, so the square root is a length and the division by $c$ is what makes this a duration rather than a distance.
+    - A `unxt.Quantity` with dimensions of **time**: the interval is a length-squared, so it is the division by $c$ that makes this a duration.
 
     **Dispatch behavior:**
 
     - Raises `ValueError` on a spacelike or null pair rather than returning `nan`: there is no clock that travels between spacelike-separated events, so the answer is not "undefined", it is "the question does not apply". Use `proper_distance` there.
     - `atol` is forwarded to the same classification `causal_character` performs, so it is what decides how near null a pair may be before being refused.
-    - A non-Lorentzian metric raises `NotImplementedError`.
 
     **Examples**
 
@@ -3402,7 +3398,6 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
 
     - The mirror of `proper_time`: raises `ValueError` on a timelike or null pair, since no frame makes timelike-separated events simultaneous.
     - `atol` is forwarded to the same classification, as for `proper_time`.
-    - A non-Lorentzian metric raises `NotImplementedError`.
 
     **Examples**
 
@@ -3427,16 +3422,10 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
 
     $$ \cosh\zeta = \frac{-g(u,v)}{\sqrt{g(u,u)\,g(v,v)}} $$
 
-    This is the one verb here that takes tangents rather than points, and it
-    exists because `angle_between` cannot serve. That verb refuses a timelike
-    pair, correctly: $g(u,u)$ and $g(v,v)$ are both negative, so `arccos` of
-    their ratio would clip to $0$ or $\pi$ and report two observers in relative
-    motion as parallel. The invariant that *does* separate them is hyperbolic,
-    so it gets its own name rather than an extra branch inside a
-    circular-angle function.
-
-    Rapidity is additive under collinear boosts where velocity is not, which is
-    what makes it the natural parameter.
+    The one verb here taking tangents rather than points. `angle_between`
+    cannot serve: $g(u,u)$ and $g(v,v)$ are both negative, so `arccos` of their
+    ratio clips to $0$ or $\pi$ and reports two observers in relative motion as
+    parallel. Rapidity is additive under collinear boosts; velocity is not.
 
     **Signatures:**
 
@@ -3458,20 +3447,17 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
 
     - Eagerly, raises `ValueError` unless **both** operands are timelike. Under `jax.jit` it cannot: the condition is a traced value, so the same test becomes a mask and the result is `nan`. Check the output rather than relying on the exception inside a traced function.
     - Calls `check_metric_is_charts` directly, where the causal verbs inherit the same guard through metric-level `interval`.
-    - A non-Lorentzian metric raises `NotImplementedError`.
 
     **Examples**
-
-    ```pycon
-    >>> import unxt as u
-    >>> import coordinax.charts as cxc
-    >>> import coordinax.manifolds as cxm
-    ```
 
     An observer at rest, and one moving at $v/c = 0.6$; the rapidity is
     $\operatorname{artanh}(0.6) = \ln 2$.
 
     ```pycon
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
     >>> at = {"ct": u.Q(0.0, "m"), "x": u.Q(0.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
     >>> rest = {"ct": u.Q(1.0, ""), "x": u.Q(0.0, ""), "y": u.Q(0.0, ""), "z": u.Q(0.0, "")}
     >>> moving = {"ct": u.Q(1.25, ""), "x": u.Q(0.75, ""), "y": u.Q(0.0, ""), "z": u.Q(0.0, "")}

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3202,6 +3202,287 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
     Q(1.629626, 'm2')
     ```
 
+(software-spec-lorentzian)=
+
+!!! info `coordinax.manifolds.lorentzian`
+
+    The verbs that read the **sign** of `interval` rather than its magnitude
+    alone. They live in a sub-namespace because they are gated on a stronger
+    precondition than the rest of the manifold API: the metric must be
+    `AbstractLorentzianMetricField`, meaning a signature $(-,+,\ldots,+)$ with
+    **exactly one** timelike direction.
+
+    Named for the *signature* and not for "spacetime": `coordinax.charts.galileanct`
+    is a 4-dimensional spacetime and is **not** Lorentzian, so a `spacetime`
+    namespace would promise membership these verbs refuse. Named `lorentzian`
+    and not `minkowski` because the gate is the signature alone — a curved
+    spacetime metric (Schwarzschild, FLRW) carries the marker and acquires all
+    of them.
+
+    Without exactly one timelike direction there is nothing to classify: a
+    positive-definite metric gives the interval one sign for every pair, and an
+    indefinite metric with several timelike directions gives varying signs that
+    do not partition pairs into past, future and elsewhere. Each verb raises
+    `NotImplementedError` rather than returning a value that could be read as a
+    classification.
+
+    | verb | reads | defined for |
+    |---|---|---|
+    | [`causal_character`](#software-spec-causal_character) | the sign of `interval` | any pair |
+    | [`proper_time`](#software-spec-proper_time) | $\sqrt{-\Delta s^2}/c$ | timelike pairs |
+    | [`proper_distance`](#software-spec-proper_distance) | $\sqrt{+\Delta s^2}$ | spacelike pairs |
+    | [`rapidity_between`](#software-spec-rapidity_between) | the hyperbolic angle | two timelike *tangents* |
+
+    `interval` itself is canonical in `coordinax.manifolds` and re-exported here,
+    since the signed quadratic form is defined for every metric.
+
+(software-spec-causal_character)=
+
+!!! info `causal_character`
+
+    Classify a pair of events by the sign of the interval between them.
+
+    $$
+    \mathrm{causal\_character}(a, b) =
+    \begin{cases}
+    \texttt{'timelike'}  & \Delta s^2 < 0 \\
+    \texttt{'null'}      & \Delta s^2 = 0 \\
+    \texttt{'spacelike'} & \Delta s^2 > 0
+    \end{cases}
+    $$
+
+    **Signatures:**
+
+    ```
+    cxm.lorentzian.causal_character(chart, a, b, /, *, atol=..., usys=None)
+    cxm.lorentzian.causal_character(metric, chart, a, b, /, *, atol=..., usys=None)
+    ```
+
+    **Arguments:**
+
+    - `chart`: the chart in whose components `a` and `b` are expressed.
+    - `metric`: an explicit Lorentzian metric; must be the chart's own.
+    - `a`, `b`: the two events, as `CDict` component dicts.
+    - `atol` (keyword): tolerance for calling $\Delta s^2$ exactly zero. A null separation is a measure-zero condition in floating point, so it needs a band rather than an equality test.
+    - `usys` (keyword, optional): unit system forwarded to metric evaluation.
+
+    **Return:**
+
+    - One of the Python strings `'timelike'`, `'null'`, `'spacelike'` — not an enum and not a number, so it cannot be accidentally arithmetic.
+
+    **Dispatch behavior:**
+
+    - It is the sign of `interval`, and inherits that verb's symmetry properties: the *classification* is symmetric in `a` and `b` even though the underlying magnitude need not be, since flipping the pair negates neither the sign of $\Delta s^2$ on a flat metric nor the class it names.
+    - The metric-level overload delegates to metric-level `interval`, which validates that `metric` is the chart's own. Going via the chart would ignore the argument, so a Lorentzian metric passed with a Riemannian chart would classify using the chart's metric and slip the precondition.
+    - A non-Lorentzian metric raises `NotImplementedError`.
+
+    **Examples**
+
+    ```pycon
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> o = {"ct": u.Q(0.0, "m"), "x": u.Q(0.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> def event(ct, x):
+    ...     return {
+    ...         "ct": u.Q(ct, "m"),
+    ...         "x": u.Q(x, "m"),
+    ...         "y": u.Q(0.0, "m"),
+    ...         "z": u.Q(0.0, "m"),
+    ...     }
+    ...
+    ```
+
+    More time than space is timelike; more space than time is spacelike; equal
+    parts is exactly a light ray.
+
+    ```pycon
+    >>> cxm.lorentzian.causal_character(cxc.minkowskict, o, event(5.0, 1.0))
+    'timelike'
+    >>> cxm.lorentzian.causal_character(cxc.minkowskict, o, event(1.0, 5.0))
+    'spacelike'
+    >>> cxm.lorentzian.causal_character(cxc.minkowskict, o, event(3.0, 3.0))
+    'null'
+    ```
+
+    A Riemannian metric has no timelike direction to classify against:
+
+    ```pycon
+    >>> a = {"x": u.Q(0.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> b = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m"), "z": u.Q(0.0, "m")}
+    >>> try:
+    ...     cxm.lorentzian.causal_character(cxc.cart3d, a, b)
+    ... except NotImplementedError as e:
+    ...     print(str(e)[:60])
+    ...
+    causal_character() requires a Lorentzian metric -- *exactly
+    ```
+
+(software-spec-proper_time)=
+
+!!! info `proper_time`
+
+    The time elapsed on a clock carried between two **timelike-separated**
+    events — the one duration all observers agree on.
+
+    $$ \tau = \frac{\sqrt{-\Delta s^2}}{c} $$
+
+    **Signatures:**
+
+    ```
+    cxm.lorentzian.proper_time(chart, a, b, /, *, usys=None)
+    cxm.lorentzian.proper_time(metric, chart, a, b, /, *, usys=None)
+    ```
+
+    **Return:**
+
+    - A `unxt.Quantity` with dimensions of **time**. The interval is a length-squared in a chart whose time axis is `ct`, so the square root is a length and the division by $c$ is what makes this a duration rather than a distance.
+
+    **Dispatch behavior:**
+
+    - Raises `ValueError` on a spacelike or null pair rather than returning `nan`: there is no clock that travels between spacelike-separated events, so the answer is not "undefined", it is "the question does not apply". Use `proper_distance` there.
+    - A non-Lorentzian metric raises `NotImplementedError`.
+
+    **Examples**
+
+    ```pycon
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> o = {"ct": u.Q(0.0, "m"), "x": u.Q(0.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> ev = {"ct": u.Q(5.0, "m"), "x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+
+    >>> cxm.lorentzian.proper_time(cxc.minkowskict, o, ev).uconvert("ns").round(4)
+    Q(16.3412, 'ns')
+    ```
+
+    A spacelike pair has no proper time, and says so:
+
+    ```pycon
+    >>> sp = {"ct": u.Q(1.0, "m"), "x": u.Q(5.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> try:
+    ...     cxm.lorentzian.proper_time(cxc.minkowskict, o, sp)
+    ... except ValueError as e:
+    ...     print(str(e)[:52])
+    ...
+    proper_time() is defined only for timelike-separated
+    ```
+
+(software-spec-proper_distance)=
+
+!!! info `proper_distance`
+
+    The distance between two **spacelike-separated** events, measured in the
+    frame where they are simultaneous.
+
+    $$ \ell = \sqrt{+\Delta s^2} $$
+
+    **Signatures:**
+
+    ```
+    cxm.lorentzian.proper_distance(chart, a, b, /, *, usys=None)
+    cxm.lorentzian.proper_distance(metric, chart, a, b, /, *, usys=None)
+    ```
+
+    **Return:**
+
+    - A `unxt.Quantity` with dimensions of **length**. No division by $c$ here, unlike `proper_time`.
+
+    **Dispatch behavior:**
+
+    - The mirror of `proper_time`: raises `ValueError` on a timelike or null pair, since no frame makes timelike-separated events simultaneous.
+    - A non-Lorentzian metric raises `NotImplementedError`.
+
+    **Examples**
+
+    ```pycon
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> o = {"ct": u.Q(0.0, "m"), "x": u.Q(0.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> sp = {"ct": u.Q(1.0, "m"), "x": u.Q(5.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+
+    >>> cxm.lorentzian.proper_distance(cxc.minkowskict, o, sp).round(6)
+    Q(4.898979, 'm')
+    ```
+
+(software-spec-rapidity_between)=
+
+!!! info `rapidity_between`
+
+    The hyperbolic angle between two timelike **tangent vectors** — the
+    relative rapidity of two observers.
+
+    $$ \cosh\zeta = \frac{-g(u,v)}{\sqrt{g(u,u)\,g(v,v)}} $$
+
+    This is the one verb here that takes tangents rather than points, and it
+    exists because `angle_between` cannot serve. That verb refuses a timelike
+    pair, correctly: $g(u,u)$ and $g(v,v)$ are both negative, so `arccos` of
+    their ratio would clip to $0$ or $\pi$ and report two observers in relative
+    motion as parallel. The invariant that *does* separate them is hyperbolic,
+    so it gets its own name rather than an extra branch inside a
+    circular-angle function.
+
+    Rapidity is additive under collinear boosts where velocity is not, which is
+    what makes it the natural parameter.
+
+    **Signatures:**
+
+    ```
+    cxm.lorentzian.rapidity_between(chart, uvec, vvec, /, *, at, usys=None)
+    cxm.lorentzian.rapidity_between(metric, chart, uvec, vvec, /, *, at, usys=None)
+    ```
+
+    **Arguments:**
+
+    - `uvec`, `vvec`: the two tangent vectors, as `CDict`s. Both must be timelike.
+    - `at` (keyword, **required**): the base point at which the metric is evaluated. Unlike the point-pair verbs there is no first argument to take it from, so it must be supplied.
+
+    **Return:**
+
+    - A dimensionless bare `Array`. Rapidity is a pure number, not an angle: it is unbounded, and `rad` would wrongly suggest it wraps.
+
+    **Dispatch behavior:**
+
+    - Raises `ValueError` unless **both** operands are timelike.
+    - Calls `check_metric_is_charts` directly, where the causal verbs inherit the same guard through metric-level `interval`.
+    - A non-Lorentzian metric raises `NotImplementedError`.
+
+    **Examples**
+
+    ```pycon
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+    ```
+
+    An observer at rest, and one moving at $v/c = 0.6$; the rapidity is
+    $\operatorname{artanh}(0.6) = \ln 2$.
+
+    ```pycon
+    >>> at = {"ct": u.Q(0.0, "m"), "x": u.Q(0.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+    >>> rest = {"ct": u.Q(1.0, ""), "x": u.Q(0.0, ""), "y": u.Q(0.0, ""), "z": u.Q(0.0, "")}
+    >>> moving = {"ct": u.Q(1.25, ""), "x": u.Q(0.75, ""), "y": u.Q(0.0, ""), "z": u.Q(0.0, "")}
+
+    >>> cxm.lorentzian.rapidity_between(cxc.minkowskict, rest, moving, at=at).round(6)
+    Array(0.693147, dtype=float64)
+    ```
+
+    A spacelike operand is refused rather than clipped:
+
+    ```pycon
+    >>> space = {"ct": u.Q(0.0, ""), "x": u.Q(1.0, ""), "y": u.Q(0.0, ""), "z": u.Q(0.0, "")}
+    >>> try:
+    ...     cxm.lorentzian.rapidity_between(cxc.minkowskict, rest, space, at=at)
+    ... except ValueError as e:
+    ...     print(str(e)[:54])
+    ...
+    rapidity_between is defined only between two timelike
+    ```
+
 (software-spec-abstractatlas)=
 
 !!! info `AbstractAtlas`


### PR DESCRIPTION
`coordinax.manifolds.lorentzian` had **no entry in the spec at all** — not the namespace, and none of its four verbs. `causal_character` and `rapidity_between` were not so much as mentioned; `proper_time` and `proper_distance` appeared once each, inside `geodesic_distance`'s "use these instead" line.

Five sections: the namespace, then a verb each. The namespace section carries what they share, so the verb entries stay short.

| verb | reads | defined for |
|---|---|---|
| `causal_character` | the sign of `interval` | any pair |
| `proper_time` | $\sqrt{-\Delta s^2}/c$ | timelike pairs |
| `proper_distance` | $\sqrt{+\Delta s^2}$ | spacelike pairs |
| `rapidity_between` | the hyperbolic angle | two timelike **tangents** |

## What's worth pinning

- **`causal_character` returns a Python `str`** — not an enum, not a number, so it cannot be accidentally arithmetic. It takes `atol`, because a null separation is measure-zero in floating point and needs a band rather than an equality test.
- **`proper_time` divides by $c$ and `proper_distance` does not**, so one is a duration and the other a length out of the same length-squared interval.
- **Each refuses the other's causal class with `ValueError`, not `nan`.** No clock travels between spacelike-separated events, so the question does not apply rather than being undefined.
- **`rapidity_between` is the odd one out** and gets the most prose: tangents rather than points, `at=` **required** because there is no first point to take the base from, and a bare dimensionless `Array` rather than an `Angle` — rapidity is unbounded, and `rad` would wrongly suggest it wraps.

That last one also gets the *why it exists*: `angle_between` refuses timelike pairs, and correctly — $g(u,u)$ and $g(v,v)$ are both negative, so `arccos` of their ratio clips to $0$ or $\pi$ and reports two observers in relative motion as parallel. The invariant that separates them is hyperbolic, so it gets its own name rather than a branch inside a circular-angle function.

The namespace section also records why it is named for the *signature*: `charts.galileanct` is a 4-dimensional spacetime and is **not** Lorentzian, so a `spacetime` namespace would promise membership these verbs refuse; `minkowski` would wrongly exclude Schwarzschild and FLRW, which carry the marker and acquire all four.

## Verification — and one trap worth naming

All **34 examples** were executed under the harness that will run them, not a bare interpreter.

That distinction is load-bearing. `JAX_ENABLE_X64 = "1"` is set in `[tool.pytest.ini_options]`, so an ad-hoc `python` session gives `float32` and every literal would have been wrong:

```
ad-hoc python : Q(1.6341238e-08, 's')      Array(0.6931472, dtype=float32)
under pytest  : Q(1.63412366e-08, 's')     Array(0.69314718, dtype=float64)
```

I gathered the first set before noticing, and every one of them would have failed CI. Verified with `pytest docs/spec.md`: **34 collected, 34 passed, 0 failed** in the added range. `prek run --all-files` clean (`blacken-docs` reformatted; re-verified after, still 0 failing). `uv run --frozen nox -s docs` succeeds with warnings as errors.

The 17 pre-existing failures elsewhere in `docs/spec.md` are untouched here — they are #733's subject.

## Stacking

Touches `docs/spec.md`, as do #732 and #733, and all three insert near the end of the verb cluster. They are independent; whichever lands last needs a trivial rebase. Once #733 is in, these examples are CI-gated automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
