### PR TITLE
🐛 fix(transforms): `LorentzBoost` beta must be dimensionless, not merely present

### DIFF
--- a/src/coordinax/transforms/_src/actions/lorentz.py
+++ b/src/coordinax/transforms/_src/actions/lorentz.py
@@ -9,6 +9,7 @@ from typing import Any, final
 
 import equinox as eqx
 import plum
+from astropy.units import UnitConversionError
 
 import quaxed.numpy as jnp
 import unxt as u
@@ -33,6 +34,31 @@ _MSG_ZERO_DIRECTION = (
     "LorentzBoost.from_rapidity requires a non-zero `direction`; the zero "
     "vector has no boost axis to normalise onto."
 )
+
+
+def _as_beta(b: Any, /) -> Shaped[Array, "3"]:
+    """Normalise ``beta`` to a bare array, requiring it to be dimensionless.
+
+    ``jnp`` here is `quaxed.numpy`, whose `asarray` is unit-aware and returns a
+    `~unxt.Quantity` unchanged. A plain ``jnp.asarray`` converter therefore did
+    nothing for a `~unxt.Quantity`, storing one in a field annotated `Array`;
+    the failure surfaced much later and unrecognisably, inside `matrix`.
+
+    A dimensionless quantity is stripped. A velocity is refused rather than
+    reinterpreted: ``0.6 m/s`` is not ``0.6 c``, and taking its number would be
+    wrong by eight orders of magnitude while looking perfectly ordinary.
+    """
+    if isinstance(b, u.AbstractQuantity):
+        try:
+            b = u.ustrip("", b)
+        except UnitConversionError as e:
+            msg = (
+                f"LorentzBoost `beta` is a velocity in units of c, and so "
+                f"dimensionless; got {u.unit_of(b)}. For a velocity use "
+                f"`LorentzBoost.from_velocity(v)`, which divides by c."
+            )
+            raise ValueError(msg) from e
+    return jnp.asarray(b, dtype=float)
 
 
 @final
