### PR TITLE
💥 refactor(curveframes): require tau_unit on the frame builders

### DIFF
--- a/packages/coordinaxs.curveframes/README.md
+++ b/packages/coordinaxs.curveframes/README.md
@@ -41,7 +41,7 @@ def helix(tau: u.Q) -> u.Q:
     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), 0.5 * t]), "m")
 
 
-frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), helix)
+frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), helix, "s")
 op = cxf.frame_transition(cxf.Alice(), frame)
 tau = u.Q(0.5, "s")
 out = cxfm.act(op, tau, u.Q(jnp.array([1.0, 0.0, 0.0]), "m"))

--- a/packages/coordinaxs.curveframes/docs/curve-charts.md
+++ b/packages/coordinaxs.curveframes/docs/curve-charts.md
@@ -24,7 +24,7 @@ For the frame-based moving-frame machinery `TubularChart` builds on, see {doc}`W
 ...     t = tau.ustrip("s")
 ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), jnp.zeros_like(t)]), "km")
 
->>> op = cxfm.TimeDep(cxfc.BishopBuilder(circle))
+>>> op = cxfm.TimeDep(cxfc.BishopBuilder(circle, "s"))
 >>> x = u.Q(jnp.array([0.5, 0.0, 0.0]), "km")
 >>> tau = u.Q(0.7, "s")
 >>> cxfm.act(op, tau, x)  # tau supplied separately from x
@@ -38,7 +38,7 @@ Q([...], 'km')
 >>> import coordinax.charts as cxc
 
 >>> BOUNDS = (u.Q(0.0, "s"), u.Q(2 * jnp.pi, "s"))
->>> chart = cxfc.TubularChart(cxfc.BishopBuilder(circle), tau_bounds=BOUNDS)
+>>> chart = cxfc.TubularChart(cxfc.BishopBuilder(circle, "s"), tau_bounds=BOUNDS)
 >>> p = {"x": u.Q(0.5, "km"), "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")}
 >>> got = cxc.pt_map(p, chart.M, cxc.cart3d, chart.M, chart)
 >>> sorted(got)
@@ -53,13 +53,13 @@ That is a categorical difference, not a stylistic one. A frame transform has no 
 `TubularChart` wraps either builder unchanged — it is agnostic to which triad supplies $\mathbf{U}_1,\mathbf{U}_2$:
 
 ```{code-block} python
->>> ch_bishop = cxfc.TubularChart(cxfc.BishopBuilder(circle), tau_bounds=BOUNDS)
+>>> ch_bishop = cxfc.TubularChart(cxfc.BishopBuilder(circle, "s"), tau_bounds=BOUNDS)
 >>> ch_bishop.components
 ('tau', 'n1', 'n2')
 >>> ch_bishop.coord_dimensions
 ('time', 'length', 'length')
 
->>> ch_frenet = cxfc.TubularChart(cxfc.FrenetSerretBuilder(circle), tau_bounds=BOUNDS)
+>>> ch_frenet = cxfc.TubularChart(cxfc.FrenetSerretBuilder(circle, "s"), tau_bounds=BOUNDS)
 >>> ch_frenet.components
 ('tau', 'n1', 'n2')
 
@@ -123,7 +123,7 @@ Make the curve's radius a live, fittable parameter by holding it in an `equinox.
 >>> HELIX_BOUNDS = (u.Q(-1.0, "s"), u.Q(6.0, "s"))
 >>> def chart_for(radius_km):
 ...     curve = Helix(radius=u.Q(radius_km, "km"))
-...     return cxfc.TubularChart(cxfc.BishopBuilder(curve), tau_bounds=HELIX_BOUNDS)
+...     return cxfc.TubularChart(cxfc.BishopBuilder(curve, "s"), tau_bounds=HELIX_BOUNDS)
 
 >>> import coordinax.manifolds as cxm
 >>> x = {"x": u.Q(1.1, "km"), "y": u.Q(0.4, "km"), "z": u.Q(0.2, "km")}
@@ -160,12 +160,12 @@ No `metric_matrix` rule is registered for `TubularChart` — it has no closed fo
 
 >>> at = {"tau": u.Q(0.7, "s"), "n1": u.Q(0.13, "km"), "n2": u.Q(-0.21, "km")}
 
->>> ch_b = cxfc.TubularChart(cxfc.BishopBuilder(helix), tau_bounds=HELIX_BOUNDS)
+>>> ch_b = cxfc.TubularChart(cxfc.BishopBuilder(helix, "s"), tau_bounds=HELIX_BOUNDS)
 >>> g_b = metric_matrix(ch_b.M, at, ch_b).matrix
 >>> bool(jnp.abs(g_b[0, 1].ustrip("km / s")) < 1e-8)  # Bishop: no d(tau).d(n1) cross term
 True
 
->>> ch_f = cxfc.TubularChart(cxfc.FrenetSerretBuilder(helix), tau_bounds=HELIX_BOUNDS)
+>>> ch_f = cxfc.TubularChart(cxfc.FrenetSerretBuilder(helix, "s"), tau_bounds=HELIX_BOUNDS)
 >>> g_f = metric_matrix(ch_f.M, at, ch_f).matrix
 >>> bool(jnp.abs(g_f[0, 1].ustrip("km / s")) < 1e-8)  # Frenet-Serret: torsion cross term
 False
@@ -427,7 +427,7 @@ The builders themselves stay $\tau$-parameterised, not unit-speed: $g_{\tau\tau}
 A bounds range spanning two periods recovers the _wrong_ branch for a point that was originally at $\tau=0.7\,\mathrm{s}$:
 
 ```{code-block} python
->>> wide = cxfc.TubularChart(cxfc.BishopBuilder(circle), tau_bounds=(u.Q(0.0, "s"), u.Q(4 * jnp.pi, "s")))
+>>> wide = cxfc.TubularChart(cxfc.BishopBuilder(circle, "s"), tau_bounds=(u.Q(0.0, "s"), u.Q(4 * jnp.pi, "s")))
 >>> on_curve = circle(u.Q(0.7, "s"))
 >>> d = {"x": on_curve[0], "y": on_curve[1], "z": on_curve[2]}
 >>> recovered = cxc.pt_map(d, wide.M, cxc.cart3d, wide.M, wide)["tau"]
@@ -505,7 +505,7 @@ Use `jax.vmap` over single points, which works and is the fast path anyway -- th
 >>> import jax
 
 >>> tubular = cxfc.TubularChart(
-...     cxfc.BishopBuilder(circle),
+...     cxfc.BishopBuilder(circle, "s"),
 ...     tau_bounds=(u.Q(0.0, "s"), u.Q(2 * jnp.pi, "s")),
 ... )
 >>> def to_cart(tau, n1):

--- a/packages/coordinaxs.curveframes/docs/guide.md
+++ b/packages/coordinaxs.curveframes/docs/guide.md
@@ -50,7 +50,7 @@ def helix(tau: u.Q) -> u.Q:
     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), 0.3 * t]), "km")
 
 
-fs_transform = cxfc.FrenetSerretBuilder(helix)
+fs_transform = cxfc.FrenetSerretBuilder(helix, "s")
 ```
 
 `FrenetSerretBuilder` uses `unxt.experimental.jacfwd` to compute unit-correct first and second derivatives of the curve, then derives the tangent, normal, and binormal via Gram–Schmidt orthogonalisation. Nothing is precomputed: `tangent`, `normal`, and `binormal` are methods on the builder, each evaluated at the $\tau$ you pass it.
@@ -103,7 +103,7 @@ fs_frame = cxfc.FrenetSerretFrame(
 `from_curve` combines both steps — it builds the transform and wraps it:
 
 ```python
-fs_frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), helix)
+fs_frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), helix, "s")
 ```
 
 This is equivalent to the direct construction above.
@@ -202,7 +202,7 @@ class Helix(eqx.Module):
         )
 
 
-builder = cxfc.FrenetSerretBuilder(Helix(jnp.asarray(1.5)))
+builder = cxfc.FrenetSerretBuilder(Helix(jnp.asarray(1.5)), "s")
 
 try:
     jax.jit(builder.rotation_matrix)(tau)
@@ -273,7 +273,7 @@ def helix(tau: u.Q) -> u.Q:
     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), 0.3 * t]), "km")
 
 
-bt = cxfc.BishopBuilder(helix)
+bt = cxfc.BishopBuilder(helix, "s")
 ```
 
 `BishopBuilder` automatically:
@@ -305,7 +305,7 @@ import dataclasses
 
 import diffrax as dfx
 
-bt = cxfc.BishopBuilder(helix)
+bt = cxfc.BishopBuilder(helix, "s")
 fast = dataclasses.replace(
     bt,
     diffeqsolver=dataclasses.replace(
@@ -337,13 +337,13 @@ For `RecursiveCheckpointAdjoint`, "forward: no" means tangent and jet propagatio
 By default, the builder picks the standard basis vector least aligned with $\mathbf{T}(\tau_0)$ via Gram–Schmidt. You can provide an explicit initial normal:
 
 ```python
-bt_custom = cxfc.BishopBuilder(helix, initial_normal=jnp.array([0.0, 0.0, 1.0]))
+bt_custom = cxfc.BishopBuilder(helix, "s", initial_normal=jnp.array([0.0, 0.0, 1.0]))
 ```
 
 The reference parameter $\tau_0$ can also be set:
 
 ```python
-bt_shifted = cxfc.BishopBuilder(helix, tau_0=u.Q(1.0, "s"))
+bt_shifted = cxfc.BishopBuilder(helix, "s", tau_0=u.Q(1.0, "s"))
 ```
 
 ### Straight Lines
@@ -356,7 +356,7 @@ def line(tau):
     return u.Q(jnp.stack([t, jnp.zeros_like(t), jnp.zeros_like(t)]), "km")
 
 
-bt_line = cxfc.BishopBuilder(line)
+bt_line = cxfc.BishopBuilder(line, "s")
 bt_line.normal1(u.Q(5.0, "s"))  # well-defined unit vector
 ```
 
