### PR TITLE
🐛 fix(transforms,curveframes): promote integers to float, don't override f32

### DIFF
--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
@@ -95,6 +95,17 @@ _MSG_PARALLEL_NORMAL = (
 )
 
 
+def _float(x: Any, /) -> Array:
+    """Convert to an array, promoting integers to float but preserving f32.
+
+    ``dtype=float`` would name the *default* float, silently widening an f32
+    input to f64 under ``jax_enable_x64`` and discarding a deliberate choice of
+    single precision. `jnp.result_type` promotes only what needs promoting.
+    """
+    arr = jnp.asarray(x)
+    return arr.astype(jnp.result_type(arr, float))
+
+
 def _orthonormalize(v: Any, T0_val: Any) -> Any:
     r"""Gram--Schmidt ``v`` against the unit tangent, then normalise.
 
@@ -365,9 +376,7 @@ class BishopBuilder(AbstractCurveFrameBuilder):
             # A supplied vector is NOT trusted to be unit or normal-plane: the
             # transport ODE conserves any error in it forever, so R would not
             # be a rotation.  Gram--Schmidt it exactly as the auto path does.
-            U1_0_val = _orthonormalize(
-                jnp.asarray(self.initial_normal, dtype=float), T0_val
-            )
+            U1_0_val = _orthonormalize(_float(self.initial_normal), T0_val)
         else:
             U1_0_val = _auto_initial_normal(T0_val)
 
@@ -376,8 +385,8 @@ class BishopBuilder(AbstractCurveFrameBuilder):
         # for JAX to trace.
         dTangent_fn = u.experimental.jacfwd(self._tangent_at, units=(tau_unit,))
 
-        tau_val = jnp.asarray(g.ustrip(tau_unit), dtype=float)
-        tau_0_val = jnp.asarray(tau_0.ustrip(tau_unit), dtype=float)
+        tau_val = _float(g.ustrip(tau_unit))
+        tau_0_val = _float(tau_0.ustrip(tau_unit))
 
         dtau = tau_val - tau_0_val
 

--- a/packages/coordinaxs.curveframes/tests/unit/test_bishop_dtype.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_bishop_dtype.py
@@ -1,0 +1,40 @@
+"""`BishopBuilder` promotes integers to float without overriding f32.
+
+``dtype=float`` names the *default* float, so under ``jax_enable_x64`` it
+widened an f32 input to f64, discarding a precision the caller chose. Asserted
+as the promotion contract rather than by toggling x64, so it holds either way
+round -- and ``jax.experimental.enable_x64`` no longer exists.
+
+Tested at `_float` rather than through `BishopBuilder`: the builder's output
+dtype is set by the curve and the ODE solver, which promote to f64 under x64
+whatever the ``initial_normal`` was, so an end-to-end assertion would be
+testing diffrax rather than this contract.
+"""
+
+import jax.numpy as jnp
+import pytest
+
+from coordinaxs.curveframes._src.bishop import _float
+
+
+@pytest.mark.parametrize(
+    "given",
+    [
+        jnp.asarray([0, 1, 0]),
+        jnp.asarray([0.0, 1.0, 0.0], dtype=jnp.float32),
+        jnp.asarray([0.0, 1.0, 0.0]),
+    ],
+    ids=["int", "f32", "default-float"],
+)
+def test_float_follows_result_type(given):
+    assert _float(given).dtype == jnp.result_type(given, float)
+
+
+def test_an_integer_input_becomes_floating():
+    """Integer arithmetic in the transport ODE would be a trap."""
+    assert jnp.issubdtype(_float(jnp.asarray([0, 1, 0])).dtype, jnp.floating)
+
+
+def test_a_python_list_still_works():
+    """Regression: `result_type` cannot read a list, `asarray` must run first."""
+    assert _float([0.0, 1.0, 0.0]).shape == (3,)

--- a/src/coordinax/transforms/_src/actions/lorentz.py
+++ b/src/coordinax/transforms/_src/actions/lorentz.py
@@ -36,34 +36,39 @@ _MSG_ZERO_DIRECTION = (
 )
 
 
+def _float(x: Any, /) -> Array:
+    """Convert to an array, promoting integers to float but preserving f32.
+
+    ``dtype=float`` would name the *default* float, silently widening an f32
+    input to f64 under ``jax_enable_x64`` and discarding a deliberate choice of
+    single precision. `jnp.result_type` promotes only what needs promoting.
+    """
+    arr = jnp.asarray(x)
+    return arr.astype(jnp.result_type(arr, float))
+
+
 def _as_beta(b: Any, /) -> Shaped[Array, "3"]:
     """Normalise ``beta`` to a bare array, requiring it to be dimensionless.
 
     ``jnp`` here is `quaxed.numpy`, whose `asarray` is unit-aware and returns a
