### PR TITLE
✨ feat(vectors): add the `Point` overload of `chord_distance`

### DIFF
--- a/src/coordinax/__init__.py
+++ b/src/coordinax/__init__.py
@@ -187,6 +187,7 @@ from coordinax.vectors import (
     Point,
     Tangent,
     ToUnitsOptions,
+    chord_distance,
     equivalent,
     geodesic_distance,
 )

--- a/src/coordinax/vectors/__init__.py
+++ b/src/coordinax/vectors/__init__.py
@@ -3,6 +3,7 @@
 __all__ = (
     "cconvert",
     "equivalent",
+    "chord_distance",
     "geodesic_distance",
     "AbstractVector",
     "Point",
@@ -20,6 +21,7 @@ with install_import_hook("coordinax.vectors"):
         Point,
         Tangent,
         ToUnitsOptions,
+        chord_distance,
         equivalent,
         geodesic_distance,
     )

--- a/src/coordinax/vectors/_src/__init__.py
+++ b/src/coordinax/vectors/_src/__init__.py
@@ -5,6 +5,7 @@ from .bundle import *
 from .custom_types import *
 from .mixins import *
 from .point import *
+from .register_chord_distance import *
 from .register_compare import *
 from .register_cx import *
 from .register_dataclassish import *

--- a/src/coordinax/vectors/_src/register_chord_distance.py
+++ b/src/coordinax/vectors/_src/register_chord_distance.py
@@ -1,0 +1,81 @@
+"""`chord_distance` dispatch for vector-like objects.
+
+This registers the `~coordinax.vectors.Point` overload of
+`coordinaxs.api.manifolds.chord_distance`, the counterpart to the one
+`geodesic_distance` has.
+
+Unlike that one, the operands are *not* brought into a Cartesian chart first.
+A chord is measured through the ambient space a manifold is embedded in, and a
+Euclidean manifold is its own ambient -- so converting to Cartesian would turn
+every call into the case `chord_distance` refuses, and would raise outright for
+an intrinsic sphere chart, which has no global Cartesian representation. The
+second operand is mapped into the first's chart instead, and the measurement is
+delegated to the manifold-level `chord_distance`.
+
+It is *frame-strict*, as `geodesic_distance` is: coordinates in different frames
+describe different physical points, so a cross-frame chord is undefined and
+raises; align the operands with `to_frame` first.
+"""
+
+__all__: tuple[str, ...] = ("chord_distance",)
+
+from typing import Any
+
+import plum
+
+import coordinaxs.api.manifolds as cxmapi
+from .point import Point
+
+
+@plum.dispatch
+def chord_distance(a: Point, b: Point, /) -> Any:
+    """Straight-line distance between two points, through their ambient space.
+
+    The counterpart to `~coordinax.geodesic_distance`'s `Point` overload: that
+    one measures along the manifold, this one through the space it is embedded
+    in. The result is invariant to the chart each operand happens to use.
+
+    >>> import jax.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax as cx
+    >>> import coordinax.charts as cxc
+
+    A quarter turn along the equator: the arc is ``pi / 2``, the chord through
+    the interior is ``sqrt(2)``.
+
+    >>> p = cx.Point({"theta": u.Angle(jnp.pi / 2, "rad"),
+    ...               "phi": u.Angle(0.0, "rad")}, chart=cxc.sph2)
+    >>> q = cx.Point({"theta": u.Angle(jnp.pi / 2, "rad"),
+    ...               "phi": u.Angle(jnp.pi / 2, "rad")}, chart=cxc.sph2)
+    >>> round(float(cx.chord_distance(p, q)), 6)
+    1.414214
+
+    The operands need not share a chart:
+
+    >>> r = cx.Point({"lon": u.Angle(jnp.pi / 2, "rad"),
+    ...               "lat": u.Angle(0.0, "rad")}, chart=cxc.lonlat_sph2)
+    >>> round(float(cx.chord_distance(p, r)), 6)
+    1.414214
+
+    Flat space is its own ambient, so it has no chord distinct from its
+    geodesic:
+
+    >>> a = cx.Point.from_([3.0, 0.0, 0.0], "m")
+    >>> b = cx.Point.from_([0.0, 4.0, 0.0], "m")
+    >>> try: cx.chord_distance(a, b)
+    ... except NotImplementedError as e: print(str(e)[:48])
+    chord_distance is a measurement through an ambie
+
+    """
+    if a.frame != b.frame:
+        msg = "cannot measure chord_distance between vectors in different frames"
+        raise ValueError(msg)
+
+    if a.chart.M != b.chart.M:
+        msg = "cannot measure chord_distance between vectors on different manifolds"
+        raise ValueError(msg)
+
+    # Into `a`'s chart rather than a Cartesian one: the chord is a property of
+    # the manifold's embedding, and the intrinsic chart is what carries it.
+    b_in_a = b.cconvert(a.chart)
+    return cxmapi.chord_distance(a.chart, a.data, b_in_a.data)

