### PR TITLE
🐛 fix: ten guards admitted NaN and returned it silently

### DIFF
--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -212,7 +212,11 @@ def _eval_tau_dense(
     s_max_val = jnp.asarray(s_max.ustrip(s_unit))
 
     margin = _S_MAX_MARGIN * jnp.abs(s_max_val)
-    out_of_domain = (s_val < -margin) | (s_val > s_max_val + margin)
+    # Negated `in-domain` rather than the two out-of-domain comparisons: a NaN
+    # `s` compares False against both, so the direct form admits it and hands
+    # back a NaN position with nothing raised.
+    in_domain = (s_val >= -margin) & (s_val <= s_max_val + margin)
+    out_of_domain = ~in_domain
 
     # No clip: every point of the solved range is real data, so the only
     # thing to do with a genuine overshoot is refuse it.

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -215,8 +215,7 @@ def _eval_tau_dense(
     # Negated `in-domain` rather than the two out-of-domain comparisons: a NaN
     # `s` compares False against both, so the direct form admits it and hands
     # back a NaN position with nothing raised.
-    in_domain = (s_val >= -margin) & (s_val <= s_max_val + margin)
-    out_of_domain = ~in_domain
+    out_of_domain = ~((s_val >= -margin) & (s_val <= s_max_val + margin))
 
     # No clip: every point of the solved range is real data, so the only
     # thing to do with a genuine overshoot is refuse it.

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -212,9 +212,7 @@ def _eval_tau_dense(
     s_max_val = jnp.asarray(s_max.ustrip(s_unit))
 
     margin = _S_MAX_MARGIN * jnp.abs(s_max_val)
-    # Negated `in-domain` rather than the two out-of-domain comparisons: a NaN
-    # `s` compares False against both, so the direct form admits it and hands
-    # back a NaN position with nothing raised.
+    # A NaN `s` is False for both out-of-domain tests, so negate in-domain.
     out_of_domain = ~((s_val >= -margin) & (s_val <= s_max_val + margin))
 
     # No clip: every point of the solved range is real data, so the only

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
@@ -159,12 +159,12 @@ def _orthonormalize(v: Any, T0_val: Any) -> Any:
     """
     w = v - jnp.dot(v, T0_val) * T0_val
     norm = jnp.linalg.norm(w)
-    # `<=`, not `<`, so that an all-zero `v` (threshold 0) still raises.
     # `~(norm > tol)`, not `norm <= tol`: a NaN compares False against both, so
-    # the `<=` form admits a NaN `v` and returns a NaN triad with nothing
-    # raised. Same reason `TubularChart`'s reach guard is written `~(f > 0)`.
-    tol = 1e-12 * jnp.linalg.norm(v)
-    w = eqx.error_if(w, ~(norm > tol), _MSG_PARALLEL_NORMAL)
+    # the `<=` form admits a NaN `v` and returns a NaN triad with nothing raised.
+    # Same reason `TubularChart`'s reach guard is written `~(f > 0)`. Negating
+    # `>` keeps the non-strict sense, so an all-zero `v` (threshold 0) still
+    # raises.
+    w = eqx.error_if(w, ~(norm > 1e-12 * jnp.linalg.norm(v)), _MSG_PARALLEL_NORMAL)
     return w / norm
 
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
@@ -160,7 +160,11 @@ def _orthonormalize(v: Any, T0_val: Any) -> Any:
     w = v - jnp.dot(v, T0_val) * T0_val
     norm = jnp.linalg.norm(w)
     # `<=`, not `<`, so that an all-zero `v` (threshold 0) still raises.
-    w = eqx.error_if(w, norm <= 1e-12 * jnp.linalg.norm(v), _MSG_PARALLEL_NORMAL)
+    # `~(norm > tol)`, not `norm <= tol`: a NaN compares False against both, so
+    # the `<=` form admits a NaN `v` and returns a NaN triad with nothing
+    # raised. Same reason `TubularChart`'s reach guard is written `~(f > 0)`.
+    tol = 1e-12 * jnp.linalg.norm(v)
+    w = eqx.error_if(w, ~(norm > tol), _MSG_PARALLEL_NORMAL)
     return w / norm
 
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
@@ -159,11 +159,8 @@ def _orthonormalize(v: Any, T0_val: Any) -> Any:
     """
     w = v - jnp.dot(v, T0_val) * T0_val
     norm = jnp.linalg.norm(w)
-    # `~(norm > tol)`, not `norm <= tol`: a NaN compares False against both, so
-    # the `<=` form admits a NaN `v` and returns a NaN triad with nothing raised.
-    # Same reason `TubularChart`'s reach guard is written `~(f > 0)`. Negating
-    # `>` keeps the non-strict sense, so an all-zero `v` (threshold 0) still
-    # raises.
+    # `~(norm > tol)`, not `norm <= tol`: a NaN is False for both, so the `<=`
+    # form returns a NaN triad. Negating `>` keeps an all-zero `v` raising.
     w = eqx.error_if(w, ~(norm > 1e-12 * jnp.linalg.norm(v)), _MSG_PARALLEL_NORMAL)
     return w / norm
 

--- a/packages/coordinaxs.curveframes/tests/unit/test_guards_reject_nan.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_guards_reject_nan.py
@@ -61,3 +61,39 @@ def test_a_nan_arc_length_is_rejected() -> None:
     assert jnp.isfinite(fast(u.Q(2.0, "km")).ustrip("km")).all()
     with pytest.raises(Exception, match="solved domain"):
         fast(u.Q(99.0, "km"))
+
+
+# --------------------------------------------------------------------------
+# The same class in core: range guards written as a direct comparison.
+
+
+def test_a_nan_boost_velocity_is_rejected() -> None:
+    """`LorentzBoost` returned a non-finite gamma instead of raising.
+
+    The guard was `beta_sq >= 1.0`, and its own comment says it exists so that
+    no derived quantity "leaks a non-finite value" -- which a NaN did, being
+    False for that comparison.
+    """
+    import coordinax.transforms as cxfm
+
+    bad = cxfm.LorentzBoost(u.Q(jnp.array([jnp.nan, 0.0, 0.0]), ""))
+    with pytest.raises(Exception, match="subluminal"):
+        _ = bad.gamma
+
+    # subluminal is unaffected
+    ok = cxfm.LorentzBoost(u.Q(jnp.array([0.5, 0.0, 0.0]), ""))
+    assert jnp.isfinite(ok.gamma)
+
+
+def test_nan_fails_the_coordinate_bounds_checks() -> None:
+    """`leq`/`geq` admitted a NaN, so an out-of-range coordinate slipped by."""
+    from coordinax._src.charts.checks import geq, leq
+
+    with pytest.raises(Exception, match="less than or equal"):
+        leq(u.Q(jnp.nan, "m"), u.Q(2, "m"))
+    with pytest.raises(Exception, match="greater than or equal"):
+        geq(u.Q(jnp.nan, "m"), u.Q(2, "m"))
+
+    # in-range values still pass
+    leq(u.Q(1.0, "m"), u.Q(2, "m"))
+    geq(u.Q(3.0, "m"), u.Q(2, "m"))

--- a/packages/coordinaxs.curveframes/tests/unit/test_guards_reject_nan.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_guards_reject_nan.py
@@ -24,26 +24,27 @@ def helix(tau: u.AbstractQuantity) -> u.AbstractQuantity:
     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), 0.3 * t]), "km")
 
 
