### PR TITLE
📝 docs(curveframes): record that DirectAdjoint is load-bearing on the primal solve

### DIFF
--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -49,7 +49,7 @@ from .attime import AtTime
 #: which could then use the cheaper `RecursiveCheckpointAdjoint`. That is
 #: false, and measurably so: swapping it in fails 10 tests with ``TypeError:
 #: can't apply forward-mode autodiff (jvp) to a custom_vjp function``, raised
-#: across `test_arclength_integration.py` and `test_arclength_shapes.py` --
+#: across ``test_arclength_integration.py`` and ``test_arclength_shapes.py`` --
 #: the induced-metric and chart round-trip paths, which forward-differentiate
 #: through the chart and so reach the primal solve. The swap does not even
 #: pay: measured on a helix in alternating trials, it was consistently

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -43,17 +43,13 @@ from .attime import AtTime
 #: differentiable in both forward and reverse mode -- see that module's
 #: comment for the full rationale.
 #:
-#: `DirectAdjoint` is load-bearing on **every** solve here, including the
-#: primal one in `_solve_tau`. It is tempting to reason that `_tau_of_s`
-#: supplies its own JVP, so autodiff never descends into the primal solve,
-#: which could then use the cheaper `RecursiveCheckpointAdjoint`. That is
-#: false, and measurably so: swapping it in fails 10 tests with ``TypeError:
-#: can't apply forward-mode autodiff (jvp) to a custom_vjp function``, raised
-#: across ``test_arclength_integration.py`` and ``test_arclength_shapes.py`` --
-#: the induced-metric and chart round-trip paths, which forward-differentiate
-#: through the chart and so reach the primal solve. The swap does not even
-#: pay: measured on a helix in alternating trials, it was consistently
-#: slower to construct and to evaluate, and indistinguishable on gradients.
+#: `DirectAdjoint` is load-bearing on the *primal* solve too, not only the
+#: JVP's quadrature: `_tau_of_s`'s custom rule does not keep autodiff out,
+#: because the induced-metric and chart round-trip paths differentiate
+#: through the chart in forward mode and so reach `_solve_tau`. Swapping in
+#: `RecursiveCheckpointAdjoint` there fails 10 tests with ``can't apply
+#: forward-mode autodiff (jvp) to a custom_vjp function``, and measured no
+#: faster anyway.
 _DIFFEQSOLVER = DiffEqSolver(
     solver=dfx.Tsit5(),
     stepsize_controller=dfx.PIDController(rtol=1e-10, atol=1e-10),

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -42,6 +42,18 @@ from .attime import AtTime
 #: `PIDController` and `DirectAdjoint`, the only adjoint that is
 #: differentiable in both forward and reverse mode -- see that module's
 #: comment for the full rationale.
+#:
+#: `DirectAdjoint` is load-bearing on **every** solve here, including the
+#: primal one in `_solve_tau`. It is tempting to reason that `_tau_of_s`
+#: supplies its own JVP, so autodiff never descends into the primal solve,
+#: which could then use the cheaper `RecursiveCheckpointAdjoint`. That is
+#: false, and measurably so: swapping it in fails 10 tests with ``TypeError:
+#: can't apply forward-mode autodiff (jvp) to a custom_vjp function``, raised
+#: across `test_arclength_integration.py` and `test_arclength_shapes.py` --
+#: the induced-metric and chart round-trip paths, which forward-differentiate
+#: through the chart and so reach the primal solve. The swap does not even
+#: pay: measured on a helix in alternating trials, it was consistently
+#: slower to construct and to evaluate, and indistinguishable on gradients.
 _DIFFEQSOLVER = DiffEqSolver(
     solver=dfx.Tsit5(),
     stepsize_controller=dfx.PIDController(rtol=1e-10, atol=1e-10),


### PR DESCRIPTION
The comment above `_DIFFEQSOLVER` explains *why* `DirectAdjoint` is needed without saying *where* — which invites an optimisation that doesn't work. This records the negative result so the next person doesn't spend the afternoon I just did.

## The reasoning that fails

`_tau_of_s` supplies its own JVP, so autodiff never descends into the primal `_solve_tau` — which could then take the cheaper `RecursiveCheckpointAdjoint`, leaving `DirectAdjoint` only for `_arclength_between`, the quadrature the JVP rule genuinely differentiates.

It's wrong. Attempting it fails **10 tests** across `test_arclength_integration.py` and `test_arclength_shapes.py`:

```
TypeError: can't apply forward-mode autodiff (jvp) to a custom_vjp function
```

The induced-metric and chart round-trip paths forward-differentiate *through the chart*, and so do reach the primal solve. The custom JVP covers `__call__`; it does not make the primal unreachable.

## It doesn't pay either

Alternating trials on a helix, baseline vs patched:

| | build | fwd | grad |
| --- | --- | --- | --- |
| baseline | 0.17 / 0.17 / 0.18 | 1.40 / 1.39 / 1.42 | 14.6 / 14.1 / 15.8 |
| patched | 0.22 / 0.22 / 0.24 | 1.74 / 1.65 / 1.61 | 15.6 / 16.8 / 14.6 |

Consistently slower to construct and evaluate, indistinguishable on gradients. The ~1.6x I originally expected was an artefact of comparing two separate runs on a loaded machine rather than a controlled A/B — worth naming, since that's the error that made the idea look attractive.

## Also learned, not recorded here

`jax.lax.stop_gradient` cannot take a curve: it rejects a bare Python function, and only an `equinox.Module` curve is a pytree of arrays. Any attempt needs `equinox.partition`/`combine` around it. Left out of the comment because it only matters to someone already going down this road, and the comment now tells them not to.

Comment only, no behaviour change. 32 tests pass in `test_arclength_smax.py`, `prek` clean including `ty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)