@@ -401,7 +401,7 @@ A `BishopFrame` pairs a `BishopBuilder` with a base frame, exactly like `FrenetS
 ### Convenience Constructor
 
 ```python
-b_frame = cxfc.BishopFrame.from_curve(cxf.Alice(), helix)
+b_frame = cxfc.BishopFrame.from_curve(cxf.Alice(), helix, "s")
 ```
 
 ### Frame Transitions
@@ -527,7 +527,7 @@ class Helix(eqx.Module):
 
 
 def readout(radius):
-    builder = cxfc.FrenetSerretBuilder(Helix(radius))
+    builder = cxfc.FrenetSerretBuilder(Helix(radius), "s")
     op = cxfm.TimeDep(builder)
     p = u.Q(jnp.array([2.0, 1.0, -0.5]), "km")
     out = cxfm.act(op, u.Q(0.4, "s"), p)

--- a/packages/coordinaxs.curveframes/docs/spec.md
+++ b/packages/coordinaxs.curveframes/docs/spec.md
@@ -344,7 +344,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
     Fields (in addition to the ABC's `curve`, `tau_unit`, `station`): none — `FrenetSerretBuilder` adds no fields beyond the base class.
 
     - `curve : Callable[[Any], Any]` — the constructing curve.
-    - `tau_unit : unxt.AbstractUnit` — unit of the curve parameter, used by `unxt.experimental.jacfwd` to compute unit-correct derivatives. Defaults to `"s"`. Static.
+    - `tau_unit : unxt.AbstractUnit` — unit of the curve parameter, used by `unxt.experimental.jacfwd` to compute unit-correct derivatives. Static. **Required**: there is no neutral default, since a curve parameter may be a time, an arc length, or an affine parameter.
     - `station : Any` — optional fixed curve parameter (a leaf); see `AbstractCurveFrameBuilder`.
 
     `rotation_matrix(tau)` computes $R = [\mathbf{T}; \mathbf{N}; \mathbf{B}]$: unit-aware first and second derivatives of `curve` via `unxt.experimental.jacfwd`, then $\mathbf{T} = \gamma'/\lVert\gamma'\rVert$, Gram–Schmidt rejection of $\gamma''$ onto $\mathbf{T}$ normalised to give $\mathbf{N}$, and $\mathbf{B} = \mathbf{T}\times\mathbf{N}$.
@@ -414,7 +414,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
     Fields (the ABC's `curve`, `tau_unit`, `station`, plus two more):
 
     - `curve : Callable[[Any], Any]` — the constructing curve.
-    - `tau_unit : unxt.AbstractUnit` — unit of the curve parameter. Defaults to `"s"`. Static.
+    - `tau_unit : unxt.AbstractUnit` — unit of the curve parameter. Static. **Required**: there is no neutral default, since a curve parameter may be a time, an arc length, or an affine parameter.
     - `station : Any` — optional fixed curve parameter (a leaf); see `AbstractCurveFrameBuilder`.
     - `tau_0 : unxt.AbstractQuantity | None` — reference parameter where the initial frame is defined (a leaf). `None` is resolved to `Q(0.0, tau_unit)` by `__post_init__`.
     - `initial_normal : Any` — initial $\mathbf{U}_{1,0}$ (dimensionless 3-vector, a leaf), or `None` for auto-selection via Gram–Schmidt.
@@ -426,7 +426,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
 
     Convenience accessors: `normal1(tau)` (row 1), `normal2(tau)` (row 2); `location(tau)`, `tangent(tau)` inherited.
 
-    Constructed directly — `BishopBuilder(curve, tau_unit="s", station=None, tau_0=None, initial_normal=None, diffeqsolver=DiffEqSolver(Tsit5(), PIDController(1e-10, 1e-10), DirectAdjoint(), max_steps=16384))` — there is no `from_curve`/`from_` classmethod on the builder; that convenience lives on `BishopFrame`.
+    Constructed directly — `BishopBuilder(curve, tau_unit, station=None, tau_0=None, initial_normal=None, diffeqsolver=DiffEqSolver(Tsit5(), PIDController(1e-10, 1e-10), DirectAdjoint(), max_steps=16384))` — there is no `from_curve`/`from_` classmethod on the builder; that convenience lives on `BishopFrame`.
 
     JAX compatibility: same as `FrenetSerretBuilder` — `curve`, `station`, `tau_0`, `initial_normal` are dynamic leaves; `tau_unit` and `diffeqsolver` are static. A plain `jax.jit` cannot hash a builder holding array leaves; use `eqx.filter_jit`.
 

--- a/packages/coordinaxs.curveframes/docs/spec.md
+++ b/packages/coordinaxs.curveframes/docs/spec.md
@@ -351,7 +351,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
 
     Convenience accessors: `normal(tau)` (row 1), `binormal(tau)` (row 2); `location(tau)`, `tangent(tau)` are inherited from `AbstractCurveFrameBuilder`.
 
-    Constructed directly — `FrenetSerretBuilder(curve, tau_unit="s", station=None)` — there is no `from_curve`/`from_` classmethod on the builder; that convenience lives on `FrenetSerretFrame`.
+    Constructed directly — `FrenetSerretBuilder(curve, tau_unit, station=None)` — there is no `from_curve`/`from_` classmethod on the builder; that convenience lives on `FrenetSerretFrame`.
 
     JAX compatibility: `FrenetSerretBuilder` is an `equinox.Module`, so it is a valid pytree. `curve`, `station` are dynamic leaves (differentiable, `vmap`-able); `tau_unit` is static. `rotation_matrix` and `__call__` operate on scalar $\tau$; batching is via `jax.vmap`. A plain `jax.jit` cannot hash a builder holding array leaves (e.g. an `equinox.Module` curve with array fields, or a `station`); use `eqx.filter_jit` in that case.
 
@@ -374,7 +374,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
     Constructors:
 
     - `FrenetSerretFrame(base_frame, xop, xop_inv)` — direct construction from a base frame and a `TimeDep`-wrapped `FrenetSerretBuilder` (forward and inverse).
-    - `from_curve(base_frame, curve, /, tau_unit="s", *, station=None)` — convenience constructor that builds `FrenetSerretBuilder(curve, tau_unit, station)`, wraps it in `TimeDep`, and sets `xop_inv = xop.inverse`.
+    - `from_curve(base_frame, curve, /, tau_unit, *, station=None)` — convenience constructor that builds `FrenetSerretBuilder(curve, tau_unit, station)`, wraps it in `TimeDep`, and sets `xop_inv = xop.inverse`.
 
     Frame transitions:
 
@@ -398,7 +398,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
         return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), jnp.zeros_like(t)]), "m")
 
 
-    fs_frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle)
+    fs_frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle, "s")
     op = cxf.frame_transition(cxf.Alice(), fs_frame)
     tau = u.Q(0.0, "s")
     p_ambient = u.Q(jnp.array([1.0, 0.0, 0.0]), "m")
@@ -447,7 +447,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
     Constructors:
 
     - `BishopFrame(base_frame, xop, xop_inv)` — direct construction.
-    - `from_curve(base_frame, curve, /, tau_unit="s", *, station=None, tau_0=None, initial_normal=None)` — convenience constructor that builds `BishopBuilder(curve, tau_unit, station, tau_0, initial_normal)`, wraps it in `TimeDep`, and sets `xop_inv = xop.inverse`.
+    - `from_curve(base_frame, curve, /, tau_unit, *, station=None, tau_0=None, initial_normal=None)` — convenience constructor that builds `BishopBuilder(curve, tau_unit, station, tau_0, initial_normal)`, wraps it in `TimeDep`, and sets `xop_inv = xop.inverse`.
 
     Frame transitions:
 
@@ -468,7 +468,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
         return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), 0.3 * t]), "m")
 
 
-    b_frame = cxfc.BishopFrame.from_curve(cxf.Alice(), curve)
+    b_frame = cxfc.BishopFrame.from_curve(cxf.Alice(), curve, "s")
     op = cxf.frame_transition(cxf.Alice(), b_frame)
     tau = u.Q(0.0, "s")
     p_ambient = u.Q(jnp.array([1.0, 0.0, 0.0]), "m")

--- a/packages/coordinaxs.curveframes/docs/tutorial.md
+++ b/packages/coordinaxs.curveframes/docs/tutorial.md
@@ -45,7 +45,7 @@ At $\tau = 0$ the curve is at $(1, 0, 0)$ km; at $\tau = \pi/2$ it is at $(0, 1,
 `FrenetSerretBuilder.from_curve` computes the Frenet–Serret frame fields automatically via JAX autodiff:
 
 ```pycon
->>> fs_xform = cxfc.FrenetSerretBuilder(circle)
+>>> fs_xform = cxfc.FrenetSerretBuilder(circle, "s")
 >>> fs_xform
 FrenetSerretBuilder(...)
 ```
@@ -72,7 +72,7 @@ Q([1., 0., 0.], 'km')
 Attach the transform to Alice's frame:
 
 ```pycon
->>> fs_frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle)
+>>> fs_frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle, "s")
 >>> fs_frame.base_frame
 Alice()
 
@@ -244,7 +244,7 @@ Define a helix with a vertical drift:
 Build the Bishop transform:
 
 ```pycon
->>> bt = cxfc.BishopBuilder(helix)
+>>> bt = cxfc.BishopBuilder(helix, "s")
 >>> bt
 BishopBuilder(...)
 ```
@@ -290,7 +290,7 @@ The Frenet–Serret frame is **singular** on a straight line (zero curvature). T
 ...     return u.Q(jnp.stack([t, jnp.zeros_like(t), jnp.zeros_like(t)]), "km")
 ...
 
->>> bt_line = cxfc.BishopBuilder(line)
+>>> bt_line = cxfc.BishopBuilder(line, "s")
 ```
 
 The normals are well-defined unit vectors at any $\tau$:
@@ -311,7 +311,7 @@ The normals are well-defined unit vectors at any $\tau$:
 Attach the Bishop transform to Alice's frame:
 
 ```pycon