-@pytest.mark.parametrize("bad", [jnp.nan, jnp.inf], ids=["nan", "inf"])
-def test_a_non_finite_initial_normal_is_rejected(bad: float) -> None:
+T0 = jnp.array([1.0, 0.0, 0.0])
+
+
+@pytest.mark.parametrize(
+    "v",
+    [[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [1.0, jnp.nan, 0.0], [1.0, jnp.inf, 0.0]],
+    ids=["parallel", "zero", "nan", "inf"],
+)
+def test_an_unusable_initial_normal_is_rejected(v: list[float]) -> None:
     """`_orthonormalize` returned a NaN triad instead of raising.
 
     The rejection was `norm <= 1e-12 * |v|`; with a NaN `v` both sides are NaN
-    and the comparison is False. Fails if it goes back to the direct form.
+    and the comparison is False. The first two cases are what the guard was
+    written for and must keep raising.
     """
-    T0 = jnp.array([1.0, 0.0, 0.0])
     with pytest.raises(eqx.EquinoxRuntimeError, match="parallel"):
-        _orthonormalize(jnp.array([1.0, bad, 0.0]), T0)
+        _orthonormalize(jnp.array(v), T0)
 
 
-def test_the_legitimate_degenerate_cases_still_raise() -> None:
-    """The case the guard was written for keeps working."""
-    T0 = jnp.array([1.0, 0.0, 0.0])
-    for v in (jnp.array([1.0, 0.0, 0.0]), jnp.array([0.0, 0.0, 0.0])):
-        with pytest.raises(eqx.EquinoxRuntimeError, match="parallel"):
-            _orthonormalize(v, T0)
-
-    # and a well-conditioned normal is untouched
+def test_a_well_conditioned_normal_is_untouched() -> None:
+    """The guard costs the valid case nothing."""
     out = _orthonormalize(jnp.array([0.0, 2.0, 0.0]), T0)
     assert jnp.allclose(jnp.asarray(out), jnp.array([0.0, 1.0, 0.0]))
 

--- a/packages/coordinaxs.curveframes/tests/unit/test_guards_reject_nan.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_guards_reject_nan.py
@@ -1,12 +1,7 @@
-"""A NaN must not walk through a guard that claims to reject bad input.
+"""The two `curveframes` guards reject what they cannot handle.
 
-`x <= tol` and `x > hi` are both False for a NaN, so a guard written as a
-direct comparison admits it and returns a NaN result with nothing raised --
-worse than the case the guard was written for, which at least errors.
-
-`TubularChart`'s reach guard already avoids this by testing `~(f > 0)`; these
-pin the same property for the two guards that were still written the direct
-way.
+Each covers the degenerate case it was written for and the non-finite ones it
+used to admit before being rewritten as a negated positive test.
 """
 
 import equinox as eqx
@@ -33,12 +28,7 @@ T0 = jnp.array([1.0, 0.0, 0.0])
     ids=["parallel", "zero", "nan", "inf"],
 )
 def test_an_unusable_initial_normal_is_rejected(v: list[float]) -> None:
-    """`_orthonormalize` returned a NaN triad instead of raising.
-
-    The rejection was `norm <= 1e-12 * |v|`; with a NaN `v` both sides are NaN
-    and the comparison is False. The first two cases are what the guard was
-    written for and must keep raising.
-    """
+    """`parallel` and `zero` are the original cases; the rest returned a NaN triad."""
     with pytest.raises(eqx.EquinoxRuntimeError, match="parallel"):
         _orthonormalize(jnp.array(v), T0)
 
@@ -49,17 +39,15 @@ def test_a_well_conditioned_normal_is_untouched() -> None:
     assert jnp.allclose(jnp.asarray(out), jnp.array([0.0, 1.0, 0.0]))
 
 
-def test_a_nan_arc_length_is_rejected() -> None:
-    """The domain guard returned a NaN position instead of raising.
-
-    The test was `(s < -margin) | (s > s_max + margin)`; a NaN is False for
-    both, so it fell through to `diffrax`, which happily interpolated a NaN.
-    """
+@pytest.mark.parametrize("s", [jnp.nan, 99.0], ids=["nan", "outside"])
+def test_an_out_of_domain_arc_length_is_rejected(s: float) -> None:
+    """A NaN fell through to `diffrax`, which happily interpolated it."""
     fast = cxfc.ArcLength(helix, "s", s_max=u.Q(5.0, "km"))
     with pytest.raises(eqx.EquinoxRuntimeError, match="solved domain"):
-        fast(u.Q(jnp.nan, "km"))
+        fast(u.Q(s, "km"))
 
-    # in-domain and genuinely-outside both behave as before
+
+def test_an_in_domain_arc_length_is_untouched() -> None:
+    """The guard costs the valid case nothing."""
+    fast = cxfc.ArcLength(helix, "s", s_max=u.Q(5.0, "km"))
     assert jnp.isfinite(fast(u.Q(2.0, "km")).ustrip("km")).all()
-    with pytest.raises(eqx.EquinoxRuntimeError, match="solved domain"):
-        fast(u.Q(99.0, "km"))

--- a/packages/coordinaxs.curveframes/tests/unit/test_guards_reject_nan.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_guards_reject_nan.py
@@ -9,6 +9,7 @@ pin the same property for the two guards that were still written the direct
 way.
 """
 
+import equinox as eqx
 import jax.numpy as jnp
 import pytest
 
@@ -31,7 +32,7 @@ def test_a_non_finite_initial_normal_is_rejected(bad: float) -> None:
     and the comparison is False. Fails if it goes back to the direct form.
     """
     T0 = jnp.array([1.0, 0.0, 0.0])
-    with pytest.raises(Exception, match="parallel"):
+    with pytest.raises(eqx.EquinoxRuntimeError, match="parallel"):
         _orthonormalize(jnp.array([1.0, bad, 0.0]), T0)
 
 
@@ -39,7 +40,7 @@ def test_the_legitimate_degenerate_cases_still_raise() -> None:
     """The case the guard was written for keeps working."""
     T0 = jnp.array([1.0, 0.0, 0.0])
     for v in (jnp.array([1.0, 0.0, 0.0]), jnp.array([0.0, 0.0, 0.0])):
-        with pytest.raises(Exception, match="parallel"):
+        with pytest.raises(eqx.EquinoxRuntimeError, match="parallel"):
             _orthonormalize(v, T0)
 
     # and a well-conditioned normal is untouched
@@ -54,46 +55,10 @@ def test_a_nan_arc_length_is_rejected() -> None:
     both, so it fell through to `diffrax`, which happily interpolated a NaN.
     """
     fast = cxfc.ArcLength(helix, "s", s_max=u.Q(5.0, "km"))
-    with pytest.raises(Exception, match="solved domain"):
+    with pytest.raises(eqx.EquinoxRuntimeError, match="solved domain"):
         fast(u.Q(jnp.nan, "km"))
 
     # in-domain and genuinely-outside both behave as before
     assert jnp.isfinite(fast(u.Q(2.0, "km")).ustrip("km")).all()
-    with pytest.raises(Exception, match="solved domain"):
+    with pytest.raises(eqx.EquinoxRuntimeError, match="solved domain"):
         fast(u.Q(99.0, "km"))
-
-
-# --------------------------------------------------------------------------
-# The same class in core: range guards written as a direct comparison.
-
-
-def test_a_nan_boost_velocity_is_rejected() -> None:
-    """`LorentzBoost` returned a non-finite gamma instead of raising.
-
-    The guard was `beta_sq >= 1.0`, and its own comment says it exists so that
-    no derived quantity "leaks a non-finite value" -- which a NaN did, being
-    False for that comparison.
-    """
-    import coordinax.transforms as cxfm
-
-    bad = cxfm.LorentzBoost(u.Q(jnp.array([jnp.nan, 0.0, 0.0]), ""))
-    with pytest.raises(Exception, match="subluminal"):
-        _ = bad.gamma
-
-    # subluminal is unaffected
-    ok = cxfm.LorentzBoost(u.Q(jnp.array([0.5, 0.0, 0.0]), ""))
-    assert jnp.isfinite(ok.gamma)
-
-
-def test_nan_fails_the_coordinate_bounds_checks() -> None:
-    """`leq`/`geq` admitted a NaN, so an out-of-range coordinate slipped by."""
-    from coordinax._src.charts.checks import geq, leq
-
-    with pytest.raises(Exception, match="less than or equal"):
-        leq(u.Q(jnp.nan, "m"), u.Q(2, "m"))
-    with pytest.raises(Exception, match="greater than or equal"):
-        geq(u.Q(jnp.nan, "m"), u.Q(2, "m"))
-
-    # in-range values still pass
-    leq(u.Q(1.0, "m"), u.Q(2, "m"))
-    geq(u.Q(3.0, "m"), u.Q(2, "m"))

--- a/packages/coordinaxs.curveframes/tests/unit/test_guards_reject_nan.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_guards_reject_nan.py
@@ -1,0 +1,63 @@
+"""A NaN must not walk through a guard that claims to reject bad input.
+
+`x <= tol` and `x > hi` are both False for a NaN, so a guard written as a
+direct comparison admits it and returns a NaN result with nothing raised --
+worse than the case the guard was written for, which at least errors.
+
+`TubularChart`'s reach guard already avoids this by testing `~(f > 0)`; these
+pin the same property for the two guards that were still written the direct
+way.
+"""
+
+import jax.numpy as jnp
+import pytest
+
+import unxt as u
+
+import coordinaxs.curveframes as cxfc
+from coordinaxs.curveframes._src.bishop import _orthonormalize
+
+
+def helix(tau: u.AbstractQuantity) -> u.AbstractQuantity:
+    t = tau.ustrip("s")
+    return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), 0.3 * t]), "km")
+
+
+@pytest.mark.parametrize("bad", [jnp.nan, jnp.inf], ids=["nan", "inf"])
+def test_a_non_finite_initial_normal_is_rejected(bad: float) -> None:
+    """`_orthonormalize` returned a NaN triad instead of raising.
+
+    The rejection was `norm <= 1e-12 * |v|`; with a NaN `v` both sides are NaN
+    and the comparison is False. Fails if it goes back to the direct form.
+    """
+    T0 = jnp.array([1.0, 0.0, 0.0])
+    with pytest.raises(Exception, match="parallel"):
+        _orthonormalize(jnp.array([1.0, bad, 0.0]), T0)
+
+
+def test_the_legitimate_degenerate_cases_still_raise() -> None:
+    """The case the guard was written for keeps working."""
+    T0 = jnp.array([1.0, 0.0, 0.0])
+    for v in (jnp.array([1.0, 0.0, 0.0]), jnp.array([0.0, 0.0, 0.0])):
+        with pytest.raises(Exception, match="parallel"):
+            _orthonormalize(v, T0)
+
+    # and a well-conditioned normal is untouched
+    out = _orthonormalize(jnp.array([0.0, 2.0, 0.0]), T0)
+    assert jnp.allclose(jnp.asarray(out), jnp.array([0.0, 1.0, 0.0]))
+
+
+def test_a_nan_arc_length_is_rejected() -> None:
+    """The domain guard returned a NaN position instead of raising.
+
+    The test was `(s < -margin) | (s > s_max + margin)`; a NaN is False for
+    both, so it fell through to `diffrax`, which happily interpolated a NaN.
+    """
+    fast = cxfc.ArcLength(helix, "s", s_max=u.Q(5.0, "km"))
+    with pytest.raises(Exception, match="solved domain"):
+        fast(u.Q(jnp.nan, "km"))
+
+    # in-domain and genuinely-outside both behave as before
+    assert jnp.isfinite(fast(u.Q(2.0, "km")).ustrip("km")).all()
+    with pytest.raises(Exception, match="solved domain"):
+        fast(u.Q(99.0, "km"))

