### PR TITLE
🐛 fix(transforms): `Rotate` and `RotationAboutAxis` coerce their array fields

### DIFF
--- a/src/coordinax/transforms/_src/actions/builders.py
+++ b/src/coordinax/transforms/_src/actions/builders.py
@@ -18,6 +18,21 @@ from .translate import Translate
 _MSG_ZERO_AXIS = "`RotationAboutAxis.axis` must be non-zero; got a zero-length axis."
 
 
+def _as_axis(axis: Any, /) -> Shaped[Array, "3"]:
+    """Normalise ``axis`` to a bare array, keeping any unit's *direction*.
+
+    ``jnp`` here is `quaxed.numpy`, whose `asarray` hands a `~unxt.Quantity`
+    back unchanged, so it cannot be used to coerce one.
+
+    Unlike a rotation matrix or a boost's beta, the axis is normalised on use:
+    ``[0, 0, 2] m`` and ``[0, 0, 1]`` name the same rotation, so the unit
+    cancels exactly and stripping it is lossless rather than a silent drop.
+    """
+    if isinstance(axis, u.AbstractQuantity):
+        axis = u.ustrip(u.unit_of(axis), axis)
+    return jnp.asarray(axis)
+
+
 @final
 class RotationAboutAxis(eqx.Module):
     r"""Uniform rotation about a fixed axis: :math:`\theta(\tau) = \omega \tau + \phi`.
@@ -53,7 +68,7 @@ class RotationAboutAxis(eqx.Module):
     """
 
     omega: u.AbstractQuantity
-    axis: Shaped[Array, "3"]
+    axis: Shaped[Array, "3"] = eqx.field(converter=_as_axis)
     phase: u.AbstractQuantity = u.Q(0.0, "rad")
 
     def __call__(self, tau: Any, /) -> Rotate:

--- a/src/coordinax/transforms/_src/actions/builders.py
+++ b/src/coordinax/transforms/_src/actions/builders.py
@@ -29,7 +29,7 @@ def _as_axis(axis: Any, /) -> Shaped[Array, "3"]:
     cancels exactly and stripping it is lossless rather than a silent drop.
     """
     if isinstance(axis, u.AbstractQuantity):
-        axis = u.ustrip(u.unit_of(axis), axis)
+        axis = axis.value
     return jnp.asarray(axis)
 
 

--- a/src/coordinax/transforms/_src/actions/rotate.py
+++ b/src/coordinax/transforms/_src/actions/rotate.py
@@ -8,8 +8,10 @@ from dataclasses import replace
 from jaxtyping import Array, Shaped
 from typing import Any, final
 
+import equinox as eqx
 import jax.scipy.spatial.transform as jtransform
 import plum
+from astropy.units import UnitConversionError
 from jax.typing import ArrayLike
 
 import quaxed.numpy as jnp
@@ -24,6 +26,33 @@ from .identity import identity
 from .linear import AbstractLinearTransform
 from coordinax.internal import pack_uniform_unit
 from coordinax.transforms._src import groups
+
+
+def _as_rotation_matrix(R: Any, /) -> Array:
+    """Normalise ``R`` to a bare array, requiring it to be dimensionless.
+
+    ``jnp`` here is `quaxed.numpy`, whose `asarray` is unit-aware and hands a
+    `~unxt.Quantity` back unchanged, so it cannot be used to coerce one.
+
+    A rotation matrix preserves lengths, so its entries are ratios: a
+    dimensionless quantity is stripped and anything else refused.
+
+    The return stays `Array`, not ``Shaped[Array, " N N"]`` -- jaxtyping
+    enforces annotations, and requiring squareness here would preempt
+    `_validate_square` and its clearer message.
+    """
+    if isinstance(R, u.AbstractQuantity):
+        try:
+            R = u.ustrip("", R)
+        except UnitConversionError as e:
+            # `UnitConversionError` is already a `ValueError`, so a bare
+            # `raise` loses no caller; its message already names the units.
+            e.add_note(
+                "Rotate `R` is a rotation matrix, whose entries are ratios and "
+                "so dimensionless."
+            )
+            raise
+    return jnp.asarray(R)
 
 
 @final
@@ -129,7 +158,7 @@ class Rotate(AbstractLinearTransform):
 
     """
 
-    R: Shaped[Array, " N N"]
+    R: Shaped[Array, " N N"] = eqx.field(converter=_as_rotation_matrix)
     """The rotation matrix."""
 
     @classmethod