->>> b_frame = cxfc.BishopFrame.from_curve(cxf.Alice(), helix)
+>>> b_frame = cxfc.BishopFrame.from_curve(cxf.Alice(), helix, "s")
 >>> b_frame.base_frame
 Alice()
 
@@ -341,7 +341,7 @@ Transform a point at the curve origin to the Bishop frame:
 Specify an explicit initial normal:
 
 ```pycon
->>> bt_custom = cxfc.BishopBuilder(helix, initial_normal=jnp.array([0.0, 0.0, 1.0]))
+>>> bt_custom = cxfc.BishopBuilder(helix, "s", initial_normal=jnp.array([0.0, 0.0, 1.0]))
 >>> U1_custom = bt_custom.normal1(tau0)
 >>> np.testing.assert_allclose(jnp.linalg.norm(U1_custom.value), 1.0, atol=1e-5)
 ```
@@ -349,7 +349,7 @@ Specify an explicit initial normal:
 Shift the reference parameter:
 
 ```pycon
->>> bt_shifted = cxfc.BishopBuilder(helix, tau_0=u.Q(1.0, "s"))
+>>> bt_shifted = cxfc.BishopBuilder(helix, "s", tau_0=u.Q(1.0, "s"))
 >>> bt_shifted.tau_0
 Q(1., 's')
 ```

--- a/packages/coordinaxs.curveframes/docs/tutorial_circle_equivalence.md
+++ b/packages/coordinaxs.curveframes/docs/tutorial_circle_equivalence.md
@@ -38,7 +38,7 @@ Q([1., 0., 0.], 'km')
 The Frenet–Serret frame has axes $(\mathbf{T}, \mathbf{N}, \mathbf{B})$ computed from the curve's first and second derivatives:
 
 ```pycon
->>> fs_frame = cxfc.FrenetSerretFrame.from_curve(cxf.alice, circle)
+>>> fs_frame = cxfc.FrenetSerretFrame.from_curve(cxf.alice, circle, "s")
 ```
 
 ### 2b — Bishop (parallel-transport) frame
@@ -49,6 +49,7 @@ The Bishop frame $(\mathbf{T}, \mathbf{U}_1, \mathbf{U}_2)$ is obtained by paral
 >>> bishop_frame = cxfc.BishopFrame.from_curve(
 ...     cxf.alice,
 ...     circle,
+...     "s",
 ...     initial_normal=jnp.array([-1.0, 0.0, 0.0]),
 ... )
 ```
@@ -184,9 +185,10 @@ Let's verify on a helix that the three frames **disagree**:
 ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), t]), "km")
 ...
 
->>> fs_helix = cxfc.FrenetSerretBuilder(helix)
+>>> fs_helix = cxfc.FrenetSerretBuilder(helix, "s")
 >>> bp_helix = cxfc.BishopBuilder(
 ...     helix,
+...     "s",
 ...     initial_normal=jnp.array([-1.0, 0.0, 0.0]),
 ... )
 

--- a/packages/coordinaxs.curveframes/docs/visualizing.md
+++ b/packages/coordinaxs.curveframes/docs/visualizing.md
@@ -30,7 +30,7 @@ def helix(tau):
     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), 0.3 * t]), "km")
 
 
-fs = cxfc.FrenetSerretBuilder(helix)
+fs = cxfc.FrenetSerretBuilder(helix, "s")
 
 # Dense sampling for the curve line, sparse sampling for the frame triads.
 ts = np.linspace(0.0, 4.0 * np.pi, 300)
@@ -67,7 +67,7 @@ The tangent always points along the direction of travel, the normal points towar
 The {doc}`Bishop frame <guide>` is _rotation-minimising_: instead of tracking the principal normal (which spins around the tangent as the curve twists), it transports its cross-section axes as smoothly as possible. On the helix this shows up as a visible lag between the Frenet normal and the Bishop `normal1` axis.
 
 ```{code-cell} python
-bishop = cxfc.BishopBuilder(helix)
+bishop = cxfc.BishopBuilder(helix, "s")
 
 fig = plt.figure(figsize=(6, 6))
 ax = fig.add_subplot(111, projection="3d")

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/__init__.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/__init__.py
@@ -24,8 +24,8 @@ Typical usage::
 
     import coordinaxs.curveframes as cxfc
 
-    fs_frame = cxfc.FrenetSerretFrame.from_curve(base_frame, curve)
-    b_frame  = cxfc.BishopFrame.from_curve(base_frame, curve)
+    fs_frame = cxfc.FrenetSerretFrame.from_curve(base_frame, curve, tau_unit)
+    b_frame  = cxfc.BishopFrame.from_curve(base_frame, curve, tau_unit)
 
 See Also
 --------

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -14,9 +14,10 @@ $$ \frac{d\tau}{ds} = \frac{1}{\|\boldsymbol{\gamma}'(\tau)\|},
 
 directly for $\tau(s)$.  Because a curve is consumed purely as a callable
 throughout `coordinaxs.curveframes` (`AbstractCurveFrameBuilder.__call__` and
-`.location` are the only two call sites), `ArcLength(curve)` is itself a curve
-and can be wrapped in any of the existing frame builders with no further
-change: e.g. ``BishopBuilder(ArcLength(curve), "s")``.
+`.location` are the only two call sites), `ArcLength(curve, "s")` is itself a
+curve and can be wrapped in any of the existing frame builders with no further
+change: e.g. ``BishopBuilder(ArcLength(curve, "s"), "km")``. The builder's unit
+is a *length*, because what the wrapper exposes is arc length.
 
 """
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -16,7 +16,7 @@ directly for $\tau(s)$.  Because a curve is consumed purely as a callable
 throughout `coordinaxs.curveframes` (`AbstractCurveFrameBuilder.__call__` and
 `.location` are the only two call sites), `ArcLength(curve)` is itself a curve
 and can be wrapped in any of the existing frame builders with no further
-change: e.g. ``BishopBuilder(ArcLength(curve))``.
+change: e.g. ``BishopBuilder(ArcLength(curve), "s")``.
 
 """
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -46,11 +46,11 @@ BuilderT = TypeVar("BuilderT", bound="AbstractCurveFrameBuilder")
 
 _MSG_TAU_UNIT_DIMENSION = (
     "this curve exposes a parameter of dimension {want}, but `tau_unit` is "
-    "{unit!r}, which is {got}. `tau_unit` defaults to 's', so this is usually "
-    "a forgotten argument: a builder over an arc-length curve needs a length, "
-    "e.g. `BishopBuilder(ArcLength(curve, 'km'), 'km')`. Left as-is, "
-    "`location` would still return correct positions -- it never consults the "
-    "unit -- while `tangent` and `rotation_matrix` would fail later inside "
+    "{unit!r}, which is {got}. A builder over an arc-length curve needs a "
+    "length, e.g. `BishopBuilder(ArcLength(curve, 'km'), 'km')` -- a common "
+    "way to land here is migrating mechanically to 's'. Left as-is, "
+    "`location` would still return correct positions, since it never consults "
+    "the unit, while `tangent` and `rotation_matrix` would fail later inside "
     "the derivative."
 )
 
@@ -187,7 +187,7 @@ class AbstractCurveFrameBuilder(eqx.Module):
             if got != want:
                 raise ValueError(
                     _MSG_TAU_UNIT_DIMENSION.format(
-                        want=want, unit=str(self.tau_unit), got=got
+                        want=want, unit=self.tau_unit, got=got
                     )
                 )
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -246,7 +246,7 @@ class AbstractCurveFrameBuilder(eqx.Module):
         ...     t = tau.ustrip("s")
         ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), t]), "m")
 
-        >>> builder = cxfc.FrenetSerretBuilder(helix)
+        >>> builder = cxfc.FrenetSerretBuilder(helix, "s")
         >>> op = builder(u.Q(0.0, "s"))
         >>> isinstance(op, cxfm.Composed)
         True
@@ -278,7 +278,7 @@ class AbstractCurveFrameBuilder(eqx.Module):
         ...     t = tau.ustrip("s")
         ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), t]), "m")
 
-        >>> cxfc.FrenetSerretBuilder(helix).location(u.Q(0.0, "s"))
+        >>> cxfc.FrenetSerretBuilder(helix, "s").location(u.Q(0.0, "s"))
         Q([1., 0., 0.], 'm')
 
         For a two-argument curve ``tau`` is the time -- see `_resolve`.
@@ -301,7 +301,7 @@ class AbstractCurveFrameBuilder(eqx.Module):
         ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t),
         ...                           jnp.zeros_like(t)]), "m")
 
-        >>> cxfc.FrenetSerretBuilder(circle).tangent(u.Q(0.0, "s"))
+        >>> cxfc.FrenetSerretBuilder(circle, "s").tangent(u.Q(0.0, "s"))
         Q([-0.,  1.,  0.], '')
 
         For a two-argument curve ``tau`` is the time -- see `_resolve`.

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -47,11 +47,12 @@ BuilderT = TypeVar("BuilderT", bound="AbstractCurveFrameBuilder")
 _MSG_TAU_UNIT_DIMENSION = (
     "this curve exposes a parameter of dimension {want}, but `tau_unit` is "
     "{unit!r}, which is {got}. A builder over an arc-length curve needs a "
-    "length, e.g. `BishopBuilder(ArcLength(curve, 'km'), 'km')` -- a common "
-    "way to land here is migrating mechanically to 's'. Left as-is, "
-    "`location` would still return correct positions, since it never consults "
-    "the unit, while `tangent` and `rotation_matrix` would fail later inside "
-    "the derivative."
+    "length, e.g. `BishopBuilder(ArcLength(curve, 's'), 'km')`: `ArcLength` "
+    "takes the *wrapped* curve's unit, typically a time, while the builder "
+    "takes the arc length the wrapper exposes. A common way to land here is "
+    "migrating mechanically to 's'. Left as-is, `location` would still return "
+    "correct positions, since it never consults the unit, while `tangent` and "
+    "`rotation_matrix` would fail later inside the derivative."
 )
 
 _MSG_TWO_ARGUMENT_NEEDS_STATION = (

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
@@ -191,8 +191,11 @@ class BishopBuilder(AbstractCurveFrameBuilder):
     curve : Callable
         A function ``tau -> Quantity[float, (3,)]``.  Make it an
         `equinox.Module` for differentiable curve parameters.
-    tau_unit : AbstractUnit or str, optional
-        Unit of the curve parameter.  Defaults to ``"s"``.
+    tau_unit : AbstractUnit or str
+        Unit of the curve parameter.  Required: there is no neutral default,
+        since a curve parameter may be a time, an arc length, or an affine
+        parameter, and the wrong unit is silently rescaled rather than
+        rejected when it is dimensionally compatible.
     station : optional
         A fixed station along the curve; see `AbstractCurveFrameBuilder`.
     tau_0 : Quantity, optional

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
@@ -258,7 +258,7 @@ class BishopBuilder(AbstractCurveFrameBuilder):
     ...     t = tau.ustrip("s")
     ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), t]), "m")
 
