### PR TITLE
🐛 fix(representations): coordinate-to-physical needs no explicit manifold either

### DIFF
--- a/src/coordinax/representations/_src/basis_change.py
+++ b/src/coordinax/representations/_src/basis_change.py
@@ -226,6 +226,40 @@ def change_basis(
 def change_basis(
     v: CDict,
     chart: cxc.AbstractChart,
+    from_basis: CoordinateBasis,
+    to_basis: PhysicalBasis,
+    /,
+    *,
+    at: CDict,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Change from coordinate basis to physical basis using the chart's manifold.
+
+    Falls back to ``chart.M`` when no explicit manifold is supplied, mirroring
+    the physical-to-coordinate rule below. Without it only the charts with a
+    bespoke rule -- the Cartesian family and `~coordinax.charts.Spherical3D` --
+    could make this change without being handed a manifold, and every other
+    orthogonal chart raised `NotFoundLookupError`.
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.representations as cxr
+
+    >>> v = {"rho": u.Q(1.0, "m/s"), "phi": u.Q(2.0, "rad/s"), "z": u.Q(3.0, "m/s")}
+    >>> at = {"rho": u.Q(2.0, "m"), "phi": u.Q(0.4, "rad"), "z": u.Q(1.0, "m")}
+    >>> cxr.change_basis(v, cxc.cyl3d, cxr.coord_basis, cxr.phys_basis, at=at)
+    {'rho': Q(1., 'm / s'), 'phi': Q(4., 'm / s'), 'z': Q(3., 'm / s')}
+
+    """
+    return cxrapi.change_basis(
+        v, chart, chart.M, from_basis, to_basis, at=at, usys=usys
+    )  # ty: ignore[invalid-return-type]
+
+
+@plum.dispatch
+def change_basis(
+    v: CDict,
+    chart: cxc.AbstractChart,
     from_basis: PhysicalBasis,
     to_basis: CoordinateBasis,
     /,

--- a/tests/unit/representations/test_change_basis.py
+++ b/tests/unit/representations/test_change_basis.py
@@ -1,6 +1,6 @@
 """Tests for change_basis function."""
 
-from typing import Any
+from typing import Any, ClassVar
 
 import jax
 import jax.numpy as jnp
@@ -438,3 +438,65 @@ class TestTriangularSolveBatching:
         )
         np.testing.assert_allclose(out.value, expected)
         assert out.unit == ul.UnitsMatrix((u.unit("1 / s"), u.unit("1 / s")))
+
+
+class TestCoordToPhysNeedsNoExplicitManifold:
+    """The no-manifold overload exists for both directions, not just one.
+
+    `phys -> coord` has always fallen back to ``chart.M``; `coord -> phys` did
+    not, so only the charts with a bespoke rule -- the Cartesian family and
+    `Spherical3D` -- could make that change without being handed a manifold.
+    Every other orthogonal chart raised `NotFoundLookupError`, which is a crash
+    rather than a missed optimisation.
+    """
+
+    CASES: ClassVar = [
+        (cxc.polar2d, {"r": 2.0, "theta": 0.4}),
+        (cxc.cyl3d, {"rho": 2.0, "phi": 0.4, "z": 1.0}),
+        (cxc.math_sph3d, {"r": 3.0, "theta": 0.5, "phi": 0.9}),
+        (cxc.lonlat_sph3d, {"lon": 0.4, "lat": 0.3, "distance": 2.0}),
+        (cxc.radial1d, {"r": 2.0}),
+        (cxc.sph2, {"theta": 0.5, "phi": 0.9}),
+    ]
+
+    @staticmethod
+    def _vec(at):
+        return {k: jnp.asarray(float(i + 1)) for i, k in enumerate(at)}
+
+    @pytest.mark.parametrize(("chart", "at"), CASES)
+    def test_it_matches_passing_the_manifold_explicitly(self, chart, at):
+        """The fallback must be the same call, not merely a call that works."""
+        atj = {k: jnp.asarray(v) for k, v in at.items()}
+        v = self._vec(at)
+        implicit = cxr.change_basis(
+            v, chart, cxr.coord_basis, cxr.phys_basis, at=atj, usys=usys
+        )
+        explicit = cxr.change_basis(
+            v, chart, chart.M, cxr.coord_basis, cxr.phys_basis, at=atj, usys=usys
+        )
+        for k in implicit:
+            np.testing.assert_allclose(implicit[k], explicit[k], rtol=0, atol=0)
+
+    @pytest.mark.parametrize(("chart", "at"), CASES)
+    def test_it_round_trips_back_to_the_coordinate_basis(self, chart, at):
+        atj = {k: jnp.asarray(v) for k, v in at.items()}
+        v = self._vec(at)
+        phys = cxr.change_basis(
+            v, chart, cxr.coord_basis, cxr.phys_basis, at=atj, usys=usys
+        )
+        back = cxr.change_basis(
+            phys, chart, cxr.phys_basis, cxr.coord_basis, at=atj, usys=usys
+        )
+        for k in v:
+            np.testing.assert_allclose(back[k], v[k], rtol=0, atol=1e-14)
+
+    def test_the_scale_factor_is_the_one_the_chart_declares(self):
+        """Cylindrical: ``h = (1, rho, 1)``, so only the angular part rescales."""
+        at = {"rho": jnp.asarray(2.0), "phi": jnp.asarray(0.4), "z": jnp.asarray(1.0)}
+        v = {"rho": jnp.asarray(1.0), "phi": jnp.asarray(2.0), "z": jnp.asarray(3.0)}
+        got = cxr.change_basis(
+            v, cxc.cyl3d, cxr.coord_basis, cxr.phys_basis, at=at, usys=usys
+        )
+        np.testing.assert_allclose(
+            [got["rho"], got["phi"], got["z"]], [1.0, 4.0, 3.0], rtol=0, atol=0
+        )


### PR DESCRIPTION
From the audit, slice 5. Additive: nothing that resolved before resolves differently.

## The gap

`change_basis` has a no-manifold overload that falls back to `chart.M`, so a caller need not repeat what the chart already knows. It existed for one direction only:

```
phys -> coord     generic rule on AbstractChart, forwards to chart.M
coord -> phys     bespoke rules only: the Cartesian family, and Spherical3D
```

So every other orthogonal chart crashed on the coordinate-to-physical change:

```
polar2d        NotFoundLookupError
cyl3d          NotFoundLookupError
math_sph3d     NotFoundLookupError
lonlat_sph3d   NotFoundLookupError
radial1d       NotFoundLookupError
sph2           NotFoundLookupError
```

A missing dispatch rule is a crash, not a missed optimisation — the same shape as #729.

## Not an arithmetic problem

Passing the manifold explicitly has always worked for these charts, and `chart.M` is the same `Rn(3)` that `Spherical3D` carries:

```python
>>> cxr.change_basis(v, cxc.cyl3d, cxm.R3, cxr.coord_basis, cxr.phys_basis, at=at)
{'rho': 1.0, 'phi': 4.0, 'z': 3.0}      # h = (1, rho, 1), rho = 2
```

Only the forwarding rule was absent. This adds the mirror of the existing `phys -> coord` fallback. Plum specificity keeps the Cartesian and `Spherical3D` rules winning.

## Verification

All ten charts now round-trip `coord -> phys -> coord` to `0.0`, and for the six that used to raise, the implicit call equals passing the manifold explicitly to `0.0`.

The tests assert that agreement rather than merely that the call succeeds — a forwarding rule that forwarded to the wrong manifold would still "work". Plus a round-trip per chart, and cylindrical's `h = (1, rho, 1)` by value.

- `tests/unit/representations` + `tests/unit/vectors` + doctests: 1056 passed
- Full suite: **11047 passed**, 7 skipped, 1 xfailed, 0 failures
- `prek` clean
