### PR TITLE
🐛 fix(manifolds): answer for a 0-d chart, and say why a metricless one refuses

### DIFF
--- a/src/coordinax/_src/euclidean/register_metric.py
+++ b/src/coordinax/_src/euclidean/register_metric.py
@@ -502,11 +502,7 @@ def metric_matrix(
 
 
 def _identity_dense(n: int, /) -> DenseMetric:
-    """Dimensionless identity metric of dimension ``n``.
-
-    `UnitsMatrix.full`, not a nested tuple: they agree for every ``n > 0``, and
-    only `full` can express the empty ``0 x 0`` case.
-    """
+    """Dimensionless identity metric of dimension ``n``."""
     return DenseMetric(
         ul.QuantityMatrix(jnp.eye(n), unit=ul.UnitsMatrix.full((n, n), ""))
     )

--- a/src/coordinax/_src/euclidean/register_metric.py
+++ b/src/coordinax/_src/euclidean/register_metric.py
@@ -3,7 +3,7 @@
 Covers :class:`~coordinax.manifolds.EuclideanManifold` paired with every
 chart in its atlas.  The rules follow a two-tier scheme:
 
-* **Cartesian charts** (``Cart0D``, ``Cart1D``, ``Cart2D``, ``Cart3D``,
+* **Cartesian charts** (``Cart1D``, ``Cart2D``, ``Cart3D``,
   ``CartND``) and **orthogonal curvilinear charts** (``Radial1D``,
   ``Polar2D``, ``Cylindrical3D``, ``Spherical3D``, ``MathSpherical3D``,
   ``LonLatSpherical3D``) have explicit analytic diagonal metrics and return
@@ -13,6 +13,8 @@ chart in its atlas.  The rules follow a two-tier scheme:
   :class:`~coordinax._src.metric.matrix.DiagonalMetric`.
 * **All other charts** compute the Jacobian pullback ``g = J^T J`` directly
   and return the result as a :class:`~coordinax._src.metric.matrix.DenseMetric`.
+  ``Cart0D`` lands here too: a 0-dimensional chart has no coordinates to
+  differentiate, so it short-circuits to the empty ``0 x 0`` metric.
 
 Which subtype a pair returns is how the library states that a chart is
 orthogonal -- see :func:`~coordinax.manifolds.metric_representation`. A chart
@@ -499,6 +501,17 @@ def metric_matrix(
 # =====================================================================
 
 
+def _identity_dense(n: int, /) -> DenseMetric:
+    """Dimensionless identity metric of dimension ``n``.
+
+    `UnitsMatrix.full`, not a nested tuple: they agree for every ``n > 0``, and
+    only `full` can express the empty ``0 x 0`` case.
+    """
+    return DenseMetric(
+        ul.QuantityMatrix(jnp.eye(n), unit=ul.UnitsMatrix.full((n, n), ""))
+    )
+
+
 @plum.dispatch
 def metric_matrix(
     M: EuclideanManifold, point: dict, chart: AbstractChart, /
@@ -527,12 +540,15 @@ def metric_matrix(
     True
 
     """
+    # A 0-dimensional chart is a point: nothing to differentiate, and the
+    # pullback is the unique empty form. Taken before the Jacobian because
+    # `jac_pt_map` stacks over the components and cannot build a (0, 0) one.
+    if not chart.components:
+        return _identity_dense(0)
     try:
         cart_chart = chart.cartesian
     except NoGlobalCartesianChartError:
-        n = M.ndim
-        unit_tup = tuple(tuple(u.unit("") for _ in range(n)) for _ in range(n))
-        return DenseMetric(ul.QuantityMatrix(jnp.eye(n), unit=ul.UnitsMatrix(unit_tup)))
+        return _identity_dense(M.ndim)
     J = cxcapi.jac_pt_map(point, chart, cart_chart, usys=None)
     JT = J.T  # ty: ignore[unresolved-attribute]
     return DenseMetric(JT @ J)

--- a/src/coordinax/_src/null/manifold.py
+++ b/src/coordinax/_src/null/manifold.py
@@ -64,19 +64,18 @@ no_manifold = NoManifold()
 def metric_matrix(
     M: NoManifold, point: dict, chart: AbstractChart, /
 ) -> AbstractMetricMatrix:
-    """Refuse, naming the manifold as the reason.
+    """Refuse, naming the missing manifold as the reason.
 
-    The generic fallback tells the caller to register a rule. That is the wrong
-    advice here: `NoManifold` is the sentinel for "no manifold specified", and a
-    chart that declares one -- `~coordinax.charts.PoincarePolar6D`, whose phase
-    space carries a symplectic form rather than a metric -- has no metric to
-    register in the first place.
+    The generic fallback advises registering a dispatch rule -- wrong for both
+    populations that reach here: a chart that left `M` unset, and one that
+    declares `no_manifold` by design.
     """
     del M, point
     msg = (
-        f"{type(chart).__name__!r} has no manifold (`M` is `no_manifold`), so it "
-        "has no metric to compute. A chart on phase space carries a symplectic "
-        "form rather than a metric; if this chart should have one, pair it with "
-        "the manifold whose geometry you mean."
+        f"{type(chart).__name__!r} has no manifold (`M` is `no_manifold`), so "
+        "there is no metric to compute. Pair the chart with the manifold whose "
+        "geometry you mean. Some charts declare no manifold by design -- a "
+        "phase-space chart carries a symplectic form rather than a metric -- "
+        "and for those there is no metric to ask for."
     )
     raise NotImplementedError(msg)

--- a/src/coordinax/_src/null/manifold.py
+++ b/src/coordinax/_src/null/manifold.py
@@ -8,10 +8,12 @@ import dataclasses
 from typing import Any, override
 
 import jax.tree_util as jtu
+import plum
 
 from .atlas import NoAtlas, no_atlas
 from .metric import NoMetric, no_metric
-from coordinax._src.base import AbstractManifold
+from coordinax._src.base import AbstractChart, AbstractManifold
+from coordinax._src.metric.matrix import AbstractMetricMatrix
 
 
 @jtu.register_static
@@ -56,3 +58,25 @@ class NoManifold(AbstractManifold):
 
 no_manifold = NoManifold()
 """Canonical instance of `coordinax.manifolds.NoManifold`."""
+
+
+@plum.dispatch
+def metric_matrix(
+    M: NoManifold, point: dict, chart: AbstractChart, /
+) -> AbstractMetricMatrix:
+    """Refuse, naming the manifold as the reason.
+
+    The generic fallback tells the caller to register a rule. That is the wrong
+    advice here: `NoManifold` is the sentinel for "no manifold specified", and a
+    chart that declares one -- `~coordinax.charts.PoincarePolar6D`, whose phase
+    space carries a symplectic form rather than a metric -- has no metric to
+    register in the first place.
+    """
+    del M, point
+    msg = (
+        f"{type(chart).__name__!r} has no manifold (`M` is `no_manifold`), so it "
+        "has no metric to compute. A chart on phase space carries a symplectic "
+        "form rather than a metric; if this chart should have one, pair it with "
+        "the manifold whose geometry you mean."
+    )
+    raise NotImplementedError(msg)

--- a/tests/unit/manifolds/test_metric_matrix_dispatch.py
+++ b/tests/unit/manifolds/test_metric_matrix_dispatch.py
@@ -395,25 +395,12 @@ class TestChartsWithoutAnOrdinaryMetric:
     """Two edge charts that reached a raw error instead of an answer or a reason."""
 
     def test_zero_dimensional_chart_has_the_empty_metric(self):
-        """A point has no coordinates, so its metric is the unique 0x0 form.
-
-        The generic rule differentiates the chart's map to Cartesian; with no
-        components there is nothing to stack into a Jacobian, and it raised
-        ``Need at least one array to stack.``
-        """
+        """A point has no coordinates, so its metric is the unique 0x0 form."""
         g = cxmapi.metric_matrix(cxm.R0, {}, cxc.cart0d)
         assert jnp.asarray(g.matrix.value).shape == (0, 0)
 
     def test_a_metricless_chart_says_why_rather_than_how_to_register(self):
-        """`PoincarePolar6D` is phase space: a symplectic form, not a metric.
-
-        The generic fallback told the caller to register a dispatch rule, which
-        is the one thing that would be wrong here.
-        """
-        with pytest.raises(NotImplementedError, match="no manifold"):
-            cxmapi.metric_matrix(cxc.poincarepolar6d.M, {}, cxc.poincarepolar6d)
-
-    def test_the_refusal_does_not_advise_registering_a_rule(self):
-        with pytest.raises(NotImplementedError) as excinfo:
+        """`PoincarePolar6D` is phase space: a symplectic form, not a metric."""
+        with pytest.raises(NotImplementedError, match="no manifold") as excinfo:
             cxmapi.metric_matrix(cxc.poincarepolar6d.M, {}, cxc.poincarepolar6d)
         assert "@plum.dispatch" not in str(excinfo.value)

--- a/tests/unit/manifolds/test_metric_matrix_dispatch.py
+++ b/tests/unit/manifolds/test_metric_matrix_dispatch.py
@@ -389,3 +389,31 @@ def test_curvilinear_metric_diagonal_is_float_for_integer_coords():
     pt = {"r": u.Q(2, "m"), "theta": u.Q(1, "rad")}  # integer magnitudes
     g = cxmapi.metric_matrix(cxm.R2, pt, cxc.polar2d).diagonal
     assert jnp.issubdtype(jnp.asarray(g.value).dtype, jnp.inexact)
+
+
+class TestChartsWithoutAnOrdinaryMetric:
+    """Two edge charts that reached a raw error instead of an answer or a reason."""
+
+    def test_zero_dimensional_chart_has_the_empty_metric(self):
+        """A point has no coordinates, so its metric is the unique 0x0 form.
+
+        The generic rule differentiates the chart's map to Cartesian; with no
+        components there is nothing to stack into a Jacobian, and it raised
+        ``Need at least one array to stack.``
+        """
+        g = cxmapi.metric_matrix(cxm.R0, {}, cxc.cart0d)
+        assert jnp.asarray(g.matrix.value).shape == (0, 0)
+
+    def test_a_metricless_chart_says_why_rather_than_how_to_register(self):
+        """`PoincarePolar6D` is phase space: a symplectic form, not a metric.
+
+        The generic fallback told the caller to register a dispatch rule, which
+        is the one thing that would be wrong here.
+        """
+        with pytest.raises(NotImplementedError, match="no manifold"):
+            cxmapi.metric_matrix(cxc.poincarepolar6d.M, {}, cxc.poincarepolar6d)
+
+    def test_the_refusal_does_not_advise_registering_a_rule(self):
+        with pytest.raises(NotImplementedError) as excinfo:
+            cxmapi.metric_matrix(cxc.poincarepolar6d.M, {}, cxc.poincarepolar6d)
+        assert "@plum.dispatch" not in str(excinfo.value)


### PR DESCRIPTION
From the audit, slice 4. Two edge charts that reached a raw error instead of an answer or a reason. Both were noted in #751's "found alongside" and left for a decision; here is the decision.

## `Cart0D` had no metric, though the module said it did

The general Euclidean rule differentiates the chart's map to Cartesian. With no components there is nothing to stack into a Jacobian:

```python
>>> cxm.metric_matrix(cxm.R0, {}, cxc.cart0d)
ValueError: Need at least one array to stack.
```

A 0-dimensional chart is a point: nothing to differentiate, and the pullback is the unique empty form. Short-circuited before the Jacobian, it returns the `0 x 0` metric.

`register_metric.py`'s own docstring already listed ``Cart0D`` among the covered charts, so this was a documented rule that did not exist. It is listed accurately now — the general rule answers for it, not the Cartesian-diagonal one, and the return type differs accordingly (`DenseMetric`, not `DiagonalMetric`).

The no-global-Cartesian branch built the same identity metric inline; both now go through `_identity_dense`. It builds units with `UnitsMatrix.full` rather than a nested tuple — checked equal for every `n > 0`, and only `full` can express the empty case (`UnitsMatrix(())` raises).

**Why here and not in `jac_pt_map`.** Stacking over a chart's components appears at 7 sites; making all of them 0-d-safe is a much larger change for a Jacobian nobody takes. The metric of a point is well-defined, so it is answered where it is asked.

## A metricless chart advised the one thing that is wrong

`PoincarePolar6D` is a chart on phase space. Its docstring is explicit:

> Phase space carries a *symplectic* form ω, not a Riemannian metric, so this chart has **no manifold metric**: `M` is `no_manifold` and there is no `metric_matrix`.

The generic fallback did not know that, and said:

```
No metric_matrix dispatch registered for manifold='NoManifold', chart='PoincarePolar6D'.
Register a rule with @plum.dispatch on metric_matrix.
```

Registering one would be mathematically wrong. `NoManifold` now refuses in its own right and names the actual reason:

```
'PoincarePolar6D' has no manifold (`M` is `no_manifold`), so it has no metric to
compute. A chart on phase space carries a symplectic form rather than a metric;
if this chart should have one, pair it with the manifold whose geometry you mean.
```

No behaviour change beyond the message — it was `NotImplementedError` before and still is, so anything catching it is unaffected.

## Verification

- 3 tests added; one pins that the refusal no longer says `@plum.dispatch`
- `tests/unit/manifolds` + `tests/unit/charts` + euclidean/null doctests: 1374 passed
- Full suite: **10947 passed**, 7 skipped, 1 xfailed, 0 failures
- `prek` clean

## Not changed, deliberately

`scale_factors(cart0d, at={})` still raises — it reaches the same empty-stack through a different path. Left out because the *metric* of a point is meaningful while its per-axis scale factors are not a thing anyone asks for; happy to add if you disagree.