-    >>> bt = cxfc.BishopBuilder(helix)
+    >>> bt = cxfc.BishopBuilder(helix, "s")
     >>> bt.location(u.Q(0.0, "s"))
     Q([1., 0., 0.], 'm')
 
@@ -283,7 +283,7 @@ class BishopBuilder(AbstractCurveFrameBuilder):
     ...     return u.Q(jnp.stack([t, jnp.zeros_like(t),
     ...                           jnp.zeros_like(t)]), "m")
 
-    >>> U1 = cxfc.BishopBuilder(line).normal1(u.Q(5.0, "s"))
+    >>> U1 = cxfc.BishopBuilder(line, "s").normal1(u.Q(5.0, "s"))
     >>> jnp.sqrt(jnp.sum(U1.value**2))
     Array(1., dtype=float64)
 
@@ -293,7 +293,7 @@ class BishopBuilder(AbstractCurveFrameBuilder):
     """The constructing curve."""
 
     tau_unit: u.AbstractUnit = eqx.field(  # ty: ignore[invalid-assignment]
-        default=u.unit("s"), static=True, converter=u.unit
+        static=True, converter=u.unit
     )
     """The unit of the curve parameter tau."""
 
@@ -429,7 +429,7 @@ class BishopBuilder(AbstractCurveFrameBuilder):
         ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t),
         ...                           jnp.zeros_like(t)]), "m")
 
-        >>> R = cxfc.BishopBuilder(circle).rotation_matrix(u.Q(0.0, "s"))
+        >>> R = cxfc.BishopBuilder(circle, "s").rotation_matrix(u.Q(0.0, "s"))
         >>> bool(jnp.allclose(R @ R.T, jnp.eye(3), atol=1e-6))
         True
 
@@ -465,7 +465,7 @@ class BishopBuilder(AbstractCurveFrameBuilder):
         ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t),
         ...                           jnp.zeros_like(t)]), "m")
 
-        >>> cxfc.BishopBuilder(circle).tangent(u.Q(0.0, "s"))
+        >>> cxfc.BishopBuilder(circle, "s").tangent(u.Q(0.0, "s"))
         Q([-0.,  1.,  0.], '')
 
         """
@@ -497,7 +497,7 @@ class BishopBuilder(AbstractCurveFrameBuilder):
         ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t),
         ...                           jnp.zeros_like(t)]), "m")
 
-        >>> U1 = cxfc.BishopBuilder(circle).normal1(u.Q(0.0, "s"))
+        >>> U1 = cxfc.BishopBuilder(circle, "s").normal1(u.Q(0.0, "s"))
         >>> float(jnp.linalg.norm(U1.value))
         1.0
 
@@ -525,7 +525,7 @@ class BishopBuilder(AbstractCurveFrameBuilder):
         ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t),
         ...                           jnp.zeros_like(t)]), "m")
 
-        >>> U2 = cxfc.BishopBuilder(circle).normal2(u.Q(0.0, "s"))
+        >>> U2 = cxfc.BishopBuilder(circle, "s").normal2(u.Q(0.0, "s"))
         >>> float(jnp.linalg.norm(U2.value))
         1.0
 
@@ -577,7 +577,7 @@ class BishopFrame(AbstractParallelTransportFrame[FrameT]):
 
     Build a frame relative to Alice:
 
-    >>> b_frame = cxfc.BishopFrame.from_curve(cxf.Alice(), circle)
+    >>> b_frame = cxfc.BishopFrame.from_curve(cxf.Alice(), circle, "s")
     >>> b_frame.base_frame
     Alice()
 
@@ -604,7 +604,7 @@ class BishopFrame(AbstractParallelTransportFrame[FrameT]):
         base_frame: FrameT,
         curve: Callable[[Any], Any],
         /,
-        tau_unit: u.AbstractUnit | str = "s",
+        tau_unit: u.AbstractUnit | str,
         *,
         station: Any = None,
         tau_0: u.AbstractQuantity | None = None,
@@ -652,7 +652,7 @@ class BishopFrame(AbstractParallelTransportFrame[FrameT]):
         ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t),
         ...                           jnp.zeros_like(t)]), "km")
 
-        >>> frame = cxfc.BishopFrame.from_curve(cxf.Alice(), circle)
+        >>> frame = cxfc.BishopFrame.from_curve(cxf.Alice(), circle, "s")
         >>> frame.base_frame
         Alice()
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
@@ -622,8 +622,11 @@ class BishopFrame(AbstractParallelTransportFrame[FrameT]):
             The ambient reference frame.
         curve : Callable
             A function ``tau -> Quantity[float, (3,)]``.
-        tau_unit : str, optional
-            Unit of the curve parameter for differentiation.
+        tau_unit : AbstractUnit or str
+            Unit of the curve parameter for differentiation.  Required: there
+            is no neutral default, since a curve parameter may be a time, an
+            arc length, or an affine parameter, and the wrong unit is silently
+            rescaled rather than rejected when it is dimensionally compatible.
         station : optional
             A fixed station along the curve; when given the frame is a fixed
             frame *field* along the curve rather than a moving frame.

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
@@ -59,7 +59,7 @@ class TubularChart(AbstractParameterizedChart):
     ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), jnp.zeros_like(t)]), "km")
 
     >>> chart = cxfc.TubularChart(
-    ...     cxfc.BishopBuilder(circle),
+    ...     cxfc.BishopBuilder(circle, "s"),
     ...     tau_bounds=(u.Q(0.0, "s"), u.Q(2 * jnp.pi, "s")),
     ... )
     >>> chart.components

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
@@ -346,8 +346,11 @@ class FrenetSerretFrame(AbstractParallelTransportFrame[FrameT]):
         curve : Callable
             A function ``tau -> Quantity[float, (3,)]`` representing
             a smooth space curve.
-        tau_unit : str, optional
-            Unit of the curve parameter for differentiation.
+        tau_unit : AbstractUnit or str
+            Unit of the curve parameter for differentiation.  Required: there
+            is no neutral default, since a curve parameter may be a time, an
+            arc length, or an affine parameter, and the wrong unit is silently
+            rescaled rather than rejected when it is dimensionally compatible.
         station : optional
             A fixed station along the curve; when given the frame is a fixed
             frame *field* along the curve rather than a moving frame.

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
@@ -92,9 +92,12 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
         A function ``tau -> Quantity[float, (3,)]`` representing a smooth space
         curve.  Make it an `equinox.Module` for differentiable curve parameters;
         a bare function's captures are trace-time constants.
-    tau_unit : AbstractUnit or str, optional
+    tau_unit : AbstractUnit or str
         Unit of the curve parameter, used by {func}`unxt.experimental.jacfwd` to
-        compute unit-correct derivatives.  Defaults to ``"s"``.
+        compute unit-correct derivatives.  Required: there is no neutral
+        default, since a curve parameter may be a time, an arc length, or an
+        affine parameter, and the wrong unit is silently rescaled rather than
+        rejected when it is dimensionally compatible.
     station : optional
         A fixed station along the curve; see `AbstractCurveFrameBuilder`.
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
@@ -110,7 +110,7 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
     ...     t = tau.ustrip("s")
     ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), t]), "m")
 
-    >>> fs = cxfc.FrenetSerretBuilder(helix)
+    >>> fs = cxfc.FrenetSerretBuilder(helix, "s")
     >>> fs.location(u.Q(0.0, "s"))
     Q([1., 0., 0.], 'm')
 
@@ -120,7 +120,7 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
     """The constructing curve."""
 
     tau_unit: u.AbstractUnit = eqx.field(  # ty: ignore[invalid-assignment]
-        default=u.unit("s"), static=True, converter=u.unit
+        static=True, converter=u.unit
     )
     """The unit of the curve parameter tau."""
 
@@ -149,7 +149,8 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
         ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t),
         ...                           jnp.zeros_like(t)]), "m")
 
-        >>> cxfc.FrenetSerretBuilder(circle).rotation_matrix(u.Q(0.0, "s")).round(3)
+        >>> fs = cxfc.FrenetSerretBuilder(circle, "s")
+        >>> fs.rotation_matrix(u.Q(0.0, "s")).round(3)
         Array([[-0.,  1.,  0.],
                [-1., -0.,  0.],
                [ 0.,  0.,  1.]], dtype=float64)
@@ -200,7 +201,7 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
         ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t),
         ...                           jnp.zeros_like(t)]), "m")
 
-        >>> cxfc.FrenetSerretBuilder(circle).tangent(u.Q(0.0, "s"))
+        >>> cxfc.FrenetSerretBuilder(circle, "s").tangent(u.Q(0.0, "s"))
         Q([-0.,  1.,  0.], '')
 
         """
@@ -229,7 +230,7 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
         ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t),
         ...                           jnp.zeros_like(t)]), "m")
 
-        >>> cxfc.FrenetSerretBuilder(circle).normal(u.Q(0.0, "s"))
+        >>> cxfc.FrenetSerretBuilder(circle, "s").normal(u.Q(0.0, "s"))
         Q([-1., -0.,  0.], '')
 
         """
@@ -255,7 +256,7 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
         ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t),
         ...                           jnp.zeros_like(t)]), "m")
 
-        >>> cxfc.FrenetSerretBuilder(circle).binormal(u.Q(0.0, "s"))
+        >>> cxfc.FrenetSerretBuilder(circle, "s").binormal(u.Q(0.0, "s"))
         Q([0., 0., 1.], '')
 
         """