@@ -245,10 +274,10 @@ class Rotate(AbstractLinearTransform):
 
         >>> op3 = op1 @ op2
         >>> op3
-        Rotate(Q(f64[3,3], ''))
+        Rotate(f64[3,3](jax))
 
         >>> jnp.allclose(op3.R, op2.R @ op1.R)
-        Q(True, '')
+        Array(True, dtype=bool)
 
         """
         if not isinstance(other, Rotate):

--- a/tests/unit/transforms/test_builders.py
+++ b/tests/unit/transforms/test_builders.py
@@ -93,11 +93,9 @@ def test_rotation_about_axis_zero_axis_raises():
 class TestAxisAcceptsQuantity:
     """`axis` is normalised on use, so a unit on it cancels exactly.
 
-    Regression: the field is annotated `Shaped[Array, "3"]` but had no
-    converter, and `jnp` in this module is `quaxed.numpy`, whose `asarray`
-    returns a `Quantity` unchanged. A `Quantity` axis was therefore stored as
-    one, and `__call__` failed with `TypeError: Error interpreting argument to
-    unvmap_any as a JAX value` -- naming nothing the caller had written.
+    Regression: no converter, and quaxed's `asarray` returns a `Quantity`
+    unchanged, so one was stored in an `Array` field and `__call__` failed on
+    ``unvmap_any``.
     """
 
     OMEGA = u.Q(90, "deg/s")
@@ -106,8 +104,10 @@ class TestAxisAcceptsQuantity:
     def _rotation(self, axis):
         return cxfm.builders.RotationAboutAxis(self.OMEGA, axis=axis)(u.Q(1.0, "s"))
 
-    def test_bare_array_is_stored_bare(self):
-        b = cxfm.builders.RotationAboutAxis(self.OMEGA, axis=self.ZHAT)
+    @pytest.mark.parametrize("unit", [None, "", "m"])
+    def test_axis_is_stored_bare(self, unit):
+        axis = self.ZHAT if unit is None else u.Q(self.ZHAT, unit)
+        b = cxfm.builders.RotationAboutAxis(self.OMEGA, axis=axis)
         assert not isinstance(b.axis, u.AbstractQuantity)
 
     @pytest.mark.parametrize("unit", ["", "m", "km"])
@@ -116,7 +116,3 @@ class TestAxisAcceptsQuantity:
         ref = self._rotation(self.ZHAT)
         got = self._rotation(u.Q(2.0 * self.ZHAT, unit))
         assert bool(jnp.allclose(got.R, ref.R, atol=1e-12))
-
-    def test_quantity_axis_is_not_stored_as_a_quantity(self):
-        b = cxfm.builders.RotationAboutAxis(self.OMEGA, axis=u.Q(self.ZHAT, "m"))
-        assert not isinstance(b.axis, u.AbstractQuantity)

--- a/tests/unit/transforms/test_builders.py
+++ b/tests/unit/transforms/test_builders.py
@@ -88,3 +88,35 @@ def test_rotation_about_axis_zero_axis_raises():
     b = cxfm.builders.RotationAboutAxis(u.Q(1, "rad/s"), axis=jnp.zeros(3))
     with pytest.raises(Exception, match="must be non-zero"):
         b(u.Q(1.0, "s"))
+
+
+class TestAxisAcceptsQuantity:
+    """`axis` is normalised on use, so a unit on it cancels exactly.
+
+    Regression: the field is annotated `Shaped[Array, "3"]` but had no
+    converter, and `jnp` in this module is `quaxed.numpy`, whose `asarray`
+    returns a `Quantity` unchanged. A `Quantity` axis was therefore stored as
+    one, and `__call__` failed with `TypeError: Error interpreting argument to
+    unvmap_any as a JAX value` -- naming nothing the caller had written.
+    """
+
+    OMEGA = u.Q(90, "deg/s")
+    ZHAT = jnp.asarray([0.0, 0.0, 1.0])
+
+    def _rotation(self, axis):
+        return cxfm.builders.RotationAboutAxis(self.OMEGA, axis=axis)(u.Q(1.0, "s"))
+
+    def test_bare_array_is_stored_bare(self):
+        b = cxfm.builders.RotationAboutAxis(self.OMEGA, axis=self.ZHAT)
+        assert not isinstance(b.axis, u.AbstractQuantity)
+
+    @pytest.mark.parametrize("unit", ["", "m", "km"])
+    def test_quantity_axis_gives_the_same_rotation(self, unit):
+        """Scale and unit both cancel: only the direction survives."""
+        ref = self._rotation(self.ZHAT)
+        got = self._rotation(u.Q(2.0 * self.ZHAT, unit))
+        assert bool(jnp.allclose(got.R, ref.R, atol=1e-12))
+
+    def test_quantity_axis_is_not_stored_as_a_quantity(self):
+        b = cxfm.builders.RotationAboutAxis(self.OMEGA, axis=u.Q(self.ZHAT, "m"))
+        assert not isinstance(b.axis, u.AbstractQuantity)

--- a/tests/unit/transforms/test_rotate.py
+++ b/tests/unit/transforms/test_rotate.py
@@ -23,6 +23,14 @@ class TestRotationMatrixIsDimensionless:
     """
 
     def test_dimensionless_quantity_is_stripped(self):
