### PR TITLE
🐛 fix(transforms): a malformed matrix reports the square check, not a raw error

### DIFF
--- a/src/coordinax/transforms/_src/actions/general_linear.py
+++ b/src/coordinax/transforms/_src/actions/general_linear.py
@@ -119,8 +119,12 @@ class Linear(AbstractLinearTransform):
 
         The group is carried across unchanged -- a group is closed under
         inverses, so whatever the matrix belonged to, its inverse does too.
+
+        Through `matrix` rather than the raw field, so a malformed one is caught
+        with the same message as everywhere else instead of surfacing as a raw
+        shape error out of `jnp.linalg.inv`.
         """
-        return type(self)(jnp.linalg.inv(self.M), self.group)
+        return type(self)(jnp.linalg.inv(self.matrix), self.group)
 
     @property
     def _raw_matrix(self) -> Any:
@@ -146,7 +150,8 @@ def simplify(op: Linear, /, *, approx: bool = True, **kw: Any) -> AbstractTransf
     The identity-matrix check inspects values, so it is skipped when
     ``approx=False``.
     """
-    if approx and jnp.allclose(op.M, jnp.eye(op.M.shape[0], dtype=op.M.dtype), **kw):
+    m = op.matrix
+    if approx and jnp.allclose(m, jnp.eye(m.shape[0], dtype=m.dtype), **kw):
         return identity
     return op
 

--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -159,7 +159,7 @@ def simplify(op: Scale, /, *, approx: bool = True, **kw: Any) -> AbstractTransfo
 
 @plum.dispatch
 def _merge(a: Scale, b: Scale, /) -> AbstractTransform | None:
-    """Merge two adjacent scalings (``a`` applied first) into one, as ``b.S @ a.S``.
+    """Merge two adjacent scalings (``a`` applied first) into ``b.matrix @ a.matrix``.
 
     Through `matrix` rather than the raw fields, so a malformed operand is
     reported by the shared validation instead of a raw matmul shape error.

--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -116,7 +116,11 @@ class Scale(AbstractLinearTransform):
         Deferred like the singular check so it survives `jit`: a plain `bool`
         on a traced value raises `TracerBoolConversionError`.
         """
-        if matrix.ndim != 2:  # let the base's square check produce the message
+        # Non-square too, not just non-2D: `jnp.diag(jnp.diagonal(m))` on a
+        # (3, 2) builds a (2, 2), and the subtraction below then dies with a
+        # raw broadcasting error before the base can say "requires a square
+        # matrix". Both shapes are the base's to report.
+        if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
             return matrix
         off = matrix - jnp.diag(jnp.diagonal(matrix))
         return eqx.error_if(matrix, jnp.any(off != 0), _MSG_NOT_DIAGONAL)
@@ -147,12 +151,17 @@ def simplify(op: Scale, /, *, approx: bool = True, **kw: Any) -> AbstractTransfo
     The identity-matrix check inspects values, so it is skipped when
     ``approx=False``.
     """
-    if approx and jnp.allclose(op.S, jnp.eye(op.S.shape[0], dtype=op.S.dtype), **kw):
+    m = op.matrix
+    if approx and jnp.allclose(m, jnp.eye(m.shape[0], dtype=m.dtype), **kw):
         return identity
     return op
 
 
 @plum.dispatch
 def _merge(a: Scale, b: Scale, /) -> AbstractTransform | None:
-    """Merge two adjacent scalings (``a`` applied first) into one, as ``b.S @ a.S``."""
-    return Scale(b.S @ a.S)
+    """Merge two adjacent scalings (``a`` applied first) into one, as ``b.S @ a.S``.
+
+    Through `matrix` rather than the raw fields, so a malformed operand is
+    reported by the shared validation instead of a raw matmul shape error.
+    """
+    return Scale(b.matrix @ a.matrix)

--- a/tests/unit/transforms/test_simplify.py
+++ b/tests/unit/transforms/test_simplify.py
@@ -406,3 +406,44 @@ class TestLinearValidatesItsGroup:
         raw_init = inspect.unwrap(cxfm.Linear.__init__)
         with pytest.raises(TypeError, match="must be an AbstractTransformGroup"):
             raw_init(object.__new__(cxfm.Linear), jnp.eye(3), NotAGroup)