@@ -303,7 +304,7 @@ class FrenetSerretFrame(AbstractParallelTransportFrame[FrameT]):
 
     Build a frame relative to Alice:
 
-    >>> fs_frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle)
+    >>> fs_frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle, "s")
     >>> fs_frame.base_frame
     Alice()
 
@@ -329,7 +330,7 @@ class FrenetSerretFrame(AbstractParallelTransportFrame[FrameT]):
         base_frame: FrameT,
         curve: Callable[[Any], Any],
         /,
-        tau_unit: u.AbstractUnit | str = "s",
+        tau_unit: u.AbstractUnit | str,
         *,
         station: Any = None,
     ) -> "FrenetSerretFrame[FrameT]":
@@ -365,7 +366,7 @@ class FrenetSerretFrame(AbstractParallelTransportFrame[FrameT]):
         ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t),
         ...                           jnp.zeros_like(t)]), "km")
 
-        >>> frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle)
+        >>> frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle, "s")
         >>> frame.base_frame
         Alice()
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/nearest.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/nearest.py
@@ -89,7 +89,7 @@ def nearest_tau(
     ...     t = tau.ustrip("s")
     ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), jnp.zeros_like(t)]), "km")
 
-    >>> b = cxfc.BishopBuilder(circle)
+    >>> b = cxfc.BishopBuilder(circle, "s")
     >>> tau = cxfc.nearest_tau(b, u.Q(jnp.array([2.0, 0.0, 0.0]), "km"),
     ...                        bounds=(u.Q(0.0, "s"), u.Q(2 * jnp.pi, "s")))
     >>> bool(jnp.allclose(tau.ustrip("s"), 0.0, atol=1e-6))

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/register_frames.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/register_frames.py
@@ -72,7 +72,7 @@ def frame_transition(
     ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t),
     ...                           jnp.zeros_like(t)]), "km")
 
-    >>> fs_frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle)
+    >>> fs_frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle, "s")
     >>> op = cxf.frame_transition(cxf.Alice(), fs_frame)
     >>> isinstance(op, cxt.AbstractTransform)
     True
@@ -109,7 +109,7 @@ def frame_transition(
     ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t),
     ...                           jnp.zeros_like(t)]), "km")
 
-    >>> fs_frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle)
+    >>> fs_frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle, "s")
     >>> op = cxf.frame_transition(fs_frame, cxf.Alice())
     >>> isinstance(op, cxt.AbstractTransform)
     True
@@ -151,8 +151,8 @@ def frame_transition(
     ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t),
     ...                           jnp.zeros_like(t)]), "km")
 
-    >>> fs1 = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle)
-    >>> fs2 = cxfc.FrenetSerretFrame.from_curve(cxf.Alex(), circle)
+    >>> fs1 = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle, "s")
+    >>> fs2 = cxfc.FrenetSerretFrame.from_curve(cxf.Alex(), circle, "s")
     >>> op = cxf.frame_transition(fs1, fs2)
     >>> isinstance(op, cxt.AbstractTransform)
     True

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/register_ptmap.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/register_ptmap.py
@@ -45,7 +45,7 @@ def pt_map(
     ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), jnp.zeros_like(t)]), "km")
 
     >>> chart = cxfc.TubularChart(
-    ...     cxfc.BishopBuilder(circle),
+    ...     cxfc.BishopBuilder(circle, "s"),
     ...     tau_bounds=(u.Q(0.0, "s"), u.Q(2 * jnp.pi, "s")),
     ... )
     >>> p = {"tau": u.Q(0.0, "s"), "n1": u.Q(0.1, "km"), "n2": u.Q(0.0, "km")}
@@ -89,7 +89,7 @@ def pt_map(
     ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), jnp.zeros_like(t)]), "km")
 
     >>> chart = cxfc.TubularChart(
-    ...     cxfc.BishopBuilder(circle),
+    ...     cxfc.BishopBuilder(circle, "s"),
     ...     tau_bounds=(u.Q(0.0, "s"), u.Q(2 * jnp.pi, "s")),
     ... )
 
@@ -152,7 +152,7 @@ def pt_map(
     ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), jnp.zeros_like(t)]), "km")
 
     >>> chart = cxfc.TubularChart(
-    ...     cxfc.BishopBuilder(circle),
+    ...     cxfc.BishopBuilder(circle, "s"),
     ...     tau_bounds=(u.Q(0.0, "s"), u.Q(2 * jnp.pi, "s")),
     ... )
     >>> p = {"tau": u.Q(0.0, "s"), "n1": u.Q(0.1, "km"), "n2": u.Q(0.0, "km")}

--- a/packages/coordinaxs.curveframes/src/coordinaxs/hypothesis/curveframes/_tubular.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/hypothesis/curveframes/_tubular.py
@@ -64,7 +64,10 @@ def _tubular_kwargs(draw: st.DrawFn, /) -> dict[str, Any]:
     """Shared draw logic behind both `charts()` and `chart_init_kwargs()`."""
     curve, (lo, hi) = draw(st.sampled_from(_CURVES))
     builder_cls = draw(st.sampled_from(_BUILDERS))
-    return {"builder": builder_cls(curve), "tau_bounds": (u.Q(lo, "s"), u.Q(hi, "s"))}
+    return {
+        "builder": builder_cls(curve, "s"),
+        "tau_bounds": (u.Q(lo, "s"), u.Q(hi, "s")),
+    }
 
 
 @plum.dispatch

--- a/packages/coordinaxs.curveframes/tests/conftest.py
+++ b/packages/coordinaxs.curveframes/tests/conftest.py
@@ -130,7 +130,7 @@ def pt_case(request: pytest.FixtureRequest) -> SimpleNamespace:
     naming ``binormal`` or ``normal2``.
     """
     spec = PARALLEL_TRANSPORT_TYPES[request.param]
-    builder = spec.builder_cls(circle)
+    builder = spec.builder_cls(circle, "s")
 
     def fields(bldr: object, tau: u.AbstractQuantity) -> tuple:
         return tuple(getattr(bldr, name)(tau) for name in spec.triad)
@@ -141,7 +141,7 @@ def pt_case(request: pytest.FixtureRequest) -> SimpleNamespace:
         builder_cls=spec.builder_cls,
         yr_builder=spec.builder_cls(circle_yr, "yr"),
         xop=cxfm.TimeDep(builder),
-        frame=spec.frame_cls.from_curve(cxf.Alice(), circle),
+        frame=spec.frame_cls.from_curve(cxf.Alice(), circle, "s"),
         frame_cls=spec.frame_cls,
         triad=spec.triad,
         tol=SimpleNamespace(**TOLERANCES[request.param]),

--- a/packages/coordinaxs.curveframes/tests/test_bishop.py
+++ b/packages/coordinaxs.curveframes/tests/test_bishop.py
@@ -38,22 +38,22 @@ VEL = {"x": u.Q(0.1, "km/s"), "y": u.Q(0.2, "km/s"), "z": u.Q(-0.3, "km/s")}
 
 @pytest.fixture
 def circle_bishop() -> cxfc.BishopBuilder:
-    return cxfc.BishopBuilder(circle)
+    return cxfc.BishopBuilder(circle, "s")
 
 
 @pytest.fixture
 def line_bishop() -> cxfc.BishopBuilder:
-    return cxfc.BishopBuilder(straight_line)
+    return cxfc.BishopBuilder(straight_line, "s")
 
 
 @pytest.fixture
 def helix_bishop() -> cxfc.BishopBuilder:
-    return cxfc.BishopBuilder(helix)
+    return cxfc.BishopBuilder(helix, "s")
 
 
 @pytest.fixture
 def line_bishop_frame() -> cxfc.BishopFrame:
-    return cxfc.BishopFrame.from_curve(cxf.Alice(), straight_line)
+    return cxfc.BishopFrame.from_curve(cxf.Alice(), straight_line, "s")
 
 
 # ── Straight line (kappa = 0) ────────────────────────────────────────
@@ -108,14 +108,14 @@ class TestBishopTau0:
 
     def test_custom_tau_0_still_yields_a_unit_tangent(self):
         """Shifting the transport origin does not disturb the tangent."""
-        bt = cxfc.BishopBuilder(circle, tau_0=u.Q(1.0, "s"))
+        bt = cxfc.BishopBuilder(circle, "s", tau_0=u.Q(1.0, "s"))
         T = bt.tangent(u.Q(1, "s"))
         assert jnp.allclose(jnp.linalg.norm(T.value), 1, atol=1e-5)
 
     def test_explicit_initial_normal_is_used(self):
         """An explicit initial_normal fixes U1 at tau_0."""
         n0 = jnp.array([0.0, 0.0, 1.0])
-        bt = cxfc.BishopBuilder(circle, initial_normal=n0)
+        bt = cxfc.BishopBuilder(circle, "s", initial_normal=n0)
         np.testing.assert_allclose(bt.normal1(u.Q(0.0, "s")).value, n0, atol=1e-6)
 
     def test_backwards_transport_is_a_rotation(self):
@@ -124,7 +124,7 @@ class TestBishopTau0:
         `odeint` integrates forward only, so a decreasing t_span silently
         yields NaN. With the default tau_0=0 that broke *every* negative tau.
         """
-        R = cxfc.BishopBuilder(helix).rotation_matrix(u.Q(-1.5, "s"))
+        R = cxfc.BishopBuilder(helix, "s").rotation_matrix(u.Q(-1.5, "s"))
         assert jnp.all(jnp.isfinite(R))
         np.testing.assert_allclose(R @ R.T, jnp.eye(3), atol=1e-5)
         np.testing.assert_allclose(jnp.linalg.det(R), 1.0, atol=1e-5)