-    `~unxt.Quantity` unchanged. A plain ``jnp.asarray`` converter therefore did
-    nothing for a `~unxt.Quantity`, storing one in a field annotated `Array`;
-    the failure surfaced much later and unrecognisably, inside `matrix`.
+    `~unxt.Quantity` unchanged, so it cannot be used to coerce one.
 
-    A dimensionless quantity is stripped. A velocity is refused rather than
-    reinterpreted: ``0.6 m/s`` is not ``0.6 c``, and taking its number would be
-    wrong by eight orders of magnitude while looking perfectly ordinary.
+    A dimensionless quantity is stripped; a velocity is refused rather than
+    reinterpreted, since ``0.6 m/s`` is not ``0.6 c``.
     """
     if isinstance(b, u.AbstractQuantity):
         try:
             b = u.ustrip("", b)
         except UnitConversionError as e:
-            # A note rather than a new exception: `UnitConversionError` is
-            # already a `ValueError`, so nothing catching the latter is lost,
-            # and astropy's own message names both units and the physical type
-            # ("speed/velocity"). Re-raising would restate that in a second
-            # traceback and swap a precise type for a vaguer one.
+            # `UnitConversionError` is already a `ValueError`, so a bare
+            # `raise` loses no caller; its message already names the units.
             e.add_note(
                 "LorentzBoost `beta` is a velocity in units of c, and so "
                 "dimensionless. For a velocity use "
                 "`LorentzBoost.from_velocity(v)`, which divides by c."
             )
             raise
-    return jnp.asarray(b, dtype=float)
+    return _float(b)
 
 
 @final
@@ -237,12 +242,12 @@ class LorentzBoost(AbstractLinearTransform):
         True
 
         """
-        d = jnp.asarray(direction, dtype=float)
+        d = _float(direction)
         norm = jnp.linalg.norm(d)
         # A zero direction has no boost axis to normalise onto; dividing would
         # give `nan` betas that then propagate silently into every matrix entry.
         norm = eqx.error_if(norm, norm == 0.0, _MSG_ZERO_DIRECTION)
-        return cls(jnp.tanh(jnp.asarray(rapidity, dtype=float)) * (d / norm))
+        return cls(jnp.tanh(_float(rapidity)) * (d / norm))
 
     # -----------------------------------------------------
     # Derived quantities

--- a/tests/unit/transforms/test_lorentz_boost.py
+++ b/tests/unit/transforms/test_lorentz_boost.py
@@ -353,12 +353,9 @@ _BETA = [0.6, 0.0, 0.0]
 class TestBetaAcceptsOnlyDimensionlessQuantities:
     """`beta` is v/c, so a `Quantity` must be dimensionless or refused.
 
-    Regression: the field converter was a bare ``jnp.asarray``, and ``jnp`` in
-    that module is `quaxed.numpy`, whose `asarray` is unit-aware and hands a
-    `Quantity` straight back. A `Quantity` was therefore stored in a field
-    annotated `Array`, and nothing complained until `matrix` failed with a
-    `TypeError` about ``unvmap_any`` -- an error naming nothing the caller had
-    written.
+    Regression: the converter was a bare quaxed ``jnp.asarray``, which returns
+    a `Quantity` unchanged, so one was stored in an `Array` field and `matrix`
+    failed later on ``unvmap_any``.
     """
 
     def test_dimensionless_quantity_is_stripped_to_an_array(self):
@@ -375,11 +372,7 @@ class TestBetaAcceptsOnlyDimensionlessQuantities:
 
     @pytest.mark.parametrize("unit", ["m/s", "km/s", "pc/Myr", "m"])
     def test_a_dimensionful_quantity_is_refused_and_redirected(self, unit):
