### PR TITLE
📝 perf: name the eager cost, and guard the raw-array route (#719)

### DIFF
--- a/docs/guides/perf.md
+++ b/docs/guides/perf.md
@@ -74,6 +74,10 @@ Pre-resolving the dispatch with `plum`'s `Function.invoke` is therefore not the 
 
 So the 300x figure is a statement about _many small eager calls_, not about throughput. Batch, and it disappears; stay eager and per-point, and the route you choose is worth 20x.
 
+```{note}
+The eager timings above were measured against `plum` as it stands today, where several functions on this path -- `ustrip`, `uconvert`, `dimension_of` -- carry signatures that are not _faithful_ (`Literal`, `Mapping[...]`, `type[...]`) and so run with their method cache disabled. [plum#290](https://github.com/beartype/plum/issues/290) proposes separating `is_cacheable` from `is_faithful`, which would let exactly those signatures be cached. Expect the `Quantity` column to improve when that lands; the shape of the advice -- batch, jit, and prefer raw arrays at the boundary -- does not depend on it.
+```
+
 ## Coordinate Changes
 
 Let's start by importing the libraries we'll need and setting up some test data.

--- a/docs/guides/perf.md
+++ b/docs/guides/perf.md
@@ -38,6 +38,42 @@ def optimized_function(*arrays: Array):
     ...
 ```
 
+## What Eager Costs, and Why
+
+The guide above teaches jitting. It is worth saying plainly what you pay if you do not, because the number is larger than most people expect.
+
+One `pt_map` from `sph3d` to `cart3d`, at a single point:
+
+| call                         | eager   | jitted, reused |
+| ---------------------------- | ------- | -------------- |
+| `dict[str, Quantity]`        | 3650 us | 23.0 us        |
+| `dict[str, Array]` + `usys=` | 179 us  | 10.4 us        |
+
+Two things follow.
+
+**Raw arrays are ~20x cheaper than quantities, before jit is involved.** Both routes compute the identical numbers -- bit for bit -- so if a pipeline is already carrying bare arrays, handing them straight to `pt_map` with an explicit `usys=` avoids the wrapper entirely. Under jit the gap narrows but does not close: 10.4 us against 23.0 us.
+
+**Almost none of that overhead is `coordinax`.** Counting `plum` dispatch resolutions for one eager call:
+
+| route                 | dispatches | of which `pt_map` |
+| --------------------- | ---------- | ----------------- |
+| `dict[str, Quantity]` | 178        | 2                 |
+| `dict[str, Array]`    | 17         | 2                 |
+
+The other 176 are `unxt` and `quax` resolving arithmetic on `Quantity` operands -- `convert`, `unit`, `ustrip`, roughly one set per primitive operation. That is inherent to eager unit-aware arithmetic rather than something `coordinax` can dispatch its way out of, which is why the remedy is to choose the route rather than to micro-optimise the call.
+
+Pre-resolving the dispatch with `plum`'s `Function.invoke` is therefore not the lever it looks like here: it removes 2 resolutions of 178, and measures 1.05x. It pays where a hot loop repeatedly re-resolves _its own_ call, which is why `norm` keeps a module-level `array_norm = norm.invoke(Array, Array)`.
+
+**Dispatch is per call, not per element.** Batched and jitted, the routes converge -- at 10,000 points, all of them land within a few percent of each other:
+
+| route, N = 10,000, jitted            | per point |
+| ------------------------------------ | --------- |
+| `dict[str, Array]`, broadcast        | 24.3 ns   |
+| `dict[str, Quantity]`, broadcast     | 23.5 ns   |
+| `dict[str, Array]`, `jit(vmap(...))` | 22.0 ns   |
+
+So the 300x figure is a statement about _many small eager calls_, not about throughput. Batch, and it disappears; stay eager and per-point, and the route you choose is worth 20x.
+
 ## Coordinate Changes
 
 Let's start by importing the libraries we'll need and setting up some test data.

--- a/docs/guides/perf.md
+++ b/docs/guides/perf.md
@@ -53,16 +53,16 @@ Two things follow.
 
 **Raw arrays are ~20x cheaper than quantities, before jit is involved.** Both routes compute the identical numbers -- bit for bit -- so if a pipeline is already carrying bare arrays, handing them straight to `pt_map` with an explicit `usys=` avoids the wrapper entirely. Under jit the gap narrows but does not close: 10.4 us against 23.0 us.
 
-**Almost none of that overhead is `coordinax`.** Counting `plum` dispatch resolutions for one eager call:
+**Almost none of that overhead is `coordinax`.** Counting calls to `plum`-dispatched functions for one eager call -- calls rather than distinct resolutions, so a cache hit still counts:
 
-| route                 | dispatches | of which `pt_map` |
-| --------------------- | ---------- | ----------------- |
-| `dict[str, Quantity]` | 178        | 2                 |
-| `dict[str, Array]`    | 17         | 2                 |
+| route                        | calls | of which `pt_map` |
+| ---------------------------- | ----- | ----------------- |
+| `dict[str, Quantity]`        | 178   | 2                 |
+| `dict[str, Array]` + `usys=` | 17    | 2                 |
 
 The other 176 are `unxt` and `quax` resolving arithmetic on `Quantity` operands -- `convert`, `unit`, `ustrip`, roughly one set per primitive operation. That is inherent to eager unit-aware arithmetic rather than something `coordinax` can dispatch its way out of, which is why the remedy is to choose the route rather than to micro-optimise the call.
 
-Pre-resolving the dispatch with `plum`'s `Function.invoke` is therefore not the lever it looks like here: it removes 2 resolutions of 178, and measures 1.05x. It pays where a hot loop repeatedly re-resolves _its own_ call, which is why `norm` keeps a module-level `array_norm = norm.invoke(Array, Array)`.
+Pre-resolving the dispatch with `plum`'s `Function.invoke` is therefore not the lever it looks like here: it removes 2 dispatched calls of 178, and measures 1.05x. It pays where a hot loop repeatedly re-resolves _its own_ call, which is why `norm` keeps a module-level `array_norm = norm.invoke(Array, Array)`.
 
 **Dispatch is per call, not per element.** Batched and jitted, the routes converge -- at 10,000 points, all of them land within a few percent of each other:
 

--- a/tests/unit/charts/test_raw_array_fast_path.py
+++ b/tests/unit/charts/test_raw_array_fast_path.py
@@ -10,6 +10,12 @@ So the cost is not something coordinax can dispatch its way out of; what it can
 do is keep the raw-array route open, which is what these tests guard. Counting
 dispatches rather than timing keeps the guard deterministic: the numbers below
 are exact and repeatable, where wall-clock would flake in CI.
+
+Counting also survives a change in how `plum` caches. `plum#290` would let the
+unfaithful signatures on this path be cached, cutting the *cost* of a dispatch
+without changing how many happen -- `unit` already caches and is still counted
+27 times per call, which is what shows this counter tallies calls rather than
+resolutions.
 """
 
 __all__: tuple[str, ...] = ()

--- a/tests/unit/charts/test_raw_array_fast_path.py
+++ b/tests/unit/charts/test_raw_array_fast_path.py
@@ -39,7 +39,13 @@ _RAW_DISPATCH_CEILING = 40
 
 
 def _count_dispatches(fn):
-    """Total `plum` dispatch resolutions performed by ``fn()``."""
+    """Count calls to `plum`-dispatched functions made by ``fn()``.
+
+    Calls, not resolutions: this patches `plum.Function.__call__`, so a cache
+    hit is counted like any other call. That is the number the guard wants --
+    it does not move when `plum` changes what it caches -- but it is not a
+    count of distinct signature resolutions. See the module docstring.
+    """
     counts = collections.Counter()
     original = plum.Function.__call__
 
@@ -75,7 +81,7 @@ def test_raw_arrays_stay_off_the_unit_machinery():
 
 
 def test_raw_arrays_cost_far_fewer_dispatches_than_quantities():
-    """The gap is the point: ~10x fewer resolutions for the same arithmetic."""
+    """The gap is the point: ~10x fewer dispatched calls for the same arithmetic."""
     raw = sum(
         _count_dispatches(
             lambda: cxc.pt_map(_RAW, cxc.sph3d, cxc.cart3d, usys=_USYS)

--- a/tests/unit/charts/test_raw_array_fast_path.py
+++ b/tests/unit/charts/test_raw_array_fast_path.py
@@ -1,0 +1,109 @@
+"""The raw-array path through `pt_map` stays cheap (#719).
+
+`pt_map` on a `dict[str, Quantity]` costs ~20x more *per eager call* than the
+same map on bare arrays. Almost none of that is coordinax: of the 178 `plum`
+dispatches one such call makes, **two** are `pt_map` itself. The rest are
+`unxt`/`quax` resolving arithmetic on `Quantity` operands -- `convert`, `unit`,
+`ustrip` -- one per primitive op.
+
+So the cost is not something coordinax can dispatch its way out of; what it can
+do is keep the raw-array route open, which is what these tests guard. Counting
+dispatches rather than timing keeps the guard deterministic: the numbers below
+are exact and repeatable, where wall-clock would flake in CI.
+"""
+
+__all__: tuple[str, ...] = ()
+
+import collections
+
+import jax.numpy as jnp
+import plum
+import pytest
+
+import unxt as u
+
+import coordinax.charts as cxc
+
+_USYS = u.unitsystems.si
+
+#: Ceiling, not a target: raw arrays measured 17 dispatches when written. The
+#: assertion is that the fast path has not collapsed into the slow one, so this
+#: leaves room to move without becoming a change-detector test.
+_RAW_DISPATCH_CEILING = 40
+
+
+def _count_dispatches(fn):
+    """Total `plum` dispatch resolutions performed by ``fn()``."""
+    counts = collections.Counter()
+    original = plum.Function.__call__
+
+    def counting(self, *args, **kwargs):
+        counts[self.__name__] += 1
+        return original(self, *args, **kwargs)
+
+    plum.Function.__call__ = counting
+    try:
+        fn()
+    finally:
+        plum.Function.__call__ = original
+    return counts
+
+
+_RAW = {"r": jnp.asarray(1.0), "theta": jnp.asarray(0.5), "phi": jnp.asarray(0.3)}
+_QTY = {"r": u.Q(1.0, "m"), "theta": u.Q(0.5, "rad"), "phi": u.Q(0.3, "rad")}
+
+
+def test_the_raw_array_route_agrees_with_the_quantity_route():
+    """The fast path is only worth having if it is the same map."""
+    out_q = cxc.pt_map(_QTY, cxc.sph3d, cxc.cart3d)
+    out_a = cxc.pt_map(_RAW, cxc.sph3d, cxc.cart3d, usys=_USYS)
+    for k in ("x", "y", "z"):
+        assert float(u.ustrip("m", out_q[k])) == float(out_a[k])
+
+
+def test_raw_arrays_stay_off_the_unit_machinery():
+    counts = _count_dispatches(
+        lambda: cxc.pt_map(_RAW, cxc.sph3d, cxc.cart3d, usys=_USYS)
+    )
+    assert sum(counts.values()) <= _RAW_DISPATCH_CEILING
+
+
+def test_raw_arrays_cost_far_fewer_dispatches_than_quantities():
+    """The gap is the point: ~10x fewer resolutions for the same arithmetic."""
+    raw = sum(
+        _count_dispatches(
+            lambda: cxc.pt_map(_RAW, cxc.sph3d, cxc.cart3d, usys=_USYS)
+        ).values()
+    )
+    qty = sum(
+        _count_dispatches(lambda: cxc.pt_map(_QTY, cxc.sph3d, cxc.cart3d)).values()
+    )
+    assert raw * 4 < qty
+
+
+@pytest.mark.parametrize(
+    ("from_chart", "to_chart", "point"),
+    [
+        (cxc.sph3d, cxc.cart3d, _RAW),
+        (
+            cxc.cart3d,
+            cxc.sph3d,
+            {k: jnp.asarray(v) for k, v in (("x", 1.0), ("y", 0.5), ("z", 0.3))},
+        ),
+        (
+            cxc.cyl3d,
+            cxc.cart3d,
+            {k: jnp.asarray(v) for k, v in (("rho", 1.0), ("phi", 0.5), ("z", 0.3))},
+        ),
+        (
+            cxc.polar2d,
+            cxc.cart2d,
+            {k: jnp.asarray(v) for k, v in (("r", 1.0), ("theta", 0.5))},
+        ),
+    ],
+    ids=["sph3d->cart3d", "cart3d->sph3d", "cyl3d->cart3d", "polar2d->cart2d"],
+)
+def test_the_raw_route_is_open_for_every_common_pair(from_chart, to_chart, point):
+    """A gap here would silently push a pure-JAX pipeline onto the slow path."""
+    out = cxc.pt_map(point, from_chart, to_chart, usys=_USYS)
+    assert not any(isinstance(v, u.AbstractQuantity) for v in out.values())

--- a/tests/unit/test_dispatch_faithfulness.py
+++ b/tests/unit/test_dispatch_faithfulness.py
@@ -59,7 +59,14 @@ def _coordinax_unfaithful() -> dict[str, list[str]]:
 
 
 def test_no_new_unfaithful_signatures() -> None:
-    """A new unfaithful signature silently disables plum's method cache."""
+    """A new unfaithful signature silently disables plum's method cache.
+
+    Watch `plum#290`: it proposes separating `is_cacheable` from `is_faithful`,
+    so that `Literal` and generic signatures can be cached despite being
+    unfaithful. If that lands, this guard is stricter than it needs to be --
+    the question becomes cacheability, and several entries in
+    `UNFAITHFUL_BY_DESIGN` may stop costing anything.
+    """
     unexpected = {
         name: sigs
         for name, sigs in _coordinax_unfaithful().items()


### PR DESCRIPTION
Addresses #719 — and corrects its premise.

## The issue said "~99% of that is dispatch". True, but not coordinax's dispatch.

Of the **178** `plum` resolutions one eager `pt_map(sph3d → cart3d)` performs, **two** are `pt_map`. I traced every caller: the rest sit in `quax/_module.py` and `unxt/_src/quantity/` — `convert` ×90, `unit` ×27, `ustrip` ×24 — roughly one set per primitive operation on a `Quantity`. None originate in this package.

So there is no dispatch here for coordinax to remove. Pre-resolving with `plum`'s `Function.invoke`, the obvious lever, measures **1.05×** — exactly what removing 2 of 178 predicts. (It does pay where a loop re-resolves its *own* call, which is why `norm` keeps a module-level `array_norm = norm.invoke(Array, Array)`.)

## What coordinax does have is a route that skips the wrapper

```
sph3d -> cart3d, one point        eager      jitted + reused
  dict[str, Quantity]            3650 us         23.0 us
  dict[str, Array] + usys=        179 us         10.4 us
```

Bit-identical outputs — diff exactly 0.0 on every component — at **20× less eager cost**, and still 2.2× under jit. It works for every chart pair tried. It was simply undocumented.

## And the 300× is about call frequency, not throughput

Batched at N = 10,000 under jit, the routes converge:

| route, jitted, N = 10,000 | per point |
| --- | --- |
| `dict[str, Array]`, broadcast | 24.3 ns |
| `dict[str, Quantity]`, broadcast | 23.5 ns |
| `dict[str, Array]`, `jit(vmap(...))` | 22.0 ns |

Dispatch is paid per **call**, not per element. Batch and it vanishes; stay eager and per-point and the route is worth 20×.

## This PR

Guidance plus a regression guard — no runtime change:

- **`docs/guides/perf.md`** — a section quantifying the eager cost, the two routes, the dispatch attribution, and why `invoke` is not the lever here.
- **`tests/unit/charts/test_raw_array_fast_path.py`** — 7 tests that count **dispatches rather than time**. 17 and 178 are exact and repeatable where wall-clock would flake in CI. The ceiling is 40, so it asserts the fast path still exists rather than detecting any change.

## Forward-compatible with plum#290

[plum#290](https://github.com/beartype/plum/issues/290) proposes separating `is_cacheable` from `is_faithful`, which targets precisely what disables the cache on this path — `ustrip` (`type[AllowValue]`), `uconvert` (`Mapping[...]`, `Literal[...]`), `dimension_of` (`type[...]`).

The guide's timings are marked as measured against plum as it stands, and the `Quantity` column should improve when that lands. **The tests are unaffected by design**: they count calls, not resolutions. `unit` already caches and is still counted 27 times per `pt_map` — which is what demonstrates the distinction.

`test_no_new_unfaithful_signatures` (#709) carries the same note, since after #290 its premise weakens: the question becomes cacheability, and part of `UNFAITHFUL_BY_DESIGN` may stop costing anything.

## Verification

- Full suite: **11040 passed**, 7 skipped, 1 xfailed
- `prek run --all-files` clean, including `ty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