@@ -136,7 +136,7 @@ class TestBishopTau0:
         vector that is not unit and normal-plane makes R not a rotation.
         """
         n0 = jnp.array([0.0, 1.0, 0.0])  # neither unit-normal to T nor unique
-        bt = cxfc.BishopBuilder(helix, initial_normal=n0)
+        bt = cxfc.BishopBuilder(helix, "s", initial_normal=n0)
         R = bt.rotation_matrix(u.Q(1.0, "s"))
         np.testing.assert_allclose(R @ R.T, jnp.eye(3), atol=1e-5)
         np.testing.assert_allclose(jnp.linalg.det(R), 1.0, atol=1e-5)
@@ -156,7 +156,7 @@ class TestBishopTau0:
         parallel vector must not sneak it past.
         """
         # Tangent of the straight line at tau_0 = 0 is +x.
-        bt = cxfc.BishopBuilder(straight_line, initial_normal=jnp.array(n0))
+        bt = cxfc.BishopBuilder(straight_line, "s", initial_normal=jnp.array(n0))
         with pytest.raises(Exception, match="parallel to the tangent"):
             bt.rotation_matrix(u.Q(1.0, "s"))
 
@@ -169,8 +169,10 @@ class TestBishopTau0:
         degenerate.
         """
         tau = u.Q(1.0, "s")
-        unit = cxfc.BishopBuilder(helix, initial_normal=jnp.array([0.0, 0.0, 1.0]))
-        tiny = cxfc.BishopBuilder(helix, initial_normal=jnp.array([0.0, 0.0, 1e-12]))
+        unit = cxfc.BishopBuilder(helix, "s", initial_normal=jnp.array([0.0, 0.0, 1.0]))
+        tiny = cxfc.BishopBuilder(
+            helix, "s", initial_normal=jnp.array([0.0, 0.0, 1e-12])
+        )
 
         R_tiny = tiny.rotation_matrix(tau)
         np.testing.assert_allclose(R_tiny, unit.rotation_matrix(tau), atol=1e-12)
@@ -236,8 +238,8 @@ class TestBishopTangentPropagation:
         agree to solver accuracy -- an oracle that needs no finite differences.
         """
         tau = u.Q(tau_val, "s")
-        bishop = cxfm.TimeDep(cxfc.BishopBuilder(helix))
-        frenet = cxfm.TimeDep(cxfc.FrenetSerretBuilder(helix))
+        bishop = cxfm.TimeDep(cxfc.BishopBuilder(helix, "s"))
+        frenet = cxfm.TimeDep(cxfc.FrenetSerretBuilder(helix, "s"))
 
         kw = {"at": AT}
         got = cxfm.act(
@@ -336,7 +338,7 @@ def _orthonormality_error(R: jax.Array) -> float:
 #: The default solve configuration, reached the way a user reaches it. The
 #: builder's field is `static=True`, so `equinox.tree_at` cannot descend into
 #: it (a static field is not a leaf) -- `dataclasses.replace` is the move.
-_DEFAULT_SOLVE = cxfc.BishopBuilder(helix).diffeqsolver
+_DEFAULT_SOLVE = cxfc.BishopBuilder(helix, "s").diffeqsolver
 
 
 def _configured(**kw: object) -> cxfc.BishopBuilder:
@@ -346,7 +348,7 @@ def _configured(**kw: object) -> cxfc.BishopBuilder:
     whole point; see `test_partial_override_preserves_the_direct_adjoint`.
     """
     return dataclasses.replace(
-        cxfc.BishopBuilder(helix),
+        cxfc.BishopBuilder(helix, "s"),
         diffeqsolver=dataclasses.replace(_DEFAULT_SOLVE, **kw),
     )
 
@@ -361,7 +363,7 @@ class TestBishopSolveConfiguration:
 
     def test_defaults_are_the_previous_constants(self):
         """The defaults reproduce the module-level constants they replaced."""
-        solve = cxfc.BishopBuilder(helix).diffeqsolver
+        solve = cxfc.BishopBuilder(helix, "s").diffeqsolver
         assert isinstance(solve, DiffEqSolver)
         assert solve.solver == dfx.Tsit5()
         assert solve.adjoint == dfx.DirectAdjoint()
@@ -376,7 +378,7 @@ class TestBishopSolveConfiguration:
         accurate to 9.403e-12 out at ``|tau| = 60``, where it also stays
         inside the 16384-step budget (~20 steps per unit of ``|dtau|``).
         """
-        R = cxfc.BishopBuilder(helix).rotation_matrix(u.Q(tau_val, "s"))
+        R = cxfc.BishopBuilder(helix, "s").rotation_matrix(u.Q(tau_val, "s"))
         assert _orthonormality_error(R) < 1e-11
         np.testing.assert_allclose(jnp.linalg.det(R), 1.0, atol=1e-11)
 
@@ -422,7 +424,7 @@ class TestBishopSolveConfiguration:
         # Configuring the solve adds no leaves: the `DiffEqSolver` carries ten
         # of its own (floats, ints, a bool, a function) once it is dynamic.
         assert len(jax.tree.leaves(bt)) == len(
-            jax.tree.leaves(cxfc.BishopBuilder(helix))
+            jax.tree.leaves(cxfc.BishopBuilder(helix, "s"))
         )
 
         # So a tree_map over the curve parameters cannot reach the config.
@@ -438,7 +440,7 @@ class TestBishopSolveConfiguration:
         merely accepted.
         """
         tau = u.Q(7.0, "s")
-        default = cxfc.BishopBuilder(helix).rotation_matrix(tau)
+        default = cxfc.BishopBuilder(helix, "s").rotation_matrix(tau)
         loose = _configured(
             stepsize_controller=dfx.PIDController(rtol=1e-3, atol=1e-3)
         ).rotation_matrix(tau)
@@ -451,7 +453,7 @@ class TestBishopSolveConfiguration:
     def test_alternative_solver_agrees_with_the_default(self):
         """A different solver is a different integrator, not a different answer."""
         tau = u.Q(7.0, "s")
-        default = cxfc.BishopBuilder(helix).rotation_matrix(tau)
+        default = cxfc.BishopBuilder(helix, "s").rotation_matrix(tau)
         dopri = _configured(solver=dfx.Dopri5()).rotation_matrix(tau)
         np.testing.assert_allclose(dopri, default, atol=1e-9)
 
@@ -471,7 +473,7 @@ class TestBishopSolveConfiguration:
         )
 
         def build(r: jax.Array) -> cxfc.BishopBuilder:
-            return cxfc.BishopBuilder(ParametricHelix(r), diffeqsolver=solve)
+            return cxfc.BishopBuilder(ParametricHelix(r), "s", diffeqsolver=solve)
 
         one = jnp.asarray(1.0)
 
@@ -541,6 +543,7 @@ class TestBishopSolveConfiguration:
             return eqx.filter_grad(
                 lambda r: cxfc.BishopBuilder(
                     ParametricHelix(r),
+                    "s",
                     diffeqsolver=dataclasses.replace(_DEFAULT_SOLVE, adjoint=adjoint),
                 ).rotation_matrix(tau)[1, 2]
             )(jnp.asarray(1.0))
@@ -577,6 +580,7 @@ class TestBishopSolveConfiguration:
             eqx.filter_grad(
                 lambda r: cxfc.BishopBuilder(
                     ParametricHelix(r),
+                    "s",
                     diffeqsolver=dataclasses.replace(_DEFAULT_SOLVE, adjoint=bs),
                 ).rotation_matrix(tau)[1, 2]
             )(jnp.asarray(1.0))
@@ -600,12 +604,12 @@ class TestBishopSolveConfiguration:
         loose = dataclasses.replace(
             _DEFAULT_SOLVE, stepsize_controller=dfx.PIDController(rtol=1e-3, atol=1e-3)
         )
-        frame = cxfc.BishopFrame.from_curve(cxf.Alice(), helix, diffeqsolver=loose)
+        frame = cxfc.BishopFrame.from_curve(cxf.Alice(), helix, "s", diffeqsolver=loose)
 
         assert frame.xop.builder.diffeqsolver is loose
         assert _orthonormality_error(frame.xop.builder.rotation_matrix(tau)) > 1e-5
 
         # The default path is untouched.
-        default = cxfc.BishopFrame.from_curve(cxf.Alice(), helix)
+        default = cxfc.BishopFrame.from_curve(cxf.Alice(), helix, "s")
         assert default.xop.builder.diffeqsolver == _DEFAULT_SOLVE
         assert _orthonormality_error(default.xop.builder.rotation_matrix(tau)) < 1e-11

--- a/packages/coordinaxs.curveframes/tests/test_capabilities.py
+++ b/packages/coordinaxs.curveframes/tests/test_capabilities.py
@@ -83,7 +83,7 @@ class TestGradThroughCurveParameter:
         r0 = 1.5
 
         def loss(radius):
-            return _readout(builder_cls(Helix(radius)))
+            return _readout(builder_cls(Helix(radius), "s"))
 
         g = jax.grad(loss)(r0)
 
@@ -96,7 +96,7 @@ class TestGradThroughCurveParameter:
 
     def test_grad_through_the_whole_builder_pytree(self):
         """`jax.grad` over the builder returns a gradient in ``curve.radius``."""
-        builder = cxfc.FrenetSerretBuilder(Helix(1.5))
+        builder = cxfc.FrenetSerretBuilder(Helix(1.5), "s")
         gbuilder = jax.grad(_readout)(builder)
 
         assert isinstance(gbuilder, cxfc.FrenetSerretBuilder)
@@ -104,7 +104,7 @@ class TestGradThroughCurveParameter:
 
         # The scalar-argument route must agree.
         def loss(radius):
-            return _readout(cxfc.FrenetSerretBuilder(Helix(radius)))
+            return _readout(cxfc.FrenetSerretBuilder(Helix(radius), "s"))
 
         assert jnp.allclose(gbuilder.curve.radius, jax.grad(loss)(1.5))
 
@@ -116,7 +116,7 @@ class TestGradThroughCurveParameter:
         """
 
         def loss(radius):
-            return _readout(cxfc.FrenetSerretBuilder(StaticHelix(radius)))
+            return _readout(cxfc.FrenetSerretBuilder(StaticHelix(radius), "s"))
 
         # equinox refuses to stash a tracer in a static field (UserWarning,
         # promoted to an error by the project's filterwarnings config).
@@ -151,7 +151,7 @@ class TestFixedStation:
     ):
         station = u.Q(0.7, "s")
         fixed = cxfm.TimeDep(builder_cls(circle, "s", station))
