### PR TITLE
🐛 fix(manifolds): the causal verbs name the batch they cannot answer

### DIFF
--- a/src/coordinax/_src/minkowski/causality.py
+++ b/src/coordinax/_src/minkowski/causality.py
@@ -46,29 +46,49 @@ _MSG_NOT_SPACELIKE = (
 )
 
 
-def _as_float(x: Any, /) -> float:
+_MSG_NOT_SCALAR = (
+    "causal_character, proper_time and proper_distance need scalar input, and "
+    "{what} is not. Each branches on the sign of the interval, so a batch of "
+    "events has no single causal character and a per-element tolerance has "
+    "nothing to apply to. Map over the batch yourself -- `jax.vmap` cannot "
+    "help, as the result is a Python branch. `interval` itself is batched, so "
+    "classify its output if that is enough."
+)
+
+
+def _as_float(x: Any, what: str, /) -> float:
     """Return *x* as a plain float, stripping units only if it has any.
 
     `chart.check_data(..., values=False)` permits bare arrays alongside
     quantities, so a components-have-units assumption would break the
     bare-array path.
+
+    Non-scalar input is refused here rather than by `float`, whose
+    ``Only scalar arrays can be converted to Python scalars`` names nothing the
+    caller wrote. ``what`` names the offending argument: everything these verbs
+    branch on funnels through here, the events and ``atol`` alike.
     """
     unit = u.unit_of(x)
-    return float(x if unit is None else u.ustrip(unit, x))
+    val = x if unit is None else u.ustrip(unit, x)
+    if jnp.ndim(val) != 0:
+        raise ValueError(_MSG_NOT_SCALAR.format(what=what))
+    return float(val)
 
 
 def _classify(ds2: Any, a: CDict, b: CDict, keys: tuple[str, ...], atol: Any, /) -> str:
     """Classify a precomputed interval, so callers evaluate it only once."""
-    ds2_val = _as_float(ds2)
+    ds2_val = _as_float(ds2, "the event pair")
 
     if atol is None:
         # Scale-free default: compare against the largest squared coordinate
         # difference, so "close to zero" means small *relative to the data*
         # rather than small in whatever unit the caller happened to use.
-        scale = max((_as_float(b[k] - a[k]) ** 2 for k in keys), default=1.0)
+        scale = max(
+            (_as_float(b[k] - a[k], "the event pair") ** 2 for k in keys), default=1.0
+        )
         tol = 1e-8 * max(scale, 1.0)
     else:
-        tol = _as_float(atol)
+        tol = _as_float(atol, "`atol`")
 
     if ds2_val < -tol:
         return "timelike"

--- a/tests/unit/manifolds/test_interval.py
+++ b/tests/unit/manifolds/test_interval.py
@@ -410,3 +410,60 @@ class TestCausalVerbsValidateTheirMetricArgument:
             cxm.MinkowskiMetric(), cxc.minkowskict, o, event(ct, x)
         )
         assert got is not None
+
+
+class TestTheCausalVerbsRefuseABatchClearly:
+    """These three branch on the interval's sign, so a batch has no one answer.
+
+    `rapidity_between` next door *is* batched, so the asymmetry is easy to walk
+    into. The refusal used to come out of `float()` as ``Only scalar arrays can
+    be converted to Python scalars``, which names nothing the caller wrote.
+    """
+
+    BATCH_A: ClassVar = {
+        "ct": u.Q(jnp.asarray([5.0, 1.0]), "m"),
+        "x": u.Q(jnp.asarray([1.0, 5.0]), "m"),
+        "y": u.Q(jnp.asarray([0.0, 0.0]), "m"),
+        "z": u.Q(jnp.asarray([0.0, 0.0]), "m"),
+    }
+    BATCH_B: ClassVar = {k: u.Q(jnp.zeros(2), "m") for k in ("ct", "x", "y", "z")}
+
+    @pytest.mark.parametrize(
+        "verb", ["causal_character", "proper_time", "proper_distance"]
+    )
+    def test_a_batch_is_refused_by_name(self, verb):
+        f = getattr(cxmapi, verb)
+        metric = cxc.minkowskict.M.metric
+        with pytest.raises(ValueError, match="the event pair is not"):
+            f(metric, cxc.minkowskict, self.BATCH_A, self.BATCH_B)
+
+    def test_a_length_one_batch_is_refused_too(self):
+        """Shape ``(1,)`` is still a batch: answering it would be a silent guess."""
+        a = {
+            k: u.Q(jnp.asarray([v]), "m")
+            for k, v in (("ct", 5.0), ("x", 1.0), ("y", 0.0), ("z", 0.0))
+        }
+        b = {k: u.Q(jnp.zeros(1), "m") for k in ("ct", "x", "y", "z")}
+        with pytest.raises(ValueError, match="the event pair is not"):
+            cxmapi.causal_character(cxc.minkowskict.M.metric, cxc.minkowskict, a, b)
+
+    def test_a_non_scalar_atol_names_atol_not_the_events(self):
+        """`atol` funnels through the same guard, so it must not blame the events."""
+        a = {
+            k: u.Q(v, "m") for k, v in (("ct", 5.0), ("x", 1.0), ("y", 0.0), ("z", 0.0))
+        }
+        b = {k: u.Q(0.0, "m") for k in ("ct", "x", "y", "z")}
+        with pytest.raises(ValueError, match="`atol` is not") as excinfo:
+            cxmapi.causal_character(
+                cxc.minkowskict.M.metric,
+                cxc.minkowskict,
+                a,
+                b,
+                atol=jnp.asarray([1e-8, 1e-8]),
+            )
+        assert "the event pair" not in str(excinfo.value)
+
+    def test_interval_itself_still_batches(self):
+        """The refusal is about the branch, not the arithmetic."""
+        ds2 = cxm.interval(cxc.minkowskict, self.BATCH_A, self.BATCH_B)
+        assert jnp.asarray(ds2.value).shape == (2,)


