### PR TITLE
⬆️ build: require unxt>=2.0.2, so a dropped unit is an error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,12 @@ dependencies = [
   "coordinaxs.api>=0.24",
   "dataclassish>=0.9.0",
   "equinox>=0.13.8",
-  "jax>=0.6.0",
-  "jaxlib>=0.6.0",
+  # >=0.7.2 is unxt 2.0.2's own floor, not a preference; 0.6.x cannot resolve
+  # alongside it. `jnp.asarray` only routes through `Quantity.__array__` from
+  # jax 0.10, so between 0.7.2 and 0.9 it still rejects a Quantity outright --
+  # strip explicitly rather than relying on the coercion in that range.
+  "jax>=0.7.2",
+  "jaxlib>=0.7.2",
   "jaxtyping>=0.3.3",
   "optional-dependencies>=0.5.0",
   "optype>=0.17.0",
@@ -35,6 +39,9 @@ dependencies = [
   "quax-blocks>=0.4.1",
   "quaxed>=0.10.5",
   "typing-extensions>=4.13.2",
+  # 2.0.2 makes `np.asarray(Quantity)` raise rather than silently drop the
+  # unit. Relied upon: dropping a unit yields a number in the wrong dimension
+  # that looks entirely plausible.
   "unxt>=2.0.2",
   "unxts.linalg>=2.0.3",
   "wadler-lindig>=0.1.6",
@@ -533,3 +540,39 @@ constraint-dependencies = [
 
 [tool.uv.workspace]
 members = ["packages/*"]
+
+# `equinox.AbstractVar` is `Annotated[T, "AbstractVar"]` to a type checker (see
+# equinox `_better_abstract.py`), i.e. indistinguishable from a real field, so
+# `dataclass_transform` counts it in the synthesised `__init__`. At runtime
+# equinox strips it -- `dataclasses.fields(Point)` is `(data, chart, frame)` and
+# `Point.__abstractvars__` is empty -- so these constructor calls are correct.
+#
+# Latent until quax 0.4.2, whose metaclass `__call__` went from `-> Any` to
+# `type[_T] -> _T`; the old signature erased the synthesised constructor and
+# checkers skipped argument checking entirely. That change is right, so this is
+# not a quax bug. `pyright` reports the same errors, so it is not ty-specific.
+# Upstream: https://github.com/patrick-kidger/equinox/issues/1256
+#
+# Scoped to the files that construct these classes, so the rules stay live
+# everywhere else. Remove when equinox can express "not a field" statically.
+[[tool.ty.overrides]]
+include = [
+  "packages/coordinaxs.interop.astropy/src/coordinaxs/interop/astropy/_src/frames.py",
+  "packages/coordinaxs.interop.astropy/src/coordinaxs/interop/astropy/_src/vec_constructors.py",
+  "packages/coordinaxs.interop.astropy/src/coordinaxs/interop/astropy/_src/vec_converters.py",
+  "src/coordinax/vectors/_src/point.py",
+  "src/coordinax/vectors/_src/register_cx.py",
+  "src/coordinax/vectors/_src/tangent.py",
+]
+
+[tool.ty.overrides.rules]
+missing-argument = "ignore"
+
+# Same cause, different symptom: `type(x)(...)` on an `AbstractDistance`
+# resolves to the abstract base, whose synthesised `__init__` does not carry
+# `check_negative`. `Distance.__init__` does accept it -- verified at runtime.
+[[tool.ty.overrides]]
+include = ["src/coordinax/distances/_src/register_primitives.py"]
+
+[tool.ty.overrides.rules]
+unknown-argument = "ignore"

--- a/src/coordinax/frames/_src/example.py
+++ b/src/coordinax/frames/_src/example.py
@@ -129,7 +129,7 @@ class Bob(AbstractReferenceFrame):
           chart=Cart3D(M=Rn(3))
       ),
       Translate(
-          {'x': Q(269813212.2, 'm / s'), 'y': Q(0.0, 'm / s'), 'z': Q(0.0, 'm / s')},
+          {'x': Q(269813212.2, 'm / s'), ...},
           chart=Cart3D(M=Rn(3)),
           semantic_kind=vel
       )

--- a/tests/unit/manifolds/test_embedded_twosphere.py
+++ b/tests/unit/manifolds/test_embedded_twosphere.py
@@ -54,6 +54,10 @@ class TestEmbeddedTwosphereAmbient:
         p = {"theta": jnp.asarray(jnp.pi / 2), "phi": jnp.asarray(0.0)}
         out = cxm.pt_embed(p, m, usys=u.unitsystems.si)
         assert set(out) == {"x", "y", "z"}
+        # `ustrip`, not `np.asarray`: the radius is 2 m, so the output carries
+        # metres. Coercing it to a bare array asserted "2.0" against a number
+        # whose unit was never checked -- the test would have passed just the
+        # same had the embedding returned 2 km.
         np.testing.assert_allclose(u.ustrip("m", out["x"]), 2.0, atol=1e-6)
 
     def test_non_singleton_spherical_ambient_takes_spherical_path(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -615,8 +615,8 @@ requires-dist = [
     { name = "coordinaxs-interop-astropy", marker = "extra == 'workspace'", editable = "packages/coordinaxs.interop.astropy" },
     { name = "dataclassish", specifier = ">=0.9.0" },
     { name = "equinox", specifier = ">=0.13.8" },
-    { name = "jax", specifier = ">=0.6.0" },
-    { name = "jaxlib", specifier = ">=0.6.0" },
+    { name = "jax", specifier = ">=0.7.2" },
+    { name = "jaxlib", specifier = ">=0.7.2" },
     { name = "jaxtyping", specifier = ">=0.3.3" },
     { name = "optional-dependencies", specifier = ">=0.5.0" },
     { name = "optype", specifier = ">=0.17.0" },
@@ -3447,7 +3447,7 @@ wheels = [
 
 [[package]]
 name = "unxts-linalg"
-version = "2.0.3"
+version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "equinox" },
@@ -3456,9 +3456,9 @@ dependencies = [
     { name = "quax" },
     { name = "unxt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/c4/307dcab757c6ebc933b6f11c78aac1a98dd82f6b9b96839f1364cc12abb5/unxts_linalg-2.0.3.tar.gz", hash = "sha256:8c745be6a4d4ed599159ea21c75ac0a6fcd9492ad687c30a585f7e9f2e59905a", size = 55864, upload-time = "2026-07-28T13:17:05.384Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/5d/8ce961bce94d27d9c2edd3ce9ca8531b1121436f095b0c3be5a8e276fd29/unxts_linalg-2.0.4.tar.gz", hash = "sha256:e13c23b46429919f5bc4bf22655be6e3375afcfc28cf917977910c2760eb7c0b", size = 59021, upload-time = "2026-08-15T07:58:49.628Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/78/56ee7aa4159f24ed467034ce6514393758a2e5400f5212f0e357f1134f99/unxts_linalg-2.0.3-py3-none-any.whl", hash = "sha256:46181cf364dc8086ab066f178258f2a923ca7ea3460955c0b509e3883b160cfc", size = 34365, upload-time = "2026-07-28T13:17:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/883884e2b32a5ed6a3613fe96017310f29abb78e383d2198128d875965a7/unxts_linalg-2.0.4-py3-none-any.whl", hash = "sha256:b837161b05f9d0f3e3779e0140dd91a0f8407e8859249a938ac57829392b7939", size = 35944, upload-time = "2026-08-15T07:58:48.461Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

```python
>>> np.asarray(u.Q(2.0, "m"))
Array(2.)          # metres silently gone
```

A number in the wrong dimension that looks entirely plausible. unxt 2.0.2 raises `UnitConversionError` instead.

## The bug it found in-tree

`test_usys_is_forwarded_to_embed` asserted against an embedding with `radius=2 m`:

```python
np.testing.assert_allclose(np.asarray(out["x"]), 2.0, atol=1e-6)
```

It would have passed just the same had the embedding returned **2 km**. Now `u.ustrip("m", out["x"])`, which checks the unit it is asserting against.

That is the whole point of the bump: the class of bug is invisible to a passing test suite.

## Version floors

`jax`/`jaxlib` move to `>=0.7.2` because that is unxt 2.0.2's own floor — 0.6.x cannot resolve alongside it. **0.7.2 through 0.9 stay supported.** The guarantee is not uniform across that range:

| | `np.asarray(Q)` | `jnp.asarray(Q)` |
|---|---|---|
| jax 0.7.2–0.9 | ✅ raises on `m` | ❌ `TypeError` on any Quantity |
| jax ≥ 0.10 | ✅ raises on `m` | ✅ raises on `m` |

`jnp.asarray` only reaches `Quantity.__array__` from jax 0.10. So `np.asarray` is protected everywhere we support, and code that must strip a dimensionless Quantity does it explicitly rather than relying on coercion.

## Three doctests

unxt's `Quantity` repr changed: scientific notation is gone (`Q(2.69813212e+08, ...)` → `Q(269813212.2, ...)`) and small arrays print values rather than shape/dtype (`Q(i64[], 'm')` → `Q(10, 'm')`).

## The `ty` suppressions

The relock also moves quax 0.4.1 → 0.4.3, which produces **14 `ty` errors**. All spurious — and worth reading before the diff looks alarming.

Bisected to **quax 0.4.2**, whose metaclass `__call__` went from `(cls, ...) -> Any` to `(cls: type[_T], ...) -> _T`. That is a *fix*: `-> Any` was erasing the `dataclass_transform`-synthesised constructor, so checkers skipped constructor argument checking entirely. Now they check — and find that `equinox.AbstractVar` is `Annotated[T, "AbstractVar"]` to a type checker, hence an `__init__` field, though equinox strips it at runtime:

```
>>> dataclasses.fields(Point)      # ('data', 'chart', 'frame')
>>> Point.__abstractvars__         # empty
```

So the constructor calls are correct and the errors name the wrong parameter — the phantom `rep` consumes the first positional slot.

Not a quax bug, not a quax-blocks bug (0.5.0 alone gives 0 errors), and not ty-specific — **`pyright` reports the same errors**. Filed upstream as patrick-kidger/equinox#1256 with a self-contained repro; aliasing to `ClassVar` under `TYPE_CHECKING` is rejected outright, so I have no fix to offer there yet.

Suppressed **per-file and per-rule**, so both rules stay live everywhere else, with the reasoning and the issue link recorded next to the block. Remove it when equinox can express "not a field" statically.

## Verification

- Full suite: **10386 passed**, 7 skipped, 1 xfailed
- `prek run --all-files` clean; `ty` at 0 errors (6 pre-existing warnings untouched)

## Follow-up

This is the first of the `np.asarray` work. The sweep for other sites that coerce a dimensionful Quantity comes next; only one was reachable by the current tests, and a passing suite is not evidence there are no others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)