### PR TITLE
✨ feat(curveframes): infer `tau_unit` from the parameter instead of requiring it

### DIFF
--- a/packages/coordinaxs.curveframes/docs/spec.md
+++ b/packages/coordinaxs.curveframes/docs/spec.md
@@ -326,7 +326,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
     Fields (declared `eqx.AbstractVar`, defined by concrete subclasses):
 
     - `curve : Callable[[Any], Any]` — the curve $\gamma \mapsto \boldsymbol{\gamma}(\gamma)$, mapping a parameter `Quantity` to a Cartesian 3-vector `Quantity`. A pytree leaf: make `curve` itself an `equinox.Module` to get differentiable/vmappable curve parameters.
-    - `tau_unit : unxt.AbstractUnit` — physical unit of the curve parameter. **Static**: it selects the differentiation units, not a numeric value.
+    - `tau_unit : unxt.AbstractUnit | None` — physical unit of the curve parameter. **Static**: it selects the differentiation units, not a numeric value. `None` (the default) reads the unit off the parameter the builder is called with -- the station when one is pinned, otherwise the call-time $\tau$. Declare it for a curve that reads its argument's `.value` rather than converting, or for a raw (unitless) parameter.
     - `gamma : Any` — an optional *fixed* curve parameter. When `None` (the default), $\tau$ itself is the curve parameter — the classic moving-frame usage. When set, the frame sits at the fixed point $\boldsymbol{\gamma}(\gamma)$ and is $\tau$-independent: a frame *field* along the curve, differentiable and `vmap`-able in `gamma`.
 
     Methods:
