### PR TITLE
🐛 fix(skills): update the `pt_map` output for canonical angular containers

### DIFF
--- a/skills/coordinax/SKILL.md
+++ b/skills/coordinax/SKILL.md
@@ -43,7 +43,8 @@ Three levels of API, cheapest first. Pick the lowest one that carries the metada
 
 >>> q = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
 >>> cx.pt_map(q, cx.cart3d, cx.sph3d)
-{'r': Q(3.74165739, 'km'), 'theta': Q(0.64052231, 'rad'), 'phi': Q(1.10714872, 'rad')}
+{'r': Q(3.74165739, 'km'), 'theta': Angle(0.64052231, 'rad'),
+ 'phi': Angle(1.10714872, 'rad')}
 
 ```
 


### PR DESCRIPTION
`main` is red, and every open PR with it.

#752 made `pt_map` return `Angle` for angular components rather than `Quantity` — the point of that change — but the `SKILL.md` doctest was written against the old behaviour and never updated:

```
skills/coordinax/SKILL.md:45: SybilFailure
Expected  {'r': Q(3.74165739, 'km'), 'theta': Q(0.64052231, 'rad'),     'phi': Q(1.10714872, 'rad')}
Got       {'r': Q(3.74165739, 'km'), 'theta': Angle(0.64052231, 'rad'), 'phi': Angle(1.10714872, 'rad')}
```

`skills/` is in `testpaths`, so this fails the **entire matrix** — every Python version, every OS — on any branch with #752 in its ancestry, which is now all of them. The failure is unrelated to whatever those branches actually change, so none of them can show a real CI signal until this lands.

## How it got through

Mine to have caught. #752's doctest sweep ran over `src/`, `packages/`, `README.md` and `docs/` — a list I wrote by hand. `skills/` was not on it.

The timing hid it: `SKILL.md` arrived in #758, which merged **after** #752's branch had its last full-suite run and **before** #752 itself merged. So no run on that branch ever saw the file, and the conflict only existed once both were in `main`.

The lesson is narrower than "run the full suite" — I did run it. It is that a hand-enumerated sweep can silently omit a path the config already knows about. `pyproject.toml` lists `testpaths`; the sweep should have read it rather than restated it.

## Scope

Checked the rest of `skills/` for the same pattern rather than fixing only the reported line — that was the only occurrence. `skills/`: **49 passed**. `nox -s precommit` clean. Full suite running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