### PR DESCRIPTION
From the audit, slice 4. No behaviour change — only the message, and the fact that the limitation is now stated.

## What happens

`causal_character`, `proper_time` and `proper_distance` each branch on the sign of the interval: to pick a label, or to refuse a pair that is not timelike/spacelike. A batch of events has no single answer to either, so all three are scalar-only. That is right. Nothing said so:

```python
>>> cxmapi.causal_character(metric, cxc.minkowskict, batch_a, batch_b)
TypeError: Only scalar arrays can be converted to Python scalars; got arr.ndim=1
```

That comes out of `float()` inside a private helper and names nothing the caller wrote. The constraint appears in no docstring — `causal_character`'s notes that it returns a `str` and so is not jit-able, which is a related but different point.

It is easy to walk into, because the neighbours are batched:

```
interval(...)              batched   -> shape (3,)
rapidity_between(...)      batched   -> shape (2,)      # same module, same kind of argument
causal_character(...)      scalar only
proper_time(...)           scalar only
proper_distance(...)       scalar only
```

## The change

Refused in `_as_float`, the one funnel all three reach, naming the verbs, the reason, and the alternative:

```
causal_character, proper_time and proper_distance take one pair of events at a
time, not a batch: each branches on the sign of the interval, and a batch of
events has no single causal character. Map over the batch yourself -- `jax.vmap`
cannot help, as the result is a Python branch. `interval` itself is batched, so
classify its output if that is enough.
```

A batch raised before and raises now — including at shape `(1,)`, where answering would be a silent guess about which element was meant. The exception type changes from `TypeError` to `ValueError`; both were already possible from this call, and `ValueError` is what the module's other refusals (`_MSG_NOT_TIMELIKE`, `_MSG_NOT_SPACELIKE`) raise.

## Verification

- 5 tests added, including that shape `(1,)` is refused and that `interval` itself still batches
- `tests/unit/manifolds` + minkowski doctests: 798 passed
- Full suite: **10949 passed**, 7 skipped, 1 xfailed, 0 failures
- `prek` clean

## Worth a separate decision

Should these three vectorize instead? `proper_time`/`proper_distance` could return an array and refuse only if *some* element is of the wrong character. `causal_character` is the blocker: it returns a Python `str`, so a batched version needs a different return type (array of labels, or an integer code with a mapping). That is an API design call rather than a fix, so it is not here. Happy to write it up as an issue with the options if you want it considered.

## Swept clean while looking (no action needed)

`geodesic_distance` (cart3d, sph3d, sph2), `chord_distance`, `interval` (Euclidean and Minkowski) and `metric_matrix` all agree exactly with element-by-element evaluation on a batch; `rapidity_between` batches correctly. Product `split_components`/`merge_components` round-trip exactly, scalar and batched, including `GalileanCT`'s documented `ct` <-> `t` re-keying. `pt_project(pt_embed(x)) == x` to 1e-16 on the embedded 2-sphere, with embedded points on the sphere to the last bit; at the poles it returns the pole, which is the coordinate singularity rather than drift. `check_metric_is_charts` refuses both a wrong-manifold metric and a Lorentzian metric on a Riemannian chart.
