### PR TITLE
📝 docs(spec): `Shear` matches the code, and `Linear` gets a section

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5627,8 +5627,7 @@ Each group corresponds to a set of transformations preserving a particular geome
     `H` is the only field: a `Shear` is a bare matrix, with no chart of its own.
     It acts on the Cartesian components of whatever chart the data is in.
 
-    **Inverse:** the inverse matrix, which for a shear negates the off-diagonal
-    entries:
+    **Inverse:** the inverse matrix:
 
     ```text
     shear.inverse == Shear(inv(H))

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5586,7 +5586,7 @@ Each group corresponds to a set of transformations preserving a particular geome
     its own. It acts on the Cartesian components of whatever chart the data is
     in. Holding the diagonal rather than the full matrix is what makes
     diagonality structural — a vector has no off-diagonal entry to check. A
-    general matrix belongs to `Linear`.
+    general matrix belongs to [`Linear`](#software-spec-transforms-linear).
 
     `Scale(S)` takes the matrix and keeps its diagonal, refusing one that is not
     square or not diagonal; `Scale.from_factors(s)` takes the factors directly.
@@ -5623,20 +5623,47 @@ Each group corresponds to a set of transformations preserving a particular geome
 
     **Fields:**
 
-    - `factor : float` — the shear factor $k$. Always constant; wrap in `TimeDep` for time dependence (see [`TimeDep`](#software-spec-transforms-timedep)).
-    - `chart : AbstractChart` — the chart in which `factor` is expressed (static).
+    - `H : Array[N, N]` — the shear matrix. Always constant; wrap in `TimeDep` for time dependence (see [`TimeDep`](#software-spec-transforms-timedep)).
+    `H` is the only field: a `Shear` is a bare matrix, with no chart of its own.
+    It acts on the Cartesian components of whatever chart the data is in.
 
-    **Inverse:**
-
-    ```text
-    shear.inverse == Shear(-factor, chart)
-    ```
-
-    **Composition:** Two `Shear` instances with the same chart combine by adding their `factor` values:
+    **Inverse:** the inverse matrix, which for a shear negates the off-diagonal
+    entries:
 
     ```text
-    Shear(k1) + Shear(k2) == Shear(k1 + k2)
+    shear.inverse == Shear(inv(H))
     ```
+
+    **Composition:** `Shear` implements no composition operator. Pipe two with
+    `|`; `simplify` fuses them into a [`Linear`](#software-spec-transforms-linear),
+    which is where a product of shear matrices lands.
+
+(software-spec-transforms-linear)=
+
+!!! info `Linear`
+
+    A **Linear** is a transformation that applies a general invertible linear map to position components while leaving other representations unchanged.
+
+    **Mathematical definition**:
+
+    $$
+    F(p) = M p, \qquad M \in GL(n, \mathbb{R}).
+    $$
+
+    Every other linear transform names a structure it preserves — `Rotate` an orientation and a metric, `Reflect` a metric, `Scale` the axes, `Shear` parallelism. `Linear` names none, which is what makes it the type a fused chain lands in: composing a rotation with a scaling leaves a matrix that is neither, and `simplify` needs somewhere to put it.
+
+    **Fields:**
+
+    - `M : Array[N, N]` — the matrix $M$. Always constant; wrap in `TimeDep` for time dependence (see [`TimeDep`](#software-spec-transforms-timedep)).
+    - `group : type[AbstractTransformGroup]` — the most specific group this matrix is known to belong to (static, default `AffineGroup`). A field rather than a class-level declaration because the answer depends on what was fused, not on the type.
+
+    **Inverse:** the inverse matrix, carrying the group across — a group is closed under inverses, so whatever the matrix belonged to, its inverse does too:
+
+    ```text
+    linear.inverse == Linear(inv(M), group)
+    ```
+
+    **Composition:** `Linear` implements no composition operator. Pipe with `|`; `simplify` fuses adjacent linear maps and sets the result's `group` to the least common supergroup of the pair, so a rotation composed with a reflection still reports `OrthogonalGroup` rather than falling all the way back to `AffineGroup`.
 
 (software-spec-transforms-timedep)=
 


### PR DESCRIPTION
The third and fourth stale entries in the transforms spec, after the `Scale` one a
reviewer caught on #750. Found by looking this time, rather than by tripping over them.

## `Shear` documented an API it never had

```diff
- - `factor : float` — the shear factor $k$.
- - `chart : AbstractChart` — the chart in which `factor` is expressed (static).
+ - `H : Array[N, N]` — the shear matrix.
```

`dataclasses.fields(Shear(H))` is `("H",)`. There is no `factor` and no `chart` — the
same fiction the `Scale` section carried. Its inverse and composition were wrong too:

| spec said | actually |
| --- | --- |
| `shear.inverse == Shear(-factor, chart)` | `Shear(inv(H))` |
| `Shear(k1) + Shear(k2) == Shear(k1 + k2)` | no composition operator; `simplify(a \| b)` yields a `Linear` |

## `Linear` had no section

It reached the exported-objects table in #730 but was never specified. That is why #750
had to *delete* a `Scale` → `Linear` link rather than ship a dangling anchor. The section
now exists — maths, both fields (`M` and the static `group`), inverse, and how `simplify`
sets the fused `group` — and that link is restored.

## Verification

Every claim was checked against the running code rather than copied from a docstring:

```
Shear:  fields=['H']   inverse -> Shear   has @: False   H @ inv(H) == I
Linear: fields=['M', 'group']   inverse carries the group across
simplify(Shear | Shear)   -> Linear
simplify(Rotate | Reflect) -> Linear, group=OrthogonalGroup
```

`nox -s docs` (the Docs (No Warnings) job) **builds clean**, so the new anchor resolves —
worth stating explicitly, since a dead anchor is exactly what I avoided in #750.

Spec examples are under CI as of #733: **1369 passed**.

## Note for later

This is the third section found stale by accident. A test asserting each `!!! info`
section's **Fields** against `dataclasses.fields` would close the class properly. I did
not add one here because it is a different kind of change from a docs correction, and
because the scope needs care — the exported-objects *table* is deliberately curated (the
`charts` row omits 50+ names on purpose), so only the per-type sections can be enforced
that way. Happy to follow up if wanted.
