### PR TITLE
⬆️ build: pick up unxts.linalg 2.0.5

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3447,7 +3447,7 @@ wheels = [
 
 [[package]]
 name = "unxts-linalg"
-version = "2.0.4"
+version = "2.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "equinox" },
@@ -3456,9 +3456,9 @@ dependencies = [
     { name = "quax" },
     { name = "unxt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/5d/8ce961bce94d27d9c2edd3ce9ca8531b1121436f095b0c3be5a8e276fd29/unxts_linalg-2.0.4.tar.gz", hash = "sha256:e13c23b46429919f5bc4bf22655be6e3375afcfc28cf917977910c2760eb7c0b", size = 59021, upload-time = "2026-08-15T07:58:49.628Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/5f/5cfc711fa609733c1a588a29aa871d0e364c459a9345c696bcb6ac2be2f2/unxts_linalg-2.0.5.tar.gz", hash = "sha256:3fab7417cfde99eb7c13e710a2a298aee743254331ef2d15b7d0a9d453aea2c5", size = 59546, upload-time = "2026-08-19T23:24:36.331Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/56/883884e2b32a5ed6a3613fe96017310f29abb78e383d2198128d875965a7/unxts_linalg-2.0.4-py3-none-any.whl", hash = "sha256:b837161b05f9d0f3e3779e0140dd91a0f8407e8859249a938ac57829392b7939", size = 35944, upload-time = "2026-08-15T07:58:48.461Z" },
+    { url = "https://files.pythonhosted.org/packages/64/68/3d14209ec0c7ba0ff60e1a1a765b7ee824d2587b516a943d5870d4c9ce28/unxts_linalg-2.0.5-py3-none-any.whl", hash = "sha256:a235f878637bf68acacef0d382c8dc295957edeb1707866c26bc3e85a66c8588", size = 36160, upload-time = "2026-08-19T23:24:35.163Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`unxts.linalg` 2.0.5 is out; the lock was still resolving **2.0.4**, so it was not being
used anywhere — not in CI, not in a fresh `uv sync`.

2.0.5 carries the `QuantityMatrix` scalar-unit-target fix
(GalacticDynamics/unxt#902 → GalacticDynamics/unxt#901) on top of what 2.0.4 already had:
the `ustrip`/`unit_of` registrations (unxt#880) and the `dot_general` / `_mk` performance
work.

## Lock only — the floor stays at `>=2.0.3`

I checked whether coordinax actually *needs* 2.0.5 and it does not. Every use of
`unxts.linalg` here either **builds** a `QuantityMatrix` or **compares** a `UnitsMatrix`:

```
basis_change.py:83        QM(L_raw, unit=UnitsMatrix.full((n, n), ""))     build
quadratic_form.py:343     QM(vec.value, unit=UnitsMatrix.full(...))        build
quadratic_form.py:416     if d.unit != UnitsMatrix.full(d.unit.shape, "")  compare
norm.py:371               if gm.unit != UnitsMatrix.full(...)              compare
scale_factors.py:106      UnitsMatrix.full(diag.shape[-1], DMLS)           build
register_metric.py:*      UnitsMatrix((...))                               build
```

Nothing calls `uconvert`/`ustrip` with a unit *target* on a `QuantityMatrix`, which is the
only thing 2.0.5 adds over 2.0.4. Raising the floor would restate the fiction #745 just
removed from the `quax` floors — a declared minimum nothing exercises. The oldest-deps
job keeps testing 2.0.3, which still works.

I also checked whether the two `!= UnitsMatrix.full(shape, "")` comparisons could use
`UnitsMatrix.is_uniform` instead. They cannot: `is_uniform` means *all entries equal*, and
an all-metres matrix is uniform without being dimensionless. So there is no simplification
hiding there either.

## Verification

Full suite on 2.0.5: **10745 passed**, 8 skipped, 1 xfailed. Lock diff is 6 lines, version
and hashes only.
