### PR TITLE
📝 docs: filenames as inline literals, repo-wide

### DIFF
--- a/packages/coordinaxs.astro/tests/unit/distances/test_distance_kind_contract.py
+++ b/packages/coordinaxs.astro/tests/unit/distances/test_distance_kind_contract.py
@@ -7,7 +7,7 @@ across all three, so they are asserted once here.
 
 What genuinely differs -- Parallax's non-negativity check, DistanceModulus's
 fixed 'mag' unit, and the conversions between them -- stays in
-`test_parallax.py` / `test_distance_modulus.py`.
+``test_parallax.py`` / ``test_distance_modulus.py``.
 """
 
 __all__: tuple[str, ...] = ()

--- a/packages/coordinaxs.curveframes/tests/conftest.py
+++ b/packages/coordinaxs.curveframes/tests/conftest.py
@@ -4,7 +4,7 @@ The Frenet-Serret and Bishop frames are two implementations of
 `AbstractCurveFrameBuilder`, wrapped by `coordinax.transforms.TimeDep`, so
 most of what the suite checks is the *contract* they share rather than anything
 specific to either. The curves and the per-type spec live here so that contract
-can be written once (`test_parallel_transport_contract.py`) and each type's
+can be written once (``test_parallel_transport_contract.py``) and each type's
 closed-form values stay in its own module.
 """
 

--- a/packages/coordinaxs.curveframes/tests/test_bishop.py
+++ b/packages/coordinaxs.curveframes/tests/test_bishop.py
@@ -1,7 +1,7 @@
 """Bishop-specific behaviour: the straight line, tau_0, and the helix.
 
 Structural guarantees shared with Frenet-Serret are asserted once in
-`test_parallel_transport_contract.py`. What is left here is what Bishop does
+``test_parallel_transport_contract.py``. What is left here is what Bishop does
 that Frenet-Serret cannot: stay well-defined on a curve with kappa=0, where the
 Frenet frame is singular -- plus the `tau_0` / `initial_normal` transport
 parameters, which only a parallel-transported frame has.

--- a/packages/coordinaxs.curveframes/tests/test_frenet_serret.py
+++ b/packages/coordinaxs.curveframes/tests/test_frenet_serret.py
@@ -2,7 +2,7 @@
 
 Structural guarantees shared with Bishop -- orthonormality, right-handedness,
 inverse semantics, `act`, `frame_transition`, jit/vmap -- are asserted once in
-`test_parallel_transport_contract.py`. What is left here is what is specific to
+``test_parallel_transport_contract.py``. What is left here is what is specific to
 Frenet-Serret: the actual (T, N, B) values, which Bishop does not share because
 its normals are parallel-transported rather than curvature-derived.
 

--- a/packages/coordinaxs.curveframes/tests/test_parallel_transport_contract.py
+++ b/packages/coordinaxs.curveframes/tests/test_parallel_transport_contract.py
@@ -12,7 +12,7 @@ carries the frame *fields* (``location``, ``tangent``, ...) and the
 `TimeDep` carries the *transform* algebra (``act``, ``inverse``,
 ``evaluate_at``). Both halves are exercised here.
 
-Closed-form values live in `test_frenet_serret.py` / `test_bishop.py`.
+Closed-form values live in ``test_frenet_serret.py`` / ``test_bishop.py``.
 """
 
 __all__: tuple[str, ...] = ()