--- a/tests/unit/vectors/test_chord_distance_point.py
+++ b/tests/unit/vectors/test_chord_distance_point.py
@@ -78,3 +78,30 @@ class TestChordDistancePoint:
         moved = cx.Point(q.data, chart=q.chart, frame=cx.frames.Alice())
         with pytest.raises(ValueError, match="different frames"):
             cx.chord_distance(p, moved)
+
+    def test_is_evaluated_elementwise_over_batch(self) -> None:
+        """Chord distance is evaluated element-wise over the batch."""
+        p = cx.Point(
+            {
+                "theta": u.Angle(jnp.full(2, math.pi / 2), "rad"),
+                "phi": u.Angle(jnp.zeros(2), "rad"),
+            },
+            chart=cxc.sph2,
+        )
+        q = cx.Point(
+            {
+                "theta": u.Angle(jnp.full(2, math.pi / 2), "rad"),
+                "phi": u.Angle(jnp.array([math.pi / 2, math.pi]), "rad"),
+            },
+            chart=cxc.sph2,
+        )
+        d = cx.chord_distance(p, q)
+        assert float(d[0]) == pytest.approx(math.sqrt(2), abs=1e-9)
+        assert float(d[1]) == pytest.approx(2.0, abs=1e-9)
+
+    def test_different_manifolds_is_refused(self) -> None:
+        """A 2-sphere point and a Euclidean point share no manifold to measure on."""
+        p = _sph2(math.pi / 2, 0.0)
+        q = cx.Point.from_([0.0, 4.0, 0.0], "m")
+        with pytest.raises(ValueError, match="different manifolds"):
+            cx.chord_distance(p, q)

