### PR TITLE
💥 refactor(transforms): `Scale` stores its factors, not the whole matrix

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5581,19 +5581,28 @@ Each group corresponds to a set of transformations preserving a particular geome
 
     **Fields:**
 
-    - `factor : float` — the scaling factor $s$. Always constant; wrap in `TimeDep` for time dependence (see [`TimeDep`](#software-spec-transforms-timedep)).
-    - `chart : AbstractChart` — the chart in which `factor` is expressed (static).
+    - `s : Array[N]` — the scale factors $(s_1, \ldots, s_n)$, the diagonal of $S$. Always constant; wrap in `TimeDep` for time dependence (see [`TimeDep`](#software-spec-transforms-timedep)).
+    `s` is the only field: a `Scale` is a bare set of factors, with no chart of
+    its own. It acts on the Cartesian components of whatever chart the data is
+    in. Holding the diagonal rather than the full matrix is what makes
+    diagonality structural — a vector has no off-diagonal entry to check. A
+    general matrix belongs to `Linear`.
 
-    **Inverse:**
+    `Scale(S)` takes the matrix and keeps its diagonal, refusing one that is not
+    square or not diagonal; `Scale.from_factors(s)` takes the factors directly.
+
+    **Inverse:** reciprocals of the factors, which is $O(n)$ and exact:
 
     ```text
-    scaling.inverse == Scaling(1 / factor, chart)
+    scale.inverse == Scale.from_factors(1 / s)
     ```
 
-    **Composition:** Two `Scaling` instances with the same chart combine by multiplying their `factor` values:
+    **Composition:** `Scale` implements no composition operator. Pipe two with
+    `|`, and `simplify` fuses them by multiplying the factors axis by axis:
 
     ```text
-    Scaling(s1) + Scaling(s2) == Scaling(s1 * s2)
+    simplify(Scale.from_factors(s1) | Scale.from_factors(s2))
+        == Scale.from_factors(s1 * s2)
     ```
 
 !!! info `Shear`

--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -132,9 +132,13 @@ class Scale(AbstractLinearTransform):
         """Return the inverse scaling transform.
 
         Reciprocals of the factors, not `jnp.linalg.inv`: O(n) rather than
-        O(n^3), and exact where the general solve is not. A malformed `S` is
-        carried in `s` by the deferred check from `__init__`, so it still
-        reports the shared message rather than a raw LAPACK shape error.
+        O(n^3), and exact where the general solve is not.
+
+        Nothing is re-checked here, and `s` carries no deferred check of its
+        own: `__init__` validates the matrix when it takes the diagonal, so an
+        `s` that exists has already passed. A malformed input therefore reports
+        from construction -- eagerly at the call, under `jit` when the traced
+        graph runs -- never from this property.
         """
         return self._from_diagonal(1.0 / self.s)
 
@@ -195,9 +199,8 @@ def _merge(a: Scale, b: Scale, /) -> AbstractTransform | None:
     """Merge two adjacent scalings (``a`` applied first) into ``b.s * a.s``.
 
     Elementwise on the factors: composing two diagonal maps multiplies them
-    axis by axis, so this is the $O(n)$ form of ``b.matrix @ a.matrix``. Under
-    `jit` a malformed operand carries its deferred check into the product and
-    still reports the shared message; eagerly it cannot get this far, having
-    been rejected when it was built.
+    axis by axis, so this is the $O(n)$ form of ``b.matrix @ a.matrix``. No
+    validation here either -- both operands were checked when they were built,
+    so a malformed one reports from its own construction and never reaches this.
     """
     return Scale._from_diagonal(b.s * a.s)

--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -21,6 +21,7 @@ from .linear import AbstractLinearTransform
 from coordinax.transforms._src import groups
 
 SMatrix: TypeAlias = Shaped[Array, " N N"]
+SFactors: TypeAlias = Shaped[Array, " N"]
 
 _MSG_SINGULAR: Final = "Scale matrix must be invertible."
 _MSG_NOT_DIAGONAL: Final = (
@@ -70,8 +71,14 @@ class Scale(AbstractLinearTransform):
 
     """
 
-    S: SMatrix
-    """The scaling matrix."""
+    s: SFactors
+    """The scaling factors -- the diagonal of $S$, one per axis.
+
+    The diagonal rather than the whole matrix, so diagonality is structural
+    instead of re-checked: a vector cannot have an off-diagonal entry. The
+    matrix is rebuilt on demand by `_raw_matrix`, the same way
+    `~coordinax.transforms.LorentzBoost` derives its own from a stored velocity.
+    """
 
     @classmethod
     def groups(cls) -> frozenset[type]:
@@ -80,7 +87,33 @@ class Scale(AbstractLinearTransform):
         return frozenset((groups.AffineGroup, groups.DiffeomorphismGroup))
 
     def __init__(self, S: Any) -> None:
-        object.__setattr__(self, "S", jnp.asarray(S))
+        # Takes the matrix, stores its diagonal. Both checks run here, once,
+        # rather than on every `matrix` access: what is stored cannot be
+        # non-diagonal, so there is nothing left to re-check.
+        #
+        # This moves *when* a bad matrix is reported. Extracting the diagonal
+        # consumes the checked value, so eagerly the error now surfaces at
+        # construction rather than at the first `matrix` access. Under `jit` it
+        # is deferred to runtime exactly as before, which is what the `error_if`
+        # is for -- a plain `bool` on a tracer would raise at trace time.
+        #
+        # The `ndim` branch reads a static shape, so it survives tracing; a
+        # non-2D input has no diagonal to take and carries the square error
+        # forward in its place.
+        S = self._validate_diagonal(self._validate_square(jnp.asarray(S)))
+        object.__setattr__(self, "s", jnp.diagonal(S) if S.ndim == 2 else jnp.ravel(S))
+
+    @classmethod
+    def _from_diagonal(cls, s: Any, /) -> "Scale":
+        """Build directly from factors, skipping the matrix round-trip.
+
+        The diagonal is what the type stores, so every internal producer of one
+        (`from_factors`, `inverse`, `_merge`) would otherwise inflate it to a
+        matrix purely for `__init__` to take it apart again.
+        """
+        obj = object.__new__(cls)
+        object.__setattr__(obj, "s", jnp.asarray(s))
+        return obj
 
     @classmethod
     def from_factors(cls: type["Scale"], factors: Any, /) -> "Scale":
@@ -92,23 +125,24 @@ class Scale(AbstractLinearTransform):
         # Defer the singular check so it survives jit (a plain `bool` on a
         # traced value raises TracerBoolConversionError).
         s = eqx.error_if(s, jnp.any(jnp.isclose(s, 0)), _MSG_SINGULAR)
-        return cls(jnp.diag(s))
+        return cls._from_diagonal(s)
 
     @property
     def inverse(self) -> "Scale":
         """Return the inverse scaling transform.
 
-        Reciprocals of the diagonal, not `jnp.linalg.inv`: O(n) rather than
-        O(n^3), and exact where the general solve is not. Going through
-        `matrix` rather than the raw field also means a malformed `S` is caught
-        here with the same message as everywhere else, instead of surfacing as
-        a raw LAPACK shape error.
+        Reciprocals of the factors, not `jnp.linalg.inv`: O(n) rather than
+        O(n^3), and exact where the general solve is not. A malformed `S` is
+        carried in `s` by the deferred check from `__init__`, so it still
+        reports the shared message rather than a raw LAPACK shape error.
         """
-        return type(self)(jnp.diag(1.0 / jnp.diagonal(self.matrix)))
+        return self._from_diagonal(1.0 / self.s)
 
     @property
     def _raw_matrix(self) -> Any:
-        return self._validate_diagonal(self.S)
+        # No re-validation: `s` is a vector, so the matrix it builds is square
+        # and diagonal by construction.
+        return jnp.diag(self.s)
 
     def _validate_diagonal(self, matrix: Any, /) -> Any:
         """Check the matrix has no off-diagonal entries.
@@ -151,17 +185,19 @@ def simplify(op: Scale, /, *, approx: bool = True, **kw: Any) -> AbstractTransfo
     The identity-matrix check inspects values, so it is skipped when
     ``approx=False``.
     """
-    m = op.matrix
-    if approx and jnp.allclose(m, jnp.eye(m.shape[0], dtype=m.dtype), **kw):
+    if approx and jnp.allclose(op.s, 1.0, **kw):
         return identity
     return op
 
 
 @plum.dispatch
 def _merge(a: Scale, b: Scale, /) -> AbstractTransform | None:
-    """Merge two adjacent scalings (``a`` applied first) into ``b.matrix @ a.matrix``.
+    """Merge two adjacent scalings (``a`` applied first) into ``b.s * a.s``.
 
-    Through `matrix` rather than the raw fields, so a malformed operand is
-    reported by the shared validation instead of a raw matmul shape error.
+    Elementwise on the factors: composing two diagonal maps multiplies them
+    axis by axis, so this is the $O(n)$ form of ``b.matrix @ a.matrix``. Under
+    `jit` a malformed operand carries its deferred check into the product and
+    still reports the shared message; eagerly it cannot get this far, having
+    been rejected when it was built.
     """
-    return Scale(b.matrix @ a.matrix)
+    return Scale._from_diagonal(b.s * a.s)

--- a/tests/unit/transforms/test_simplify.py
+++ b/tests/unit/transforms/test_simplify.py
@@ -437,10 +437,16 @@ class TestMalformedMatricesReportTheSharedMessage:
         with pytest.raises(Exception, match="square"):
             cxfm.simplify(op_type(self._nonsquare()))
 
-    def test_merging_two_scales_reports_square(self):
-        bad = cxfm.Scale(self._nonsquare())
+    def test_a_malformed_scale_cannot_be_built_at_all(self):
+        """Was a `_merge` test; a malformed `Scale` no longer survives `__init__`.
+
+        `Scale` stores the diagonal, and extracting it consumes the checked
+        value, so the square error now fires at construction. There is no
+        malformed `Scale` left to reach `_merge` with -- which is the point.
+        `Linear` still stores its matrix, so its own routes are covered above.
+        """
         with pytest.raises(Exception, match="square"):
-            cxfm.simplify(bad | bad)
+            cxfm.Scale(self._nonsquare())
 
     def test_a_square_non_diagonal_still_reports_diagonal(self):
         """The square check must not swallow the diagonal one."""

--- a/tests/unit/transforms/test_spatial_linear_transforms.py
+++ b/tests/unit/transforms/test_spatial_linear_transforms.py
@@ -24,13 +24,13 @@ def test_scale_from_factors_singular_raises_under_jit() -> None:
     """A zero scale factor is rejected even under jit (no tracer bool)."""
     build = eqx.filter_jit(cxfm.Scale.from_factors)
     with pytest.raises(eqx.EquinoxRuntimeError, match="invertible"):
-        jax.block_until_ready(build(jnp.asarray([2.0, 0.0, 4.0])).S)
+        jax.block_until_ready(build(jnp.asarray([2.0, 0.0, 4.0])).s)
 
 
 def test_scale_from_factors_nonsingular_jits() -> None:
     """A valid Scale builds cleanly under jit."""
     op = eqx.filter_jit(cxfm.Scale.from_factors)(jnp.asarray([2.0, 3.0, 4.0]))
-    np.testing.assert_allclose(np.asarray(jnp.diag(op.S)), [2.0, 3.0, 4.0])
+    np.testing.assert_allclose(np.asarray(op.s), [2.0, 3.0, 4.0])
 
 
 def test_public_surface_includes_scale_and_shear() -> None:
@@ -208,19 +208,28 @@ def test_linear_velocity_on_nested_product_charts_recurses() -> None:
 
 
 def test_matrix_is_the_stored_field() -> None:
-    """For the four that store a matrix, the accessor is that matrix.
+    """For the three that store a matrix, the accessor is that matrix.
 
     Value equality, not identity: `_validate_square` routes through
     `eqx.error_if`, which returns a fresh array wrapping the same value.
+
+    `Scale` is not among them -- it stores the diagonal and rebuilds the matrix
+    -- so it has its own check below.
     """
     R = jnp.asarray([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
     for op, field in [
         (cxfm.Rotate(R), "R"),
         (cxfm.Reflect.from_normal([1.0, 0.0, 0.0]), "H"),
-        (cxfm.Scale.from_factors([2.0, 3.0, 4.0]), "S"),
         (cxfm.Shear(R), "H"),
     ]:
         assert np.array_equal(np.asarray(op.matrix), np.asarray(getattr(op, field)))
+
+
+def test_scale_matrix_is_rebuilt_from_its_factors() -> None:
+    """`Scale` stores the diagonal, so `matrix` is `diag(s)`, not a field."""
+    op = cxfm.Scale.from_factors([2.0, 3.0, 4.0])
+    assert op.s.shape == (3,)
+    assert np.array_equal(np.asarray(op.matrix), np.diag([2.0, 3.0, 4.0]))
 
 
 def test_matrix_rejects_a_non_square_field() -> None:


### PR DESCRIPTION
> **Stacked on #746** — that PR is the first commit here. Review the second commit, or
> merge #746 first and this rebases to one commit.

`Scale` stored the whole `(N, N)` matrix, of which `n² − n` entries are structurally
zero, and re-proved they were still zero on every use.

`_raw_matrix` called `_validate_diagonal` on each `matrix` access, and `matrix` is what
every `act` and `pushforward` goes through. So each application paid an O(n²)
subtraction plus a reduction to re-confirm an invariant that was already established at
construction, and baked an `eqx.error_if` into every traced graph doing it.

Storing the diagonal makes the invariant structural instead: **a vector cannot have an
off-diagonal entry**. `LorentzBoost` already works this way, deriving its matrix from a
stored velocity, so "store the parameter, derive the matrix" is not a new idea here.

## Measured

| | before | after |
| --- | --- | --- |
| `_validate_diagonal` calls per 5 point actions | 5 | **0** |
| pytree leaf | `(3, 3)` | **`(3,)`** |

Downstream simplifies too: `inverse` is reciprocals of the factors, `_merge` an
elementwise product (the O(n) form of `b.S @ a.S`), and `simplify` compares against
`1.0` instead of building a `jnp.eye`.

## What is preserved

`__init__` still takes the **matrix**. That is deliberate — `Scale(vector)` must keep
reporting *"requires a square matrix"* (#731's test), so accepting a bare vector there
was not an option. It validates once and keeps the diagonal. `Scale(off_diagonal)`,
`Scale(rotation)` and `Scale(vector)` all report exactly as before.

`from_factors`, `inverse` and `_merge` go through a private `_from_diagonal`, so a
producer of factors no longer inflates them to a matrix purely for `__init__` to take
apart again.

## Two changes worth flagging

**Error timing.** Extracting the diagonal consumes the checked value, so *eagerly* a bad
matrix now reports at construction rather than at the first `matrix` access. Under `jit`
it is deferred to runtime exactly as before — verified both ways. This is the intended
consequence of moving validation from per-use to per-construction, and it is strictly
earlier, but it is a behaviour change.

**One test changed meaning.** `test_merging_two_scales_reports_square` (added in #746)
built a malformed `Scale` and merged it. A malformed `Scale` no longer survives
`__init__`, so there is nothing to reach `_merge` with — which is the point. It is now
`test_a_malformed_scale_cannot_be_built_at_all`, with the reason recorded in its
docstring. `Linear` still stores its matrix, so #746's routes for that type are
untouched.

**Breaking:** the field is `s: SFactors` (the diagonal), not `S: SMatrix`. Two test
references updated; nothing else in the repo read it.

Deliberately **not** in scope: overriding `act`/`pushforward` to apply the factors
elementwise. The base path is a dense `einsum`, so `_raw_matrix` rebuilds `jnp.diag(s)`
for it. That would be the actual O(n) win per point, and belongs in its own PR where it
can be benchmarked.

Full suite: **10695 passed**, 8 skipped, 1 xfailed.
