### PR TITLE
⚡️ perf(transforms): `Scale` scales each axis instead of contracting a matrix

### DIFF
--- a/src/coordinax/transforms/_src/actions/linear.py
+++ b/src/coordinax/transforms/_src/actions/linear.py
@@ -29,10 +29,12 @@ from .utils import is_flat_chart, require_matching_keys
 from coordinax.internal import pack_uniform_unit
 
 
-def _matmul_cdict(matrix: Array, d: CDict, comps: tuple[str, ...], /) -> CDict:
+def _matmul_cdict(
+    op: "AbstractLinearTransform", matrix: Array, d: CDict, comps: tuple[str, ...], /
+) -> CDict:
     """Apply ``matrix`` to a Cartesian cdict ``d``, packed into a shared unit."""
     v, unit = pack_uniform_unit(d, keys=comps)
-    return cast("CDict", cxc.cdict(jnp.einsum("ij,...j->...i", matrix, v), unit, comps))
+    return cast("CDict", cxc.cdict(op._contract(matrix, v), unit, comps))
 
 
 class AbstractLinearTransform(AbstractTransform):
@@ -104,6 +106,10 @@ class AbstractLinearTransform(AbstractTransform):
             f"canonical Cartesian chart {type(cart).__name__} (ndim={cart.ndim!r}).",
         )
 
+    def _contract(self, matrix: Array, arr: Any, /) -> Any:
+        """Contract the validated ``matrix`` with trailing-axis components."""
+        return jnp.einsum("ij,...j->...i", matrix, arr)
+
     def _matrix(
         self, cart: cxc.AbstractChart[Any, Any, Any], tau: Any = None, /
     ) -> Array:
