### PR TITLE
📝 docs(representations): acceleration is the plain second derivative only in an affine chart

### DIFF
--- a/src/coordinax/representations/_src/semantics.py
+++ b/src/coordinax/representations/_src/semantics.py
@@ -636,15 +636,23 @@ class Acceleration(AbstractTangentSemanticKind):
     r"""Acceleration semantic kind.
 
     An acceleration semantic kind indicates that the represented tangent data
-    is an **acceleration vector** — the second time derivative of position on
-    a manifold.
+    is an **acceleration vector** — the covariant second derivative of position
+    along a curve on a manifold.
 
     Mathematical Definition:
 
     Let $\gamma: \mathbb{R} \to M$ be a smooth curve on manifold $M$. The
-    acceleration at time $t$ is the tangent vector $\ddot{\gamma}(t) \in
-    T_{\gamma(t)} M$ (or more precisely, $\nabla_{\dot{\gamma}}\dot{\gamma}$
-    in the covariant sense, but in flat space simply the second derivative).
+    acceleration at time $t$ is the tangent vector
+    $\nabla_{\dot{\gamma}}\dot{\gamma} \in T_{\gamma(t)} M$.
+
+    It coincides with the plain second derivative $\ddot{q}^i$ of the
+    coordinates only in an **affine chart** -- the condition is the chart, not
+    flatness -- so in a curvilinear chart the two differ by the Christoffel
+    term $\Gamma^i_{jk}\dot{q}^j\dot{q}^k$, nonzero even on flat
+    $\mathbb{R}^3$. This decides what conversion returns: being a tangent
+    vector, an acceleration pushes forward linearly as $J a$, so converting a
+    trajectory's Cartesian $\ddot{q}$ to a curvilinear chart yields the
+    acceleration *vector's* components there, not that chart's $\ddot{q}$.
 
     Examples
     --------

--- a/tests/unit/representations/test_cconvert_tangent.py
+++ b/tests/unit/representations/test_cconvert_tangent.py
@@ -155,3 +155,63 @@ class TestCconvertAtRequired:
             cxr.cconvert(
                 v, cxc.cart2d, cxr.coord_disp, cxc.polar2d, cxr.coord_disp, usys=usys
             )
+
+
+_T = 0.7
+
+
+def _gamma(t):
+    """A helix in cart3d: the trajectory both transformation laws are read off."""
+    return jnp.stack([jnp.cos(t), jnp.sin(t), 0.3 * t])
+
+
+def _to_sph(xyz):
+    x, y, z = xyz
+    r = jnp.sqrt(x**2 + y**2 + z**2)
+    return jnp.stack([r, jnp.arccos(z / r), jnp.arctan2(y, x)])
+
+
+def _sph_of_t(t):
+    return _to_sph(_gamma(t))
+
+
+_XYZ = _gamma(_T)
+_V = jax.jacfwd(_gamma)(_T)
+_A = jax.jacfwd(jax.jacfwd(_gamma))(_T)
+_AT = dict(zip("xyz", _XYZ, strict=True))
+
+
+def _convert(vec, kind):
+    """Convert a cart3d tangent vector to sph3d, at the point on the curve."""
+    v = dict(zip("xyz", vec, strict=True))
+    got = cxr.cconvert(v, cxc.cart3d, kind, cxc.sph3d, kind, at=_AT, usys=usys)
+    return np.asarray([float(got[k]) for k in ("r", "theta", "phi")])
+
+
+class TestAccelerationPushesForwardAsAVector:
+    """An acceleration is a tangent vector, so it converts as ``J a``.
+
+    The two differ by the Christoffel term, so they disagree in spherical
+    coordinates on flat R^3.
+    """
+
+    def test_it_is_the_linear_pushforward(self):
+        """``J a`` exactly -- the transformation law for a tangent vector."""
+        want = np.asarray(jax.jacfwd(_to_sph)(_XYZ) @ _A)
+        got = _convert(_A, cxr.coord_acc)
+        np.testing.assert_allclose(got, want, rtol=0, atol=1e-14)
+
+    def test_it_is_not_the_coordinate_second_derivative(self):
+        """The two differ by the Christoffel term, here on *flat* R^3.
+
+        If this ever starts passing, `cconvert` has begun adding the
+        non-tensorial term and accelerations no longer transform as vectors.
+        """
+        qddot = np.asarray(jax.jacfwd(jax.jacfwd(_sph_of_t))(_T))
+        assert np.max(np.abs(_convert(_A, cxr.coord_acc) - qddot)) > 0.5
+
+    def test_velocity_has_no_such_gap(self):
+        """First derivatives *are* tangent vectors, so velocity agrees with d/dt."""
+        want = np.asarray(jax.jacfwd(_sph_of_t)(_T))
+        got = _convert(_V, cxr.coord_vel)
+        np.testing.assert_allclose(got, want, rtol=0, atol=1e-14)


### PR DESCRIPTION
From the audit, slice 5. Docs and tests only — no behaviour change.

## What was wrong

`Acceleration`'s docstring:

> the acceleration at time $t$ is the tangent vector $\ddot{\gamma}(t)$ (or more precisely, $\nabla_{\dot{\gamma}}\dot{\gamma}$ in the covariant sense, **but in flat space simply the second derivative**).

Flatness is not the condition — the **chart** is. Christoffel symbols are nonzero in any curvilinear chart, flat space included. For a helix $\gamma(t) = (\cos t, \sin t, 0.3t)$ at $t = 0.7$, in spherical coordinates on flat $\mathbb{R}^3$:

```
covariant acceleration, spherical components   [-0.979, -0.201, 0]
d^2/dt^2 of the spherical coordinates          [ 0.084,  0.035, 0]
difference (the Christoffel term)              [ 1.063,  0.236, 0]
```

So the two differ by an O(1) amount exactly where the docstring promises they agree.

## Why it matters beyond wording

It decides what `cconvert` returns. An acceleration is a tangent vector, so it pushes forward linearly:

```
cconvert(a, cart3d, coord_acc, sph3d, coord_acc, at=...)  ==  J @ a     (exactly, 0.0)
d^2/dt^2 of the target coordinates                        ==  J @ a + J-dot @ q-dot
```

Converting a trajectory's Cartesian $\ddot q$ to a curvilinear chart therefore gives the acceleration *vector's* components there, not that chart's $\ddot q$. The library is right; the docstring invites the opposite reading. I read it the wrong way myself and spent a while proving the library wrong before proving myself wrong — which is the argument for fixing the wording rather than leaving it.

Velocity has no such trap: a first derivative genuinely is a tangent vector, and the conversion matches $d/dt$ of the target coordinates to 7e-18.

## The change

- The definition now leads with $\nabla_{\dot\gamma}\dot\gamma$, names the affine chart as the condition, and states the consequence for conversion.
- Three tests pin the *law*, not the prose: the conversion equals `J a` exactly; it differs from the coordinate second derivative by more than 0.5 on flat $\mathbb{R}^3$ (so if that ever starts agreeing, `cconvert` has begun adding the non-tensorial term); and velocity agrees with `d/dt`.

## Verification

- `tests/unit/representations` + `tests/unit/vectors` + representations doctests: 1040 passed
- Full suite: **11031 passed**, 7 skipped, 1 xfailed, 0 failures
- `prek` clean

## Found alongside, not in this PR

`change_basis`'s no-manifold overload is registered only for the Cartesian charts and `sph3d`. `polar2d`, `cyl3d`, `math_sph3d`, `lonlat_sph3d`, `radial1d` and `sph2` all raise `NotFoundLookupError`, even though the *with*-manifold form handles them correctly (`cyl3d` gives `h·v = [1, 4, 3]` and round-trips to 0.0) and their `chart.M` is the same `Rn(3)` that `sph3d` carries. Same shape as #729: a missing rule is a crash, not a missed optimisation. Filing separately.