@@ -144,9 +170,7 @@ class LorentzBoost(AbstractLinearTransform):
 
     """
 
-    beta: Shaped[Array, "3"] = eqx.field(
-        converter=lambda b: jnp.asarray(b, dtype=float)
-    )
+    beta: Shaped[Array, "3"] = eqx.field(converter=_as_beta)
     """Boost velocity in units of ``c`` (dimensionless 3-vector)."""
 
     @classmethod

--- a/src/coordinax/transforms/_src/actions/lorentz.py
+++ b/src/coordinax/transforms/_src/actions/lorentz.py
@@ -52,12 +52,17 @@ def _as_beta(b: Any, /) -> Shaped[Array, "3"]:
         try:
             b = u.ustrip("", b)
         except UnitConversionError as e:
-            msg = (
-                f"LorentzBoost `beta` is a velocity in units of c, and so "
-                f"dimensionless; got {u.unit_of(b)}. For a velocity use "
-                f"`LorentzBoost.from_velocity(v)`, which divides by c."
+            # A note rather than a new exception: `UnitConversionError` is
+            # already a `ValueError`, so nothing catching the latter is lost,
+            # and astropy's own message names both units and the physical type
+            # ("speed/velocity"). Re-raising would restate that in a second
+            # traceback and swap a precise type for a vaguer one.
+            e.add_note(
+                "LorentzBoost `beta` is a velocity in units of c, and so "
+                "dimensionless. For a velocity use "
+                "`LorentzBoost.from_velocity(v)`, which divides by c."
             )
-            raise ValueError(msg) from e
+            raise
     return jnp.asarray(b, dtype=float)
 
 

--- a/tests/unit/transforms/test_lorentz_boost.py
+++ b/tests/unit/transforms/test_lorentz_boost.py
@@ -345,3 +345,46 @@ class TestTimeDepComposition:
         g = jax.grad(gamma_of_rate)(0.1)
         assert jnp.isfinite(g)
         assert float(g) > 0.0  # faster rate -> larger gamma
+
+
+_BETA = [0.6, 0.0, 0.0]
+
+
+class TestBetaAcceptsOnlyDimensionlessQuantities:
+    """`beta` is v/c, so a `Quantity` must be dimensionless or refused.
+
+    Regression: the field converter was a bare ``jnp.asarray``, and ``jnp`` in
+    that module is `quaxed.numpy`, whose `asarray` is unit-aware and hands a
+    `Quantity` straight back. A `Quantity` was therefore stored in a field
+    annotated `Array`, and nothing complained until `matrix` failed with a
+    `TypeError` about ``unvmap_any`` -- an error naming nothing the caller had
+    written.
+    """
+
+    def test_dimensionless_quantity_is_stripped_to_an_array(self):
+        b = cxfm.LorentzBoost(u.Q(jnp.asarray(_BETA), ""))
+        assert not isinstance(b.beta, u.AbstractQuantity)
+        assert bool(jnp.allclose(b.beta, jnp.asarray(_BETA)))
+
+    def test_stripped_quantity_matches_a_bare_array(self):
+        """The two spellings must give the same operator, not merely both work."""
+        from_q = cxfm.LorentzBoost(u.Q(jnp.asarray(_BETA), ""))
+        from_arr = cxfm.LorentzBoost(jnp.asarray(_BETA))
+        assert bool(jnp.allclose(from_q.matrix, from_arr.matrix, atol=1e-14))
+        assert bool(jnp.allclose(from_q.gamma, 1.25, atol=1e-12))
+
+    @pytest.mark.parametrize("unit", ["m/s", "km/s", "pc/Myr", "m"])
+    def test_a_dimensionful_quantity_is_refused_and_redirected(self, unit):
+        """``0.6 m/s`` is not ``0.6 c`` -- off by eight orders of magnitude.
+
+        A length is in here too: the guard is "dimensionless or nothing", not
+        "not a velocity".
+        """
+        with pytest.raises(ValueError, match="from_velocity"):
+            cxfm.LorentzBoost(u.Q(jnp.asarray(_BETA), unit))
+
+    def test_from_velocity_is_the_supported_route(self):
+        """Positive control: the redirect the error names actually works."""
+        c = u.Q(299792458.0, "m/s")
+        b = cxfm.LorentzBoost.from_velocity(u.Q(jnp.asarray([0.6, 0.0, 0.0]), "") * c)
+        assert bool(jnp.allclose(b.beta, jnp.asarray(_BETA), atol=1e-12))


### PR DESCRIPTION
First finding of the `asarray` sweep (follow-up to #737). Pre-existing, independent of everything else open.

## The bug

`lorentz.py` does `import quaxed.numpy as jnp`, and **quaxed's `asarray` is unit-aware** — it hands a `Quantity` straight back rather than converting it:

```pycon
>>> quaxed.numpy.asarray(u.Q(0.6, ""), dtype=float)
Q(0.6, '')            # unchanged
>>> jax.numpy.asarray(u.Q(0.6, ""), dtype=float)
Array(0.6)            # converted
```

So `beta`'s converter was a **no-op for `Quantity` input**, storing one in a field annotated `Shaped[Array, "3"]`:

```pycon
>>> b = cxfm.LorentzBoost(u.Q([0.6, 0, 0], ""))   # dimensionless, exactly what beta is
>>> b.beta
Q([0.6, 0., 0.], '')                              # wrong type, no complaint
>>> b.matrix
TypeError: Error interpreting argument to unvmap_any as a JAX value
```

A legitimate input, accepted at construction, failing later with an error naming nothing the caller wrote.

And a velocity was equally accepted:

```pycon
>>> cxfm.LorentzBoost(u.Q([0.6, 0, 0], "m/s"))    # constructs
```

**0.6 m/s is not 0.6 c.** Had that number reached the arithmetic it would have been wrong by eight orders of magnitude while looking entirely ordinary — beta ~ 2e-9, gamma indistinguishable from 1.

## The fix

A dimensionless `Quantity` is stripped; anything else is refused, pointing at `from_velocity`, which is the constructor that divides by c:

```
LorentzBoost `beta` is a velocity in units of c, and so dimensionless; got m / s.
For a velocity use `LorentzBoost.from_velocity(v)`, which divides by c.
```

The guard is "dimensionless or nothing", not "not a velocity" — a length is refused too.

## Provenance

**Not caused by the unxt 2.0.2 bump.** Reproduced against quax 0.4.1 / unxt 2.0.0: identical behaviour. It has been latent for as long as the converter has used quaxed's `asarray`.

## How it was found

Sweeping `asarray` call sites that can receive a `Quantity` — 274 sites, 39 taking a variable rather than a literal. Among the transform constructors `LorentzBoost` was the only one that leaked:

| constructor | `Q(x, "")` |
|---|---|
| `Rotate.from_` | converts to `Array` ✅ |
| `Scale.from_factors` | refuses ✅ |
| `Reflect.from_normal` | refuses ✅ |
| `LorentzBoost` | **stored the Quantity** ❌ |

## Verification

- Full suite: **10859 passed**, 7 skipped, 1 xfailed
- `prek run --all-files` clean, including `ty`
- Six tests: the strip, that a stripped `Quantity` gives the *same operator* as the bare array (not merely that both work), four dimensionful units refused, and a positive control that the `from_velocity` route the error names actually works

🤖 Generated with [Claude Code](https://claude.com/claude-code)