+        """Also pins that the converter runs despite `Rotate.__init__`.
+
+        `Rotate` defines a custom ``__init__`` that assigns ``R`` through
+        `object.__setattr__`, which looks like it would bypass the field
+        converter. Equinox re-applies converters after ``__init__`` regardless,
+        so it does not -- but the reading is easy to get wrong, and deleting
+        the converter on that belief would restore the bug silently.
+        """
         op = cxfm.Rotate(u.Q(_RZ90, ""))
         assert not isinstance(op.R, u.AbstractQuantity)
 

--- a/tests/unit/transforms/test_rotate.py
+++ b/tests/unit/transforms/test_rotate.py
@@ -1,0 +1,42 @@
+"""Tests for ``coordinax.transforms.Rotate``."""
+
+__all__: tuple[str, ...] = ()
+
+import jax.numpy as jnp
+import pytest
+
+import unxt as u
+
+import coordinax.transforms as cxfm
+
+_RZ90 = jnp.asarray([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+
+
+class TestRotationMatrixIsDimensionless:
+    """`R`'s entries are ratios, so a dimensionful matrix is refused.
+
+    Regression: the field is annotated `Shaped[Array, " N N"]` but had no
+    converter, and `jnp` in that module is `quaxed.numpy`, whose `asarray`
+    returns a `Quantity` unchanged. `Rotate(u.Q(eye, ""))` therefore stored a
+    `Quantity` and failed later inside `jnp.linalg.det`, naming nothing the
+    caller had written.
+    """
+
+    def test_dimensionless_quantity_is_stripped(self):
+        op = cxfm.Rotate(u.Q(_RZ90, ""))
+        assert not isinstance(op.R, u.AbstractQuantity)
+
+    def test_agrees_with_the_bare_array(self):
+        """Stripping must give the same operator, not merely a working one."""
+        got = cxfm.Rotate(u.Q(_RZ90, "")).matrix
+        ref = cxfm.Rotate(_RZ90).matrix
+        assert bool(jnp.allclose(got, ref, atol=1e-14))
+
+    @pytest.mark.parametrize("unit", ["m", "s", "rad"])
+    def test_dimensionful_matrix_is_refused(self, unit):
+        with pytest.raises(ValueError, match="dimensionless"):
+            cxfm.Rotate(u.Q(_RZ90, unit))
+
+    def test_bare_array_is_unaffected(self):
+        """Positive control: the ordinary path still works."""
+        assert not isinstance(cxfm.Rotate(_RZ90).R, u.AbstractQuantity)

--- a/tests/unit/transforms/test_rotate.py
+++ b/tests/unit/transforms/test_rotate.py
@@ -15,24 +15,22 @@ _RZ90 = jnp.asarray([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
 class TestRotationMatrixIsDimensionless:
     """`R`'s entries are ratios, so a dimensionful matrix is refused.
 
-    Regression: the field is annotated `Shaped[Array, " N N"]` but had no
-    converter, and `jnp` in that module is `quaxed.numpy`, whose `asarray`
-    returns a `Quantity` unchanged. `Rotate(u.Q(eye, ""))` therefore stored a
-    `Quantity` and failed later inside `jnp.linalg.det`, naming nothing the
-    caller had written.
+    Regression: no converter, and quaxed's `asarray` returns a `Quantity`
+    unchanged, so one was stored in an `Array` field and `matrix` failed later
+    inside `jnp.linalg.det`.
     """
 
-    def test_dimensionless_quantity_is_stripped(self):
-        """Also pins that the converter runs despite `Rotate.__init__`.
+    @pytest.mark.parametrize(
+        "R", [_RZ90, u.Q(_RZ90, "")], ids=["bare", "dimensionless"]
+    )
+    def test_r_is_stored_bare(self, R):
+        """The converter runs despite `Rotate.__init__`.
 
-        `Rotate` defines a custom ``__init__`` that assigns ``R`` through
-        `object.__setattr__`, which looks like it would bypass the field
-        converter. Equinox re-applies converters after ``__init__`` regardless,
-        so it does not -- but the reading is easy to get wrong, and deleting
-        the converter on that belief would restore the bug silently.
+        Equinox re-applies converters after ``__init__``, so that
+        ``object.__setattr__`` does not bypass this one -- deleting it on that
+        reading would restore the bug silently.
         """
-        op = cxfm.Rotate(u.Q(_RZ90, ""))
-        assert not isinstance(op.R, u.AbstractQuantity)
+        assert not isinstance(cxfm.Rotate(R).R, u.AbstractQuantity)
 
     def test_agrees_with_the_bare_array(self):
         """Stripping must give the same operator, not merely a working one."""
@@ -44,7 +42,3 @@ class TestRotationMatrixIsDimensionless:
     def test_dimensionful_matrix_is_refused(self, unit):
         with pytest.raises(ValueError, match="dimensionless"):
             cxfm.Rotate(u.Q(_RZ90, unit))
-
-    def test_bare_array_is_unaffected(self):
-        """Positive control: the ordinary path still works."""
-        assert not isinstance(cxfm.Rotate(_RZ90).R, u.AbstractQuantity)


### PR DESCRIPTION
Sibling of #741 — the same bug in the two remaining places. Independent of it; either can merge first.

## The bug

`jnp` in these modules is `quaxed.numpy`, whose `asarray` is unit-aware and hands a `Quantity` back unchanged. Neither field had a converter at all, so both stored a `Quantity` in a field annotated as a bare `Array` and failed later, out of code the caller never wrote:

```pycon
>>> cxfm.Rotate(u.Q(eye, "")).matrix          # dimensionless: perfectly reasonable input
TypeError: jnp.linalg.det requires ndarray or scalar arguments

>>> RotationAboutAxis(omega, axis=u.Q(zhat, ""))(u.Q(1.0, "s"))
TypeError: Error interpreting argument to unvmap_any as a JAX value
```

Both also accepted a **dimensionful** quantity — a rotation matrix in metres.

## Guarded differently, deliberately

This is the part worth a reviewer's attention:

| field | dimensionless `Q` | dimensionful `Q` | why |
|---|---|---|---|
| `Rotate.R` | stripped | **refused** | a rotation preserves lengths, so its entries are ratios; a unit on them is meaningless |
| `RotationAboutAxis.axis` | stripped | **stripped** | normalised on use, so the unit cancels *exactly* |

For the axis this is lossless, not a silent drop — verified:

```
axis = [0, 0, 1]        -> R
axis = Q([0,0,2], "")   -> R   identical
axis = Q([0,0,2], "m")  -> R   identical
```

Refusing a displacement vector as a rotation axis would be obstructive, and the magnitude is discarded by the normalisation regardless.

## The class is closed, not sampled

Walking the AST for every class field annotated as a bare `Array` across `src` and `packages`:

| class | field | guard |
|---|---|---|
| `Distance.value`, `Parallax.value`, `DistanceModulus.value` | | pre-existing — refuse a `Quantity` |
| `LorentzBoost.beta` | | #741 |
| `Rotate.R`, `RotationAboutAxis.axis` | | **here** |

Six fields, all now guarded. The converter-with-`asarray` shape is likewise exhausted: every other `eqx.field` converter in the repo uses a unit-aware helper.

## One thing the tests caught

The converter first returned `Shaped[Array, " N N"]`. jaxtyping enforces that, so a non-square matrix started failing *inside the converter* with a jaxtyping error, preempting `_validate_square` and its far clearer message — breaking an existing test. The return is `Array`, with a comment saying why.

## Verification

- `prek run --all-files` clean, including `ty`
- 10 tests: strip, agreement with the bare array (same operator, not merely both working), three dimensionful units refused for `R`, three accepted for `axis` with identical rotations, and bare-array positive controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)