@@ -344,14 +344,14 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
     Fields (in addition to the ABC's `curve`, `tau_unit`, `station`): none — `FrenetSerretBuilder` adds no fields beyond the base class.
 
     - `curve : Callable[[Any], Any]` — the constructing curve.
-    - `tau_unit : unxt.AbstractUnit` — unit of the curve parameter, used by `unxt.experimental.jacfwd` to compute unit-correct derivatives. Static. **Required**: there is no neutral default, since a curve parameter may be a time, an arc length, or an affine parameter.
+    - `tau_unit : unxt.AbstractUnit | None` — unit of the curve parameter, used by `unxt.experimental.jacfwd` to compute unit-correct derivatives. Static. `None` (the default) reads the unit off the parameter the builder is called with -- the station when one is pinned, otherwise the call-time $\tau$. Declare it for a curve that reads its argument's `.value` rather than converting, or for a raw (unitless) parameter.
     - `station : Any` — optional fixed curve parameter (a leaf); see `AbstractCurveFrameBuilder`.
 
     `rotation_matrix(tau)` computes $R = [\mathbf{T}; \mathbf{N}; \mathbf{B}]$: unit-aware first and second derivatives of `curve` via `unxt.experimental.jacfwd`, then $\mathbf{T} = \gamma'/\lVert\gamma'\rVert$, Gram–Schmidt rejection of $\gamma''$ onto $\mathbf{T}$ normalised to give $\mathbf{N}$, and $\mathbf{B} = \mathbf{T}\times\mathbf{N}$.
 
     Convenience accessors: `normal(tau)` (row 1), `binormal(tau)` (row 2); `location(tau)`, `tangent(tau)` are inherited from `AbstractCurveFrameBuilder`.
 
-    Constructed directly — `FrenetSerretBuilder(curve, tau_unit, station=None)` — there is no `from_curve`/`from_` classmethod on the builder; that convenience lives on `FrenetSerretFrame`.
+    Constructed directly — `FrenetSerretBuilder(curve, tau_unit=None, station=None)` — there is no `from_curve`/`from_` classmethod on the builder; that convenience lives on `FrenetSerretFrame`.
 
     JAX compatibility: `FrenetSerretBuilder` is an `equinox.Module`, so it is a valid pytree. `curve`, `station` are dynamic leaves (differentiable, `vmap`-able); `tau_unit` is static. `rotation_matrix` and `__call__` operate on scalar $\tau$; batching is via `jax.vmap`. A plain `jax.jit` cannot hash a builder holding array leaves (e.g. an `equinox.Module` curve with array fields, or a `station`); use `eqx.filter_jit` in that case.
 
@@ -374,7 +374,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
     Constructors:
 
     - `FrenetSerretFrame(base_frame, xop, xop_inv)` — direct construction from a base frame and a `TimeDep`-wrapped `FrenetSerretBuilder` (forward and inverse).
-    - `from_curve(base_frame, curve, /, tau_unit, *, station=None)` — convenience constructor that builds `FrenetSerretBuilder(curve, tau_unit, station)`, wraps it in `TimeDep`, and sets `xop_inv = xop.inverse`.
+    - `from_curve(base_frame, curve, /, tau_unit=None, *, station=None)` — convenience constructor that builds `FrenetSerretBuilder(curve, tau_unit, station)`, wraps it in `TimeDep`, and sets `xop_inv = xop.inverse`.
 
     Frame transitions:
 
@@ -414,9 +414,9 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
     Fields (the ABC's `curve`, `tau_unit`, `station`, plus two more):
 
     - `curve : Callable[[Any], Any]` — the constructing curve.
-    - `tau_unit : unxt.AbstractUnit` — unit of the curve parameter. Static. **Required**: there is no neutral default, since a curve parameter may be a time, an arc length, or an affine parameter.
+    - `tau_unit : unxt.AbstractUnit | None` — unit of the curve parameter. Static. `None` (the default) reads the unit off the parameter the builder is called with -- the station when one is pinned, otherwise the call-time $\tau$. Declare it for a curve that reads its argument's `.value` rather than converting, or for a raw (unitless) parameter.
     - `station : Any` — optional fixed curve parameter (a leaf); see `AbstractCurveFrameBuilder`.
-    - `tau_0 : unxt.AbstractQuantity | None` — reference parameter where the initial frame is defined (a leaf). `None` is resolved to `Q(0.0, tau_unit)` by `__post_init__`.
+    - `tau_0 : unxt.AbstractQuantity | None` — reference parameter where the initial frame is defined (a leaf). `None` is resolved to `Q(0.0, tau_unit)` by `__post_init__` when the unit is declared, and at call time when it is being inferred. Only the declared case leaves it a pytree leaf; pass `tau_0` explicitly to differentiate through it otherwise.
     - `initial_normal : Any` — initial $\mathbf{U}_{1,0}$ (dimensionless 3-vector, a leaf), or `None` for auto-selection via Gram–Schmidt.
     - `diffeqsolver : diffraxtra.DiffEqSolver` — the whole `diffrax` configuration (solver, step-size controller, adjoint, step budget) in one **static** field (hashable, contributes no array leaves, so the builder's pytree stays about the curve). Defaults below.
 
@@ -426,7 +426,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
 
     Convenience accessors: `normal1(tau)` (row 1), `normal2(tau)` (row 2); `location(tau)`, `tangent(tau)` inherited.
 
-    Constructed directly — `BishopBuilder(curve, tau_unit, station=None, tau_0=None, initial_normal=None, diffeqsolver=DiffEqSolver(Tsit5(), PIDController(1e-10, 1e-10), DirectAdjoint(), max_steps=16384))` — there is no `from_curve`/`from_` classmethod on the builder; that convenience lives on `BishopFrame`.
+    Constructed directly — `BishopBuilder(curve, tau_unit=None, station=None, tau_0=None, initial_normal=None, diffeqsolver=DiffEqSolver(Tsit5(), PIDController(1e-10, 1e-10), DirectAdjoint(), max_steps=16384))` — there is no `from_curve`/`from_` classmethod on the builder; that convenience lives on `BishopFrame`.
 
     JAX compatibility: same as `FrenetSerretBuilder` — `curve`, `station`, `tau_0`, `initial_normal` are dynamic leaves; `tau_unit` and `diffeqsolver` are static. A plain `jax.jit` cannot hash a builder holding array leaves; use `eqx.filter_jit`.
 
@@ -447,7 +447,7 @@ Every curve frame is built from a `coordinax.transforms.TimeDep` wrapping one of
     Constructors:
 
     - `BishopFrame(base_frame, xop, xop_inv)` — direct construction.
-    - `from_curve(base_frame, curve, /, tau_unit, *, station=None, tau_0=None, initial_normal=None)` — convenience constructor that builds `BishopBuilder(curve, tau_unit, station, tau_0, initial_normal)`, wraps it in `TimeDep`, and sets `xop_inv = xop.inverse`.
+    - `from_curve(base_frame, curve, /, tau_unit=None, *, station=None, tau_0=None, initial_normal=None)` — convenience constructor that builds `BishopBuilder(curve, tau_unit, station, tau_0, initial_normal)`, wraps it in `TimeDep`, and sets `xop_inv = xop.inverse`.
 
     Frame transitions:
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/__init__.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/__init__.py
@@ -24,8 +24,13 @@ Typical usage::
 
     import coordinaxs.curveframes as cxfc
 
-    fs_frame = cxfc.FrenetSerretFrame.from_curve(base_frame, curve[, tau_unit])
-    b_frame  = cxfc.BishopFrame.from_curve(base_frame, curve[, tau_unit])
+    # `tau_unit` is read off the parameter the frame is evaluated at:
+    fs_frame = cxfc.FrenetSerretFrame.from_curve(base_frame, curve)
+    b_frame  = cxfc.BishopFrame.from_curve(base_frame, curve)
+
+    # ... or stated outright, which a `.value`-reading curve needs:
+    fs_frame = cxfc.FrenetSerretFrame.from_curve(base_frame, curve, "s")
+    b_frame  = cxfc.BishopFrame.from_curve(base_frame, curve, "s")
 
 See Also
 --------

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/__init__.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/__init__.py
@@ -24,8 +24,8 @@ Typical usage::
 
     import coordinaxs.curveframes as cxfc
 
-    fs_frame = cxfc.FrenetSerretFrame.from_curve(base_frame, curve, tau_unit)
-    b_frame  = cxfc.BishopFrame.from_curve(base_frame, curve, tau_unit)
+    fs_frame = cxfc.FrenetSerretFrame.from_curve(base_frame, curve[, tau_unit])
+    b_frame  = cxfc.BishopFrame.from_curve(base_frame, curve[, tau_unit])
 
 See Also
 --------

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -56,13 +56,27 @@ _MSG_TAU_UNIT_DIMENSION = (
 )
 
 
+#: Which value carries no unit is the whole of what makes this actionable: a
+#: pinned `station` is what the builder evaluates at, so a `Quantity` at call
+#: time does not help, and advising one sends the reader to the wrong place.
 _MSG_TAU_UNIT_UNINFERABLE = (
-    "this builder has no `tau_unit` and was called with a parameter that "
-    "carries no unit, so there is nothing to read it off. Either pass a "
-    "`Quantity` parameter, e.g. `builder(u.Q(1.0, 's'))`, or declare the unit "
-    "on the builder, e.g. `BishopBuilder(curve, 's')`, which is what a raw "
-    "(unitless) parameter needs."
+    "this builder has no `tau_unit`, and the {source} it evaluates at carries "
+    "no unit, so there is nothing to read it off. Either pass {fix}, or "
+    "declare the unit on the builder, e.g. `BishopBuilder(curve, 's')`, which "
+    "is what a raw (unitless) value needs."
 )
+
+_SOURCE_STATION = (
+    "pinned `station`",
+    "a `Quantity` station, e.g. `station=u.Q(0.3, 's')`",
+)
+_SOURCE_TAU = (
+    "call-time parameter",
+    "a `Quantity` parameter, e.g. `builder(u.Q(1.0, 's'))`",
+)
+#: `_tau_unit_at`'s callers hand it a bound or a stored coordinate rather than
+#: a call argument, so it names neither and points at the value itself.
+_SOURCE_VALUE = ("value", "one as a `Quantity`")
 
 
 def unit_or_none(obj: Any, /) -> u.AbstractUnit | None:
@@ -280,7 +294,8 @@ class AbstractCurveFrameBuilder(eqx.Module):
             return self.tau_unit
         tau_unit = cast("u.AbstractUnit | None", u.unit_of(param))
         if tau_unit is None:
-            raise TypeError(_MSG_TAU_UNIT_UNINFERABLE)
+            source, fix = _SOURCE_VALUE
+            raise TypeError(_MSG_TAU_UNIT_UNINFERABLE.format(source=source, fix=fix))
         # Same check `__check_init__` runs on a declared unit -- for an
         # inferred one this is the first moment it can run at all.
         check_param_dimension(self.curve, tau_unit)
@@ -303,11 +318,13 @@ class AbstractCurveFrameBuilder(eqx.Module):
         A raw parameter with no declared unit is the one combination that
         cannot be served -- nothing anywhere states the unit -- and raises.
         """
-        param = tau if self.station is None else self.station
+        pinned = self.station is not None
+        param = self.station if pinned else tau
         if u.unit_of(param) is not None:
             return param
         if self.tau_unit is None:
-            raise TypeError(_MSG_TAU_UNIT_UNINFERABLE)
+            source, fix = _SOURCE_STATION if pinned else _SOURCE_TAU
+            raise TypeError(_MSG_TAU_UNIT_UNINFERABLE.format(source=source, fix=fix))
         return u.Q(param, self.tau_unit)
 
     @abc.abstractmethod

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -287,8 +287,28 @@ class AbstractCurveFrameBuilder(eqx.Module):
         return tau_unit
 
     def _param(self, tau: Any, /) -> Any:
-        """Return the curve parameter: ``tau``, or the fixed ``station``."""
-        return tau if self.station is None else self.station
+        r"""Return the curve parameter as a `Quantity`: ``tau``, or the station.
+
+        A raw (unitless) parameter is the **array fastpath**: bare arrays
+        carrying no unit, which is the cheapest way in and the reason
+        `tau_unit` is still worth declaring. Those numbers mean nothing on
+        their own, so they are wrapped here with the declared `tau_unit` --
+        the same role a `unxt.AbstractUnitSystem` plays for the raw-array
+        route elsewhere in `coordinax`.
+
+        Doing it at this one funnel covers every accessor at once: `__call__`,
+        `location`, and both builders' triads all take their curve parameter
+        from here, so none of them has to know whether it arrived wrapped.
+
+        A raw parameter with no declared unit is the one combination that
+        cannot be served -- nothing anywhere states the unit -- and raises.
+        """
+        param = tau if self.station is None else self.station
+        if u.unit_of(param) is not None:
+            return param
+        if self.tau_unit is None:
+            raise TypeError(_MSG_TAU_UNIT_UNINFERABLE)
+        return u.Q(param, self.tau_unit)
 
     @abc.abstractmethod
     def rotation_matrix(self, tau: Any, /) -> Array:

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -18,7 +18,7 @@ import dataclasses
 
 from collections.abc import Callable
 from jaxtyping import Array
-from typing import Any
+from typing import Any, cast
 from typing_extensions import TypeVar
 
 import equinox as eqx
@@ -54,6 +54,46 @@ _MSG_TAU_UNIT_DIMENSION = (
     "correct positions, since it never consults the unit, while `tangent` and "
     "`rotation_matrix` would fail later inside the derivative."
 )
+
+
+_MSG_TAU_UNIT_UNINFERABLE = (
+    "this builder has no `tau_unit` and was called with a parameter that "
+    "carries no unit, so there is nothing to read it off. Either pass a "
+    "`Quantity` parameter, e.g. `builder(u.Q(1.0, 's'))`, or declare the unit "
+    "on the builder, e.g. `BishopBuilder(curve, 's')`, which is what a raw "
+    "(unitless) parameter needs."
+)
+
+
+def unit_or_none(obj: Any, /) -> u.AbstractUnit | None:
+    """Field converter: pass `None` through, otherwise coerce to a unit.
+
+    `None` is not "no unit", it is *infer the unit from the parameter the
+    builder is called with* -- see `AbstractCurveFrameBuilder._tau_unit_at`.
+    """
+    return None if obj is None else cast("u.AbstractUnit", u.unit(obj))
+
+
+def check_param_dimension(curve: Any, tau_unit: u.AbstractUnit, /) -> None:
+    """Raise if ``tau_unit`` contradicts the dimension ``curve`` declares.
+
+    Read from the *instance*, not the type, so a wrapper can forward what it
+    wraps -- `AtTime(ArcLength(...), t)` still exposes a length, and that is
+    the composition the docs recommend, so it is the one most worth catching.
+
+    A curve that declares nothing is unconstrained: most curves are bare
+    functions, and a Python callable cannot be asked what unit its argument
+    takes.
+    """
+    want = getattr(curve, "_param_dimension", None)
+    if want is None:
+        return
+    got = str(u.dimension_of(tau_unit))
+    if got != want:
+        raise ValueError(
+            _MSG_TAU_UNIT_DIMENSION.format(want=want, unit=tau_unit, got=got)
+        )
+
 
 _MSG_TWO_ARGUMENT_NEEDS_STATION = (
     "this curve takes two positional arguments, `gamma(tau, t)`, so the "
@@ -131,9 +171,11 @@ class AbstractCurveFrameBuilder(eqx.Module):
     curve : Callable
         The curve $\tau \mapsto \boldsymbol{\gamma}(\tau)$, mapping a
         parameter `Quantity` to a Cartesian 3-vector `Quantity`.
-    tau_unit : AbstractUnit
+    tau_unit : AbstractUnit, optional
         Physical unit of the curve parameter (e.g. ``"s"``).  Static: it selects
-        the differentiation units, not a numeric value.
+        the differentiation units, not a numeric value.  `None` (the default)
+        reads it off the parameter the builder is called with, which is what
+        a `Quantity` already carries -- see `_tau_unit_at`.
     station : Any, optional
         A *fixed* curve parameter — a station along the curve.  When `None`
         (the default) $\tau$ itself is the curve parameter — the classic
@@ -144,7 +186,7 @@ class AbstractCurveFrameBuilder(eqx.Module):
     """
 
     curve: eqx.AbstractVar[Callable[[Any], Any]]
-    tau_unit: eqx.AbstractVar[u.AbstractUnit]
+    tau_unit: eqx.AbstractVar[u.AbstractUnit | None]
     station: eqx.AbstractVar[Any]
 
     def __check_init__(self) -> None:
@@ -172,25 +214,17 @@ class AbstractCurveFrameBuilder(eqx.Module):
         if _is_two_argument(self.curve) and self.station is None:
             raise ValueError(_MSG_TWO_ARGUMENT_NEEDS_STATION)
 
-        # A curve that knows what it exposes is checked against `tau_unit`
-        # here, where the mistake is, rather than left to surface unevenly
-        # later: `location` ignores `tau_unit` and returns correct positions,
-        # while the autodiff paths raise a conversion error far from the
-        # construction that caused it (#718).
+        # A curve that knows what it exposes is checked against a *declared*
+        # `tau_unit` here, where the mistake is, rather than left to surface
+        # unevenly later: `location` ignores `tau_unit` and returns correct
+        # positions, while the autodiff paths raise a conversion error far
+        # from the construction that caused it (#718).
         #
-        # Read from the *instance*, not the type, so a wrapper can forward
-        # what it wraps -- `AtTime(ArcLength(...), t)` still exposes a
-        # length, and that is the composition the docs recommend, so it is
-        # the one most worth catching.
-        want = getattr(self.curve, "_param_dimension", None)
-        if want is not None:
-            got = str(u.dimension_of(self.tau_unit))
-            if got != want:
-                raise ValueError(
-                    _MSG_TAU_UNIT_DIMENSION.format(
-                        want=want, unit=self.tau_unit, got=got
-                    )
-                )
+        # An undeclared unit has nothing to check yet -- there is no wrong
+        # answer to catch until a parameter arrives. `_tau_unit_at` runs the
+        # same check on the inferred unit at that point.
+        if self.tau_unit is not None:
+            check_param_dimension(self.curve, self.tau_unit)
 
     def _resolve(  # noqa: PYI019  (see BuilderT: `Self` breaks beartype)
         self: BuilderT, tau: Any, /
@@ -219,6 +253,38 @@ class AbstractCurveFrameBuilder(eqx.Module):
         return self, tau
 
     # ---------------------------------------------------------------
+
+    def _tau_unit_at(self, param: Any, /) -> u.AbstractUnit:
+        r"""Resolve the curve parameter's unit: declared, or read off ``param``.
+
+        A declared `tau_unit` wins, so the explicit form keeps working
+        unchanged. `None` reads `unxt.unit_of` on the parameter actually being
+        evaluated -- the station when one is pinned, otherwise the call-time
+        $\tau$ -- which is the unit the caller has already stated by handing
+        over a `Quantity`.
+
+        Inferring is *safer* than any default, including a correct one: a
+        declared unit is a second, independent statement of the same fact, and
+        two statements can disagree. `unxt.experimental.jacfwd` converts rather
+        than reinterprets, so on a curve that reads its argument with `ustrip`
+        the disagreement is absorbed and the answer stays right; on a curve
+        that reads `.value` it is not, and the frame comes back silently wrong.
+        Reading the unit off the parameter removes the second statement, so
+        there is nothing left to disagree.
+
+        Declaring it still earns its place in two cases the parameter cannot
+        settle: a curve that reads `.value` rather than converting, and a raw
+        (unitless) parameter, which carries no unit to read.
+        """
+        if self.tau_unit is not None:
+            return self.tau_unit
+        tau_unit = cast("u.AbstractUnit | None", u.unit_of(param))
+        if tau_unit is None:
+            raise TypeError(_MSG_TAU_UNIT_UNINFERABLE)
+        # Same check `__check_init__` runs on a declared unit -- for an
+        # inferred one this is the first moment it can run at all.
+        check_param_dimension(self.curve, tau_unit)
+        return tau_unit
 
     def _param(self, tau: Any, /) -> Any:
         """Return the curve parameter: ``tau``, or the fixed ``station``."""

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
@@ -49,7 +49,7 @@ __all__ = ("BishopBuilder", "BishopFrame")
 
 from collections.abc import Callable
 from jaxtyping import Array
-from typing import Any, cast, final
+from typing import Any, final
 
 import diffrax as dfx
 import equinox as eqx
@@ -59,7 +59,12 @@ from diffraxtra import DiffEqSolver
 import coordinax.transforms as cxfm
 import unxt as u
 
-from .base import AbstractCurveFrameBuilder, AbstractParallelTransportFrame, FrameT
+from .base import (
+    AbstractCurveFrameBuilder,
+    AbstractParallelTransportFrame,
+    FrameT,
+    unit_or_none,
+)
 from .frenetserret import _normalize
 
 #: Default integrator for the parallel-transport ODE.  `DirectAdjoint` is the
@@ -191,11 +196,14 @@ class BishopBuilder(AbstractCurveFrameBuilder):
     curve : Callable
         A function ``tau -> Quantity[float, (3,)]``.  Make it an
         `equinox.Module` for differentiable curve parameters.
-    tau_unit : AbstractUnit or str
-        Unit of the curve parameter.  Required: there is no neutral default,
-        since a curve parameter may be a time, an arc length, or an affine
-        parameter, and the wrong unit is silently rescaled rather than
-        rejected when it is dimensionally compatible.
+    tau_unit : AbstractUnit or str, optional
+        Unit of the curve parameter.  `None` (the default) reads it off the
+        parameter the builder is called with.  There is no neutral unit to
+        default to -- a curve parameter may be a time, an arc length, or an
+        affine parameter -- so rather than pick one, take the one the caller
+        already stated by passing a `Quantity`.  Declare it for a curve that
+        reads its argument's ``.value`` rather than converting, or for a raw
+        (unitless) parameter, which carries no unit to read.
     station : optional
         A fixed station along the curve; see `AbstractCurveFrameBuilder`.
     tau_0 : Quantity, optional
@@ -279,6 +287,17 @@ class BishopBuilder(AbstractCurveFrameBuilder):
     >>> type(fast.diffeqsolver.adjoint).__name__, fast.diffeqsolver.max_steps
     ('DirectAdjoint', 16384)
 
+    The unit may be left off, in which case it is read off the parameter --
+    which is a `Quantity`, so it states its own unit already:
+
+    >>> cxfc.BishopBuilder(helix).tangent(u.Q(0.0, "s"))
+    Q([-0.        ,  0.70710678,  0.70710678], '')
+
+    Declaring it is still accepted and gives the same answer:
+
+    >>> cxfc.BishopBuilder(helix, "s").tangent(u.Q(0.0, "s"))
+    Q([-0.        ,  0.70710678,  0.70710678], '')
+
     The Bishop frame works on a straight line (where Frenet-Serret is singular):
 
     >>> def line(tau: u.Q) -> u.Q:
@@ -295,10 +314,10 @@ class BishopBuilder(AbstractCurveFrameBuilder):
     curve: Callable[[Any], Any]
     """The constructing curve."""
 
-    tau_unit: u.AbstractUnit = eqx.field(  # ty: ignore[invalid-assignment]
-        static=True, converter=u.unit
+    tau_unit: u.AbstractUnit | None = eqx.field(
+        default=None, static=True, converter=unit_or_none
     )
-    """The unit of the curve parameter tau."""
+    """The unit of the curve parameter tau; `None` infers it from the call."""
 
     station: Any = None
     """Optional fixed station along the curve (a leaf); `None` means "use tau"."""
@@ -306,7 +325,9 @@ class BishopBuilder(AbstractCurveFrameBuilder):
     tau_0: u.AbstractQuantity | None = None
     """Reference parameter value where the initial frame is defined (a leaf).
 
-    `None` is resolved to ``Q(0.0, tau_unit)`` by ``__post_init__``.
+    `None` is resolved to ``Q(0.0, tau_unit)`` by ``__post_init__`` when the
+    unit is declared, and at call time when it is being inferred -- the
+    earliest that unit is known.
     """
 
     initial_normal: Any = None
@@ -341,15 +362,25 @@ class BishopBuilder(AbstractCurveFrameBuilder):
     """
 
     def __post_init__(self) -> None:
-        """Resolve a `None` ``tau_0`` to zero in ``tau_unit`` (a pytree leaf)."""
-        if self.tau_0 is None:
+        """Resolve a `None` ``tau_0`` to zero in a *declared* ``tau_unit``.
+
+        Materialising it is what makes the default ``tau_0`` a pytree leaf, and
+        so differentiable and vmappable exactly like an explicit one.
+
+        An inferred ``tau_unit`` is not known until a parameter arrives, so
+        there the resolution moves to `_solve_U1` and the *default* ``tau_0``
+        is not a leaf. Pass it explicitly to differentiate through it -- which
+        also declares its unit, and is the only way to say "start somewhere
+        other than zero" regardless.
+        """
+        if self.tau_0 is None and self.tau_unit is not None:
             self.tau_0 = u.Q(0.0, self.tau_unit)
 
     # ---------------------------------------------------------------
 
     def _tangent_at(self, g: Any, /) -> u.AbstractQuantity:
         r"""Compute unit tangent $\mathbf{T} = \gamma'/\|\gamma'\|$."""
-        dcurve = u.experimental.jacfwd(self.curve, units=(self.tau_unit,))
+        dcurve = u.experimental.jacfwd(self.curve, units=(self._tau_unit_at(g),))
         return _normalize(dcurve(g.astype(float)))
 
     def _solve_U1(self, g: Any, /) -> Array:
@@ -371,8 +402,16 @@ class BishopBuilder(AbstractCurveFrameBuilder):
         derivative survives.  Both signs of $\Delta$ are handled by the same
         expression -- no forward-only workaround is needed.
         """
-        tau_unit = self.tau_unit
-        tau_0 = cast("u.AbstractQuantity", self.tau_0)
+        tau_unit = self._tau_unit_at(g)
+        # Resolve `tau_0` and restate it in `tau_unit`, so the nested
+        # `_tangent_at` below infers the same unit as this solve rather than
+        # whichever convertible one `tau_0` happened to be given in.
+        tau_0_in = self.tau_0
+        tau_0 = (
+            u.Q(0.0, tau_unit)
+            if tau_0_in is None
+            else u.Q(tau_0_in.ustrip(tau_unit), tau_unit)
+        )
 
         T0_val = self._tangent_at(tau_0).value
         if self.initial_normal is not None:
@@ -607,7 +646,7 @@ class BishopFrame(AbstractParallelTransportFrame[FrameT]):
         base_frame: FrameT,
         curve: Callable[[Any], Any],
         /,
-        tau_unit: u.AbstractUnit | str,
+        tau_unit: u.AbstractUnit | str | None = None,
         *,
         station: Any = None,
         tau_0: u.AbstractQuantity | None = None,
@@ -622,11 +661,13 @@ class BishopFrame(AbstractParallelTransportFrame[FrameT]):
             The ambient reference frame.
         curve : Callable
             A function ``tau -> Quantity[float, (3,)]``.
-        tau_unit : AbstractUnit or str
-            Unit of the curve parameter for differentiation.  Required: there
-            is no neutral default, since a curve parameter may be a time, an
-            arc length, or an affine parameter, and the wrong unit is silently
-            rescaled rather than rejected when it is dimensionally compatible.
+        tau_unit : AbstractUnit or str, optional
+            Unit of the curve parameter for differentiation.  `None` (the
+            default) reads it off the parameter the frame is evaluated at.
+            There is no neutral unit to default to -- a curve parameter may be
+            a time, an arc length, or an affine parameter -- so rather than
+            pick one, take the one the caller already stated by passing a
+            `Quantity`.
         station : optional
             A fixed station along the curve; when given the frame is a fixed
             frame *field* along the curve rather than a moving frame.

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
@@ -203,7 +203,8 @@ class BishopBuilder(AbstractCurveFrameBuilder):
         affine parameter -- so rather than pick one, take the one the caller
         already stated by passing a `Quantity`.  Declare it for a curve that
         reads its argument's ``.value`` rather than converting, or for a raw
-        (unitless) parameter, which carries no unit to read.
+        (unitless) parameter or ``station``, neither of which carries a unit
+        to read.
     station : optional
         A fixed station along the curve; see `AbstractCurveFrameBuilder`.
     tau_0 : Quantity, optional

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
@@ -107,7 +107,13 @@ class TubularChart(AbstractParameterizedChart):
     def coord_dimensions(self) -> tuple[str, str, str]:
         # The first coordinate inherits whatever the curve is parameterised by,
         # so this cannot be a class-level tuple the way most charts declare it.
-        return (str(u.dimension_of(self.builder.tau_unit)), "length", "length")
+        #
+        # `tau_bounds` is the source rather than the builder: it is a required
+        # field holding the tau range as a `Quantity`, so it carries the unit
+        # structurally -- which is what this property needs and an inferring
+        # builder, having no call parameter here, cannot supply.
+        tau_unit = self.builder._tau_unit_at(self.tau_bounds[0])
+        return (str(u.dimension_of(tau_unit)), "length", "length")
 
     @property
     def cartesian(self) -> cxc.Cart3D:
@@ -174,7 +180,7 @@ class TubularChart(AbstractParameterizedChart):
         matters.
         """
         tau, n1, n2 = data["tau"], data["n1"], data["n2"]
-        unit = self.builder.tau_unit
+        unit = self.builder._tau_unit_at(tau)
         # Derive the unit from the curve (as ``nearest.py`` and
         # ``register_ptmap.py`` do), not hardcode `"km"`: the scale cancels in
         # `dot(dx,T)/speed`, but a hardcoded unit raises `UnitConversionError`

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
@@ -173,8 +173,13 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
 
         # Unit-aware first and second derivatives via unxt. `g` is built
         # first: it is what the parameter unit is read off when undeclared.
-        g = b._param(p).astype(float)
+        # Resolve the unit *before* `.astype`: a unitless parameter has no
+        # `.astype`, so doing it the other way round reports the accident
+        # (`AttributeError`) instead of the cause (`_tau_unit_at`'s message,
+        # which names both ways to fix it).
+        g = b._param(p)
         tau_unit = b._tau_unit_at(g)
+        g = g.astype(float)
         dcurve = u.experimental.jacfwd(b.curve, units=(tau_unit,))
         d2curve = u.experimental.jacfwd(dcurve, units=(tau_unit,))
 
@@ -219,8 +224,9 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
 
         """
         b, p = self._resolve(tau)
-        g = b._param(p).astype(float)
+        g = b._param(p)
         dcurve = u.experimental.jacfwd(b.curve, units=(b._tau_unit_at(g),))
+        g = g.astype(float)
         return u.Q(_normalize(dcurve(g)).value, "")
 
     def normal(self, tau: Any, /) -> u.Q:

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
@@ -27,7 +27,12 @@ import coordinax.transforms as cxfm
 import quaxed.numpy as qnp
 import unxt as u
 
-from .base import AbstractCurveFrameBuilder, AbstractParallelTransportFrame, FrameT
+from .base import (
+    AbstractCurveFrameBuilder,
+    AbstractParallelTransportFrame,
+    FrameT,
+    unit_or_none,
+)
 
 
 def _normalize(v: Any) -> Any:
@@ -92,12 +97,15 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
         A function ``tau -> Quantity[float, (3,)]`` representing a smooth space
         curve.  Make it an `equinox.Module` for differentiable curve parameters;
         a bare function's captures are trace-time constants.
-    tau_unit : AbstractUnit or str
+    tau_unit : AbstractUnit or str, optional
         Unit of the curve parameter, used by {func}`unxt.experimental.jacfwd` to
-        compute unit-correct derivatives.  Required: there is no neutral
-        default, since a curve parameter may be a time, an arc length, or an
-        affine parameter, and the wrong unit is silently rescaled rather than
-        rejected when it is dimensionally compatible.
+        compute unit-correct derivatives.  `None` (the default) reads it off
+        the parameter the builder is called with.  There is no neutral unit to
+        default to -- a curve parameter may be a time, an arc length, or an
+        affine parameter -- so rather than pick one, take the one the caller
+        already stated by passing a `Quantity`.  Declare it for a curve that
+        reads its argument's ``.value`` rather than converting, or for a raw
+        (unitless) parameter, which carries no unit to read.
     station : optional
         A fixed station along the curve; see `AbstractCurveFrameBuilder`.
 
@@ -122,8 +130,8 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
     curve: Callable[[Any], Any]
     """The constructing curve."""
 
-    tau_unit: u.AbstractUnit = eqx.field(  # ty: ignore[invalid-assignment]
-        static=True, converter=u.unit
+    tau_unit: u.AbstractUnit | None = eqx.field(
+        default=None, static=True, converter=unit_or_none
     )
     """The unit of the curve parameter tau."""
 
@@ -163,11 +171,13 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
         # of the time slice, at the pinned station. See `_resolve`.
         b, p = self._resolve(tau)
 
-        # Unit-aware first and second derivatives via unxt
-        dcurve = u.experimental.jacfwd(b.curve, units=(b.tau_unit,))
-        d2curve = u.experimental.jacfwd(dcurve, units=(b.tau_unit,))
-
+        # Unit-aware first and second derivatives via unxt. `g` is built
+        # first: it is what the parameter unit is read off when undeclared.
         g = b._param(p).astype(float)
+        tau_unit = b._tau_unit_at(g)
+        dcurve = u.experimental.jacfwd(b.curve, units=(tau_unit,))
+        d2curve = u.experimental.jacfwd(dcurve, units=(tau_unit,))
+
         dp = dcurve(g)
         d2p = d2curve(g)
 
@@ -209,8 +219,9 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
 
         """
         b, p = self._resolve(tau)
-        dcurve = u.experimental.jacfwd(b.curve, units=(b.tau_unit,))
-        return u.Q(_normalize(dcurve(b._param(p).astype(float))).value, "")
+        g = b._param(p).astype(float)
+        dcurve = u.experimental.jacfwd(b.curve, units=(b._tau_unit_at(g),))
+        return u.Q(_normalize(dcurve(g)).value, "")
 
     def normal(self, tau: Any, /) -> u.Q:
         r"""Return the unit normal vector $\mathbf{N}(\tau)$ (row 1 of R).
@@ -333,7 +344,7 @@ class FrenetSerretFrame(AbstractParallelTransportFrame[FrameT]):
         base_frame: FrameT,
         curve: Callable[[Any], Any],
         /,
-        tau_unit: u.AbstractUnit | str,
+        tau_unit: u.AbstractUnit | str | None = None,
         *,
         station: Any = None,
     ) -> "FrenetSerretFrame[FrameT]":
@@ -346,11 +357,13 @@ class FrenetSerretFrame(AbstractParallelTransportFrame[FrameT]):
         curve : Callable
             A function ``tau -> Quantity[float, (3,)]`` representing
             a smooth space curve.
-        tau_unit : AbstractUnit or str
-            Unit of the curve parameter for differentiation.  Required: there
-            is no neutral default, since a curve parameter may be a time, an
-            arc length, or an affine parameter, and the wrong unit is silently
-            rescaled rather than rejected when it is dimensionally compatible.
+        tau_unit : AbstractUnit or str, optional
+            Unit of the curve parameter for differentiation.  `None` (the
+            default) reads it off the parameter the frame is evaluated at.
+            There is no neutral unit to default to -- a curve parameter may be
+            a time, an arc length, or an affine parameter -- so rather than
+            pick one, take the one the caller already stated by passing a
+            `Quantity`.
         station : optional
             A fixed station along the curve; when given the frame is a fixed
             frame *field* along the curve rather than a moving frame.

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
@@ -105,7 +105,8 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
         affine parameter -- so rather than pick one, take the one the caller
         already stated by passing a `Quantity`.  Declare it for a curve that
         reads its argument's ``.value`` rather than converting, or for a raw
-        (unitless) parameter, which carries no unit to read.
+        (unitless) parameter or ``station``, neither of which carries a unit
+        to read.
     station : optional
         A fixed station along the curve; see `AbstractCurveFrameBuilder`.
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/nearest.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/nearest.py
@@ -96,7 +96,9 @@ def nearest_tau(
     True
 
     """
-    unit = builder.tau_unit
+    # The bounds are the tau range, so they carry tau's unit themselves -- no
+    # need to consult the builder, which may not have one declared.
+    unit = builder._tau_unit_at(bounds[0])
     # `jnp.asarray` narrows only here: `ustrip` is typed as a broad union, and
     # `ty` rejects `hi - lo` between two of them. Everywhere else the bare
     # `ustrip` is enough.

--- a/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
@@ -409,8 +409,42 @@ def test_a_unitless_parameter_has_nothing_to_infer_from() -> None:
     It fails with a message naming both ways out, rather than an
     `AttributeError` from inside the derivative.
     """
-    with pytest.raises(TypeError, match="carries no unit"):
-        cxfc.BishopBuilder(curve_gyr).tangent(2.0)
+    for cls in (cxfc.BishopBuilder, cxfc.FrenetSerretBuilder):
+        # Both accessors, because they resolve the unit on separate paths:
+        # `FrenetSerretBuilder` reached `.astype(float)` first and reported the
+        # accident rather than the cause.
+        with pytest.raises(TypeError, match="carries no unit"):
+            cls(curve_gyr).tangent(2.0)
+        with pytest.raises(TypeError, match="carries no unit"):
+            cls(curve_gyr).rotation_matrix(2.0)
+
+
+def test_a_raw_array_parameter_works_when_the_unit_is_declared() -> None:
+    """The array fastpath: bare arrays, given meaning by the declared unit.
+
+    This is what `tau_unit` is *for* once inference covers the `Quantity`
+    case. It is wrapped at `_param`, the single funnel every accessor takes
+    its curve parameter from, so all of them accept a raw parameter and every
+    one agrees with the `Quantity` call to the bit.
+
+    Before this, a raw parameter died with `NotFoundLookupError` from inside
+    `unxt`'s `ustrip` dispatch, several frames below the call -- declaring the
+    unit did not help, so the fastpath was documented but unreachable.
+    """
+    raw, quantity = jnp.asarray(0.7), u.Q(0.7, "s")
+    for cls in (cxfc.BishopBuilder, cxfc.FrenetSerretBuilder):
+        b = cls(curve1, "s")
+        for meth in ("location", "tangent", "rotation_matrix"):
+            got, want = getattr(b, meth)(raw), getattr(b, meth)(quantity)
+            got, want = getattr(got, "value", got), getattr(want, "value", want)
+            assert jnp.allclose(jnp.asarray(got), jnp.asarray(want)), (cls, meth)
+
+    # A raw `station` takes the same funnel, so it is covered by the same wrap.
+    pinned = cxfc.BishopBuilder(curve1, "s", station=jnp.asarray(0.3))
+    assert jnp.allclose(
+        pinned.tangent(quantity).value,
+        cxfc.BishopBuilder(curve1, "s", station=u.Q(0.3, "s")).tangent(quantity).value,
+    )
 
 
 def test_the_dimension_guard_still_fires_on_an_inferred_unit() -> None:

--- a/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
@@ -413,10 +413,32 @@ def test_a_unitless_parameter_has_nothing_to_infer_from() -> None:
         # Both accessors, because they resolve the unit on separate paths:
         # `FrenetSerretBuilder` reached `.astype(float)` first and reported the
         # accident rather than the cause.
-        with pytest.raises(TypeError, match="carries no unit"):
-            cls(curve_gyr).tangent(2.0)
-        with pytest.raises(TypeError, match="carries no unit"):
-            cls(curve_gyr).rotation_matrix(2.0)
+        for meth in ("tangent", "rotation_matrix"):
+            with pytest.raises(TypeError, match="call-time parameter"):
+                getattr(cls(curve_gyr), meth)(2.0)
+
+
+def test_a_unitless_station_blames_the_station_not_the_call() -> None:
+    """A pinned `station` is what the builder evaluates at, so it is the culprit.
+
+    The call-time parameter can be a perfectly good `Quantity` and the builder
+    still has nothing to read, because it never looks at it. Advising "pass a
+    `Quantity` parameter" here sends the reader to the one place that is
+    already correct, so the message names the station and shows how to fix
+    *that*.
+    """
+    b = cxfc.BishopBuilder(curve_gyr, station=jnp.asarray(0.3))
+    with pytest.raises(TypeError, match="pinned `station`"):
+        b.tangent(u.Q(1.0, "Gyr"))  # a Quantity, and it does not help
+
+    # Declaring the unit is the other way out, and does work.
+    pinned = cxfc.BishopBuilder(curve_gyr, "Gyr", station=jnp.asarray(0.3))
+    assert jnp.allclose(
+        pinned.tangent(u.Q(1.0, "Gyr")).value,
+        cxfc.BishopBuilder(curve_gyr, station=u.Q(0.3, "Gyr"))
+        .tangent(u.Q(1.0, "Gyr"))
+        .value,
+    )
 
 
 def test_a_raw_array_parameter_works_when_the_unit_is_declared() -> None:

--- a/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
@@ -41,6 +41,17 @@ def curve1(tau: u.AbstractQuantity) -> u.AbstractQuantity:
     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), 0.3 * t]), "km")
 
 
+def curve_gyr(tau: u.AbstractQuantity) -> u.AbstractQuantity:
+    """A curve genuinely parametrised in Gyr, in kpc -- the galactic case.
+
+    It *converts* its argument rather than reading the magnitude, which is how
+    every curve in this package's docs is written and what makes a dimensionally
+    compatible mismatch harmless.
+    """
+    t = tau.ustrip("Gyr")
+    return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), 0.3 * t]), "kpc")
+
+
 def curve2(s: u.AbstractQuantity, t: u.AbstractQuantity) -> u.AbstractQuantity:
     """A time-dependent curve: it bends and stretches with ``t``."""
     sv, tv = s.ustrip("km"), t.ustrip("s")