@@ -144,7 +150,7 @@ def act(
         raise TypeError(msg)
 
     matrix = op._matrix(chart, tau)
-    return jnp.einsum("ij,...j->...i", matrix, x_arr)
+    return op._contract(matrix, x_arr)
 
 
 @plum.dispatch
@@ -169,7 +175,7 @@ def act(
         raise ValueError(msg)
 
     matrix = op._matrix(cart, tau)
-    return jnp.einsum("ij,...j->...i", matrix, x)  # ty: ignore[invalid-return-type]
+    return op._contract(matrix, x)
 
 
 @plum.dispatch
@@ -216,7 +222,7 @@ def act(
     matrix = op._matrix(cart, tau)
 
     p_cart = cxc.pt_map(x, chart, cart, usys=usys)
-    p_cart_out = _matmul_cdict(matrix, p_cart, comps_cart)
+    p_cart_out = _matmul_cdict(op, matrix, p_cart, comps_cart)
     out = cxc.pt_map(p_cart_out, cart, chart, usys=usys)
     return cast("CDict", out)
 
@@ -325,7 +331,7 @@ def pushforward(
 
     # Flat chart: the Jacobian is the identity, so M acts directly, no base point.
     if is_flat_chart(chart):
-        return _matmul_cdict(matrix, v, comps_cart)
+        return _matmul_cdict(op, matrix, v, comps_cart)
 
     # Non-flat: push the tangent through the chart Jacobian at `at`, apply M in
     # Cartesian, then pull back (anchoring the inverse Jacobian at M @ at).
@@ -338,8 +344,8 @@ def pushforward(
         raise TypeError(msg)
     at_cart = cxc.pt_map(at, chart, cart, usys=usys)
     p_cart = cxr.tangent_map(v, chart, rep, cart, at=at, usys=usys)  # ty: ignore[missing-argument]
-    p_cart_out = _matmul_cdict(matrix, p_cart, comps_cart)
-    at_out = _matmul_cdict(matrix, at_cart, comps_cart)
+    p_cart_out = _matmul_cdict(op, matrix, p_cart, comps_cart)
+    at_out = _matmul_cdict(op, matrix, at_cart, comps_cart)
     return cxr.tangent_map(p_cart_out, cart, rep, chart, at=at_out, usys=usys)  # ty: ignore[missing-argument]
 
 

--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -142,6 +142,16 @@ class Scale(AbstractLinearTransform):
         """
         return self._from_diagonal(1.0 / self.s)
 
+    def _contract(self, matrix: Any, arr: Any, /) -> Any:
+        """Scale each axis, rather than contracting a mostly-zero matrix.
+
+        Takes the diagonal of the *validated* ``matrix`` rather than reading
+        `s` directly: the shape checks ride along on that array as deferred
+        `equinox.error_if` nodes, and reading the field instead would silently
+        drop them.
+        """
+        return jnp.diagonal(matrix) * arr
+
     @property
     def _raw_matrix(self) -> Any:
         # No re-validation: `s` is a vector, so the matrix it builds is square

--- a/tests/unit/transforms/test_spatial_linear_transforms.py
+++ b/tests/unit/transforms/test_spatial_linear_transforms.py
@@ -2,6 +2,8 @@
 
 __all__: tuple[str, ...] = ()
 
+from typing import ClassVar
+
 import equinox as eqx
 import jax
 import numpy as np
@@ -237,3 +239,52 @@ def test_matrix_rejects_a_non_square_field() -> None:
     op = cxfm.Rotate(jnp.zeros((2, 3)))
     with pytest.raises(eqx.EquinoxTracetimeError, match="requires a square matrix"):
         _ = op.matrix
+
+
+class TestScaleContractsElementwise:
+    """`Scale` scales each axis instead of contracting a mostly-zero matrix.
+
+    An optimisation, so the tests are about it staying *equivalent*: same
+    numbers as the dense path, and the same shape validation.
+    """
+
+    FACTORS: ClassVar = (2.0, 3.0, 4.0)
+
+    def _pair(self):
+        """The same map as a `Scale` and as a dense `Linear`."""
+        return (
+            cxfm.Scale.from_factors(jnp.asarray(self.FACTORS)),
+            cxfm.Linear(jnp.diag(jnp.asarray(self.FACTORS))),
+        )
+
+    @pytest.mark.parametrize("shape", [(), (10,)])
+    def test_point_action_matches_the_dense_contraction(self, shape):
+        """`Linear` holds the same matrix and still uses the einsum."""
+        op, dense = self._pair()
+        comps = ("x", "y", "z")
+        pt = {k: u.Q(jnp.full(shape, i + 1.0), "m") for i, k in enumerate(comps)}
+        got = cxfm.act(op, None, pt, cxc.cart3d, cxr.point)
+        want = cxfm.act(dense, None, pt, cxc.cart3d, cxr.point)
+        for k in comps:
+            np.testing.assert_allclose(_to_np(got[k], "m"), _to_np(want[k], "m"))
+
+    def test_pushforward_matches_the_dense_contraction(self):
+        op, dense = self._pair()
+        comps = ("x", "y", "z")
+        v = {k: u.Q(1.0, "m/s") for k in comps}
+        got = cxfm.act(op, None, v, cxc.cart3d, cxr.tangent_geom, cxr.coord_vel)
+        want = cxfm.act(dense, None, v, cxc.cart3d, cxr.tangent_geom, cxr.coord_vel)
+        for k in comps:
+            np.testing.assert_allclose(_to_np(got[k], "m/s"), _to_np(want[k], "m/s"))
+
+    def test_the_chart_dimension_check_still_fires(self):
+        """The reason `_contract` reads the *validated matrix*, not `s`.
+
+        The shape checks ride on that array as deferred `error_if` nodes;
+        reading the field directly would drop them and let a 3x3 `Scale` act on
+        a 2D chart.
+        """
+        op, _ = self._pair()
+        pt = {k: u.Q(1.0, "m") for k in ("x", "y")}
+        with pytest.raises(Exception, match="does not match"):
+            cxfm.act(op, None, pt, cxc.cart2d, cxr.point)


### PR DESCRIPTION
The follow-up #750 named and deliberately left out.

#750 stored the scale factors, but the *action* stayed dense: `_raw_matrix` rebuilt
`jnp.diag(s)` and the base contracted it with `jnp.einsum("ij,...j->...i", ...)`, spending
$n^2$ multiply-adds on a map that needs $n$.

The contraction becomes an overridable `_contract` on `AbstractLinearTransform` — default
unchanged, so `Rotate`, `Reflect`, `Shear` and `Linear` keep the einsum — and `Scale`
overrides it with an elementwise product.

## Measured

I benchmarked before implementing, because the honest answer might have been "XLA already
fuses this, don't bother". It nearly was: a **bare-kernel** benchmark flatters the change
badly, and the **real `act` path** is dominated by dispatch, `pt_map` and cdict packing —
a single point costs ~1330 µs eager / ~29 µs jit, and `Scale` and `Rotate` were within
noise of each other.

So the numbers below are the real end-to-end operation under `jit`, with `Rotate` as an
untouched control measured in the same runs (it moves only with machine noise):

| batch | before | after | speedup |
| ---: | ---: | ---: | ---: |
| 1 | 30.5 µs | 31.1 µs | — |
| 100 | 35.0 µs | 32.7 µs | 1.07× |
| 10 000 | 112.4 µs | 47.0 µs | **2.4×** |
| 200 000 | 1409.3 µs | 322.3 µs | **4.4×** |

Nothing at `batch=1`, where fixed overhead swamps everything. The win is on batched data,
which is where the einsum was actually costing something.

## The part worth reviewing

`_contract` takes `jnp.diagonal(matrix)` rather than reading `self.s`:

```python
def _contract(self, matrix: Any, arr: Any, /) -> Any:
    return jnp.diagonal(matrix) * arr
```

Reading the field would be the obvious simplification and it would be **wrong**. The
chart-dimension and square checks are attached to the array returned by `_matrix()` as
deferred `equinox.error_if` nodes; discarding that array discards the checks, and a 3×3
`Scale` would happily act on a 2D chart. A test pins it:

```python
with pytest.raises(Exception, match="does not match"):
    cxfm.act(op, None, pt_2d, cxc.cart2d, cxr.point)
```

## Tests

Equivalence against `Linear` holding the same matrix — which still goes through the
einsum — for the point action (scalar and batched) and the pushforward, plus the
validation test above.

Also removed a `ty: ignore[invalid-return-type]` in `linear.py` that this change made
redundant; `ty` flagged it as an unused directive.

Full suite: **10714 passed**, 8 skipped, 1 xfailed. Lint and `ty` clean (6 diagnostics,
same as `main`).