--- a/packages/coordinaxs.curveframes/tests/unit/test_arclength_byo.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_arclength_byo.py
@@ -1,6 +1,6 @@
 """Bring-your-own curve types through the arc-length machinery.
 
-`test_arclength_shapes.py` covers the four parameterisation shapes built from
+``test_arclength_shapes.py`` covers the four parameterisation shapes built from
 plain functions. This module is the complement: the same shapes, but built
 from a user's own class -- an `equinox.Module` -- rather than a plain
 function. A curve is consumed purely as a callable throughout

--- a/packages/coordinaxs.curveframes/tests/unit/test_arclength_smax.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_arclength_smax.py
@@ -9,7 +9,7 @@ fast path and gradient correctness are independent; the tests are organised
 around that independence, not around `s_max` alone.
 
 Per this codebase's testing standard, every test states what would have to
-break in `_src/arclength.py` for it to fail.
+break in ``_src/arclength.py`` for it to fail.
 
 `s_max=None` is `ArcLength`'s own default, so the no-precompute case is
 parametrised as a value rather than a separate branch.

--- a/packages/coordinaxs.curveframes/tests/unit/test_tubular_chart_hypothesis.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_tubular_chart_hypothesis.py
@@ -69,7 +69,7 @@ def test_component_domains_are_free_for_every_component(chart) -> None:
     of the split.
 
     No `component_domains` overload is registered for `TubularChart`, so it
-    falls through to the generic `AbstractChart` rule at `domains.py:124`:
+    falls through to the generic `AbstractChart` rule at ``domains.py:124``:
     unconstrained (`Interval()`, i.e. `FREE`) for every component. That is the
     sensible answer here, not just the default one: `n1`/`n2`'s legal range is
     the curve's local reach, which depends on curvature at a *point*, not a

--- a/packages/coordinaxs.hypothesis/tests/unit/charts/test_domains.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/charts/test_domains.py
@@ -66,7 +66,7 @@ def test_every_concrete_chart_is_covered() -> None:
     but this package cannot add them to `CHARTS` without depending on the
     satellite package, which is backwards. Each satellite package is
     responsible for its own `component_domains` coverage in its own tests
-    (see `coordinaxs.curveframes`'s `test_tubular_chart_hypothesis.py`).
+    (see `coordinaxs.curveframes`'s ``test_tubular_chart_hypothesis.py``).
     """
     concrete = {
         c.__name__

--- a/packages/coordinaxs.hypothesis/tests/unit/utils/annotations/test_jax_dtypes.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/utils/annotations/test_jax_dtypes.py
@@ -47,7 +47,7 @@ def test_float64_offered_iff_x64() -> None:
 #: Out-of-process: the x64 setting is read once, at JAX import.
 #:
 #: This is the one place `deadline=None` is still written by hand. The
-#: subprocess runs `python -c`, which never loads the root `conftest.py`, so
+#: subprocess runs `python -c`, which never loads the root ``conftest.py``, so
 #: the profile registered there -- the reason no other test needs it -- does
 #: not reach this interpreter.
 _X32_SCRIPT = """

--- a/packages/coordinaxs.interop.astropy/tests/test_ptmap_cdict.py
+++ b/packages/coordinaxs.interop.astropy/tests/test_ptmap_cdict.py
@@ -10,7 +10,7 @@ The chart <-> representation correspondence is the whole of the test:
 * ``lonlat_sph3d`` <-> ``SphericalRepresentation``        (lon, lat, distance)
 
 Only CDict (dict of `unxt.Quantity`) inputs are covered here;
-`coordinax.vectors.Point` <-> Astropy lives in `test_vectors.py`.
+`coordinax.vectors.Point` <-> Astropy lives in ``test_vectors.py``.
 """
 
 __all__: tuple[str, ...] = ()

--- a/packages/coordinaxs.interop.astropy/tests/test_vectors.py
+++ b/packages/coordinaxs.interop.astropy/tests/test_vectors.py
@@ -2,7 +2,7 @@
 
 `Point.cconvert(target)` must agree with Astropy's `represent_as(target)` for
 every supported chart pair; that correspondence is the `CCONVERT_CASES` table.
-CDict-level agreement is covered separately in `test_ptmap_cdict.py`.
+CDict-level agreement is covered separately in ``test_ptmap_cdict.py``.
 """
 
 __all__: tuple[str, ...] = ()

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -351,7 +351,7 @@ def _prolong_slotwise(
 # generic tangent funnel in prolong.py — which recovers time dependence by
 # differentiating the point action — has nothing to differentiate and is
 # provably blind to it (it would silently return the data unchanged). The
-# rules below are the ladder rule that `translate.py` applies to a static
+# rules below are the ladder rule that ``translate.py`` applies to a static
 # fibre offset, re-homed for the `TimeDep` families that now carry all
 # time dependence.
 #

--- a/src/coordinax/transforms/_src/actions/timedep.py
+++ b/src/coordinax/transforms/_src/actions/timedep.py
@@ -97,7 +97,7 @@ class ComposedBuilder(eqx.Module):
 
     That ``|`` fallback is why `simplify` never builds one of these: for a
     fibre offset it yields, at every tau, a `Composed` holding an offset of
-    ladder order >= 1 -- exactly the spelling `add.py` rejects. Only an
+    ladder order >= 1 -- exactly the spelling ``add.py`` rejects. Only an
     EXPLICIT ``a @ b`` gets here, where the caller has asked for pointwise
     composition and owns that constraint.
 
@@ -454,7 +454,7 @@ def _try_matmul(a: Any, b: Any, /) -> AbstractTransform | None:
 
 # NOTE: there is deliberately no `_merge` rule for `TimeDep`. Folding two
 # families into one requires the `ComposedBuilder` `|` fallback, which for a
-# fibre offset materializes a `Composed` that `add.py` rejects -- turning a
+# fibre offset materializes a `Composed` that ``add.py`` rejects -- turning a
 # working pipeline into one that raises. `Composed` already represents the
 # pair correctly; the merge was only ever an optimization. An explicit
 # `a @ b` still composes pointwise: that is the caller asking for it.


### PR DESCRIPTION
Finishes what #742 started in `coordinaxs.curveframes`. A filename is not a Python object, so single backticks ask Sphinx to resolve a reference that cannot exist — and the docs build runs `-n -W` (`noxfile.py:200-202`), where an unresolved reference is an **error**, not a warning.

## Classification

Rather than sweep blind, I walked each file's AST to find which docstring (if any) encloses the line and whether its owner is public. That's the only thing that decides whether Sphinx can reach it:

| count | context | can Sphinx reach it? |
| --- | --- | --- |
| 12 | test files | no — tests aren't autodoc'd |
| 2 | plain `#` comments | no — never parsed as docs |
| 1 | private docstring | not today — `docs/conf.py` sets no `private-members` |
| **1** | **docstring of public `ComposedBuilder`** | **yes — real build risk** |

So exactly one of the seventeen could fail the build today: `src/coordinax/transforms/_src/actions/timedep.py:100`.

## Why sweep the other sixteen anyway

Each is a single token in a comment or docstring, the edit is mechanical, and leaving them means this gets re-flagged one file at a time — it already has been, twice. Cheap uniformity rather than speculative fixing.

Worth noting the risky one was **not** in either file the earlier review rounds pointed at. Eyeballing would have missed it; the classification is what found it.

## Verification

`prek` clean including `ty`.

Two suites could not be run because they fail at collection on `main` as well — `coordinaxs.interop.astropy` and `coordinaxs.astro/tests/unit/distances`. I confirmed that by stashing this change and re-running, so it is pre-existing and unrelated. Everything touched here is a comment or docstring, so no runtime behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)