--- a/src/coordinax/_src/charts/checks.py
+++ b/src/coordinax/_src/charts/checks.py
@@ -115,8 +115,7 @@ def leq(
     """
     name = f" {name}" if name else name
     msg = f"The input{name} must be less than or equal to {comp_name}."
-    # `~(x <= max)` rather than `x > max`: a NaN is False for both, so the
-    # direct form admits it silently.
+    # `~(x <= max)`, not `x > max`: a NaN is False for both, admitting it.
     return eqx.error_if(x, u.ustrip("", jnp.any(~(x <= max_val))), msg)
 
 

--- a/src/coordinax/_src/charts/checks.py
+++ b/src/coordinax/_src/charts/checks.py
@@ -115,7 +115,9 @@ def leq(
     """
     name = f" {name}" if name else name
     msg = f"The input{name} must be less than or equal to {comp_name}."
-    return eqx.error_if(x, u.ustrip("", jnp.any(x > max_val)), msg)
+    # `~(x <= max)` rather than `x > max`: a NaN is False for both, so the
+    # direct form admits it silently.
+    return eqx.error_if(x, u.ustrip("", jnp.any(~(x <= max_val))), msg)
 
 
 def geq(
@@ -144,7 +146,8 @@ def geq(
     """
     name = f" {name}" if name else name
     msg = f"The input{name} must be greater than or equal to {comp_name}."
-    return eqx.error_if(x, u.ustrip("", jnp.any(x < min_val)), msg)
+    # `~(x >= min)`, for the NaN reason given in `leq`.
+    return eqx.error_if(x, u.ustrip("", jnp.any(~(x >= min_val))), msg)
 
 
 def check_manifolds_match_charts(

--- a/src/coordinax/transforms/_src/actions/builders.py
+++ b/src/coordinax/transforms/_src/actions/builders.py
@@ -14,6 +14,7 @@ import coordinax.charts as cxc
 from .custom_types import CDict
 from .rotate import Rotate
 from .translate import Translate
+from .utils import _unnormalisable
 
 _MSG_ZERO_AXIS = (
     "`RotationAboutAxis.axis` must be non-zero and finite; normalising anything "
@@ -78,14 +79,9 @@ class RotationAboutAxis(eqx.Module):
         """Build the `Rotate` operator at time parameter ``tau``."""
         theta = jnp.asarray(u.ustrip("rad", self.omega * tau + self.phase))
         norm = jnp.linalg.vector_norm(self.axis)
-        # `axis / norm` is a unit vector only where `axis` is finite and non-zero,
-        # which is exactly a finite positive `norm`: the norm is NaN iff a component
-        # is, `inf` iff a component is, and 0 iff the axis is. Testing `norm == 0`
-        # alone caught the last of the three and let the other two normalise to the
-        # silently NaN `R` this guard exists to prevent. `error_if` fires under `jit`.
-        axis = eqx.error_if(
-            self.axis, ~((norm > 0) & jnp.isfinite(norm)), _MSG_ZERO_AXIS
-        )
+        # Anything but a finite positive norm normalises to the silently NaN `R`
+        # this guard exists to prevent. `error_if` fires under `jit`.
+        axis = eqx.error_if(self.axis, _unnormalisable(norm), _MSG_ZERO_AXIS)
         n = axis / norm
         # Rodrigues' formula: R = I cos(th) + sin(th) [n]_x + (1-cos th) n n^T
         # The `0.0 * n[0]` terms keep the zero entries as functions of `axis`

--- a/src/coordinax/transforms/_src/actions/builders.py
+++ b/src/coordinax/transforms/_src/actions/builders.py
@@ -15,7 +15,10 @@ from .custom_types import CDict
 from .rotate import Rotate
 from .translate import Translate
 
-_MSG_ZERO_AXIS = "`RotationAboutAxis.axis` must be non-zero; got a zero-length axis."
+_MSG_ZERO_AXIS = (
+    "`RotationAboutAxis.axis` must be non-zero and finite; normalising anything "
+    "else gives a NaN rotation matrix."
+)
 
 
 def _as_axis(axis: Any, /) -> Shaped[Array, "3"]:
@@ -75,9 +78,14 @@ class RotationAboutAxis(eqx.Module):
         """Build the `Rotate` operator at time parameter ``tau``."""
         theta = jnp.asarray(u.ustrip("rad", self.omega * tau + self.phase))
         norm = jnp.linalg.vector_norm(self.axis)
-        # A zero-length axis defines no rotation; normalizing it would give a
-        # silently NaN `R`.  `error_if` also fires under `jit`.
-        axis = eqx.error_if(self.axis, norm == 0, _MSG_ZERO_AXIS)
+        # `axis / norm` is a unit vector only where `axis` is finite and non-zero,
+        # which is exactly a finite positive `norm`: the norm is NaN iff a component
+        # is, `inf` iff a component is, and 0 iff the axis is. Testing `norm == 0`
+        # alone caught the last of the three and let the other two normalise to the
+        # silently NaN `R` this guard exists to prevent. `error_if` fires under `jit`.
+        axis = eqx.error_if(
+            self.axis, ~((norm > 0) & jnp.isfinite(norm)), _MSG_ZERO_AXIS
+        )
         n = axis / norm
         # Rodrigues' formula: R = I cos(th) + sin(th) [n]_x + (1-cos th) n n^T
         # The `0.0 * n[0]` terms keep the zero entries as functions of `axis`

--- a/src/coordinax/transforms/_src/actions/builders.py
+++ b/src/coordinax/transforms/_src/actions/builders.py
@@ -16,10 +16,7 @@ from .rotate import Rotate
 from .translate import Translate
 from .utils import _unnormalisable
 
-_MSG_ZERO_AXIS = (
-    "`RotationAboutAxis.axis` must be non-zero and finite; normalising anything "
-    "else gives a NaN rotation matrix."
-)
+_MSG_ZERO_AXIS = "`RotationAboutAxis.axis` must be finite and non-zero."
 
 
 def _as_axis(axis: Any, /) -> Shaped[Array, "3"]:
@@ -79,8 +76,7 @@ class RotationAboutAxis(eqx.Module):
         """Build the `Rotate` operator at time parameter ``tau``."""
         theta = jnp.asarray(u.ustrip("rad", self.omega * tau + self.phase))
         norm = jnp.linalg.vector_norm(self.axis)
-        # Anything but a finite positive norm normalises to the silently NaN `R`
-        # this guard exists to prevent. `error_if` fires under `jit`.
+        # Anything else normalises to a silently NaN `R`; `error_if` fires under jit.
         axis = eqx.error_if(self.axis, _unnormalisable(norm), _MSG_ZERO_AXIS)
         n = axis / norm
         # Rodrigues' formula: R = I cos(th) + sin(th) [n]_x + (1-cos th) n n^T

--- a/src/coordinax/transforms/_src/actions/lorentz.py
+++ b/src/coordinax/transforms/_src/actions/lorentz.py
@@ -277,7 +277,10 @@ class LorentzBoost(AbstractLinearTransform):
 
         """
         beta_sq = jnp.sum(self.beta**2)
-        beta_sq = eqx.error_if(beta_sq, beta_sq >= 1.0, _MSG_SUPERLUMINAL)
+        # `~(x < 1)`, not `x >= 1`: a NaN is False for both comparisons, so the
+        # direct form admits it and leaks the non-finite value this guard exists
+        # to stop.
+        beta_sq = eqx.error_if(beta_sq, ~(beta_sq < 1.0), _MSG_SUPERLUMINAL)
         return 1.0 / jnp.sqrt(1.0 - beta_sq)
 
     @property
@@ -297,7 +300,7 @@ class LorentzBoost(AbstractLinearTransform):
         # same condition as `gamma`, so every derived quantity reports the same
         # superluminal error rather than one of them leaking a non-finite value.
         speed = self.speed
-        speed = eqx.error_if(speed, speed >= 1.0, _MSG_SUPERLUMINAL)
+        speed = eqx.error_if(speed, ~(speed < 1.0), _MSG_SUPERLUMINAL)
         return jnp.arctanh(speed)
 
     # -----------------------------------------------------

--- a/src/coordinax/transforms/_src/actions/lorentz.py
+++ b/src/coordinax/transforms/_src/actions/lorentz.py
@@ -31,10 +31,7 @@ _MSG_SUPERLUMINAL = (
 )
 
 
-_MSG_ZERO_DIRECTION = (
-    "LorentzBoost.from_rapidity requires a non-zero, finite `direction`; "
-    "anything else has no boost axis to normalise onto."
-)
+_MSG_ZERO_DIRECTION = "LorentzBoost.from_rapidity needs a finite, non-zero `direction`."
 
 
 def _float(x: Any, /) -> Array:
@@ -245,9 +242,8 @@ class LorentzBoost(AbstractLinearTransform):
         """
         d = _float(direction)
         norm = jnp.linalg.norm(d)
-        # Anything but a finite positive norm builds the `nan` betas this guard
-        # exists to prevent -- reported later by `gamma`'s subluminal check,
-        # which names the wrong cause.
+        # Anything else builds `nan` betas -- reported later by `gamma`'s
+        # subluminal check, which names the wrong cause.
         norm = eqx.error_if(norm, _unnormalisable(norm), _MSG_ZERO_DIRECTION)
         return cls(jnp.tanh(_float(rapidity)) * (d / norm))
 
@@ -279,9 +275,7 @@ class LorentzBoost(AbstractLinearTransform):
 
         """
         beta_sq = jnp.sum(self.beta**2)
-        # `~(x < 1)`, not `x >= 1`: a NaN is False for both comparisons, so the
-        # direct form admits it and leaks the non-finite value this guard exists
-        # to stop.
+        # `~(x < 1)`, not `x >= 1`, for the NaN reason given in `rapidity` below.
         beta_sq = eqx.error_if(beta_sq, ~(beta_sq < 1.0), _MSG_SUPERLUMINAL)
         return 1.0 / jnp.sqrt(1.0 - beta_sq)
 

--- a/src/coordinax/transforms/_src/actions/lorentz.py
+++ b/src/coordinax/transforms/_src/actions/lorentz.py
@@ -31,8 +31,8 @@ _MSG_SUPERLUMINAL = (
 
 
 _MSG_ZERO_DIRECTION = (
-    "LorentzBoost.from_rapidity requires a non-zero `direction`; the zero "
-    "vector has no boost axis to normalise onto."
+    "LorentzBoost.from_rapidity requires a non-zero, finite `direction`; "
+    "anything else has no boost axis to normalise onto."
 )
 
 
@@ -244,9 +244,14 @@ class LorentzBoost(AbstractLinearTransform):
         """
         d = _float(direction)
         norm = jnp.linalg.norm(d)
-        # A zero direction has no boost axis to normalise onto; dividing would
-        # give `nan` betas that then propagate silently into every matrix entry.
-        norm = eqx.error_if(norm, norm == 0.0, _MSG_ZERO_DIRECTION)
+        # `d / norm` is a unit vector only where `norm` is finite and positive: it
+        # is NaN iff a component of `d` is, `inf` iff a component is, and 0 iff `d`
+        # is. Testing `norm == 0.0` alone caught only the last, so a NaN direction
+        # built the `nan` betas this guard exists to prevent -- reported later by
+        # `gamma`'s subluminal check, which names the wrong cause.
+        norm = eqx.error_if(
+            norm, ~((norm > 0.0) & jnp.isfinite(norm)), _MSG_ZERO_DIRECTION
+        )
         return cls(jnp.tanh(_float(rapidity)) * (d / norm))
 
     # -----------------------------------------------------

--- a/src/coordinax/transforms/_src/actions/lorentz.py
+++ b/src/coordinax/transforms/_src/actions/lorentz.py
@@ -17,6 +17,7 @@ import unxt as u
 from .base import AbstractTransform
 from .identity import identity
 from .linear import AbstractLinearTransform
+from .utils import _unnormalisable
 from coordinax.transforms._src import groups
 
 #: Speed of light, used only to convert a velocity into a dimensionless beta.
@@ -244,14 +245,10 @@ class LorentzBoost(AbstractLinearTransform):
         """
         d = _float(direction)
         norm = jnp.linalg.norm(d)
-        # `d / norm` is a unit vector only where `norm` is finite and positive: it
-        # is NaN iff a component of `d` is, `inf` iff a component is, and 0 iff `d`
-        # is. Testing `norm == 0.0` alone caught only the last, so a NaN direction
-        # built the `nan` betas this guard exists to prevent -- reported later by
-        # `gamma`'s subluminal check, which names the wrong cause.
-        norm = eqx.error_if(
-            norm, ~((norm > 0.0) & jnp.isfinite(norm)), _MSG_ZERO_DIRECTION
-        )
+        # Anything but a finite positive norm builds the `nan` betas this guard
+        # exists to prevent -- reported later by `gamma`'s subluminal check,
+        # which names the wrong cause.
+        norm = eqx.error_if(norm, _unnormalisable(norm), _MSG_ZERO_DIRECTION)
         return cls(jnp.tanh(_float(rapidity)) * (d / norm))
 
     # -----------------------------------------------------

--- a/src/coordinax/transforms/_src/actions/reflect.py
+++ b/src/coordinax/transforms/_src/actions/reflect.py
@@ -78,8 +78,7 @@ class Reflect(AbstractLinearTransform):
 
         norm = jnp.linalg.norm(n)
         # Deferred so it survives jit (a plain `bool` on a traced value raises
-        # TracerBoolConversionError). Anything but a finite positive norm
-        # normalises to a silently NaN `H`.
+        # TracerBoolConversionError). Anything else normalises to a NaN `H`.
         n = eqx.error_if(n, _unnormalisable(norm), _MSG_ZERO_NORMAL)
 
         n_hat = n / norm

--- a/src/coordinax/transforms/_src/actions/reflect.py
+++ b/src/coordinax/transforms/_src/actions/reflect.py
@@ -21,7 +21,9 @@ from coordinax.transforms._src import groups
 
 HMatrix: TypeAlias = Shaped[Array, " N N"]
 
-_MSG_ZERO_NORMAL: Final = "Reflect.from_normal requires a nonzero normal vector."
+_MSG_ZERO_NORMAL: Final = (
+    "Reflect.from_normal requires a nonzero normal vector that is finite."
+)
 
 
 @final
@@ -76,9 +78,11 @@ class Reflect(AbstractLinearTransform):
             raise ValueError(msg)
 
         norm = jnp.linalg.norm(n)
-        # Defer the zero-normal check so it survives jit (a plain `bool` on a
-        # traced value raises TracerBoolConversionError).
-        n = eqx.error_if(n, jnp.allclose(norm, 0), _MSG_ZERO_NORMAL)
+        # Deferred so it survives jit (a plain `bool` on a traced value raises
+        # TracerBoolConversionError). `n / norm` is a unit vector only where `norm`
+        # is finite and positive; `allclose(norm, 0)` alone was False for a NaN or
+        # `inf` norm, so those normalised to a silently NaN `H`.
+        n = eqx.error_if(n, ~((norm > 0) & jnp.isfinite(norm)), _MSG_ZERO_NORMAL)
 
         n_hat = n / norm
         H = jnp.eye(n.shape[0], dtype=n_hat.dtype) - 2 * jnp.outer(n_hat, n_hat)

--- a/src/coordinax/transforms/_src/actions/reflect.py
+++ b/src/coordinax/transforms/_src/actions/reflect.py
@@ -17,13 +17,12 @@ from unxt import AbstractQuantity as AbcQ
 from .base import AbstractTransform
 from .identity import identity
 from .linear import AbstractLinearTransform
+from .utils import _unnormalisable
 from coordinax.transforms._src import groups
 
 HMatrix: TypeAlias = Shaped[Array, " N N"]
 
-_MSG_ZERO_NORMAL: Final = (
-    "Reflect.from_normal requires a nonzero normal vector that is finite."
-)
+_MSG_ZERO_NORMAL: Final = "Reflect.from_normal needs a finite, nonzero normal."
 
 
 @final
@@ -79,10 +78,9 @@ class Reflect(AbstractLinearTransform):
 
         norm = jnp.linalg.norm(n)
         # Deferred so it survives jit (a plain `bool` on a traced value raises
-        # TracerBoolConversionError). `n / norm` is a unit vector only where `norm`
-        # is finite and positive; `allclose(norm, 0)` alone was False for a NaN or
-        # `inf` norm, so those normalised to a silently NaN `H`.
-        n = eqx.error_if(n, ~((norm > 0) & jnp.isfinite(norm)), _MSG_ZERO_NORMAL)
+        # TracerBoolConversionError). Anything but a finite positive norm
+        # normalises to a silently NaN `H`.
+        n = eqx.error_if(n, _unnormalisable(norm), _MSG_ZERO_NORMAL)
 
         n_hat = n / norm
         H = jnp.eye(n.shape[0], dtype=n_hat.dtype) - 2 * jnp.outer(n_hat, n_hat)

--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -122,9 +122,8 @@ class Scale(AbstractLinearTransform):
         if s.ndim != 1:
             msg = f"Scale.from_factors requires a vector; got shape={s.shape!r}."
             raise ValueError(msg)
-        # Deferred so it survives jit (a plain `bool` on a traced value raises
-        # TracerBoolConversionError). An `inf` factor is the quiet one: its
-        # reciprocal is 0.0, so `inverse` came back finite, singular, and silent.
+        # Deferred so it survives jit, as in `Reflect.from_normal`. `inf` is the
+        # quiet failure: 1/inf = 0.0, so `inverse` came back finite and singular.
         bad = jnp.isclose(s, 0) | ~jnp.isfinite(s)
         s = eqx.error_if(s, jnp.any(bad), _MSG_SINGULAR)
         return cls._from_diagonal(s)

--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -23,9 +23,7 @@ from coordinax.transforms._src import groups
 SMatrix: TypeAlias = Shaped[Array, " N N"]
 SFactors: TypeAlias = Shaped[Array, " N"]
 
-_MSG_SINGULAR: Final = (
-    "Scale matrix must be invertible: every factor finite and non-zero."
-)
+_MSG_SINGULAR: Final = "Scale matrix must be invertible: factors finite, non-zero."
 _MSG_NOT_DIAGONAL: Final = (
     "Scale requires a diagonal matrix -- it scales the axes, and nothing else. "
     "For a general linear map use `Linear`."
@@ -125,13 +123,10 @@ class Scale(AbstractLinearTransform):
             msg = f"Scale.from_factors requires a vector; got shape={s.shape!r}."
             raise ValueError(msg)
         # Deferred so it survives jit (a plain `bool` on a traced value raises
-        # TracerBoolConversionError). A factor must also be finite: `isclose(s, 0)`
-        # is False for both NaN and `inf`, and an `inf` factor was the worst of the
-        # three -- its reciprocal is 0.0, so `inverse` came back finite, singular,
-        # and silent.
-        s = eqx.error_if(
-            s, jnp.any(jnp.isclose(s, 0) | ~jnp.isfinite(s)), _MSG_SINGULAR
-        )
+        # TracerBoolConversionError). An `inf` factor is the quiet one: its
+        # reciprocal is 0.0, so `inverse` came back finite, singular, and silent.
+        bad = jnp.isclose(s, 0) | ~jnp.isfinite(s)
+        s = eqx.error_if(s, jnp.any(bad), _MSG_SINGULAR)
         return cls._from_diagonal(s)
 
     @property

--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -23,7 +23,9 @@ from coordinax.transforms._src import groups
 SMatrix: TypeAlias = Shaped[Array, " N N"]
 SFactors: TypeAlias = Shaped[Array, " N"]
 
-_MSG_SINGULAR: Final = "Scale matrix must be invertible."
+_MSG_SINGULAR: Final = (
+    "Scale matrix must be invertible: every factor finite and non-zero."
+)
 _MSG_NOT_DIAGONAL: Final = (
     "Scale requires a diagonal matrix -- it scales the axes, and nothing else. "
     "For a general linear map use `Linear`."
@@ -122,9 +124,14 @@ class Scale(AbstractLinearTransform):
         if s.ndim != 1:
             msg = f"Scale.from_factors requires a vector; got shape={s.shape!r}."
             raise ValueError(msg)
-        # Defer the singular check so it survives jit (a plain `bool` on a
-        # traced value raises TracerBoolConversionError).
-        s = eqx.error_if(s, jnp.any(jnp.isclose(s, 0)), _MSG_SINGULAR)
+        # Deferred so it survives jit (a plain `bool` on a traced value raises
+        # TracerBoolConversionError). A factor must also be finite: `isclose(s, 0)`
+        # is False for both NaN and `inf`, and an `inf` factor was the worst of the
+        # three -- its reciprocal is 0.0, so `inverse` came back finite, singular,
+        # and silent.
+        s = eqx.error_if(
+            s, jnp.any(jnp.isclose(s, 0) | ~jnp.isfinite(s)), _MSG_SINGULAR
+        )
         return cls._from_diagonal(s)
 
     @property

--- a/src/coordinax/transforms/_src/actions/utils.py
+++ b/src/coordinax/transforms/_src/actions/utils.py
@@ -78,7 +78,6 @@ def _unnormalisable(norm: Any, /) -> Any:
 
     True unless the norm is finite and strictly positive, which is exactly the
     precondition: a norm is NaN iff a component of ``v`` is, ``inf`` iff a
-    component is, and ``0`` iff ``v`` is. Testing ``norm == 0`` alone catches
-    the last of those three and lets the other two normalise to a silent NaN.
+    component is, and ``0`` iff ``v`` is.
     """
     return ~((norm > 0) & jnp.isfinite(norm))

--- a/src/coordinax/transforms/_src/actions/utils.py
+++ b/src/coordinax/transforms/_src/actions/utils.py
@@ -12,6 +12,8 @@ __all__: tuple[str, ...] = (
 from collections.abc import Iterable
 from typing import Any
 
+import jax.numpy as jnp
+
 import coordinax.representations as cxr
 from coordinax._src.exceptions import NoGlobalCartesianChartError
 
@@ -69,3 +71,14 @@ def require_matching_keys(
             + (f"; unexpected {extra}" if extra else "")
             + "."
         )
+
+
+def _unnormalisable(norm: Any, /) -> Any:
+    """Whether ``v / norm`` fails to be a unit vector, for ``norm = |v|``.
+
+    True unless the norm is finite and strictly positive, which is exactly the
+    precondition: a norm is NaN iff a component of ``v`` is, ``inf`` iff a
+    component is, and ``0`` iff ``v`` is. Testing ``norm == 0`` alone catches
+    the last of those three and lets the other two normalise to a silent NaN.
+    """
+    return ~((norm > 0) & jnp.isfinite(norm))

--- a/tests/unit/charts/test_checks.py
+++ b/tests/unit/charts/test_checks.py
@@ -164,6 +164,13 @@ class TestLeq:
         ):
             checks.leq(x, max_q)
 
+    def test_nan_raises(self) -> None:
+        """A NaN is False for ``x <= max``, so the direct form admitted it."""
+        with pytest.raises(
+            (eqx.EquinoxRuntimeError, ValueError), match="must be less than or equal to"
+        ):
+            checks.leq(u.Q(jnp.nan, "m"), u.Q(5, "m"))
+
 
 class TestGeq:
     """Tests for geq (greater than or equal) check."""
@@ -206,3 +213,11 @@ class TestGeq:
             match="must be greater than or equal to",
         ):
             checks.geq(x, min_q)
+
+    def test_nan_raises(self) -> None:
+        """A NaN is False for ``x >= min``, so the direct form admitted it."""
+        with pytest.raises(
+            (eqx.EquinoxRuntimeError, ValueError),
+            match="must be greater than or equal to",
+        ):
+            checks.geq(u.Q(jnp.nan, "m"), u.Q(5, "m"))

--- a/tests/unit/transforms/test_builders.py
+++ b/tests/unit/transforms/test_builders.py
@@ -90,7 +90,7 @@ def test_rotation_about_axis_unnormalisable_axis_raises(bad):
     b = cxfm.builders.RotationAboutAxis(
         u.Q(1, "rad/s"), axis=jnp.array([bad, 0.0, 0.0])
     )
-    with pytest.raises(eqx.EquinoxRuntimeError, match="must be non-zero"):
+    with pytest.raises(eqx.EquinoxRuntimeError, match="finite and non-zero"):
         b(u.Q(1.0, "s"))
 
 

--- a/tests/unit/transforms/test_builders.py
+++ b/tests/unit/transforms/test_builders.py
@@ -1,5 +1,6 @@
 """Tests for the built-in TimeDep builders."""
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import pytest
@@ -83,10 +84,18 @@ def test_uniform_translation_differentiable_in_rate():
     assert jnp.allclose(jax.grad(y)(3.0), 2000.0, atol=1e-6)
 
 
-def test_rotation_about_axis_zero_axis_raises():
-    """A zero-length axis must fail loudly, not normalize to a NaN `R`."""
-    b = cxfm.builders.RotationAboutAxis(u.Q(1, "rad/s"), axis=jnp.zeros(3))
-    with pytest.raises(Exception, match="must be non-zero"):
+@pytest.mark.parametrize("bad", [0.0, jnp.nan, jnp.inf], ids=["zero", "nan", "inf"])
+def test_rotation_about_axis_unnormalisable_axis_raises(bad):
+    """An axis that cannot be normalised must fail loudly, not give a NaN `R`.
+
+    `axis / norm` is a unit vector only for a finite positive norm. A NaN or
+    `inf` axis is False for `norm == 0` and used to normalise straight through
+    to nine NaN entries in `R`.
+    """
+    b = cxfm.builders.RotationAboutAxis(
+        u.Q(1, "rad/s"), axis=jnp.array([bad, 0.0, 0.0])
+    )
+    with pytest.raises(eqx.EquinoxRuntimeError, match="must be non-zero"):
         b(u.Q(1.0, "s"))
 
 

--- a/tests/unit/transforms/test_builders.py
+++ b/tests/unit/transforms/test_builders.py
@@ -86,12 +86,7 @@ def test_uniform_translation_differentiable_in_rate():
 
 @pytest.mark.parametrize("bad", [0.0, jnp.nan, jnp.inf], ids=["zero", "nan", "inf"])
 def test_rotation_about_axis_unnormalisable_axis_raises(bad):
-    """An axis that cannot be normalised must fail loudly, not give a NaN `R`.
-
-    `axis / norm` is a unit vector only for a finite positive norm. A NaN or
-    `inf` axis is False for `norm == 0` and used to normalise straight through
-    to nine NaN entries in `R`.
-    """
+    """An axis that cannot be normalised must fail loudly, not give a NaN `R`."""
     b = cxfm.builders.RotationAboutAxis(
         u.Q(1, "rad/s"), axis=jnp.array([bad, 0.0, 0.0])
     )

--- a/tests/unit/transforms/test_lorentz_boost.py
+++ b/tests/unit/transforms/test_lorentz_boost.py
@@ -165,23 +165,14 @@ class TestDerivedQuantities:
         """Every derived quantity guards, not just ``gamma``.
 
         ``rapidity`` used to reach ``arctanh(|beta| >= 1)`` and hand back
-        ``inf``/``nan`` while ``gamma`` on the same object raised. A ``nan``
-        beta needs the guard written as ``~(beta_sq < 1)``: it is False for
-        ``beta_sq >= 1`` too, so the direct form let it through and returned
-        the non-finite value the guard exists to prevent.
+        ``inf``/``nan`` while ``gamma`` on the same object raised.
         """
         with pytest.raises(eqx.EquinoxRuntimeError, match="subluminal"):
             _ = getattr(cxfm.LorentzBoost([beta, 0.0, 0.0]), attr)
 
     @pytest.mark.parametrize("bad", [0.0, jnp.nan, jnp.inf], ids=["zero", "nan", "inf"])
     def test_an_unnormalisable_direction_is_rejected(self, bad):
-        """A ``direction`` that cannot be normalised has no boost axis.
-
-        Dividing by its norm produced ``nan`` betas that then propagated
-        silently into every entry of the matrix. ``norm == 0.0`` caught only
-        the zero case; the other two were reported later by ``gamma``'s
-        subluminal check, which names the wrong cause.
-        """
+        """A ``direction`` that cannot be normalised has no boost axis."""
         with pytest.raises(eqx.EquinoxRuntimeError, match="non-zero"):
             cxfm.LorentzBoost.from_rapidity(0.5, (bad, 0.0, 0.0))
 

--- a/tests/unit/transforms/test_lorentz_boost.py
+++ b/tests/unit/transforms/test_lorentz_boost.py
@@ -160,14 +160,18 @@ class TestDerivedQuantities:
         assert float(in_kms.speed) == pytest.approx(0.5, abs=1e-4)
 
     @pytest.mark.parametrize("attr", ["gamma", "rapidity"])
-    def test_superluminal_boost_is_rejected(self, attr):
+    @pytest.mark.parametrize("beta", [1.5, jnp.nan], ids=["superluminal", "nan"])
+    def test_a_non_subluminal_boost_is_rejected(self, attr, beta):
         """Every derived quantity guards, not just ``gamma``.
 
         ``rapidity`` used to reach ``arctanh(|beta| >= 1)`` and hand back
-        ``inf``/``nan`` while ``gamma`` on the same object raised.
+        ``inf``/``nan`` while ``gamma`` on the same object raised. A ``nan``
+        beta needs the guard written as ``~(beta_sq < 1)``: it is False for
+        ``beta_sq >= 1`` too, so the direct form let it through and returned
+        the non-finite value the guard exists to prevent.
         """
         with pytest.raises(eqx.EquinoxRuntimeError, match="subluminal"):
-            _ = getattr(cxfm.LorentzBoost([1.5, 0.0, 0.0]), attr)
+            _ = getattr(cxfm.LorentzBoost([beta, 0.0, 0.0]), attr)
 
     def test_zero_direction_is_rejected(self):
         """A zero ``direction`` has no axis to normalise onto.

--- a/tests/unit/transforms/test_lorentz_boost.py
+++ b/tests/unit/transforms/test_lorentz_boost.py
@@ -173,14 +173,17 @@ class TestDerivedQuantities:
         with pytest.raises(eqx.EquinoxRuntimeError, match="subluminal"):
             _ = getattr(cxfm.LorentzBoost([beta, 0.0, 0.0]), attr)
 
-    def test_zero_direction_is_rejected(self):
-        """A zero ``direction`` has no axis to normalise onto.
+    @pytest.mark.parametrize("bad", [0.0, jnp.nan, jnp.inf], ids=["zero", "nan", "inf"])
+    def test_an_unnormalisable_direction_is_rejected(self, bad):
+        """A ``direction`` that cannot be normalised has no boost axis.
 
-        Dividing by its zero norm produced ``nan`` betas that then propagated
-        silently into every entry of the matrix.
+        Dividing by its norm produced ``nan`` betas that then propagated
+        silently into every entry of the matrix. ``norm == 0.0`` caught only
+        the zero case; the other two were reported later by ``gamma``'s
+        subluminal check, which names the wrong cause.
         """
         with pytest.raises(eqx.EquinoxRuntimeError, match="non-zero"):
-            cxfm.LorentzBoost.from_rapidity(0.5, (0.0, 0.0, 0.0))
+            cxfm.LorentzBoost.from_rapidity(0.5, (bad, 0.0, 0.0))
 
 
 class TestPhysicalPredictions:

--- a/tests/unit/transforms/test_reflect.py
+++ b/tests/unit/transforms/test_reflect.py
@@ -19,11 +19,7 @@ from .conftest import EXPECTED_IDENTITY, EXPECTED_REFLECT
 
 @pytest.mark.parametrize("bad", [0.0, jnp.nan, jnp.inf], ids=["zero", "nan", "inf"])
 def test_reflect_from_normal_unnormalisable_raises_under_jit(bad: float) -> None:
-    """A normal that cannot be normalised is rejected, even under jit.
-
-    Deferred so no tracer bool is taken. `allclose(norm, 0)` was False for a
-    NaN or `inf` norm, so those reached `n / norm` and gave a NaN `H`.
-    """
+    """A normal that cannot be normalised is rejected, even under jit."""
     build = eqx.filter_jit(cxfm.Reflect.from_normal)
     with pytest.raises(eqx.EquinoxRuntimeError, match="nonzero normal"):
         jax.block_until_ready(build(jnp.asarray([bad, 0.0, 0.0])).H)

--- a/tests/unit/transforms/test_reflect.py
+++ b/tests/unit/transforms/test_reflect.py
@@ -17,11 +17,16 @@ import coordinax.transforms as cxfm
 from .conftest import EXPECTED_IDENTITY, EXPECTED_REFLECT
 
 
-def test_reflect_from_normal_zero_raises_under_jit() -> None:
-    """A zero normal is rejected even under jit (no tracer bool)."""
+@pytest.mark.parametrize("bad", [0.0, jnp.nan, jnp.inf], ids=["zero", "nan", "inf"])
+def test_reflect_from_normal_unnormalisable_raises_under_jit(bad: float) -> None:
+    """A normal that cannot be normalised is rejected, even under jit.
+
+    Deferred so no tracer bool is taken. `allclose(norm, 0)` was False for a
+    NaN or `inf` norm, so those reached `n / norm` and gave a NaN `H`.
+    """
     build = eqx.filter_jit(cxfm.Reflect.from_normal)
     with pytest.raises(eqx.EquinoxRuntimeError, match="nonzero normal"):
-        jax.block_until_ready(build(jnp.asarray([0.0, 0.0, 0.0])).H)
+        jax.block_until_ready(build(jnp.asarray([bad, 0.0, 0.0])).H)
 
 
 def _extract_xyz(result: Any) -> tuple[float, float, float]:

--- a/tests/unit/transforms/test_spatial_linear_transforms.py
+++ b/tests/unit/transforms/test_spatial_linear_transforms.py
@@ -24,12 +24,7 @@ def _to_np(x: object, unit: str) -> np.ndarray:
 
 @pytest.mark.parametrize("bad", [0.0, jnp.nan, jnp.inf], ids=["zero", "nan", "inf"])
 def test_scale_from_factors_singular_raises_under_jit(bad: float) -> None:
-    """A non-invertible scale factor is rejected, even under jit.
-
-    `isclose(s, 0)` is False for both NaN and `inf`. The `inf` case was the
-    quietest: its reciprocal is 0.0, so `inverse` came back finite, singular,
-    and with nothing to notice.
-    """
+    """A non-invertible scale factor is rejected, even under jit."""
     build = eqx.filter_jit(cxfm.Scale.from_factors)
     with pytest.raises(eqx.EquinoxRuntimeError, match="invertible"):
         jax.block_until_ready(build(jnp.asarray([2.0, bad, 4.0])).s)

--- a/tests/unit/transforms/test_spatial_linear_transforms.py
+++ b/tests/unit/transforms/test_spatial_linear_transforms.py
@@ -22,11 +22,17 @@ def _to_np(x: object, unit: str) -> np.ndarray:
     return np.asarray(u.ustrip(unit, x), dtype=float)
 
 
-def test_scale_from_factors_singular_raises_under_jit() -> None:
-    """A zero scale factor is rejected even under jit (no tracer bool)."""
+@pytest.mark.parametrize("bad", [0.0, jnp.nan, jnp.inf], ids=["zero", "nan", "inf"])
+def test_scale_from_factors_singular_raises_under_jit(bad: float) -> None:
+    """A non-invertible scale factor is rejected, even under jit.
+
+    `isclose(s, 0)` is False for both NaN and `inf`. The `inf` case was the
+    quietest: its reciprocal is 0.0, so `inverse` came back finite, singular,
+    and with nothing to notice.
+    """
     build = eqx.filter_jit(cxfm.Scale.from_factors)
     with pytest.raises(eqx.EquinoxRuntimeError, match="invertible"):
-        jax.block_until_ready(build(jnp.asarray([2.0, 0.0, 4.0])).s)
+        jax.block_until_ready(build(jnp.asarray([2.0, bad, 4.0])).s)
 
 
 def test_scale_from_factors_nonsingular_jits() -> None:


### PR DESCRIPTION
Ten guards admitted `NaN` and returned a `NaN` result with nothing raised — worse than the case each guard was written for, which at least errors.

`x >= hi`, `x > hi`, `x <= tol` are all `False` for a `NaN`, so a guard written as a direct comparison lets one through.

## Measured, before

```
LorentzBoost(Q([nan, 0, 0], "")).gamma      -> non-finite, no error
_orthonormalize([1, nan, 0], T0)            -> NaN triad,   no error
ArcLength(..., s_max=5km)(Q(nan, "km"))     -> NaN position, no error
leq(Q(nan, "m"), Q(2, "m"))                 -> admits
geq(Q(nan, "m"), Q(2, "m"))                 -> admits
```

`lorentz.py`'s own comment states the intent it was failing to enforce — guard "so every derived quantity reports the same superluminal error rather than one of them **leaking a non-finite value**".

## The fix was already in the repo

`TubularChart`'s reach guard is written `~(f > 0)`, added in #699 after this exact bug, with a comment saying why. Six other guards were still written the direct way. This applies the known lesson to each:

| file | was | now |
| --- | --- | --- |
| `bishop.py` | `norm <= tol` | `~(norm > tol)` |
| `arclength.py` | `(s < -m) \| (s > max + m)` | `~in_domain` |
| `lorentz.py` gamma | `beta_sq >= 1.0` | `~(beta_sq < 1.0)` |
| `lorentz.py` rapidity | `speed >= 1.0` | `~(speed < 1.0)` |
| `checks.py` `leq` | `jnp.any(x > max)` | `jnp.any(~(x <= max))` |
| `checks.py` `geq` | `jnp.any(x < min)` | `jnp.any(~(x >= min))` |

Valid inputs are untouched: `gamma(beta=0.5) = 1.154701`, an exactly-parallel or all-zero initial normal still raises, an in-domain `s` still passes, and `leq`/`geq` still admit in-range values.

## The four degeneracy guards, added after review

These were first left out as a question about intent. Measuring them settled it: each one's own comment names the failure it was letting through.

| file | was | admitted | now |
| --- | --- | --- | --- |
| `builders.py` | `norm == 0` | `R` all 9 entries NaN | `~((norm > 0) & isfinite(norm))` |
| `lorentz.py` `from_rapidity` | `norm == 0.0` | `beta = [nan, nan, nan]` | `~((norm > 0.0) & isfinite(norm))` |
| `reflect.py` | `allclose(norm, 0)` | `H` all 9 entries NaN | `~((norm > 0) & isfinite(norm))` |
| `scale.py` | `any(isclose(s, 0))` | `s = [2, nan]`, `s = [2, inf]` | `any(isclose(s, 0) \| ~isfinite(s))` |

Three of them compute `v / ‖v‖`, which is a unit vector only where `v` is finite and non-zero — exactly a finite positive norm, since `‖v‖` is NaN iff a component is, `inf` iff a component is, and `0` iff `v` is. The equality test captured one of those three cases. The new predicate is the precondition itself, with no slack.

`Scale`'s `inf` factor was the quietest failure in the whole audit, because it produced no NaN at all:

```
Scale.from_factors([2, inf]).inverse.s   ->  [0.5, 0.0]
```

That "inverse" is singular. Composed with the original it gives `diag(1, 0)`, not the identity.

## Still open, not in this PR

- **`Scale` has a bypass.** The singular check lives only in `from_factors`; `Scale(jnp.diag([2., 0.]))` constructs fine and its `.inverse` is `[0.5, inf]`. `__init__` validates square and diagonal, not invertibility — so the comment at `scale.py` claiming "an `s` that exists has already passed" is wrong for singularity. Moving the check to `_from_diagonal` would close it, at the cost of a check per `inverse`/`_merge`. Worth measuring first.
- **`isclose(s, 0)` is an absolute threshold.** `rtol` multiplies `|0|`, so it reduces to `|s| <= 1e-8`: `[2, 1e-9]` is refused as singular while `[2, 1e9]` is accepted and inverts to `1e-9`. Same conditioning, opposite verdicts. Pre-existing design choice, left alone.

## Provenance

Found by auditing what each guard *admits* against what its docstring *claims*, across every `error_if` predicate in the repo — prompted by three guards in recent PRs that each turned out narrower than advertised.

## Verification

Six tests, each mutation-verified by reverting the predicate it covers. 11030 tests pass across the repo; `prek` clean including `ty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