@@ -330,17 +341,94 @@ def test_a_wrapper_forwards_the_dimension_it_wraps() -> None:
     assert cxfc.AtTime(curve2, u.Q(0.5, "s"))._param_dimension is None
 
 
-def test_tau_unit_is_required() -> None:
-    """There is no default to be wrong: omission fails before an object exists.
+def test_tau_unit_is_inferred_from_the_parameter_when_undeclared() -> None:
+    """An undeclared unit is read off the `Quantity` the builder is called with.
 
-    Seconds are not a neutral fallback -- in galactic dynamics the natural
-    parameter is Myr or Gyr, and a Gyr curve read as seconds is off by 3.15e16
-    with no error anywhere, because the units are dimensionally compatible and
-    `ustrip` simply rescales.
+    A declared unit is a second, independent statement of a fact the parameter
+    already carries, and two statements can disagree. Reading it off the
+    parameter removes the second statement, so there is nothing to disagree.
     """
-    with pytest.raises(TypeError, match="tau_unit"):
-        cxfc.BishopBuilder(curve1)
-    with pytest.raises(TypeError, match="tau_unit"):
-        cxfc.FrenetSerretBuilder(curve1)
-    cxfc.BishopBuilder(curve1, "s")  # any unit is allowed, none is assumed
+    tau = u.Q(2.0, "Gyr")
+    for cls in (cxfc.BishopBuilder, cxfc.FrenetSerretBuilder):
+        declared = cls(curve_gyr, "Gyr").rotation_matrix(tau)
+        inferred = cls(curve_gyr).rotation_matrix(tau)
+        assert jnp.allclose(declared, inferred), (cls.__name__, declared, inferred)
+
+
+def test_a_dimensionally_compatible_mismatch_is_absorbed_by_a_converting_curve() -> (
+    None
+):
+    """Declaring "s" for a Gyr curve is *not* wrong when the curve converts.
+
+    `unxt.experimental.jacfwd` strips with ``ustrip(unit, arg)`` -- a
+    conversion, not a reinterpretation -- so 2 Gyr declared as "s" reaches the
+    curve as 6.3e16 s, the curve's own ``ustrip("Gyr")`` converts it back, and
+    the derivative comes out in ``kpc/s`` instead of ``kpc/Gyr``: the same
+    physical quantity, differently labelled.
+
+    Recorded because the opposite was believed: that such a curve came back
+    "off by 3.15e16 with no error anywhere". It does not, and the distinction
+    decides what `tau_unit` is actually for -- see the next test for the case
+    where the mismatch really does corrupt the answer.
+    """
+    tau = u.Q(2.0, "Gyr")
+    right = cxfc.BishopBuilder(curve_gyr, "Gyr").rotation_matrix(tau)
+    wrong = cxfc.BishopBuilder(curve_gyr, "s").rotation_matrix(tau)
+    assert jnp.allclose(right, wrong)
+
+
+def test_a_value_reading_curve_is_the_case_that_needs_the_unit() -> None:
+    """A curve that reads ``.value`` trusts the declared unit, so a wrong one lies.
+
+    This is the one place `tau_unit` is load-bearing: the curve never converts,
+    so whatever magnitude the declaration produces is taken at face value.
+    Inference cannot be wrong here, because it hands the curve back exactly the
+    numbers the caller passed.
+    """
+
+    def by_value(tau: u.AbstractQuantity) -> u.AbstractQuantity:
+        t = tau.value  # assumes it was handed its own unit
+        return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), 0.3 * t]), "kpc")
+
+    tau = u.Q(2.0, "Gyr")
+    truth = cxfc.BishopBuilder(by_value, "Gyr").tangent(tau)
+    assert jnp.allclose(cxfc.BishopBuilder(by_value).tangent(tau).value, truth.value)
+
+    # Silently wrong, and finite: `tangent` returns a plausible unit vector
+    # that is simply not this curve's. The parallel-transport path is louder --
+    # the ODE gives up on a curve made 3.15e16 times stiffer -- so `tangent`
+    # is what pins the *silent* failure.
+    assert not jnp.allclose(
+        cxfc.BishopBuilder(by_value, "s").tangent(tau).value, truth.value
+    )
+
+
+def test_a_unitless_parameter_has_nothing_to_infer_from() -> None:
+    """The other case that must declare: a raw parameter carries no unit.
+
+    It fails with a message naming both ways out, rather than an
+    `AttributeError` from inside the derivative.
+    """
+    with pytest.raises(TypeError, match="carries no unit"):
+        cxfc.BishopBuilder(curve_gyr).tangent(2.0)
+
+
+def test_the_dimension_guard_still_fires_on_an_inferred_unit() -> None:
+    """Nothing is given up by inferring: the #718 guard runs on it too.
+
+    With no declaration there is nothing to check at construction, so the check
+    moves to the first call that supplies a parameter -- still before any wrong
+    number is returned.
+    """
+    arc = cxfc.ArcLength(curve1, "s")  # exposes a *length*
+    b = cxfc.BishopBuilder(arc)
+    with pytest.raises(ValueError, match="dimension length"):
+        b.tangent(u.Q(1.0, "s"))
+    b.tangent(u.Q(1.0, "km"))  # a length is what it wants, and needs no declaring
+
+
+def test_declaring_the_unit_is_still_accepted() -> None:
+    """The explicit form is unchanged -- inference is a default, not a removal."""
+    cxfc.BishopBuilder(curve1, "s")
     cxfc.BishopBuilder(curve1, "Gyr")
+    cxfc.FrenetSerretBuilder(curve1, "s")


### PR DESCRIPTION
Follow-up to #756, as flagged in its description.

## Why

#756 removed a bad default by making `tau_unit` required. This removes it a second way, which costs no migration and is strictly safer: a `Quantity` parameter **already states its unit**, so the builders read it off the parameter instead of asking the caller to declare it again.

```python
BishopBuilder(curve)(u.Q(2.0, "Gyr"))   # tau_unit inferred: Gyr
BishopBuilder(curve, "Gyr")             # still accepted, unchanged
```

A declaration is an independent *second* statement of a fact the parameter already carries, and two statements can disagree. Removing the second statement leaves nothing to disagree.

## What the required unit was actually protecting

Narrower than #756 assumed, and worth stating precisely because it decides the design.

`unxt.experimental.jacfwd` strips with `ustrip(unit, arg)` — a **conversion**, not a reinterpretation. `Q(2.0, "Gyr")` declared as `"s"` reaches the curve as `Q(6.3e16, "s")`; the curve's own `ustrip("Gyr")` converts it back. Measured on a Gyr/kpc helix, declared-`"s"` and declared-`"Gyr"` builders return **bit-identical** `rotation_matrix`, `tangent` and `location`.

The declaration is load-bearing in exactly two cases, both now covered by tests:

| curve style | wrong declared unit | inferred |
| --- | --- | --- |
| `tau.ustrip("Gyr")` — converts | harmless, absorbed | same answer |
| `tau.value` — reads the magnitude | **silently wrong** | correct by construction |
| raw, unitless parameter | required | `TypeError` naming both fixes |

For the `.value` curve only `tangent` fails quietly — the parallel-transport ODE gives up outright on a curve made 3.15e16× stiffer, which is why the test pins `tangent` rather than `rotation_matrix`.

Inference cannot be wrong in the `.value` case: it hands the curve back exactly the numbers the caller passed.

## Nothing is given up

- **#718's dimension guard still fires.** With no declaration there is nothing to check at construction, so it runs on the inferred unit at the first call that supplies a parameter — still before any wrong number is returned. `BishopBuilder(ArcLength(c, "s"))(u.Q(1.0, "s"))` raises exactly as `BishopBuilder(ArcLength(c, "s"), "s")` does.
- **The explicit form is untouched.** Inference is a default, not a removal.
- **#756's docs sweep stands.** Every example still states its unit; that was always about the reader, not the compiler.

## Where a declaration is still required

`ArcLength`/`LagrangianArcLength` keep a **required** `tau_unit`. Their $\tau$ is internal — generated by the reparametrisation ODE, never passed in — so nothing at call time carries it. This is a real asymmetry, not an oversight.

`TubularChart.coord_dimensions` is structural and has no call parameter, so it reads `tau_bounds[0]`, a required field that carries $\tau$'s unit anyway. `nearest_tau` likewise reads its bounds. Neither needs the builder to declare anything.

## The one cost

`BishopBuilder.__post_init__` still materialises `tau_0` when the unit is *declared*, so the default `tau_0` stays a differentiable pytree leaf. When the unit is inferred it cannot — the unit is not known until a parameter arrives — so an inferring builder's **default** `tau_0` is not a leaf. Pass `tau_0` explicitly to differentiate through it; that also declares its unit.

Found by 5 failing tests that were right to fail, and confined to the new opt-in path.

## Verification

- 976 `coordinaxs.curveframes` tests pass
- `prek run` clean on all touched files, including `ty`
- new tests pin: declared ≡ inferred for both builders; the compatible-mismatch absorption; the `.value` failure; the unitless `TypeError`; the guard on an inferred unit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