-        moving = cxfm.TimeDep(builder_cls(circle))
+        moving = cxfm.TimeDep(builder_cls(circle, "s"))
 
         assert jnp.allclose(
             cxfm.act(fixed, u.Q(tau_val, "s"), P).ustrip("km"),
@@ -191,7 +191,9 @@ class TestFixedStation:
 
     def test_frame_from_curve_accepts_station(self):
         station = u.Q(0.7, "s")
-        frame = cxfc.FrenetSerretFrame.from_curve(cxf.Alice(), circle, station=station)
+        frame = cxfc.FrenetSerretFrame.from_curve(
+            cxf.Alice(), circle, "s", station=station
+        )
         assert frame.xop.builder.station is station
 
         op = cxf.frame_transition(cxf.Alice(), frame)
@@ -206,7 +208,7 @@ class TestJitWithArrayLeaves:
     """A builder holding array leaves needs `eqx.filter_jit`, not `jax.jit`."""
 
     def test_filter_jit_works_where_jax_jit_cannot_hash(self):
-        builder = cxfc.FrenetSerretBuilder(Helix(jnp.asarray(1.5)))
+        builder = cxfc.FrenetSerretBuilder(Helix(jnp.asarray(1.5)), "s")
 
         # Plain jax.jit hashes the bound method, hence the module, hence the
         # array leaf -- the ergonomic cliff of the differentiable-curve design.

--- a/packages/coordinaxs.curveframes/tests/test_frenet_serret.py
+++ b/packages/coordinaxs.curveframes/tests/test_frenet_serret.py
@@ -33,7 +33,7 @@ from .conftest import circle, circle_yr, helix, inverse_rotation
 
 @pytest.fixture
 def circle_fs() -> cxfc.FrenetSerretBuilder:
-    return cxfc.FrenetSerretBuilder(circle)
+    return cxfc.FrenetSerretBuilder(circle, "s")
 
 
 @pytest.fixture
@@ -138,7 +138,7 @@ class TestTangentFastPathMatchesBase:
 
     @pytest.mark.parametrize("tau", [0.0, 0.7, 2.3])
     def test_override_equals_row0_of_R(self, tau: float):
-        builder = cxfc.FrenetSerretBuilder(helix)
+        builder = cxfc.FrenetSerretBuilder(helix, "s")
         t = u.Q(tau, "s")
         base = cxfc.AbstractCurveFrameBuilder.tangent(builder, t)
         np.testing.assert_allclose(base.value, builder.tangent(t).value, atol=1e-6)

--- a/packages/coordinaxs.curveframes/tests/test_parallel_transport_contract.py
+++ b/packages/coordinaxs.curveframes/tests/test_parallel_transport_contract.py
@@ -241,7 +241,7 @@ class TestConstructors:
     """A builder is built from a bare curve; the frame wraps it in TimeDep."""
 
     def test_builder_from_bare_curve(self, pt_case: SimpleNamespace) -> None:
-        built = pt_case.builder_cls(circle)
+        built = pt_case.builder_cls(circle, "s")
         np.testing.assert_allclose(
             built.location(u.Q(0, "s")).value, [1, 0, 0], atol=pt_case.tol.tight
         )

--- a/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
@@ -270,16 +270,17 @@ def test_eulerian_holds_arc_length_where_lagrangian_follows_the_material_point()
 
 
 def test_tau_unit_must_match_the_dimension_the_curve_exposes() -> None:
-    """`BishopBuilder(ArcLength(curve, "km"))` -- forgetting the second unit.
+    """Passing a time where the curve exposes a length.
 
-    `tau_unit` defaults to "s", so this is an easy omission, and it used to
-    construct happily.
+    `tau_unit` is required now, so plain omission is a `TypeError` before any
+    object exists. This covers the other half: a unit supplied and *wrong*,
+    which no amount of required-ness catches.
     """
     arc = cxfc.ArcLength(curve1, "s")  # exposes arc length: a *length*
     with pytest.raises(ValueError, match="dimension length"):
-        cxfc.BishopBuilder(arc)
+        cxfc.BishopBuilder(arc, "s")
     with pytest.raises(ValueError, match="dimension length"):
-        cxfc.FrenetSerretBuilder(arc)
+        cxfc.FrenetSerretBuilder(arc, "s")
     cxfc.BishopBuilder(arc, "km")  # correct, and still fine
 
 
@@ -291,7 +292,7 @@ def test_the_wrong_unit_is_only_half_visible_when_unguarded() -> None:
     sanity-checks positions first would conclude it works.
 
     A plain function cannot advertise what it exposes, so a length-parametrised
-    one still slips through with the default "s". That is the residual case the
+    one still slips through when "s" is passed. That is the residual case the
     `_param_dimension` guard does not cover; the wrappers do advertise, which
     is where the mistake is easiest to make.
     """
@@ -300,7 +301,7 @@ def test_the_wrong_unit_is_only_half_visible_when_unguarded() -> None:
         d = tau.ustrip("km")
         return u.Q(jnp.stack([d, jnp.zeros_like(d), jnp.zeros_like(d)]), "km")
 
-    b = cxfc.BishopBuilder(by_length)  # default "s", but the curve wants a length
+    b = cxfc.BishopBuilder(by_length, "s")  # a time, but the curve wants a length
     s_val = u.Q(1.0, "km")
 
     got = b.location(s_val).ustrip("km")
@@ -308,12 +309,6 @@ def test_the_wrong_unit_is_only_half_visible_when_unguarded() -> None:
 
     with pytest.raises(apyu.UnitConversionError, match="not convertible"):
         b.tangent(s_val)
-
-
-def test_a_plain_curve_keeps_the_default() -> None:
-    """No breaking change: a curve that advertises nothing is unconstrained."""
-    assert str(cxfc.BishopBuilder(curve1).tau_unit) == "s"
-    cxfc.BishopBuilder(curve1, "km")  # and an unusual unit is still allowed
 
 
 def test_a_wrapper_forwards_the_dimension_it_wraps() -> None:
@@ -333,3 +328,19 @@ def test_a_wrapper_forwards_the_dimension_it_wraps() -> None:
 
     # A wrapper over a curve that claims nothing must claim nothing itself.
     assert cxfc.AtTime(curve2, u.Q(0.5, "s"))._param_dimension is None
+
+
+def test_tau_unit_is_required() -> None:
+    """There is no default to be wrong: omission fails before an object exists.
+
+    Seconds are not a neutral fallback -- in galactic dynamics the natural
+    parameter is Myr or Gyr, and a Gyr curve read as seconds is off by 3.15e16
+    with no error anywhere, because the units are dimensionally compatible and
+    `ustrip` simply rescales.
+    """
+    with pytest.raises(TypeError, match="tau_unit"):
+        cxfc.BishopBuilder(curve1)
+    with pytest.raises(TypeError, match="tau_unit"):
+        cxfc.FrenetSerretBuilder(curve1)
+    cxfc.BishopBuilder(curve1, "s")  # any unit is allowed, none is assumed
+    cxfc.BishopBuilder(curve1, "Gyr")

--- a/packages/coordinaxs.curveframes/tests/unit/test_nearest.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_nearest.py
@@ -28,7 +28,7 @@ def _point_at(builder, tau_v, n1, n2):
 
 @pytest.mark.parametrize("builder_cls", [cxfc.BishopBuilder, cxfc.FrenetSerretBuilder])
 def test_recovers_the_generating_tau(builder_cls) -> None:
-    b = builder_cls(helix)
+    b = builder_cls(helix, "s")
     x = _point_at(b, 0.7, 0.13, -0.21)
     got = nearest_tau(b, x, bounds=BOUNDS)
     assert jnp.allclose(got.ustrip("s"), 0.7, atol=1e-6)
@@ -40,14 +40,14 @@ def test_finds_the_nearest_root_not_merely_a_stationary_one() -> None:
     The helix has stationary points of the distance near tau = 3.99 and
     -2.87; the seeded scan must still return 0.7.
     """
-    b = cxfc.BishopBuilder(helix)
+    b = cxfc.BishopBuilder(helix, "s")
     x = _point_at(b, 0.7, 0.13, -0.21)
     got = nearest_tau(b, x, bounds=(u.Q(-4.0, "s"), u.Q(12.0, "s")), n_seed=128)
     assert jnp.allclose(got.ustrip("s"), 0.7, atol=1e-6)
 
 
 def test_is_jittable() -> None:
-    b = cxfc.BishopBuilder(helix)
+    b = cxfc.BishopBuilder(helix, "s")
     x = _point_at(b, 0.7, 0.13, -0.21)
     got = jax.jit(lambda xx: nearest_tau(b, xx, bounds=BOUNDS))(x)
     assert jnp.allclose(got.ustrip("s"), 0.7, atol=1e-6)
@@ -60,7 +60,7 @@ def test_nonconvergence_raises_eagerly() -> None:
     deterministic way to exercise the non-convergence guard independent of
     the default-tolerance dtype scaling.
     """
-    b = cxfc.BishopBuilder(helix)
+    b = cxfc.BishopBuilder(helix, "s")
     x = _point_at(b, 0.7, 0.13, -0.21)
     with pytest.raises(RuntimeError, match="did not converge"):
         nearest_tau(b, x, bounds=BOUNDS, rtol=1e-300, atol=1e-300)
@@ -77,7 +77,7 @@ def test_polish_does_not_walk_onto_a_local_maximum() -> None:
         t = tau.ustrip("s")
         return u.Q(jnp.stack([t, 0.6 * jnp.sin(6 * t), jnp.zeros_like(t)]), "km")
 
-    b = cxfc.FrenetSerretBuilder(wavy)
+    b = cxfc.FrenetSerretBuilder(wavy, "s")
     x = u.Q(jnp.array([4.4, -1.4, 0.0]), "km")
     got = nearest_tau(b, x, bounds=(u.Q(-5.0, "s"), u.Q(5.0, "s")), n_seed=64)
 
@@ -91,7 +91,7 @@ def test_nonconvergence_raises_under_jit() -> None:
     A bare `eqx.error_if` whose result is unused is dead-code-eliminated, so
     the traced branch can pass silently while the eager branch still works.
     """
-    b = cxfc.BishopBuilder(helix)
+    b = cxfc.BishopBuilder(helix, "s")
     x = _point_at(b, 0.7, 0.13, -0.21)
 
     @jax.jit

--- a/packages/coordinaxs.curveframes/tests/unit/test_tubular_chart.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_tubular_chart.py
@@ -26,7 +26,7 @@ BOUNDS = (u.Q(0.0, "s"), u.Q(2 * jnp.pi, "s"))
 
 
 def _chart(**kw):
-    return cxfc.TubularChart(cxfc.BishopBuilder(circle), tau_bounds=BOUNDS, **kw)
+    return cxfc.TubularChart(cxfc.BishopBuilder(circle, "s"), tau_bounds=BOUNDS, **kw)
 
 
 def test_is_on_the_parameterized_branch() -> None:
@@ -72,7 +72,7 @@ def test_the_chart_carries_the_builders_leaves() -> None:
 def test_static_bounds_drop_their_leaves() -> None:
     """`tau_bounds` follows the usual opt-in rule for chart parameters."""
     ch = cxfc.TubularChart(
-        cxfc.BishopBuilder(circle),
+        cxfc.BishopBuilder(circle, "s"),
         tau_bounds=(u.StaticQuantity(-1.0, "s"), u.StaticQuantity(7.0, "s")),
     )
     assert len(jax.tree.leaves(ch)) == 2  # builder only
@@ -134,10 +134,10 @@ def test_the_reach_guard_also_fires_under_jit() -> None:
 def test_the_reach_guard_fires_on_a_nan_factor_from_a_pinned_station() -> None:
     """See the `~(f > 0)` vs `f <= 0` comment in `TubularChart.check_data`.
 
-    Reachable via public API: `FrenetSerretBuilder(curve, station=...)`.
+    Reachable via public API: `FrenetSerretBuilder(curve, "s", station=...)`.
     """
     ch = cxfc.TubularChart(
-        cxfc.FrenetSerretBuilder(circle, station=u.Q(0.5, "s")), tau_bounds=BOUNDS
+        cxfc.FrenetSerretBuilder(circle, "s", station=u.Q(0.5, "s")), tau_bounds=BOUNDS
     )
     at = {"tau": u.Q(0.7, "s"), "n1": u.Q(0.2, "km"), "n2": u.Q(0.0, "km")}
     assert jnp.isnan(ch.jacobian_factor(at))
@@ -211,7 +211,7 @@ def test_identity_falls_back_through_cartesian_for_different_charts() -> None:
         return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), jnp.ones_like(t)]), "km")
 
     ch1 = _chart()
-    ch2 = cxfc.TubularChart(cxfc.BishopBuilder(shifted), tau_bounds=BOUNDS)
+    ch2 = cxfc.TubularChart(cxfc.BishopBuilder(shifted, "s"), tau_bounds=BOUNDS)
     p = {"tau": u.Q(0.7, "s"), "n1": u.Q(0.13, "km"), "n2": u.Q(-0.21, "km")}
     got = cxc.pt_map(p, ch1.M, ch1, ch2.M, ch2)
 
@@ -254,7 +254,7 @@ def test_bishop_metric_is_diagonal_with_unit_normal_blocks() -> None:
     `test_frenet_metric_has_torsion_cross_terms` for the contrast on the same
     curve.
     """
-    ch = cxfc.TubularChart(cxfc.BishopBuilder(_helix), tau_bounds=_HELIX_BOUNDS)
+    ch = cxfc.TubularChart(cxfc.BishopBuilder(_helix, "s"), tau_bounds=_HELIX_BOUNDS)
     g = metric_matrix(ch.M, _HELIX_AT, ch).matrix
 
     assert jnp.allclose(g[0, 1].ustrip("km / s"), 0.0, atol=1e-8)
@@ -269,6 +269,8 @@ def test_frenet_metric_has_torsion_cross_terms() -> None:
     Same `_helix` and same point as the Bishop test above: Bishop is
     diagonal there, Frenet--Serret is not, ten orders of magnitude apart.
     """
-    ch = cxfc.TubularChart(cxfc.FrenetSerretBuilder(_helix), tau_bounds=_HELIX_BOUNDS)
+    ch = cxfc.TubularChart(
+        cxfc.FrenetSerretBuilder(_helix, "s"), tau_bounds=_HELIX_BOUNDS
+    )
     g = metric_matrix(ch.M, _HELIX_AT, ch).matrix
     assert not jnp.allclose(g[0, 1].ustrip("km / s"), 0.0, atol=1e-6)

--- a/packages/coordinaxs.curveframes/tests/unit/test_tubular_differentiable.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_tubular_differentiable.py
@@ -32,7 +32,7 @@ BOUNDS = (u.Q(-1.0, "s"), u.Q(6.0, "s"))
 
 def _chart(radius_km: float) -> cxfc.TubularChart:
     curve = Helix(radius=u.Q(radius_km, "km"))
-    return cxfc.TubularChart(cxfc.BishopBuilder(curve), tau_bounds=BOUNDS)
+    return cxfc.TubularChart(cxfc.BishopBuilder(curve, "s"), tau_bounds=BOUNDS)
 
 
 def test_a_live_curve_parameter_is_a_leaf() -> None:

--- a/tests/benchmark/test_curveframes.py
+++ b/tests/benchmark/test_curveframes.py
@@ -40,7 +40,7 @@ def _helix(tau):
 
 @pytest.fixture
 def frame():
-    return cxfm.TimeDep(cxfc.FrenetSerretBuilder(_helix))
+    return cxfm.TimeDep(cxfc.FrenetSerretBuilder(_helix, "s"))
 
 
 TAU = u.Q(0.7, "s")


### PR DESCRIPTION
Closes #718.

## Why

`BishopBuilder` and `FrenetSerretBuilder` defaulted `tau_unit` to `"s"`, as did `from_curve` on both frames. That default is not neutral — it encodes one domain's convention as the library's.

In galactic dynamics the natural curve parameter is Myr or Gyr and lengths are kpc, so `"s"` is the wrong convention to bake in. `ArcLength`/`LagrangianArcLength` already require the unit, from #712. This brings the builders into line.

### What the wrong unit actually costs

An earlier draft of this description claimed a Gyr curve read as seconds is "off by 3.15e16 with no error anywhere". That is not right, and the correction is worth stating because it bounds what this change buys.

`unxt.experimental.jacfwd` strips its argument with `ustrip(unit, arg)` — a **conversion**, not a reinterpretation. So `Q(2.0, "Gyr")` declared as `"s"` reaches the curve as `Q(6.3e16, "s")`, the curve's own `ustrip("Gyr")` converts it back, and the derivative comes out in `kpc/s` instead of `kpc/Gyr`: the same physical quantity, differently labelled. Measured on a Gyr/kpc helix, the declared-`"s"` and declared-`"Gyr"` builders return **bit-identical** `rotation_matrix`, `tangent` and `location`.

The mismatch corrupts the answer only for a curve that reads `.value` rather than converting — and there only `tangent` fails quietly; the parallel-transport ODE gives up outright on a curve made 3.15e16 times stiffer. An incompatible unit (a length on a time curve) already raised `UnitConversionError` on its own.

So the case for removing the default is that `"s"` is the wrong default for this library's users, not that it silently corrupts every result. That is still a good reason, and it is the honest one.

## Migration

```
BishopBuilder(curve)             ->  BishopBuilder(curve, "s")
FrenetSerretBuilder(curve)       ->  FrenetSerretBuilder(curve, "s")
Frame.from_curve(base, curve)    ->  Frame.from_curve(base, curve, "s")
```

Passing `"s"` reproduces the old behaviour exactly, so it is mechanical for anyone whose curve really was time-parametrised.

### A grep for the class name will not find every call site

Updating this repo took five passes, and only three of the four shapes were findable that way:

| shape | findable by name? |
| --- | --- |
| `BishopBuilder(curve)` | yes |
| `Frame.from_curve(base, curve)` | no — different name |
| `BishopBuilder(curve, tau_0=...)` | no — not "one argument" |
| `spec.builder_cls(curve)` | **no — indirect through a variable** |

The last was a conftest fixture, and it accounted for 142 collection errors that sat *unchanged* across three runs while the failure count fell 141 → 46 → 15. Constant error counts alongside falling failures is the signal for a single shared cause. Downstream code with factory or fixture indirection has the same blind spot.

## Scope here

99 call sites — 78 constructions, 21 `from_curve` — plus the signature sketches in `spec.md` and `__init__.py` that advertised the default.

The docs are as much the point as the code. Every example now states the unit, so a reader working in Myr/kpc sees it as something to choose rather than something the library has assumed for them.

## This does not make #753's guard redundant

The two catch different mistakes, and both tests now exist:

- **required-ness** catches *omission* — `TypeError` before an object exists
- **the dimension guard** catches *commission* — passing `"s"` to a builder over an arc-length curve still raises, because what that curve exposes is a length

The guard tests in #753 now pass `"s"` explicitly, which is the only way left to reach the guard.

## Follow-up

Requiring the unit is not the only way to remove a bad default. A `Quantity` parameter already states its unit, so the builders can read it off the parameter instead of asking the caller to declare it a second time — which is strictly safer, since an inferred unit cannot disagree with what the caller passed, and needs no migration at all. That lands as a follow-up PR immediately after this one; the docs sweep and the #718 guard here are unaffected by it.

## Verification

- full `coordinaxs.curveframes` suite passes
- clean `rm -rf docs/_build && nox -s docs`, no warnings
- `prek run --all-files` clean, including `ty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