+
+
+class TestMalformedMatricesReportTheSharedMessage:
+    """Every route to a malformed matrix reports the base's square-check message.
+
+    `Scale.inverse` already did (#731). These are the routes that still reached
+    a raw JAX error first: a non-*square* 2D matrix slipped past the diagonal
+    check's `ndim` guard, and `simplify`/`_merge`/`Linear.inverse` read the raw
+    field rather than the validated `matrix`.
+    """
+
+    NONSQUARE = (3, 2)
+
+    def _nonsquare(self):
+        return jnp.ones(self.NONSQUARE)
+
+    @pytest.mark.parametrize("op_type", [cxfm.Scale, cxfm.Linear])
+    def test_matrix_reports_square(self, op_type):
+        with pytest.raises(Exception, match="square"):
+            _ = op_type(self._nonsquare()).matrix
+
+    @pytest.mark.parametrize("op_type", [cxfm.Scale, cxfm.Linear])
+    def test_inverse_reports_square(self, op_type):
+        with pytest.raises(Exception, match="square"):
+            _ = op_type(self._nonsquare()).inverse.matrix
+
+    @pytest.mark.parametrize("op_type", [cxfm.Scale, cxfm.Linear])
+    def test_simplify_reports_square(self, op_type):
+        with pytest.raises(Exception, match="square"):
+            cxfm.simplify(op_type(self._nonsquare()))
+
+    def test_merging_two_scales_reports_square(self):
+        bad = cxfm.Scale(self._nonsquare())
+        with pytest.raises(Exception, match="square"):
+            cxfm.simplify(bad | bad)
+
+    def test_a_square_non_diagonal_still_reports_diagonal(self):
+        """The square check must not swallow the diagonal one."""
+        shear = jnp.asarray([[1.0, 0.5, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+        with pytest.raises(Exception, match="diagonal"):
+            _ = cxfm.Scale(shear).matrix


### PR DESCRIPTION
Follow-up to #731, addressing its two review comments (it merged before they were
handled).

#731 routed `Scale.inverse` through `matrix` so that a malformed matrix reports the
shared *"requires a square matrix"* message instead of a raw LAPACK shape error. The
principle was right. It was applied in one place, and the reviewer caught the rest.

## 1. A non-square 2D matrix never reached the square check

`_validate_diagonal` guarded on `ndim` alone:

```python
if matrix.ndim != 2:  # let the base's square check produce the message
    return matrix
off = matrix - jnp.diag(jnp.diagonal(matrix))
```

A `(3, 2)` has `ndim == 2`, so it walked straight into the subtraction —
`jnp.diagonal` gives `(2,)`, `jnp.diag` makes it `(2, 2)`, and `(3, 2) - (2, 2)`
raises before the base can say anything:

```
TypeError: sub got incompatible shapes for broadcasting: (3, 2), (2, 2).
```

Non-square is now deferred to the base along with non-2D — both shapes are its to
report.

## 2. Four routes read the raw field instead of the validated `matrix`

| site | was | raw error |
| --- | --- | --- |
| `Linear.inverse` | `jnp.linalg.inv(self.M)` | `Argument to inv must have shape [..., n, n], got (3, 2).` |
| `simplify(Linear)` | `op.M` | `and got incompatible shapes for broadcasting: (3, 2), (3, 3).` |
| `simplify(Scale)` | `op.S` | same |
| `_merge(Scale, Scale)` | `b.S @ a.S` | raw matmul shape error |

`Linear._raw_matrix` still returns `self.M` — that one is correct by design, since it
is the accessor the base's `matrix` property validates.

## Result

All six routes now report the same thing:

```
EquinoxTracetimeError: Scale requires a square matrix; got shape (3, 2).
EquinoxTracetimeError: Linear requires a square matrix; got shape (3, 2).
```

Tests cover each route for both types, plus a check that the square guard does not
swallow the diagonal one (a square-but-sheared matrix still reports `diagonal`).

Full suite: **10694 passed, 8 skipped, 1 xfailed**.
