### PR TITLE
🐛 fix(charts): an unsupported transition raises, instead of asserting

### DIFF
--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/register_ptmap.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/register_ptmap.py
@@ -14,6 +14,7 @@ import plum
 
 import coordinax.charts as cxc
 import unxt as u
+from coordinax._src.charts.checks import check_manifold_matches_chart
 from coordinax._src.custom_types import OptUSys
 from coordinax.manifolds import Rn
 from coordinaxs.api.custom_types import CDict
@@ -98,7 +99,7 @@ def pt_map(
 
     """
     del to_M
-    assert from_M == from_chart.M  # noqa: S101
+    check_manifold_matches_chart(from_M, from_chart, "from_M")
     b = from_chart.builder
 
     # Raw in -> raw out, as everywhere else in `pt_map`: the caller who came
@@ -166,7 +167,7 @@ def pt_map(
 
     """
     del from_M
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifold_matches_chart(to_M, to_chart, "to_M")
     b = to_chart.builder
 
     raw = u.unit_of(p["x"]) is None

--- a/src/coordinax/_src/charts/checks.py
+++ b/src/coordinax/_src/charts/checks.py
@@ -170,9 +170,29 @@ def check_manifolds_match_charts(
     to_M Rn(2) is not to_chart's manifold Rn(3)
 
     """
-    if from_M != from_chart.M:
-        msg = f"from_M {from_M} is not from_chart's manifold {from_chart.M}"
-        raise MismatchedManifoldError(msg)
-    if to_M != to_chart.M:
-        msg = f"to_M {to_M} is not to_chart's manifold {to_chart.M}"
+    check_manifold_matches_chart(from_M, from_chart, "from_M")
+    check_manifold_matches_chart(to_M, to_chart, "to_M")
+
+
+def check_manifold_matches_chart(M: Any, chart: Any, label: str, /) -> None:
+    """Refuse one manifold argument that is not its chart's own.
+
+    The single-sided form, for the rules that take both manifolds but only use
+    one -- `coordinaxs.curveframes` has two, each `del`-ing the other.
+
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+    >>> from coordinax._src.charts.checks import check_manifold_matches_chart
+
+    >>> check_manifold_matches_chart(cxm.R3, cxc.sph3d, "to_M")
+
+    >>> try:
+    ...     check_manifold_matches_chart(cxm.R2, cxc.sph3d, "to_M")
+    ... except cxc.MismatchedManifoldError as e:
+    ...     print(e)
+    to_M Rn(2) is not to_chart's manifold Rn(3)
+
+    """
+    if M != chart.M:
+        msg = f"{label} {M} is not {label.replace('_M', '_chart')}'s manifold {chart.M}"
         raise MismatchedManifoldError(msg)

--- a/src/coordinax/_src/charts/checks.py
+++ b/src/coordinax/_src/charts/checks.py
@@ -11,7 +11,7 @@ import quaxed.numpy as jnp
 import unxt as u
 from unxt import AbstractQuantity as AbcQ
 
-from coordinax._src.exceptions import MismatchedManifoldError
+from coordinax._src.exceptions import ManifoldMismatchError
 
 _0d = u.Angle(jnp.array(0), "rad")
 _pid = u.Angle(jnp.array(180), "deg")
@@ -165,7 +165,7 @@ def check_manifolds_match_charts(
 
     >>> try:
     ...     check_manifolds_match_charts(cxm.R3, cxc.cart3d, cxm.R2, cxc.sph3d)
-    ... except cxc.MismatchedManifoldError as e:
+    ... except cxc.ManifoldMismatchError as e:
     ...     print(e)
     to_M Rn(2) is not to_chart's manifold Rn(3)
 
@@ -188,11 +188,11 @@ def check_manifold_matches_chart(M: Any, chart: Any, label: str, /) -> None:
 
     >>> try:
     ...     check_manifold_matches_chart(cxm.R2, cxc.sph3d, "to_M")
-    ... except cxc.MismatchedManifoldError as e:
+    ... except cxc.ManifoldMismatchError as e:
     ...     print(e)
     to_M Rn(2) is not to_chart's manifold Rn(3)
 
     """
     if M != chart.M:
         msg = f"{label} {M} is not {label.replace('_M', '_chart')}'s manifold {chart.M}"
-        raise MismatchedManifoldError(msg)
+        raise ManifoldMismatchError(msg)

--- a/src/coordinax/_src/charts/checks.py
+++ b/src/coordinax/_src/charts/checks.py
@@ -2,12 +2,16 @@
 
 __all__ = ("polar_range", "strictly_positive", "leq", "geq")
 
+from typing import Any
+
 import equinox as eqx
 import jax
 
 import quaxed.numpy as jnp
 import unxt as u
 from unxt import AbstractQuantity as AbcQ
+
+from coordinax._src.exceptions import MismatchedManifoldError
 
 _0d = u.Angle(jnp.array(0), "rad")
 _pid = u.Angle(jnp.array(180), "deg")
@@ -141,3 +145,34 @@ def geq(
     name = f" {name}" if name else name
     msg = f"The input{name} must be greater than or equal to {comp_name}."
     return eqx.error_if(x, u.ustrip("", jnp.any(x < min_val)), msg)
+
+
+def check_manifolds_match_charts(
+    from_M: Any, from_chart: Any, to_M: Any, to_chart: Any, /
+) -> None:
+    """Refuse a `pt_map` whose manifolds are not its charts' own.
+
+    The rules take the manifolds explicitly as well as the charts. Naming one
+    that is not the chart's own -- or asking across two manifolds, which no
+    rule implements -- is refused here rather than by a bare ``assert``, which
+    disappears under ``python -O``.
+
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+    >>> from coordinax._src.charts.checks import check_manifolds_match_charts
+
+    >>> check_manifolds_match_charts(cxm.R3, cxc.cart3d, cxm.R3, cxc.sph3d)
+
+    >>> try:
+    ...     check_manifolds_match_charts(cxm.R3, cxc.cart3d, cxm.R2, cxc.sph3d)
+    ... except cxc.MismatchedManifoldError as e:
+    ...     print(e)
+    to_M Rn(2) is not to_chart's manifold Rn(3)
+
+    """
+    if from_M != from_chart.M:
+        msg = f"from_M {from_M} is not from_chart's manifold {from_chart.M}"
+        raise MismatchedManifoldError(msg)
+    if to_M != to_chart.M:
+        msg = f"to_M {to_M} is not to_chart's manifold {to_chart.M}"
+        raise MismatchedManifoldError(msg)

--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -16,6 +16,7 @@ import unxts.linalg as ul
 from unxt import AbstractQuantity as ABCQ  # noqa: N814
 
 import coordinaxs.api.charts as cxcapi
+from .checks import check_manifolds_match_charts
 from .containers import canonical_containers
 from .d0 import Cart0D
 from .d1 import Cart1D, Radial1D, Time1D
@@ -36,6 +37,7 @@ from coordinax._src.base import AbstractChart
 from coordinax._src.base.manifold import AbstractManifold
 from coordinax._src.custom_types import OptUSys
 from coordinax._src.euclidean import RN, EuclideanManifold, Rn
+from coordinax._src.exceptions import MismatchedManifoldError
 from coordinax._src.null import NoManifold
 from coordinax._src.product.chart import CartesianProductChart
 from coordinax._src.product.manifold import CartesianProductManifold
@@ -242,8 +244,7 @@ def pt_map(
     {'x': Q(3.061617e-16, 'm'), 'y': Q(5., 'm')}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     # Even though there's a dispatch for the Self-to-Self case, we still check
     # for it here to avoid infinite recursion.
@@ -253,7 +254,12 @@ def pt_map(
     # Now we know from_chart and to_chart are different, so we can safely call.
     from_cart = from_chart.cartesian
     to_cart = to_chart.cartesian
-    assert from_cart == to_cart  # noqa: S101
+    if from_cart != to_cart:
+        msg = (
+            f"no transition from {from_chart} to {to_chart}: their Cartesian "
+            f"charts differ ({from_cart} vs {to_cart})"
+        )
+        raise MismatchedManifoldError(msg)
 
     p_cart = cxcapi.pt_map(p, from_M, from_chart, to_M, from_cart, usys=usys)
     p_out = cxcapi.pt_map(p_cart, from_M, from_cart, to_M, to_chart, usys=usys)
@@ -327,8 +333,7 @@ def pt_map(
 
     """
     del usys  # unused
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     return canonical_containers(p, to_chart)
 
 
@@ -368,8 +373,7 @@ def pt_map(
 
     """
     del usys  # unused
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     return canonical_containers({"x": p["r"]}, to_chart)
 
@@ -406,8 +410,7 @@ def pt_map(
 
     """
     del usys  # unused
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     return canonical_containers({"r": p["x"]}, to_chart)
 
 
@@ -445,8 +448,7 @@ def pt_map(
      'y': Array(5., dtype=float64, ...)}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     theta = uconvert_to_rad(p["theta"], usys)
     x = p["r"] * jnp.cos(theta)
@@ -484,8 +486,7 @@ def pt_map(
 
     """
     del usys  # unused
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     r_ = jnp.hypot(p["x"], p["y"])
     theta = jnp.arctan2(p["y"], p["x"])
@@ -523,8 +524,7 @@ def pt_map(
      'z': 2.0}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     phi = uconvert_to_rad(p["phi"], usys)
     x = p["rho"] * jnp.cos(phi)
@@ -565,8 +565,7 @@ def pt_map(
      'z': Array(1.2246468e-16, dtype=float64, ...)}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     r_ = p["r"]
     theta = uconvert_to_rad(p["theta"], usys)
@@ -608,8 +607,7 @@ def pt_map(
      'z': Array(0., dtype=float64, ...)}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     r_ = p["distance"]
     lon = uconvert_to_rad(p["lon"], usys)
@@ -655,8 +653,7 @@ def pt_map(
     {'x': Q(1.2246468e-16, 'm'), 'y': Q(0., 'm'), 'z': Q(2., 'm')}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     lon_coslat, r_ = p["lon_coslat"], p["distance"]
     lat = uconvert_to_rad(p["lat"], usys)
@@ -706,8 +703,7 @@ def pt_map(
     {'x': Q(2., 'm'), 'y': Q(0., 'm'), 'z': Q(1.2246468e-16, 'm')}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     r_ = p["r"]
     theta = uconvert_to_rad(p["theta"], usys)
@@ -759,8 +755,7 @@ def pt_map(
      'z': Array(1.11803399, dtype=float64)}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     # Calculate cylindrical distance
     nu, mu = p["nu"], p["mu"]
@@ -813,8 +808,7 @@ def pt_map(
 
     """
     del usys  # Unused
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     rho = jnp.hypot(p["x"], p["y"])
     phi = jnp.atan2(p["y"], p["x"])
     return canonical_containers({"rho": rho, "phi": phi, "z": p["z"]}, to_chart)
@@ -851,8 +845,7 @@ def pt_map(
      'distance': Array(1., dtype=float64, weak_type=True)}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     # from_chart -> Spherical3D -> to_chart
     sph3d = Spherical3D(M=from_chart.M)
     p_sph = cxcapi.pt_map(p, from_M, from_chart, to_M, sph3d, usys=usys)
@@ -892,8 +885,7 @@ def pt_map(
 
     """
     del usys
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     x, y, z = p["x"], p["y"], p["z"]
     r = jnp.sqrt(x**2 + y**2 + z**2)
     # Avoid division by zero: when r == 0, set theta = 0 by convention
@@ -935,8 +927,7 @@ def pt_map(
 
     """
     del usys  # unused
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     r_ = jnp.hypot(p["rho"], p["z"])
     # Avoid division by zero: when r == 0, set theta = 0 by convention
     theta = jnp.acos(jnp.where(r_ == 0, jnp.ones(r_.shape), p["z"] / r_))
@@ -975,8 +966,7 @@ def pt_map(
      'z': Array(1.2246468e-16, dtype=float64, ...)}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     theta = uconvert_to_rad(p["theta"], usys)
     rho = p["r"] * jnp.sin(theta)
     z = p["r"] * jnp.cos(theta)
@@ -1013,8 +1003,7 @@ def pt_map(
     {'lon': 0, 'lat': 1.5707963267948966, 'distance': 1.0}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     lat = (
         u.Q(90, "deg") if isinstance(p["theta"], ABCQ) else jnp.pi / 2
     ) - uconvert_to_rad(p["theta"], usys)
@@ -1055,8 +1044,7 @@ def pt_map(
      'lat': 1.5707963267948966, 'distance': 1.0}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     lat = (
         u.Q(90, "deg") if isinstance(p["theta"], ABCQ) else jnp.pi / 2
     ) - uconvert_to_rad(p["theta"], usys)
@@ -1097,8 +1085,7 @@ def pt_map(
 
     """
     del usys  # Unused
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     return canonical_containers(
         {"r": p["r"], "theta": p["phi"], "phi": p["theta"]}, to_chart
     )
@@ -1135,8 +1122,7 @@ def pt_map(
 
     """
     del usys  # Unused
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     return canonical_containers(
         {"r": p["r"], "theta": p["phi"], "phi": p["theta"]}, to_chart
     )
@@ -1186,8 +1172,7 @@ def pt_map(
      'z': Array(1.11803399, dtype=float64)}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     nu, mu = p["nu"], p["mu"]
     if not isinstance(nu, ABCQ) or not isinstance(mu, ABCQ):
@@ -1259,8 +1244,7 @@ def pt_map(
      'nu': Array(2.47920271, dtype=float64), 'phi': 0}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     # Pre-compute common terms
     R2 = p["rho"] ** 2
@@ -1335,8 +1319,7 @@ def pt_map(
     {'mu': Q(9., 'm2'), 'nu': Q(4., 'm2'), 'phi': Angle(0., 'rad')}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     cyl = Cylindrical3D(M=from_chart.M)
     p_cyl = cxcapi.pt_map(p, from_M, from_chart, to_M, cyl, usys=usys)
     out = cxcapi.pt_map(p_cyl, from_M, cyl, to_M, to_chart, usys=usys)
@@ -1383,8 +1366,7 @@ def pt_map(
     {'mu': Q(9.85889894, 'm2'), 'nu': Q(1.14110106, 'm2'), 'phi': Angle(0., 'rad')}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     # Cast to the result type
     dtype = jnp.result_type(
@@ -1467,8 +1449,12 @@ def pt_map(
     {'x': Q(1., 'm'), 'y': Q(2., 'm'), 'z': Q(3., 'm')}
 
     """
-    assert from_chart.M in (from_M, to_chart.M)  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    if from_chart.M not in (from_M, to_chart.M) or to_M != to_chart.M:
+        msg = (
+            f"no transition from {from_chart} on {from_M} to {to_chart} on "
+            f"{to_M}: the manifolds do not line up"
+        )
+        raise MismatchedManifoldError(msg)
 
     # If target is CartND, we can't convert (would be infinite recursion)
     if isinstance(to_chart, CartND):
@@ -1555,9 +1541,16 @@ def pt_map(
     {'q': Q([0., 0., 5.], 'm')}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_chart.M in (from_M, RN)  # noqa: S101
-    assert to_M in (from_M, RN)  # noqa: S101
+    if (
+        from_M != from_chart.M
+        or to_chart.M not in (from_M, RN)
+        or to_M not in (from_M, RN)
+    ):
+        msg = (
+            f"no transition from {from_chart} on {from_M} to {to_chart} on "
+            f"{to_M}: the manifolds do not line up"
+        )
+        raise MismatchedManifoldError(msg)
 
     # If source is CartND, we can't convert (would be infinite recursion)
     if isinstance(from_chart, CartND):
@@ -1644,8 +1637,7 @@ def pt_map(
 
     """
     del usys  # Unused
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     return q
 
 
@@ -1856,8 +1848,7 @@ def pt_map(
 
     """
     del usys
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     _require_cart3d_phase_space(from_chart, direction="to")
 
     pos, vel = from_chart.split_components(p)
@@ -1922,8 +1913,7 @@ def pt_map(
 
     """
     del usys
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     _require_cart3d_phase_space(to_chart, direction="from")
 
     rho, z, dt_rho, dt_z = p["rho"], p["z"], p["dt_rho"], p["dt_z"]

--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -37,7 +37,7 @@ from coordinax._src.base import AbstractChart
 from coordinax._src.base.manifold import AbstractManifold
 from coordinax._src.custom_types import OptUSys
 from coordinax._src.euclidean import RN, EuclideanManifold, Rn
-from coordinax._src.exceptions import MismatchedManifoldError
+from coordinax._src.exceptions import ManifoldMismatchError
 from coordinax._src.null import NoManifold
 from coordinax._src.product.chart import CartesianProductChart
 from coordinax._src.product.manifold import CartesianProductManifold
@@ -259,7 +259,7 @@ def pt_map(
             f"no transition from {from_chart} to {to_chart}: their Cartesian "
             f"charts differ ({from_cart} vs {to_cart})"
         )
-        raise MismatchedManifoldError(msg)
+        raise ManifoldMismatchError(msg)
 
     p_cart = cxcapi.pt_map(p, from_M, from_chart, to_M, from_cart, usys=usys)
     p_out = cxcapi.pt_map(p_cart, from_M, from_cart, to_M, to_chart, usys=usys)
@@ -1454,7 +1454,7 @@ def pt_map(
             f"no transition from {from_chart} on {from_M} to {to_chart} on "
             f"{to_M}: the manifolds do not line up"
         )
-        raise MismatchedManifoldError(msg)
+        raise ManifoldMismatchError(msg)
 
     # If target is CartND, we can't convert (would be infinite recursion)
     if isinstance(to_chart, CartND):
@@ -1550,7 +1550,7 @@ def pt_map(
             f"no transition from {from_chart} on {from_M} to {to_chart} on "
             f"{to_M}: the manifolds do not line up"
         )
-        raise MismatchedManifoldError(msg)
+        raise ManifoldMismatchError(msg)
 
     # If source is CartND, we can't convert (would be infinite recursion)
     if isinstance(from_chart, CartND):

--- a/src/coordinax/_src/exceptions.py
+++ b/src/coordinax/_src/exceptions.py
@@ -43,7 +43,7 @@ class MismatchedManifoldError(Exception):
 
     >>> p = {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m"), "z": u.Q(3.0, "m")}
     >>> try:
-    ...     cxc.pt_map(p, cxm.R3, cxc.cart3d, cxm.R2, cxc.cart2d)
+    ...     cxc.pt_map(p, cxm.R3, cxc.cart3d, cxm.R2, cxc.sph3d)
     ... except cxc.MismatchedManifoldError as e:
     ...     print(e)
     to_M Rn(2) is not to_chart's manifold Rn(3)

--- a/src/coordinax/_src/exceptions.py
+++ b/src/coordinax/_src/exceptions.py
@@ -1,6 +1,6 @@
 """Exceptions for coordinax.charts module."""
 
-__all__ = ("MismatchedManifoldError", "NoGlobalCartesianChartError")
+__all__ = ("ManifoldMismatchError", "NoGlobalCartesianChartError")
 
 
 class NoGlobalCartesianChartError(Exception):
@@ -22,7 +22,7 @@ class NoGlobalCartesianChartError(Exception):
     """
 
 
-class MismatchedManifoldError(Exception):
+class ManifoldMismatchError(Exception):
     """Raised when a manifold argument disagrees with the chart it accompanies.
 
     The `pt_map` rules take the manifolds explicitly as well as the charts, so
@@ -44,7 +44,7 @@ class MismatchedManifoldError(Exception):
     >>> p = {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m"), "z": u.Q(3.0, "m")}
     >>> try:
     ...     cxc.pt_map(p, cxm.R3, cxc.cart3d, cxm.R2, cxc.sph3d)
-    ... except cxc.MismatchedManifoldError as e:
+    ... except cxc.ManifoldMismatchError as e:
     ...     print(e)
     to_M Rn(2) is not to_chart's manifold Rn(3)
 

--- a/src/coordinax/_src/exceptions.py
+++ b/src/coordinax/_src/exceptions.py
@@ -1,6 +1,6 @@
 """Exceptions for coordinax.charts module."""
 
-__all__ = ("NoGlobalCartesianChartError",)
+__all__ = ("MismatchedManifoldError", "NoGlobalCartesianChartError")
 
 
 class NoGlobalCartesianChartError(Exception):
@@ -18,5 +18,34 @@ class NoGlobalCartesianChartError(Exception):
     - Use an ``EmbeddedChart`` to embed in 3D Euclidean space
     - Use local projections when available
     - Work directly in the intrinsic coordinates
+
+    """
+
+
+class MismatchedManifoldError(Exception):
+    """Raised when a manifold argument disagrees with the chart it accompanies.
+
+    The `pt_map` rules take the manifolds explicitly as well as the charts, so
+    a caller can name a manifold that is not the chart's own -- or ask for a
+    transition between charts on different manifolds, which no rule implements.
+
+    Previously a bare ``assert``. That reported the same condition, but only
+    while assertions run: under ``python -O`` the guard vanishes and the call
+    proceeds on a mismatched pair instead of refusing. It is also
+    indistinguishable, by type, from a genuine broken invariant elsewhere in
+    the call.
+
+    Examples
+    --------
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.manifolds as cxm
+
+    >>> p = {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m"), "z": u.Q(3.0, "m")}
+    >>> try:
+    ...     cxc.pt_map(p, cxm.R3, cxc.cart3d, cxm.R2, cxc.cart2d)
+    ... except cxc.MismatchedManifoldError as e:
+    ...     print(e)
+    to_M Rn(2) is not to_chart's manifold Rn(3)
 
     """

--- a/src/coordinax/_src/product/chart.py
+++ b/src/coordinax/_src/product/chart.py
@@ -24,6 +24,7 @@ from coordinax._src.base import (
     AbstractStaticChart,
     chart_dataclass_decorator,
 )
+from coordinax._src.charts.checks import check_manifolds_match_charts
 from coordinax._src.charts.containers import canonical_containers
 from coordinax._src.custom_types import Ds, Ks, OptUSys
 from coordinaxs.api.custom_types import CDict
@@ -435,8 +436,7 @@ def pt_map(
     Q(1., 'm')
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     # Product charts can't safely use the cartesian intermediate because their
     # cartesian version is still a product chart, which would recurse here. Do

--- a/src/coordinax/_src/spherical/register_ptmap.py
+++ b/src/coordinax/_src/spherical/register_ptmap.py
@@ -21,6 +21,7 @@ from .chart import (
 )
 from .manifold import Sn
 from coordinax._src.base import AbstractChart
+from coordinax._src.charts.checks import check_manifolds_match_charts
 from coordinax._src.charts.containers import canonical_containers
 from coordinax._src.custom_types import OptUSys
 from coordinax._src.utils import uconvert_to_rad
@@ -75,8 +76,7 @@ def pt_map(
 
     """
     del usys  # unused
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     return canonical_containers(p, to_chart)
 
@@ -113,8 +113,7 @@ def pt_map(
     ['phi', 'theta']
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     canon = SphericalTwoSphere(M=to_M)
     p_canon = cxcapi.pt_map(p, from_M, from_chart, to_M, canon, usys=usys)
@@ -155,8 +154,7 @@ def pt_map(
 
     """
     del usys  # Unused
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     lat = p["theta"]
     lat = u.Q(90, "deg") - lat if is_any_quantity(lat) else jnp.pi / 2 - lat
@@ -188,8 +186,7 @@ def pt_map(
 
     """
     del usys
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     theta = p["lat"]
     theta = u.Q(90, "deg") - theta if is_any_quantity(theta) else jnp.pi / 2 - theta
@@ -230,8 +227,7 @@ def pt_map(
     True
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     lat = (
         u.Q(90, "deg") if is_any_quantity(p["theta"]) else jnp.pi / 2
@@ -264,8 +260,7 @@ def pt_map(
     {'theta': Angle(90., 'deg'), 'phi': Angle(45., 'deg')}
 
     """
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     lat = uconvert_to_rad(p["lat"], usys)
     theta = (u.Q(90, "deg") if is_any_quantity(p["lat"]) else jnp.pi / 2) - lat
@@ -302,8 +297,7 @@ def pt_map(
 
     """
     del usys  # Unused
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     return canonical_containers({"theta": p["phi"], "phi": p["theta"]}, to_chart)
 
 
@@ -332,7 +326,6 @@ def pt_map(
 
     """
     del usys  # Unused
-    assert from_M == from_chart.M  # noqa: S101
-    assert to_M == to_chart.M  # noqa: S101
+    check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     return canonical_containers({"theta": p["phi"], "phi": p["theta"]}, to_chart)

--- a/src/coordinax/charts.py
+++ b/src/coordinax/charts.py
@@ -86,7 +86,7 @@ __all__ = (
     "AbstractDimensionalFlag",
     "DIMENSIONAL_FLAGS",
     "CHART_CLASSES",
-    "MismatchedManifoldError",
+    "ManifoldMismatchError",
     "NoGlobalCartesianChartError",
     # -------------------------------------------
     "cartesian_chart",
@@ -222,7 +222,7 @@ with install_import_hook("coordinax.charts"):
         time1d,
     )
     from coordinax._src.exceptions import (
-        MismatchedManifoldError,
+        ManifoldMismatchError,
         NoGlobalCartesianChartError,
     )
     from coordinax._src.minkowski import MinkowskiCT, minkowskict

--- a/src/coordinax/charts.py
+++ b/src/coordinax/charts.py
@@ -86,6 +86,7 @@ __all__ = (
     "AbstractDimensionalFlag",
     "DIMENSIONAL_FLAGS",
     "CHART_CLASSES",
+    "MismatchedManifoldError",
     "NoGlobalCartesianChartError",
     # -------------------------------------------
     "cartesian_chart",
@@ -220,7 +221,10 @@ with install_import_hook("coordinax.charts"):
         sph3d,
         time1d,
     )
-    from coordinax._src.exceptions import NoGlobalCartesianChartError
+    from coordinax._src.exceptions import (
+        MismatchedManifoldError,
+        NoGlobalCartesianChartError,
+    )
     from coordinax._src.minkowski import MinkowskiCT, minkowskict
     from coordinax._src.product import (
         AbstractCartesianProductChart,

--- a/tests/unit/charts/test_unsupported_transition.py
+++ b/tests/unit/charts/test_unsupported_transition.py
@@ -1,0 +1,71 @@
+"""An unsupported `pt_map` refuses, and keeps refusing under ``python -O``.
+
+The rules take the manifolds explicitly as well as the charts, so a caller can
+name one that is not the chart's own. That was guarded by bare ``assert``s,
+which `python -O` strips: the call then proceeded on a mismatched pair and
+returned a number computed from charts that do not belong to the manifolds
+given.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+import coordinaxs.api.charts as cxcapi
+
+P3 = {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m"), "z": u.Q(3.0, "m")}
+
+
+class TestMismatchedManifoldIsRefused:
+    """Naming a manifold that is not the chart's own is refused, not computed."""
+
+    def test_wrong_target_manifold(self) -> None:
+        with pytest.raises(cxc.MismatchedManifoldError, match="to_M"):
+            cxcapi.pt_map(P3, cxm.R3, cxc.cart3d, cxm.R2, cxc.sph3d)
+
+    def test_wrong_source_manifold(self) -> None:
+        with pytest.raises(cxc.MismatchedManifoldError, match="from_M"):
+            cxcapi.pt_map(P3, cxm.R2, cxc.cart3d, cxm.R3, cxc.sph3d)
+
+    def test_incompatible_cartesian_charts(self) -> None:
+        with pytest.raises(
+            cxc.MismatchedManifoldError, match="Cartesian charts differ"
+        ):
+            cxcapi.pt_map(P3, cxm.R3, cxc.cart3d, cxm.R2, cxc.cart2d)
+
+    def test_it_is_not_an_assertion(self) -> None:
+        """`AssertionError` is what this used to raise, and is too broad.
+
+        Anything else in the call raising one would have been indistinguishable
+        from a refusal.
+        """
+        with pytest.raises(cxc.MismatchedManifoldError) as exc:
+            cxcapi.pt_map(P3, cxm.R3, cxc.cart3d, cxm.R2, cxc.sph3d)
+        assert not isinstance(exc.value, AssertionError)
+
+
+def test_refusal_survives_optimised_mode() -> None:
+    """Under ``-O`` the old bare `assert` vanished and the call returned a value.
+
+    Run in a subprocess because `-O` is an interpreter flag: it strips
+    assertions at compile time, so it cannot be toggled from inside this one.
+    """
+    script = (
+        "import unxt as u, coordinax.charts as cxc, coordinax.manifolds as cxm\n"
+        "import coordinaxs.api.charts as api\n"
+        "p = {'x': u.Q(1.0,'m'), 'y': u.Q(2.0,'m'), 'z': u.Q(3.0,'m')}\n"
+        "try:\n"
+        "    api.pt_map(p, cxm.R3, cxc.cart3d, cxm.R2, cxc.sph3d)\n"
+        "    print('RETURNED')\n"
+        "except cxc.MismatchedManifoldError:\n"
+        "    print('REFUSED')\n"
+    )
+    out = subprocess.run(  # noqa: S603
+        [sys.executable, "-O", "-c", script], capture_output=True, text=True, check=True
+    )
+    assert out.stdout.strip() == "REFUSED"

--- a/tests/unit/charts/test_unsupported_transition.py
+++ b/tests/unit/charts/test_unsupported_transition.py
@@ -25,17 +25,15 @@ class TestMismatchedManifoldIsRefused:
     """Naming a manifold that is not the chart's own is refused, not computed."""
 
     def test_wrong_target_manifold(self) -> None:
-        with pytest.raises(cxc.MismatchedManifoldError, match="to_M"):
+        with pytest.raises(cxc.ManifoldMismatchError, match="to_M"):
             cxcapi.pt_map(P3, cxm.R3, cxc.cart3d, cxm.R2, cxc.sph3d)
 
     def test_wrong_source_manifold(self) -> None:
-        with pytest.raises(cxc.MismatchedManifoldError, match="from_M"):
+        with pytest.raises(cxc.ManifoldMismatchError, match="from_M"):
             cxcapi.pt_map(P3, cxm.R2, cxc.cart3d, cxm.R3, cxc.sph3d)
 
     def test_incompatible_cartesian_charts(self) -> None:
-        with pytest.raises(
-            cxc.MismatchedManifoldError, match="Cartesian charts differ"
-        ):
+        with pytest.raises(cxc.ManifoldMismatchError, match="Cartesian charts differ"):
             cxcapi.pt_map(P3, cxm.R3, cxc.cart3d, cxm.R2, cxc.cart2d)
 
     def test_cartnd_source_with_mismatched_target(self) -> None:
@@ -46,12 +44,12 @@ class TestMismatchedManifoldIsRefused:
         a shape no other rule exercises.
         """
         p = {"q": u.Q([3.0, 4.0], "m")}
-        with pytest.raises(cxc.MismatchedManifoldError, match="do not line up"):
+        with pytest.raises(cxc.ManifoldMismatchError, match="do not line up"):
             cxcapi.pt_map(p, cxm.RN, cxc.cartnd, cxm.R3, cxc.polar2d)
 
     def test_cartnd_target_with_mismatched_source(self) -> None:
         p = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m")}
-        with pytest.raises(cxc.MismatchedManifoldError, match="do not line up"):
+        with pytest.raises(cxc.ManifoldMismatchError, match="do not line up"):
             cxcapi.pt_map(p, cxm.R3, cxc.cart2d, cxm.R2, cxc.cartnd)
 
     def test_it_is_not_an_assertion(self) -> None:
@@ -60,7 +58,7 @@ class TestMismatchedManifoldIsRefused:
         Anything else in the call raising one would have been indistinguishable
         from a refusal.
         """
-        with pytest.raises(cxc.MismatchedManifoldError) as exc:
+        with pytest.raises(cxc.ManifoldMismatchError) as exc:
             cxcapi.pt_map(P3, cxm.R3, cxc.cart3d, cxm.R2, cxc.sph3d)
         assert not isinstance(exc.value, AssertionError)
 
@@ -78,7 +76,7 @@ def test_refusal_survives_optimised_mode() -> None:
         "try:\n"
         "    api.pt_map(p, cxm.R3, cxc.cart3d, cxm.R2, cxc.sph3d)\n"
         "    print('RETURNED')\n"
-        "except cxc.MismatchedManifoldError:\n"
+        "except cxc.ManifoldMismatchError:\n"
         "    print('REFUSED')\n"
     )
     out = subprocess.run(  # noqa: S603

--- a/tests/unit/charts/test_unsupported_transition.py
+++ b/tests/unit/charts/test_unsupported_transition.py
@@ -38,6 +38,22 @@ class TestMismatchedManifoldIsRefused:
         ):
             cxcapi.pt_map(P3, cxm.R3, cxc.cart3d, cxm.R2, cxc.cart2d)
 
+    def test_cartnd_source_with_mismatched_target(self) -> None:
+        """The `CartND` rules guard differently and need their own cases.
+
+        Each accepts `RN` as well as the concrete manifold, so their condition
+        is a membership test rather than the equality the paired guard uses --
+        a shape no other rule exercises.
+        """
+        p = {"q": u.Q([3.0, 4.0], "m")}
+        with pytest.raises(cxc.MismatchedManifoldError, match="do not line up"):
+            cxcapi.pt_map(p, cxm.RN, cxc.cartnd, cxm.R3, cxc.polar2d)
+
+    def test_cartnd_target_with_mismatched_source(self) -> None:
+        p = {"x": u.Q(3.0, "m"), "y": u.Q(4.0, "m")}
+        with pytest.raises(cxc.MismatchedManifoldError, match="do not line up"):
+            cxcapi.pt_map(p, cxm.R3, cxc.cart2d, cxm.R2, cxc.cartnd)
+
     def test_it_is_not_an_assertion(self) -> None:
         """`AssertionError` is what this used to raise, and is too broad.
 


### PR DESCRIPTION
The `pt_map` rules take the manifolds explicitly as well as the charts, so a caller can name one that is not the chart's own. That was guarded by **80 bare `assert`s** — and `python -O` strips assertions.

On `main`, under `-O`:

```
pt_map(p, R3, cart3d, R2, sph3d)
-> {'r': Q(3.74165739, 'm'), 'theta': Angle(0.64052231, 'rad'), 'phi': Angle(1.10714872, 'rad')}
```

A number computed from charts that do not belong to the manifolds given, returned without complaint. Not a theoretical concern — that is the actual output.

The guard was also **indistinguishable by type** from any other broken invariant in the call. That is what forced #752's sweep to match assertion *source text* to decide whether a failure was a refusal or a bug; this removes the need for that.

## The change

`ManifoldMismatchError`, raised by a shared `check_manifolds_match_charts` for the 37 identical `from_M`/`to_M` pairs, and inline for the four one-off shapes (`from_cart == to_cart`, and three `in`-membership variants).

It is **fewer lines than the asserts it replaces** — each two-line pair collapses to one call — and the messages name the mismatch:

```
to_M Rn(2) is not to_chart's manifold Rn(3)
no transition from Cart3D(...) to Cart2D(...): their Cartesian charts differ
```

The name is deliberately general rather than `NoChartTransitionError`, because it covers two different failures: the caller naming a manifold that isn't the chart's (where a transition may well exist), and two charts genuinely living on different manifolds. "No transition" would be a lie for the first; both are two manifolds failing to agree.

## `coordinaxs.curveframes` too

Review caught that the workspace package still had bare `assert`s, so two `pt_map` routes kept exactly the `-O` vulnerability this PR exists to close — my original sweep covered four files under `src/` and never reached the packages.

Those two do not have the paired shape the rest use; each checks one manifold and `del`s the other. So the single-sided `check_manifold_matches_chart` was added, the pair form now delegates to it twice, and the message format is derived from the label — byte-identical to before. Then enumerated across all of `src/` and `packages/` rather than trusting the file the review named: **no manifold `assert`s remain anywhere in the tree**.

## Coverage

`codecov/patch` initially failed, and the cause is inherent to the change rather than an oversight: a bare `assert` counts as covered when it **passes**, so 80 guards were "covered" while never once refusing anything. Written as `if ... raise`, a block only counts when it fires — which immediately showed that nothing exercised a mismatched `CartND` transition.

Intersecting the diff's added lines against the uncovered set pinned it to exactly two blocks. Both `CartND` rules accept `RN` as well as the concrete manifold, so their condition is a membership test rather than the equality the other 37 use — a shape unique to them. Two tests, one per direction; **no added line remains uncovered**, and `checks.py` is at 100%.

## Verification

- **755 passed** across `tests/unit/charts` and the touched modules' doctests; full suite **11255 passed**, 0 failures; `nox -s precommit` clean.
- `test_unsupported_transition.py` covers the refusal shapes including both `CartND` directions, asserts the error is **not** an `AssertionError`, and pins the `-O` behaviour.
- The `-O` test runs in a **subprocess**: the flag strips assertions at compile time, so it cannot be toggled from inside the suite. Verified it fails against `main` and passes here.

## Note on #752

That PR's sweep classifies unsupported pairs by catching broadly and pinning how many succeed. It keeps working unchanged here — the count is the same, only the exception type differs — but with a dedicated error, a future version could catch `ManifoldMismatchError` precisely instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