-        """``0.6 m/s`` is not ``0.6 c`` -- off by eight orders of magnitude.
-
-        A length is in here too: the guard is "dimensionless or nothing", not
-        "not a velocity".
-        """
+        """``0.6 m/s`` is not ``0.6 c`` -- off by eight orders of magnitude."""
         with pytest.raises(ValueError, match="from_velocity"):
             cxfm.LorentzBoost(u.Q(jnp.asarray(_BETA), unit))
 
@@ -388,3 +381,34 @@ class TestBetaAcceptsOnlyDimensionlessQuantities:
         c = u.Q(299792458.0, "m/s")
         b = cxfm.LorentzBoost.from_velocity(u.Q(jnp.asarray([0.6, 0.0, 0.0]), "") * c)
         assert bool(jnp.allclose(b.beta, jnp.asarray(_BETA), atol=1e-12))
+
+
+class TestBetaDtypePromotion:
+    """Integers are promoted; a float dtype is preserved, not overridden.
+
+    ``dtype=float`` names the *default* float, so under ``jax_enable_x64`` it
+    widened an f32 input to f64 -- discarding a choice a caller makes for
+    memory or accelerator reasons. Asserted as the promotion contract rather
+    than by toggling x64, so it holds either way round.
+    """
+
+    @pytest.mark.parametrize(
+        "given",
+        [
+            jnp.asarray([0, 0, 0]),
+            jnp.asarray([0.6, 0.0, 0.0], dtype=jnp.float32),
+            jnp.asarray([0.6, 0.0, 0.0]),
+        ],
+        ids=["int", "f32", "default-float"],
+    )
+    def test_dtype_follows_result_type(self, given):
+        assert cxfm.LorentzBoost(given).beta.dtype == jnp.result_type(given, float)
+
+    def test_an_integer_beta_becomes_floating(self):
+        """Integer arithmetic in ``1 - beta**2`` would be a trap."""
+        beta = cxfm.LorentzBoost(jnp.asarray([0, 0, 0])).beta
+        assert jnp.issubdtype(beta.dtype, jnp.floating)
+
+    def test_a_python_list_still_works(self):
+        """Regression: `result_type` cannot read a list, `asarray` must run first."""
+        assert cxfm.LorentzBoost([0.6, 0.0, 0.0]).beta.shape == (3,)


### PR DESCRIPTION
Follow-up to #741, from a question asked in its review: does `beta`'s converter really need `dtype=float`?

Promoting integers — yes. Naming the *default* float — no, and that is what `dtype=float` does.

## The bug

```python
jnp.asarray(x, dtype=float)   # "the default float", not "some float"
```

Under `jax_enable_x64` that silently widens an f32 input to f64, discarding a precision the caller chose for memory or accelerator reasons:

| input | before | after |
|---|---|---|
| `int [0,0,0]` | f64 | f64 ✅ promoted |
| **`f32`** | **f64** ← silent widening | **f32** ✅ preserved |
| `f64` | f64 | f64 |
| `[0.6, 0.0, 0.0]` (list) | f64 | f64 |

Dormant in-tree because **x64 is off by default here**, so no test could see it. It appears the moment a user enables x64, which is routine in scientific JAX.

Promoting integers is still right: `beta` is v/c, and leaving it integer would make `1 - beta**2` and its `sqrt` do integer arithmetic first.

## The fix

`jnp.result_type(arr, float)` promotes only what needs promoting. Six sites share a small `_float` helper, defined locally in each of the two modules rather than coupling the packages:

- `lorentz`: `beta`, `direction`, `rapidity`
- `curveframes.bishop`: `initial_normal`, `tau`, `tau_0`

## Two things testing caught that reasoning did not

**`jnp.result_type` cannot read a Python list**, and `LorentzBoost([0.6, 0.0, 0.0])` is the form used throughout the docstrings — `dtype=float` tolerated it. The helper calls `asarray` first, and there is a regression test for exactly that.

**`jax.experimental.enable_x64` no longer exists**, so the dtype test cannot toggle x64. It asserts the promotion *contract* instead — `beta.dtype == jnp.result_type(given, float)` — which holds under either setting.

## Also included

The comment trim from #741's review, which missed that merge: the post-mortem paragraph, the eight-orders-of-magnitude aside, the five-line justification of `add_note` over `raise`, and the six-line regression narrative. All of it is already in the commit log. Carried here rather than opened as a PR of pure deletions, since it is the same function.

## Verification

- Full suite: **10938 passed**, 7 skipped, 1 xfailed
- `prek run --all-files` clean, including `ty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)