### PR TITLE
🔧 build: drop the `ty` overrides that #725 made unnecessary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -539,39 +539,3 @@ constraint-dependencies = [
 
 [tool.uv.workspace]
 members = ["packages/*"]
-
-# `equinox.AbstractVar` is `Annotated[T, "AbstractVar"]` to a type checker (see
-# equinox `_better_abstract.py`), i.e. indistinguishable from a real field, so
-# `dataclass_transform` counts it in the synthesised `__init__`. At runtime
-# equinox strips it -- `dataclasses.fields(Point)` is `(data, chart, frame)` and
-# `Point.__abstractvars__` is empty -- so these constructor calls are correct.
-#
-# Latent until quax 0.4.2, whose metaclass `__call__` went from `-> Any` to
-# `type[_T] -> _T`; the old signature erased the synthesised constructor and
-# checkers skipped argument checking entirely. That change is right, so this is
-# not a quax bug. `pyright` reports the same errors, so it is not ty-specific.
-# Upstream: https://github.com/patrick-kidger/equinox/issues/1256
-#
-# Scoped to the files that construct these classes, so the rules stay live
-# everywhere else. Remove when equinox can express "not a field" statically.
-[[tool.ty.overrides]]
-include = [
-  "packages/coordinaxs.interop.astropy/src/coordinaxs/interop/astropy/_src/frames.py",
-  "packages/coordinaxs.interop.astropy/src/coordinaxs/interop/astropy/_src/vec_constructors.py",
-  "packages/coordinaxs.interop.astropy/src/coordinaxs/interop/astropy/_src/vec_converters.py",
-  "src/coordinax/vectors/_src/point.py",
-  "src/coordinax/vectors/_src/register_cx.py",
-  "src/coordinax/vectors/_src/tangent.py",
-]
-
-[tool.ty.overrides.rules]
-missing-argument = "ignore"
-
-# Same cause, different symptom: `type(x)(...)` on an `AbstractDistance`
-# resolves to the abstract base, whose synthesised `__init__` does not carry
-# `check_negative`. `Distance.__init__` does accept it -- verified at runtime.
-[[tool.ty.overrides]]
-include = ["src/coordinax/distances/_src/register_primitives.py"]
-
-[tool.ty.overrides.rules]
-unknown-argument = "ignore"


### PR DESCRIPTION
Follows up my note on #737. Pure `pyproject.toml` deletion — 36 lines, no code change.

#737 added two `[[tool.ty.overrides]]` blocks for the equinox `AbstractVar` problem:
`missing-argument = "ignore"` across six files, and `unknown-argument = "ignore"` in a
seventh. #725 had already fixed that at the root — `rep` became a derived abstract
*property* instead of an `AbstractVar`, so it stopped being counted in the
`dataclass_transform`-synthesised `__init__`.

## Evidence

Checked with exactly the toolchain that produces those errors — quax 0.4.3,
quax-blocks 0.5.0, unxt 2.0.2, jax 0.10.0, ty 0.0.34:

```
$ uv run ty check | grep -cE "missing-argument|unknown-argument"
0
```

on precisely the seven excluded files. Removing both blocks takes the diagnostic count
from **7 to 6**, because the `unknown-argument` override had made the inline
`ty: ignore` in `register_primitives.py:107` redundant — `ty` was reporting it as an
*unused* directive. Without the override it does its job again, which is the clearest
sign the override was covering ground already covered.

The six remaining diagnostics are all pre-existing on `main` and unrelated (two
`possibly-missing-submodule` in curveframes, four `unused-ignore-comment` elsewhere).
I have left them alone to keep this diff to one concern.

## Why it is worth removing rather than leaving

`missing-argument` was switched off entirely in six files, including
`vectors/_src/point.py` and `vectors/_src/tangent.py`. A genuinely missing constructor
argument in any of them would now pass silently — and that is precisely the class of
bug #725 existed to surface.

`ty check` passes.
