### PR TITLE
📝 docs(curveframes): filenames as inline literals, package-wide

### DIFF
--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -236,7 +236,7 @@ def _arclength_between(
     Rescaled to $\sigma \in [0, 1]$ for the reason `_solve_tau` is, which
     applies here to ``tau_0``.
     """
-    # `jnp.asarray` narrows only here, as in `nearest.py`: `ustrip` is typed as
+    # `jnp.asarray` narrows only here, as in ``nearest.py``: `ustrip` is typed as
     # a broad union that `-` is not defined across, though every runtime member
     # supports it.
     tau_0_val = jnp.asarray(tau_0.ustrip(tau_unit))
@@ -293,8 +293,8 @@ def _tau_of_s(
     curve -- so a perturbation via `equinox.tree_at` silently loses the
     $\partial\tau/\partial\theta$ term (issue #713 has the measured
     numbers). And `BishopBuilder` differentiates the curve it wraps in
-    forward mode (`bishop.py`'s `_tangent_at` uses `unxt.experimental.jacfwd`),
-    which a `custom_vjp` cannot support -- `bishop.py:68` documents the same
+    forward mode (``bishop.py``'s `_tangent_at` uses `unxt.experimental.jacfwd`),
+    which a `custom_vjp` cannot support -- ``bishop.py:68`` documents the same
     trap for `RecursiveCheckpointAdjoint`. A custom JVP serves forward mode
     directly and reverse mode by transposition, so one rule covers both.
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
@@ -128,7 +128,7 @@ class TubularChart(AbstractParameterizedChart):
             # on-curve speed (and factor) `0/0 = nan`, and `nan <= 0` is
             # False too -- negating `nan > 0` (also False) catches it.
             #
-            # Hybrid form, matching `_src/charts/checks.py` (see `nearest.py`
+            # Hybrid form, matching ``_src/charts/checks.py`` (see ``nearest.py``
             # for the full mechanics): `eqx.error_if` under trace, plain
             # `ValueError` when concrete. The return value MUST be threaded
             # back into `data` -- an unused result silently vanishes under
@@ -157,8 +157,8 @@ class TubularChart(AbstractParameterizedChart):
         """
         tau, n1, n2 = data["tau"], data["n1"], data["n2"]
         unit = self.builder.tau_unit
-        # Derive the unit from the curve (as `nearest.py` and
-        # `register_ptmap.py` do), not hardcode `"km"`: the scale cancels in
+        # Derive the unit from the curve (as ``nearest.py`` and
+        # ``register_ptmap.py`` do), not hardcode `"km"`: the scale cancels in
         # `dot(dx,T)/speed`, but a hardcoded unit raises `UnitConversionError`
         # for a dimensionless curve.
         ambient_unit = self.builder.location(tau).unit

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/nearest.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/nearest.py
@@ -170,7 +170,7 @@ def nearest_tau(
     )
 
     # Must surface non-convergence, not return silently (hybrid form,
-    # matching `_src/charts/checks.py`). The return value MUST be threaded
+    # matching ``_src/charts/checks.py``). The return value MUST be threaded
     # through -- an unused `eqx.error_if` result is dead-code-eliminated and
     # the guard vanishes under `jit`.
     msg = "nearest-point solve did not converge"

--- a/packages/coordinaxs.curveframes/src/coordinaxs/hypothesis/curveframes/_tubular.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/hypothesis/curveframes/_tubular.py
@@ -79,7 +79,7 @@ def chart_init_kwargs(
 ) -> dict[str, Any]:
     """`chart_init_kwargs()` overload for `TubularChart`.
 
-    `tests/unit/charts/test_chart_classes.py`-style tests call
+    ``tests/unit/charts/test_chart_classes.py``-style tests call
     `chart_init_kwargs(chart_cls)` directly (not only through `charts()`), so
     this needs its own overload rather than relying on the `charts()`
     overload below to shadow the generic annotation-derived one.


### PR DESCRIPTION
Follow-up to #738, which fixed this in a single comment.

Single backticks make Sphinx resolve the contents as a Python reference, and the docs build runs `-n -W` (`noxfile.py:200-202`), so an unresolved one is a build **error**. A filename isn't an object to resolve — it wants double backticks.

## Scope

Eight occurrences across four files. Seven are in plain `#` comments or private docstrings, which Sphinx never renders (`autodoc_default_options` sets no `private-members`) — cosmetic.

**One is not.** `_tubular.py`'s `tests/unit/charts/test_chart_classes.py` sits in the docstring of `chart_init_kwargs`, which is **public** and therefore rendered. That's the only occurrence that could actually fail a docs build, and it's in a different file from the two that prompted this — which is the argument for sweeping the package rather than fixing the two I'd been pointed at.

| file | occurrences | context |
| --- | --- | --- |
| `_src/arclength.py` | 3 | comment + private docstring |
| `_src/chart.py` | 4 | comments |
| `_src/nearest.py` | 1 | comment |
| `hypothesis/.../_tubular.py` | 1 | **public docstring** |

## Also caught

`bishop.py:68` — a filename-with-line-number. My first scan anchored on a closing backtick straight after `.py` and missed it; the broader pattern found it.

Comments and docstrings only, no behaviour change. **954 passed**, `prek` clean including `ty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)