### PR TITLE
👷 ci: only test newest Python on macOS/Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           import os
 
           versions = json.loads(os.environ["PYTHON_VERSIONS"])
-          edge_versions = list(dict.fromkeys([versions[0], versions[-1]]))
+          edge_versions = [versions[-1]]
 
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
               f.write(f"python-all={json.dumps(versions)}\n")


### PR DESCRIPTION
Drops the 3.12 job from the macOS/Windows test matrix, leaving only 3.14.

`edge_versions` now resolves to just the newest entry of `PYTHON_VERSIONS`, so the cross-platform job runs 1 version per OS instead of 2 — 2 fewer CI jobs per run. Linux still tests the full 3.12/3.13/3.14 range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)