### PR TITLE
🐛 fix(curveframes): a builder reads the curve it is given, not the wrapper's signature

### DIFF
--- a/packages/coordinaxs.curveframes/docs/guide.md
+++ b/packages/coordinaxs.curveframes/docs/guide.md
@@ -453,6 +453,49 @@ bt_circle = cxfc.BishopBuilder(arc_circle, "km")
 bt_circle.tangent(u.Q(1.0, "km"))
 ```
 
+### A Station on a Curve That Moves
+
+When the wrapped curve is time-dependent, `gamma(s, t)`, the builder's call-time parameter becomes the **time**, and `station` fixes where along the curve the frame sits. Which wrapper you reach for decides what "where" means:
+
+```python
+def stretching(s, t):
+    """A curve that stretches and bends as t grows."""
+    sv, tv = s.ustrip("km"), t.ustrip("s")
+    return u.Q(
+        jnp.stack([sv * (1 + 0.5 * tv), 0.1 * tv * sv**2, jnp.zeros_like(sv)]), "km"
+    )
+
+
+s0 = u.Q(1.3, "km")
+
+# Eulerian: a fixed *arc length* along whatever the curve is now
+eulerian = cxfc.BishopBuilder(cxfc.ArcLength(stretching, "km"), "km", station=s0)
+
+# Lagrangian: the material point that was at s0 on the reference slice
+material = cxfc.BishopBuilder(
+    cxfc.LagrangianArcLength(stretching, u.Q(0.0, "s"), "km"), "km", station=s0
+)
+```
+
+On a curve that stretches, the two separate. The Eulerian station stays put — it is defined by arc length, which is re-measured on each slice — while the material one is carried outwards with the curve:
+
+| t   | Eulerian distance from origin | Lagrangian |
+| --- | ----------------------------- | ---------- |
+| 0.0 | 1.300                         | 1.300      |
+| 0.8 | 1.299                         | 1.825      |
+| 1.7 | 1.299                         | 2.422      |
+
+```python
+def radius(b, t_val):
+    return float(jnp.linalg.norm(b.location(u.Q(t_val, "s")).ustrip("km")))
+
+
+assert abs(radius(eulerian, 1.7) - 1.3) < 0.01  # Eulerian holds its arc length
+assert radius(material, 1.7) > 2.0  # the material point is carried out
+```
+
+They coincide at `t = 0` only because that is the reference slice. A rigid motion cannot tell them apart; a stretching one can, which is why it is the honest test.
+
 For the different shapes an arc-length curve can arrive in — including a user's own class parametrised by time, by arc length, as a two-argument combo, or backed by sampled data — see {doc}`the BYO curve tutorial <byo_curve>`. For the Eulerian/Lagrangian distinction for time-dependent curves and a stitching pitfall, see {ref}`Working With Curve Charts <arc-length-reparametrisation>`'s _Arc-Length Reparametrisation_ section.
 
 ## Design Notes

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -25,7 +25,7 @@ __all__ = ("ArcLength", "LagrangianArcLength")
 import inspect
 
 from collections.abc import Callable
-from typing import Any, cast, final
+from typing import Any, ClassVar, cast, final
 
 import diffrax as dfx
 import equinox as eqx
@@ -600,6 +600,12 @@ class ArcLength(eqx.Module):
     one-argument ``curve``; see the class docstring.
     """
 
+    #: Dimension of the parameter this wrapper *exposes*. Reparametrising by
+    #: arc length makes it a length, whatever the wrapped curve was
+    #: parametrised by -- so a builder over this can check its `tau_unit`
+    #: against it at construction rather than failing later (#718).
+    _param_dimension: ClassVar[str] = "length"
+
     _two_argument: bool = eqx.field(static=True)
     """Whether ``curve`` takes ``(tau, t)`` rather than just ``tau``.
 
@@ -760,6 +766,10 @@ class LagrangianArcLength(eqx.Module):
     Q([1.5, 0. , 0. ], 'km')
 
     """
+
+    #: Same as `ArcLength`: the exposed parameter is an arc length, though
+    #: measured on the fixed reference slice `t0` rather than the current one.
+    _param_dimension: ClassVar[str] = "length"
 
     curve: Callable[[Any, Any], Any]
     """The wrapped, two-argument curve."""

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -418,9 +418,18 @@ _MSG_S_MAX_TWO_ARGUMENT = (
 def _is_two_argument(curve: Callable[..., Any], /) -> bool:
     """Report whether ``curve`` takes ``(tau, t)`` rather than just ``(tau)``.
 
-    The question is what the *call* accepts, so the second parameter must be
-    both **positional** and **required**. Weakening either half misreads
-    ordinary signatures:
+    A wrapper that *knows* its own arity is asked first, via a
+    ``_two_argument`` attribute. `ArcLength` defaults ``t`` in its
+    ``__call__`` so that a wrapped one-argument curve can still be called
+    ``arc(s)`` -- convenient, but it makes the signature describe the
+    wrapper rather than what it wraps, and a builder consulting that
+    signature concludes "one-argument" for a wrapper that genuinely needs a
+    time. `AtTime` needs no such attribute: it binds the time, so being
+    one-argument is the truth about it (see #748).
+
+    Otherwise the signature is read. The question is then what the *call*
+    accepts, so the second parameter must be both **positional** and
+    **required**. Weakening either half misreads ordinary signatures:
 
     ============================  ====================  ==================
     signature                     ``curve(tau)`` works  reading
@@ -447,6 +456,10 @@ def _is_two_argument(curve: Callable[..., Any], /) -> bool:
     an ambiguous one, so it raises here with its own message instead of being
     forced into a reading that cannot work.
     """
+    declared = getattr(curve, "_two_argument", None)
+    if isinstance(declared, bool):
+        return declared
+
     try:
         params = list(inspect.signature(curve).parameters.values())
     except (TypeError, ValueError) as e:

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/attime.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/attime.py
@@ -67,6 +67,17 @@ class AtTime(eqx.Module):
         self.t = t
 
     @property
+    def _param_dimension(self) -> str | None:
+        """Forward what the wrapped curve exposes, if it says.
+
+        Binding the time changes the arity, not the dimension of the
+        remaining parameter: `AtTime(ArcLength(curve), t)` still exposes an
+        arc length. A builder checks this against its `tau_unit`, so
+        forwarding is what lets that check see through the wrapper.
+        """
+        return getattr(self.curve, "_param_dimension", None)
+
+    @property
     def curve(self) -> Callable[[Any, Any], Any]:
         """The wrapped, time-dependent curve, reassembled from its two halves."""
         return eqx.combine(self._curve_dynamic, self._curve_static)

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -172,11 +172,16 @@ class AbstractCurveFrameBuilder(eqx.Module):
             raise ValueError(_MSG_TWO_ARGUMENT_NEEDS_STATION)
 
         # A curve that knows what it exposes is checked against `tau_unit`
-        # here, where the mistake is, rather than leaving it to surface
-        # unevenly later: `location` ignores `tau_unit` entirely and returns
-        # correct positions, while the autodiff paths raise a conversion
-        # error far from the construction that caused it (#718).
-        want = getattr(type(self.curve), "_param_dimension", None)
+        # here, where the mistake is, rather than left to surface unevenly
+        # later: `location` ignores `tau_unit` and returns correct positions,
+        # while the autodiff paths raise a conversion error far from the
+        # construction that caused it (#718).
+        #
+        # Read from the *instance*, not the type, so a wrapper can forward
+        # what it wraps -- `AtTime(ArcLength(...), t)` still exposes a
+        # length, and that is the composition the docs recommend, so it is
+        # the one most worth catching.
+        want = getattr(self.curve, "_param_dimension", None)
         if want is not None:
             got = str(u.dimension_of(self.tau_unit))
             if got != want:

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -44,6 +44,16 @@ FrameT = TypeVar(
 #: Hence the explicit TypeVar, and the `noqa` at the signature.
 BuilderT = TypeVar("BuilderT", bound="AbstractCurveFrameBuilder")
 
+_MSG_TAU_UNIT_DIMENSION = (
+    "this curve exposes a parameter of dimension {want}, but `tau_unit` is "
+    "{unit!r}, which is {got}. `tau_unit` defaults to 's', so this is usually "
+    "a forgotten argument: a builder over an arc-length curve needs a length, "
+    "e.g. `BishopBuilder(ArcLength(curve, 'km'), 'km')`. Left as-is, "
+    "`location` would still return correct positions -- it never consults the "
+    "unit -- while `tangent` and `rotation_matrix` would fail later inside "
+    "the derivative."
+)
+
 _MSG_TWO_ARGUMENT_NEEDS_STATION = (
     "this curve takes two positional arguments, `gamma(tau, t)`, so the "
     "builder's call-time parameter is the time `t` and the station along the "
@@ -160,6 +170,21 @@ class AbstractCurveFrameBuilder(eqx.Module):
         """
         if _is_two_argument(self.curve) and self.station is None:
             raise ValueError(_MSG_TWO_ARGUMENT_NEEDS_STATION)
+
+        # A curve that knows what it exposes is checked against `tau_unit`
+        # here, where the mistake is, rather than leaving it to surface
+        # unevenly later: `location` ignores `tau_unit` entirely and returns
+        # correct positions, while the autodiff paths raise a conversion
+        # error far from the construction that caused it (#718).
+        want = getattr(type(self.curve), "_param_dimension", None)
+        if want is not None:
+            got = str(u.dimension_of(self.tau_unit))
+            if got != want:
+                raise ValueError(
+                    _MSG_TAU_UNIT_DIMENSION.format(
+                        want=want, unit=str(self.tau_unit), got=got
+                    )
+                )
 
     def _resolve(  # noqa: PYI019  (see BuilderT: `Self` breaks beartype)
         self: BuilderT, tau: Any, /

--- a/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
@@ -24,6 +24,7 @@ second one is required.
 
 import functools as ft
 
+import astropy.units as apyu
 import jax
 import jax.numpy as jnp
 import pytest
@@ -305,7 +306,7 @@ def test_the_wrong_unit_is_only_half_visible_when_unguarded() -> None:
     got = b.location(s_val).ustrip("km")
     assert jnp.allclose(got, jnp.array([1.0, 0.0, 0.0])), got
 
-    with pytest.raises(Exception, match="not convertible"):
+    with pytest.raises(apyu.UnitConversionError, match="not convertible"):
         b.tangent(s_val)
 
 
@@ -313,3 +314,22 @@ def test_a_plain_curve_keeps_the_default() -> None:
     """No breaking change: a curve that advertises nothing is unconstrained."""
     assert str(cxfc.BishopBuilder(curve1).tau_unit) == "s"
     cxfc.BishopBuilder(curve1, "km")  # and an unusual unit is still allowed
+
+
+def test_a_wrapper_forwards_the_dimension_it_wraps() -> None:
+    """`AtTime(ArcLength(curve), t)` still exposes an arc length.
+
+    Binding the time changes the arity, not the dimension of the remaining
+    parameter. Reading `_param_dimension` off the *type* missed this, so the
+    guard did not fire and `tangent` failed later with a conversion error --
+    and this is the composition the docs recommend as the remedy for a
+    two-argument curve, so it is the one most worth catching.
+    """
+    frozen = cxfc.AtTime(cxfc.ArcLength(curve2, "km"), u.Q(0.5, "s"))
+    assert frozen._param_dimension == "length"
+    with pytest.raises(ValueError, match="dimension length"):
+        cxfc.BishopBuilder(frozen, "s")
+    cxfc.BishopBuilder(frozen, "km")  # correct unit is unaffected
+
+    # A wrapper over a curve that claims nothing must claim nothing itself.
+    assert cxfc.AtTime(curve2, u.Q(0.5, "s"))._param_dimension is None

--- a/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
@@ -261,3 +261,55 @@ def test_eulerian_holds_arc_length_where_lagrangian_follows_the_material_point()
     # then they separate: the Eulerian one stays put, the Lagrangian one does not
     assert abs(radius(eul, 1.7) - 1.3) < 0.01, radius(eul, 1.7)
     assert radius(lag, 1.7) > 2.0, radius(lag, 1.7)
+
+
+# --------------------------------------------------------------------------
+# #718: a curve that knows what it exposes is checked against `tau_unit` at
+# construction, rather than failing unevenly later.
+
+
+def test_tau_unit_must_match_the_dimension_the_curve_exposes() -> None:
+    """`BishopBuilder(ArcLength(curve, "km"))` -- forgetting the second unit.
+
+    `tau_unit` defaults to "s", so this is an easy omission, and it used to
+    construct happily.
+    """
+    arc = cxfc.ArcLength(curve1, "s")  # exposes arc length: a *length*
+    with pytest.raises(ValueError, match="dimension length"):
+        cxfc.BishopBuilder(arc)
+    with pytest.raises(ValueError, match="dimension length"):
+        cxfc.FrenetSerretBuilder(arc)
+    cxfc.BishopBuilder(arc, "km")  # correct, and still fine
+
+
+def test_the_wrong_unit_is_only_half_visible_when_unguarded() -> None:
+    """Why this is checked at construction, and what the guard does not reach.
+
+    With the wrong `tau_unit`, `location` returns *correct* positions -- it
+    never consults the unit -- while the autodiff paths raise. Anyone who
+    sanity-checks positions first would conclude it works.
+
+    A plain function cannot advertise what it exposes, so a length-parametrised
+    one still slips through with the default "s". That is the residual case the
+    `_param_dimension` guard does not cover; the wrappers do advertise, which
+    is where the mistake is easiest to make.
+    """
+
+    def by_length(tau: u.AbstractQuantity) -> u.AbstractQuantity:
+        d = tau.ustrip("km")
+        return u.Q(jnp.stack([d, jnp.zeros_like(d), jnp.zeros_like(d)]), "km")
+
+    b = cxfc.BishopBuilder(by_length)  # default "s", but the curve wants a length
+    s_val = u.Q(1.0, "km")
+
+    got = b.location(s_val).ustrip("km")
+    assert jnp.allclose(got, jnp.array([1.0, 0.0, 0.0])), got
+
+    with pytest.raises(Exception, match="not convertible"):
+        b.tangent(s_val)
+
+
+def test_a_plain_curve_keeps_the_default() -> None:
+    """No breaking change: a curve that advertises nothing is unconstrained."""
+    assert str(cxfc.BishopBuilder(curve1).tau_unit) == "s"
+    cxfc.BishopBuilder(curve1, "km")  # and an unusual unit is still allowed

--- a/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
@@ -31,6 +31,7 @@ import pytest
 import unxt as u
 
 import coordinaxs.curveframes as cxfc
+from coordinaxs.curveframes._src.arclength import _is_two_argument
 
 
 def curve1(tau: u.AbstractQuantity) -> u.AbstractQuantity:
@@ -195,3 +196,68 @@ def test_a_partial_frozen_time_is_still_one_argument() -> None:
     """`ft.partial` leaves the bound parameter visible, with a default."""
     frozen = ft.partial(curve2, t=u.Q(0.5, "s"))
     cxfc.BishopBuilder(frozen, "km")
+
+
+# --------------------------------------------------------------------------
+# #748: a wrapper reports the arity of what it wraps, not of its own
+# convenience signature.
+
+
+def test_arclength_reports_the_arity_of_the_curve_it_wraps() -> None:
+    """`ArcLength.__call__` defaults ``t``; that is about the wrapper, not the curve.
+
+    Reading the signature concluded "one-argument" for a wrapper that
+    genuinely needs a time, so a builder called ``arc(station)`` and
+    `ArcLength` raised. Fails if `_is_two_argument` goes back to inspecting
+    the wrapper's own signature.
+    """
+    assert _is_two_argument(cxfc.ArcLength(curve2, "km")) is True
+    assert _is_two_argument(cxfc.ArcLength(curve1, "s")) is False
+    # `AtTime` binds the time, so one-argument is the truth about it.
+    assert _is_two_argument(cxfc.AtTime(curve2, u.Q(0.5, "s"))) is False
+
+
+def test_the_eulerian_station_composes_into_a_builder() -> None:
+    """The composition the docs promise: a frame at a fixed *arc length*.
+
+    This raised `TypeError: ... must be called as arc(s, t)` before #748.
+    """
+    s0 = u.Q(1.3, "km")
+    b = cxfc.BishopBuilder(cxfc.ArcLength(curve2, "km"), "km", station=s0)
+
+    # at t = 0 the curve is the straight line (s, 0, 0), so arc length 1.3
+    # lands exactly on x = 1.3.
+    got = b.location(u.Q(0.0, "s")).ustrip("km")
+    assert jnp.allclose(got, jnp.array([1.3, 0.0, 0.0]), atol=1e-8), got
+
+    # and the frame evolves with t rather than being pinned at construction
+    t0 = b.tangent(u.Q(0.0, "s")).ustrip("")
+    t1 = b.tangent(u.Q(1.7, "s")).ustrip("")
+    assert float(jnp.linalg.norm(t1 - t0)) > 0.1, (t0, t1)
+
+
+def test_eulerian_holds_arc_length_where_lagrangian_follows_the_material_point() -> (
+    None
+):
+    """The physical distinction, on a curve that genuinely stretches.
+
+    An Eulerian station sits at a fixed arc length, so its distance from the
+    origin barely moves; a Lagrangian one keeps its material label and is
+    carried outwards. Fails if the two wrappers are conflated -- which a
+    rigid motion could not detect.
+    """
+    s0 = u.Q(1.3, "km")
+    eul = cxfc.BishopBuilder(cxfc.ArcLength(curve2, "km"), "km", station=s0)
+    lag = cxfc.BishopBuilder(
+        cxfc.LagrangianArcLength(curve2, u.Q(0.0, "s"), "km"), "km", station=s0
+    )
+
+    def radius(b, t_val: float) -> float:
+        return float(jnp.linalg.norm(b.location(u.Q(t_val, "s")).ustrip("km")))
+
+    # both start at the same place, since t0 = 0 is the reference slice
+    assert abs(radius(eul, 0.0) - radius(lag, 0.0)) < 1e-8
+
+    # then they separate: the Eulerian one stays put, the Lagrangian one does not
+    assert abs(radius(eul, 1.7) - 1.3) < 0.01, radius(eul, 1.7)
+    assert radius(lag, 1.7) > 2.0, radius(lag, 1.7)


### PR DESCRIPTION
Two fixes to how a builder reads the curve it is given. Closes #748; addresses the detectable half of #718.

## 1. A wrapper reports the arity of the curve it wraps (#748)

`BishopBuilder(ArcLength(curve2, "km"), "km", station=s0)` — the **Eulerian station**, a frame at a fixed arc length along a curve that is itself moving — raised `TypeError: ... must be called as arc(s, t)`.

`_is_two_argument` read signatures, and `ArcLength.__call__` defaults `t` so a wrapped *one*-argument curve can still be called `arc(s)`. Convenient, but the signature then describes the wrapper rather than what it wraps: the builder concluded "one-argument", called `arc(station)`, and `ArcLength` raised because the wrapped curve still needed a time.

The asymmetry was the tell — the Lagrangian composition worked only because `LagrangianArcLength` happens to require `t`.

`_is_two_argument` now asks for a `_two_argument` attribute first, which `ArcLength` already computed at construction. `AtTime` needs no attribute: it binds the time, so one-argument is the truth about it.

The physics this unlocks, at station 1.3 km on a stretching curve:

| t | Eulerian \|x\| | Lagrangian \|x\| |
| --- | --- | --- |
| 0.0 | 1.300 | 1.300 |
| 0.8 | **1.299** | 1.825 |
| 1.7 | **1.299** | 2.422 |

The Eulerian station holds its arc length because arc length is re-measured on each slice; the material point is carried outwards. They agree at `t = 0` only because that is the reference slice — and a rigid motion could not separate them at all, which is why the test uses a stretching one.

## 2. `tau_unit` is checked against what the curve exposes (#718)

`BishopBuilder(ArcLength(curve, "km"))` — forgetting the second unit — constructed happily, and the failure was not merely late but **half-silent**:

| call | correct `tau_unit="km"` | default `tau_unit="s"` |
| --- | --- | --- |
| `.location(s)` | `[0.575, 0.818, 0.287]` | **identical** |
| `.tangent(s)` | `[-0.783, 0.551, 0.287]` | `UnitConversionError` |

`location` never consults `tau_unit`, so positions come back correct; only the autodiff paths raise. Anyone who sanity-checks positions first concludes it works.

`ArcLength` and `LagrangianArcLength` now advertise `_param_dimension = "length"`, and `__check_init__` compares it against `dimension_of(tau_unit)`.

This costs none of the three things #718 weighs against changing this — the `"s"` default stands, no existing call site moves, and it is a static comparison rather than the construction-time curve call the issue sketches (one such call is an ODE solve for an `ArcLength` curve).

**It does not cover a plain function**, which cannot advertise anything: a length-parametrised bare function still takes the default and keeps the behaviour above. A test pins that residual case rather than implying it is closed. Closing #718 fully needs the breaking change — dropping the `"s"` default — which is worth doing on its own, since seconds are not a neutral default outside SI-flavoured domains.

## Docs

The guide gains the section this composition never had. It existed only in a design note, which is part of why the gap survived to merge. Its example defines its curve and **asserts** the table above rather than printing it — guide code fences are executed, which I had wrongly assumed they were not.

## Verification

Each guard mutation-tested: neutering it fails exactly the tests that target it, and no others.

- 962 curveframes tests pass
- clean `rm -rf docs/_build && nox -s docs`, no warnings
- `prek` clean including `ty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