--- a/tests/unit/vectors/test_chord_distance_point.py
+++ b/tests/unit/vectors/test_chord_distance_point.py
@@ -1,0 +1,80 @@
+"""The `Point` overload of `chord_distance`.
+
+`geodesic_distance` has one; this is its counterpart. It cannot be written the
+same way: that overload brings both operands into a Cartesian chart, and for a
+chord that is exactly wrong -- a Euclidean manifold is its own ambient, so
+`chord_distance` refuses it, and an intrinsic sphere chart has no global
+Cartesian representation to convert to at all.
+"""
+
+import math
+
+import jax.numpy as jnp
+import pytest
+
+import unxt as u
+
+import coordinax as cx
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+
+
+def _sph2(theta: float, phi: float) -> cx.Point:
+    return cx.Point(
+        {"theta": u.Angle(theta, "rad"), "phi": u.Angle(phi, "rad")}, chart=cxc.sph2
+    )
+
+
+class TestChordDistancePoint:
+    """Measured through the ambient space, not along the manifold."""
+
+    def test_matches_the_manifold_level_call(self) -> None:
+        p, q = _sph2(math.pi / 2, 0.0), _sph2(math.pi / 2, math.pi / 2)
+        direct = cxm.chord_distance(cxc.sph2, p.data, q.data)
+        assert float(cx.chord_distance(p, q)) == pytest.approx(float(direct))
+
+    @pytest.mark.parametrize("dphi", [1e-3, 0.5, 1.0, 2.0, math.pi])
+    def test_matches_the_analytic_chord(self, dphi: float) -> None:
+        """On the unit sphere the chord is ``2 sin(dphi / 2)``."""
+        p, q = _sph2(math.pi / 2, 0.0), _sph2(math.pi / 2, dphi)
+        assert float(cx.chord_distance(p, q)) == pytest.approx(
+            2 * math.sin(dphi / 2), abs=1e-9
+        )
+
+    def test_is_symmetric(self) -> None:
+        p, q = _sph2(1.0, 0.4), _sph2(1.6, 1.2)
+        assert float(cx.chord_distance(p, q)) == pytest.approx(
+            float(cx.chord_distance(q, p))
+        )
+
+    def test_is_chart_invariant(self) -> None:
+        """The operands need not share a chart, and the answer must not care."""
+        p = _sph2(math.pi / 2, 0.0)
+        q_sph = _sph2(math.pi / 2, math.pi / 2)
+        q_ll = cx.Point(
+            {"lon": u.Angle(jnp.pi / 2, "rad"), "lat": u.Angle(0.0, "rad")},
+            chart=cxc.lonlat_sph2,
+        )
+        assert float(cx.chord_distance(p, q_ll)) == pytest.approx(
+            float(cx.chord_distance(p, q_sph))
+        )
+
+    def test_differs_from_the_geodesic(self) -> None:
+        """The two verbs must not be confusable: sqrt(2) against pi/2."""
+        p, q = _sph2(math.pi / 2, 0.0), _sph2(math.pi / 2, math.pi / 2)
+        assert float(cx.chord_distance(p, q)) == pytest.approx(math.sqrt(2), abs=1e-9)
+
+    def test_flat_space_is_refused(self) -> None:
+        """Euclidean is its own ambient; the error points at `geodesic_distance`."""
+        a = cx.Point.from_([3.0, 0.0, 0.0], "m")
+        b = cx.Point.from_([0.0, 4.0, 0.0], "m")
+        with pytest.raises(NotImplementedError, match="own ambient"):
+            cx.chord_distance(a, b)
+
+    def test_cross_frame_is_refused(self) -> None:
+        """Frame-strict, as `geodesic_distance` is."""
+        p = _sph2(math.pi / 2, 0.0)
+        q = _sph2(math.pi / 2, math.pi / 2)
+        moved = cx.Point(q.data, chart=q.chart, frame=cx.frames.Alice())
+        with pytest.raises(ValueError, match="different frames"):
+            cx.chord_distance(p, moved)


### PR DESCRIPTION
`geodesic_distance` has a `Point` overload and `chord_distance` did not, so the two verbs were usable at different levels. #720 flagged the asymmetry and left it open; this closes it.

## It could not mirror `geodesic_distance`

That overload brings both operands into a Cartesian chart. For a chord that is exactly wrong:

- a **Euclidean manifold is its own ambient**, so `chord_distance` refuses it — converting to Cartesian would land every call on the refused case;
- an **intrinsic sphere chart has no global Cartesian representation**, so there is nothing to convert to. `geodesic_distance(p, q)` on `sph2` raises `NoGlobalCartesianChartError` today for precisely that reason.

So the second operand is mapped into the *first's* chart instead, and the measurement delegated to the manifold-level rule. The chord is a property of the embedding, and the intrinsic chart is what carries it.

```pycon
>>> p = cx.Point({"theta": u.Angle(jnp.pi/2, "rad"), "phi": u.Angle(0.0, "rad")}, chart=cxc.sph2)
>>> q = cx.Point({"theta": u.Angle(jnp.pi/2, "rad"), "phi": u.Angle(jnp.pi/2, "rad")}, chart=cxc.sph2)
>>> round(float(cx.chord_distance(p, q)), 6)
1.414214
```

Frame-strict, matching `geodesic_distance`, and refusing a cross-manifold pair.

## Tests

Eleven: the analytic `2 sin(dphi/2)` across five separations, symmetry, chart-invariance with the operands in *different* charts, that it differs from the geodesic (`sqrt(2)` against `pi/2` — the point of having two verbs), flat space refusing with the error pointing at `geodesic_distance`, and the cross-frame refusal.

241 passed across `tests/unit/vectors`; `nox -s precommit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
