### PR TITLE
✨ feat(transforms): `Affine`, so an interleaved affine chain is one kernel

### DIFF
--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/frame_transforms.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/frame_transforms.py
@@ -49,18 +49,21 @@ def frame_transition(
     >>> op = cxf.frame_transition(my_frame, gcf_frame)
     >>> op
     Composed((
-      Rotate(f64[3,3](jax)),
-      Translate(
-          {...},
-          chart=Cart3D(M=Rn(3))
+      Affine(
+        f64[3,3](jax),
+        {...},
+        Cart3D(M=Rn(3))
       ),
-      Rotate(f64[3,3](jax)),
       Translate(
           {...},
           chart=Cart3D(M=Rn(3)),
           semantic_kind=vel
       )
     ))
+
+    The rotation and the position offset fused into one
+    `~coordinax.transforms.Affine`; the velocity kick cannot join them, since it
+    shifts the tangent rather than the point.
 
     """  # noqa: E501
     fromframe_to_icrs = frame_transition(from_frame, icrs)
@@ -197,23 +200,16 @@ def frame_transition(
           chart=Cart3D(M=Rn(3)),
           semantic_kind=vel
       ),
-      Rotate(f64[3,3](jax)),
-      Translate(
-          {...},
-          chart=Cart3D(M=Rn(3))
-      ),
-      Rotate(f64[3,3](jax)),
-      Translate(
-          {...},
-          chart=Cart3D(M=Rn(3))
-      ),
-      Rotate(f64[3,3](jax)),
+      Linear(f64[3,3](jax)),
       Translate(
           {...},
           chart=Cart3D(M=Rn(3)),
           semantic_kind=vel
       )
     ))
+
+    The two position offsets cancel exactly here, so the fused `Affine` reduces
+    further to a pure `~coordinax.transforms.Linear`.
 
     """
     if from_frame == to_frame:

--- a/src/coordinax/transforms/__init__.py
+++ b/src/coordinax/transforms/__init__.py
@@ -37,6 +37,7 @@ __all__: tuple[str, ...] = (
     "Composed",
     "Translate",
     "LorentzBoost",
+    "Affine",
     "Linear",
     "Rotate",
     "Reflect",
@@ -54,6 +55,7 @@ with install_import_hook("coordinax.transforms"):
     from ._src.actions import (
         AbstractCompositeTransform,
         AbstractTransform,
+        Affine,
         Boost,
         Composed,
         Identity,

--- a/src/coordinax/transforms/_src/actions/__init__.py
+++ b/src/coordinax/transforms/_src/actions/__init__.py
@@ -1,6 +1,7 @@
 """Coordinax Frame Transformations Package."""
 
 from .add import *
+from .affine import *
 from .base import *
 from .boost import *
 from .builders import *

--- a/src/coordinax/transforms/_src/actions/affine.py
+++ b/src/coordinax/transforms/_src/actions/affine.py
@@ -1,0 +1,395 @@
+"""Affine transform: one kernel for a linear map plus an offset."""
+# ruff: noqa: I001
+
+__all__ = ("Affine",)
+
+
+from typing import Any, TypeAlias, cast, final
+
+import equinox as eqx
+import plum
+from jaxtyping import Array, Shaped
+
+import quaxed.numpy as jnp
+import unxt as u
+from unxt.quantity import AllowValue
+
+import coordinax.charts as cxc
+import coordinax.representations as cxr
+import coordinaxs.api.transforms as cxfmapi
+
+from .base import AbstractTransform
+from .custom_types import CDict, OptUSys
+from .identity import identity
+from .linear import AbstractLinearTransform
+from .utils import is_flat_chart, require_matching_keys
+from coordinax.internal import pack_uniform_unit
+from .translate import Translate
+from coordinax.transforms._src import groups
+
+AMatrix: TypeAlias = Shaped[Array, " N N"]
+
+
+def _apply(matrix: Any, d: CDict, comps: tuple[str, ...], /) -> CDict:
+    """Contract ``matrix`` with a Cartesian cdict, packed into a shared unit.
+
+    `linear.py` has an equivalent, but it routes through the *operator* so a
+    subclass can override the contraction. `Affine` is not one of those
+    operators, and `_merge` applies a matrix belonging to a neighbour, so a
+    plain function is both simpler and correct here.
+    """
+    v, unit = pack_uniform_unit(d, keys=comps)
+    return cast("CDict", cxc.cdict(jnp.einsum("ij,...j->...i", matrix, v), unit, comps))
+
+
+@final
+class Affine(AbstractTransform):
+    r"""Operator for a Cartesian affine map, applied as one kernel.
+
+    An affine transform applies
+
+    $$
+    x \mapsto A x + b,
+    $$
+
+    with $A$ an invertible matrix and $b$ an offset.
+
+    This exists for *composition*, not for expressiveness: a rotation followed
+    by a translation is already sayable as ``R | T``. The point is that a chain
+    of affine operators -- the shape every frame transition takes, e.g.
+    ``Rotate | Translate | Rotate | Translate`` -- collapses into a single
+    `Affine`, so the whole chain costs one chart round-trip, one matrix
+    contraction and one addition, rather than one of each per operator.
+
+    The adjacent-pair peephole cannot do this on its own: in that chain the two
+    `Rotate` operators are not neighbours, so there is no pair to merge.
+
+    Examples
+    --------
+    >>> import quaxed.numpy as jnp
+    >>> import unxt as u
+    >>> import coordinax as cx
+    >>> import coordinax.charts as cxc
+    >>> import coordinax.transforms as cxfm
+
+    An interleaved affine chain collapses to one operator:
+
+    >>> R = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+    >>> T = cxfm.Translate.from_([1.0, 0.0, 0.0], "m")
+    >>> cxfm.simplify(R | T | R | T)
+    Affine(...)
+
+    and it agrees with the chain it replaces:
+
+    >>> p = cx.Point.from_(u.Q(jnp.asarray([1.0, 2.0, 3.0]), "m"), cxc.cart3d)
+    >>> chain, fused = R | T | R | T, cxfm.simplify(R | T | R | T)
+    >>> bool(jnp.allclose(chain(p)["x"].ustrip("m"), fused(p)["x"].ustrip("m")))
+    True
+
+    """
+
+    A: AMatrix
+    """The linear part, acting on the chart's Cartesian components."""
+
+    delta: CDict
+    """The offset $b$, in ``chart``'s Cartesian components."""
+
+    chart: cxc.AbstractChart = eqx.field(static=True)
+    """The Cartesian chart ``delta`` is expressed in (static)."""
+
+    def __init__(self, A: Any, delta: CDict, chart: cxc.AbstractChart) -> None:
+        object.__setattr__(self, "A", jnp.asarray(A))
+        object.__setattr__(self, "delta", delta)
+        object.__setattr__(self, "chart", chart)
+
+    @classmethod
+    def groups(cls) -> frozenset[type]:
+        """Return the groups to which this map belongs."""
+        del cls
+        return frozenset((groups.AffineGroup, groups.DiffeomorphismGroup))
+
+    @property
+    def inverse(self) -> "Affine":
+        r"""Return the inverse affine map, $x \mapsto A^{-1}(x - b)$.
+
+        The offset is carried through the inverse linear part, not merely
+        negated: undoing $Ax + b$ means subtracting $b$ *before* applying
+        $A^{-1}$.
+        """
+        inv = jnp.linalg.inv(self.A)
+        keys = tuple(self.delta)
+        neg = {k: -self.delta[k] for k in keys}
+        return Affine(inv, _apply(inv, neg, keys), self.chart)
+
+
+# ============================================================================
+# act
+
+
+@plum.dispatch
+def act(
+    op: Affine,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+    *,
+    usys: OptUSys = None,
+    **kw: Any,
+) -> CDict:
+    """Redispatch a CDict to the geometry-specific implementation.
+
+    Mirrors the linear base: the geometry, not the representation, decides
+    whether this is a point action or a pushforward.
+    """
+    out = cxfmapi.act(op, tau, x, chart, rep.geom_kind, rep, usys=usys, **kw)
+    return cast("CDict", out)
+
+
+@plum.dispatch
+def act(
+    op: Affine,
+    tau: Any,
+    x: CDict,
+    chart: cxc.AbstractChart,
+    geom: cxr.PointGeometry,
+    rep: cxr.Representation,
+    /,
+    *,
+    usys: OptUSys = None,
+    **kw: Any,
+) -> CDict:
+    """Apply the affine map to a point.
+
+    One kernel: to Cartesian once, contract, add, and back once -- however many
+    operators were fused to build this one.
+    """
+    del tau, geom, rep, kw
+
+    cart = chart.cartesian
+    comps = cart.components
+    p_cart = cxc.pt_map(x, chart, cart, usys=usys)
+    mapped = _apply(op.A, p_cart, comps)
+    shifted = {k: mapped[k] + op.delta[k] for k in comps}
+    return cast("CDict", cxc.pt_map(shifted, cart, chart, usys=usys))
+
+
+# ============================================================================
+# pushforward -- tangent geometry
+
+
+@plum.dispatch
+def pushforward(
+    op: Affine,
+    tau: Any,
+    v: CDict,
+    chart: cxc.AbstractChart,
+    rep: cxr.Representation,
+    /,
+    *,
+    at: CDict | None = None,
+    usys: OptUSys = None,
+) -> CDict:
+    r"""Push a tangent vector through the affine map: $v \mapsto A v$.
+
+    The offset does not appear: the Jacobian of $x \mapsto Ax + b$ is $A$, so
+    a *tangent* sees only the linear part. The offset does still matter on a
+    non-flat chart, because the pulled-back Jacobian must be anchored at the
+    image of the base point -- and that image is $A\,\mathrm{at} + b$, not
+    $A\,\mathrm{at}$. Anchoring at the latter is the mistake this dispatch
+    exists to avoid; delegating to the linear pushforward would make it.
+    """
+    del tau
+    ref = f"do not match the chart's {sorted(chart.components)}"
+    for name, d in (("tangent", v), *(() if at is None else (("base point", at),))):
+        pre = f"pushforward({type(op).__name__}, ...): the {name} components "
+        require_matching_keys(d, chart.components, pre + ref)
+
+    cart = chart.cartesian
+    comps = cart.components
+
+    # Flat chart: the chart Jacobian is the identity, so A acts directly and no
+    # base point is needed -- the offset is irrelevant to a tangent here.
+    if is_flat_chart(chart):
+        return _apply(op.A, v, comps)
+
+    if at is None:
+        msg = (
+            f"pushforward({type(op).__name__}, ..., {rep!r}) on a non-Cartesian "
+            f"chart ({chart!r}) requires 'at' (base point in chart coords) so "
+            "the Jacobian pushforward can be evaluated."
+        )
+        raise TypeError(msg)
+
+    at_cart = cxc.pt_map(at, chart, cart, usys=usys)
+    p_cart = cxr.tangent_map(v, chart, rep, cart, at=at, usys=usys)  # ty: ignore[missing-argument]
+    p_cart_out = _apply(op.A, p_cart, comps)
+    mapped_at = _apply(op.A, at_cart, comps)
+    at_out = {k: mapped_at[k] + op.delta[k] for k in comps}
+    # `ty: ignore` as in `linear.py`: plum's `tangent_map` overload set is not
+    # visible to the checker, which reads the four-positional form as missing
+    # `to_rep`.
+    return cxr.tangent_map(p_cart_out, cart, rep, chart, at=at_out, usys=usys)  # ty: ignore[missing-argument]
+
+
+# ============================================================================
+# simplify
+
+
+@plum.dispatch
+def simplify(op: Affine, /, *, approx: bool = True, **kw: Any) -> AbstractTransform:
+    """Collapse a degenerate affine map back to a simpler operator.
+
+    A zero offset is a pure linear map, and an identity linear part is a pure
+    translation; both checks read values, so both are skipped when
+    ``approx=False``.
+    """
+    from .general_linear import Linear  # noqa: PLC0415  (cycle: Linear -> Affine)
+
+    if not approx:
+        return op
+
+    n = op.A.shape[0]
+    # `ustrip(AllowValue, ...)` accepts a Quantity or a bare array alike, so
+    # there is no need to sniff for `.value` -- the same hand-rolled unwrapping
+    # that was removed from the manifolds code earlier.
+    no_shift = all(
+        bool(jnp.allclose(u.ustrip(AllowValue, u.unit_of(v) or "", v), 0.0, **kw))
+        for v in op.delta.values()
+    )
+    is_eye = bool(jnp.allclose(op.A, jnp.eye(n, dtype=op.A.dtype), **kw))
+
+    if is_eye and no_shift:
+        return identity
+    if no_shift:
+        return simplify(Linear(op.A), approx=approx, **kw)
+    if is_eye:
+        return Translate(op.delta, op.chart)
+    return op
+
+
+# ============================================================================
+# _merge -- absorbing neighbours, which is the whole point
+
+
+def _parts(op: AbstractTransform, /) -> tuple[Any, CDict | None, Any] | None:
+    """Read ``op`` as ``(A, b, chart)``, or `None` if it is not static affine.
+
+    `None` for either part means "identity for that part": a linear operator
+    contributes no offset, a translation no matrix.
+    """
+    if isinstance(op, Affine):
+        return op.A, op.delta, op.chart
+    if isinstance(op, AbstractLinearTransform):
+        return op.matrix, None, None
+    if isinstance(op, Translate):
+        # Only a *position* offset is affine on points. A fibre kick
+        # (`semantic_kind` of order >= 1) acts on the tangent, and a
+        # left-adding one is a different map; neither belongs in `A x + b`.
+        if op.semantic_kind.order != 0 or not op.right_add:
+            return None
+        if op.chart != op.chart.cartesian:
+            return None  # a non-Cartesian offset is not componentwise
+        return None, op.delta, op.chart
+    return None
+
+
+def _fuse(a: AbstractTransform, b: AbstractTransform, /) -> AbstractTransform | None:
+    r"""Fuse two adjacent static affine operators into one `Affine`.
+
+    With ``a`` applied first, $x \mapsto A_b(A_a x + b_a) + b_b$, so the fused
+    parts are $A_b A_a$ and $A_b b_a + b_b$. The offset is pushed *through*
+    the second matrix -- adding the two offsets would be wrong whenever
+    $A_b \neq I$.
+
+    Same-type pairs never reach here: `Rotate | Rotate` and the rest have their
+    own, more specific rules, and plum prefers those.
+    """
+    pa, pb = _parts(a), _parts(b)
+    if pa is None or pb is None:
+        return None
+
+    A_a, b_a, chart_a = pa
+    A_b, b_b, chart_b = pb
+
+    chart = chart_a if chart_a is not None else chart_b
+    if chart is None:  # two pure linear maps: not ours, the linear rule has it
+        return None
+    if chart_a is not None and chart_b is not None and chart_a != chart_b:
+        return None  # offsets in different charts do not add componentwise
+
+    comps = chart.components
+    n = (A_a if A_a is not None else A_b).shape[0]
+    if len(comps) != n:
+        return None
+
+    A = (
+        A_b @ A_a
+        if (A_a is not None and A_b is not None)
+        else (A_a if A_b is None else A_b)
+    )
+
+    # b = A_b @ b_a + b_b
+    shifted = _apply(A_b, b_a, comps) if (b_a is not None and A_b is not None) else b_a
+    if shifted is None:
+        delta = b_b
+    elif b_b is None:
+        delta = shifted
+    else:
+        delta = {k: shifted[k] + b_b[k] for k in comps}
+
+    return Affine(A if A is not None else jnp.eye(n), delta, chart)
+
+
+# Registered as explicit pairs rather than one `Affine | AbstractLinearTransform
+# | Translate` union on both sides. That union overlaps `_merge(AbstractAdd,
+# AbstractAdd)` on a `(Translate, Translate)` call without being narrower than
+# it -- `Translate` is an `AbstractAdd` but `Affine` is not -- so neither
+# signature dominates and every such call raises `AmbiguousLookupError`.
+#
+# `(Translate, Translate)` is deliberately absent: two position offsets already
+# merge into a `Translate`, which is a better answer than an `Affine` with an
+# identity matrix.
+
+
+@plum.dispatch
+def _merge(a: Affine, b: Affine, /) -> AbstractTransform | None:
+    """Fuse two affine maps."""
+    return _fuse(a, b)
+
+
+@plum.dispatch
+def _merge(a: Affine, b: AbstractLinearTransform, /) -> AbstractTransform | None:
+    """Absorb a following linear map."""
+    return _fuse(a, b)
+
+
+@plum.dispatch
+def _merge(a: AbstractLinearTransform, b: Affine, /) -> AbstractTransform | None:
+    """Absorb a preceding linear map."""
+    return _fuse(a, b)
+
+
+@plum.dispatch
+def _merge(a: Affine, b: Translate, /) -> AbstractTransform | None:
+    """Absorb a following translation."""
+    return _fuse(a, b)
+
+
+@plum.dispatch
+def _merge(a: Translate, b: Affine, /) -> AbstractTransform | None:
+    """Absorb a preceding translation."""
+    return _fuse(a, b)
+
+
+@plum.dispatch
+def _merge(a: AbstractLinearTransform, b: Translate, /) -> AbstractTransform | None:
+    """Seed an affine chain: a linear map followed by a translation."""
+    return _fuse(a, b)
+
+
+@plum.dispatch
+def _merge(a: Translate, b: AbstractLinearTransform, /) -> AbstractTransform | None:
+    """Fuse a translation then a linear map; the offset rides through."""
+    return _fuse(a, b)

--- a/src/coordinax/transforms/_src/actions/composed.py
+++ b/src/coordinax/transforms/_src/actions/composed.py
@@ -110,7 +110,18 @@ class Composed(AbstractCompositeTransform, Generic[*Ts]):
     Composed(( Translate(...), Rotate(...), Identity() ))
 
     >>> cxfm.simplify(pipe3)
-    Composed(( Translate(...), Rotate(...) ))
+    Affine(...)
+
+    The identity is gone -- and so is the pipe: a translation followed by a
+    rotation is affine, so `simplify` fuses the pair into a single
+    `~coordinax.transforms.Affine` rather than leaving two kernels to apply.
+    A pair that is *not* static affine stays a `Composed`:
+
+    >>> import coordinax.representations as cxr
+    >>> from dataclassish import replace
+    >>> kick = replace(shift, semantic_kind=cxr.vel)
+    >>> cxfm.simplify(rotate | kick)
+    Composed(( Rotate(...), Translate(...) ))
 
     """
 

--- a/tests/unit/transforms/test_affine.py
+++ b/tests/unit/transforms/test_affine.py
@@ -1,0 +1,141 @@
+"""`Affine` collapses an interleaved affine chain into one kernel (#546)."""
+
+__all__: tuple[str, ...] = ()
+
+import jax
+import numpy as np
+import pytest
+
+import quaxed.numpy as jnp
+import unxt as u
+from dataclassish import replace
+
+import coordinax as cx
+import coordinax.charts as cxc
+import coordinax.representations as cxr
+import coordinax.transforms as cxfm
+
+_ROT = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+_SHIFT = cxfm.Translate.from_([1.0, 0.0, 0.0], "m")
+_SCALE = cxfm.Scale.from_factors(jnp.asarray([2.0, 2.0, 2.0]))
+_FLIP = cxfm.Reflect.from_normal([1.0, 0.0, 0.0])
+
+
+def _point(xyz=(1.0, 2.0, 3.0)):
+    return cx.Point.from_(u.Q(jnp.asarray(xyz), "m"), cxc.cart3d)
+
+
+def _xyz(p):
+    return np.asarray([float(u.ustrip("m", p[k])) for k in ("x", "y", "z")])
+
+
+CHAINS = {
+    "linear-then-shift": _ROT | _SHIFT,
+    "shift-then-linear": _SHIFT | _ROT,
+    "interleaved": _ROT | _SHIFT | _ROT | _SHIFT,
+    "mixed-types": _SHIFT | _ROT | _FLIP | _SHIFT | _SCALE,
+}
+
+
+class TestAffineCollapse:
+    """A maximal run of static affine operators fuses into one `Affine`."""
+
+    @pytest.mark.parametrize("chain", CHAINS.values(), ids=CHAINS.keys())
+    def test_it_collapses_to_a_single_affine(self, chain):
+        """Including chains no adjacent-pair rule can reach.
+
+        In `Rotate | Translate | Rotate | Translate` no two `Rotate`s are
+        neighbours, which is exactly why the Level 1 peephole leaves it alone.
+        """
+        assert isinstance(cxfm.simplify(chain), cxfm.Affine)
+
+    @pytest.mark.parametrize("chain", CHAINS.values(), ids=CHAINS.keys())
+    def test_the_fused_operator_agrees_with_the_chain(self, chain):
+        """Behaviour-preserving: the whole point of a *simplification*."""
+        p = _point()
+        np.testing.assert_allclose(
+            _xyz(cxfm.simplify(chain)(p)), _xyz(chain(p)), atol=1e-5
+        )
+
+    def test_the_offset_rides_through_the_matrix(self):
+        """`T | R` is not `R` with the same offset -- order matters.
+
+        Composing (I, b) then (A, 0) gives `A x + A b`, not `A x + b`. A fused
+        operator that merely carried `b` across would agree with the chain only
+        when `A` is the identity.
+        """
+        fused = cxfm.simplify(_SHIFT | _ROT)
+        naive = cxfm.Affine(_ROT.matrix, _SHIFT.delta, cxc.cart3d)
+        p = _point()
+        np.testing.assert_allclose(_xyz(fused(p)), _xyz((_SHIFT | _ROT)(p)), atol=1e-5)
+        assert not np.allclose(_xyz(fused(p)), _xyz(naive(p)), atol=1e-5)
+
+    def test_inverse_round_trips(self):
+        p = _point()
+        fused = cxfm.simplify(CHAINS["interleaved"])
+        np.testing.assert_allclose(_xyz(fused.inverse(fused(p))), _xyz(p), atol=1e-5)
+
+    def test_it_reports_the_affine_group(self):
+        fused = cxfm.simplify(CHAINS["interleaved"])
+        assert cxfm.groups.AffineGroup in fused.groups()
+
+
+class TestAffineIsTraceSafe:
+    """`simplify` keeps the contract #539 established."""
+
+    def test_it_still_fuses_without_approx(self):
+        """The fusion is structural, so `approx=False` does not disable it."""
+        assert isinstance(
+            cxfm.simplify(CHAINS["interleaved"], approx=False), cxfm.Affine
+        )
+
+    def test_it_traces(self):
+        fused = cxfm.simplify(CHAINS["interleaved"], approx=False)
+        got = jax.jit(lambda q: fused(q))(_point())
+        np.testing.assert_allclose(_xyz(got), _xyz(fused(_point())), atol=1e-5)
+
+
+class TestAffineRefusesWhatIsNotStaticAffine:
+    """Each of these would be a *wrong* fusion, so the pair must not merge."""
+
+    def test_a_fibre_offset_is_refused(self):
+        """`semantic_kind=vel` shifts the tangent, not the point."""
+        kick = replace(_SHIFT, semantic_kind=cxr.vel)
+        assert not isinstance(cxfm.simplify(_ROT | kick), cxfm.Affine)
+
+    def test_a_left_adding_offset_is_refused(self):
+        assert not isinstance(
+            cxfm.simplify(_ROT | replace(_SHIFT, right_add=False)), cxfm.Affine
+        )
+
+    def test_a_non_cartesian_offset_is_refused(self):
+        """`x + b` is componentwise only in Cartesian components."""
+        sph = cxfm.Translate(
+            {"r": u.Q(1.0, "m"), "theta": u.Q(0.0, "rad"), "phi": u.Q(0.0, "rad")},
+            cxc.sph3d,
+        )
+        assert not isinstance(cxfm.simplify(_ROT | sph), cxfm.Affine)
+
+    def test_a_time_dependent_boost_is_refused(self):
+        """A `Boost`'s offset grows with tau, so no *static* pair holds it."""
+        boost = cxfm.Boost(
+            {"x": u.Q(1.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")},
+            cxc.cart3d,
+        )
+        assert not isinstance(cxfm.simplify(_ROT | boost), cxfm.Affine)
+
+
+class TestLevelOneStillWins:
+    """Same-type pairs keep their better answers; `Affine` is the fallback."""
+
+    @pytest.mark.parametrize(
+        ("chain", "want"),
+        [
+            (_ROT | _ROT, cxfm.Rotate),
+            (_SCALE | _SCALE, cxfm.Scale),
+            (_SHIFT | _SHIFT, cxfm.Translate),
+        ],
+        ids=["rotate", "scale", "translate"],
+    )
+    def test_same_type_pairs_do_not_become_affine(self, chain, want):
+        assert isinstance(cxfm.simplify(chain), want)

--- a/tests/unit/transforms/test_simplify.py
+++ b/tests/unit/transforms/test_simplify.py
@@ -72,12 +72,18 @@ def test_identity_strip_re_exposes_adjacency() -> None:
 
 
 def test_non_mergeable_pair_is_preserved() -> None:
+    """A pair with no combining rule survives `simplify` untouched.
+
+    `Rotate | Translate` used to be the example here, but that pair is static
+    affine and now fuses into an `Affine` (#546). A fibre kick does not: it
+    shifts the tangent, not the point, so there is no `A x + b` to fuse it into.
+    """
     R = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
-    T = cxfm.Translate.from_([1, 0, 0], "km")
-    out = cxfm.simplify(cxfm.Composed((R, T)))
+    kick = replace(cxfm.Translate.from_([1, 0, 0], "km"), semantic_kind=cxr.vel)
+    out = cxfm.simplify(cxfm.Composed((R, kick)))
     assert isinstance(out, cxfm.Composed)
     assert len(out.transforms) == 2
-    _acts_equal(out, cxfm.Composed((R, T)))
+    _acts_equal(out, cxfm.Composed((R, kick)))
 
 
 def test_different_semantic_kind_translates_do_not_merge() -> None:


### PR DESCRIPTION
Closes #546 — the Level 2 half deferred from #539 (which I closed as complete: its Level 1
peephole landed across #727/#728/#730/#731).

## The problem

A frame transition is `Rotate | Translate | Rotate | Translate`. The adjacent-pair
peephole cannot touch it — **no two `Rotate`s are neighbours**, so there is no pair to
merge — and the chain stays four kernel applications.

`Affine` holds `x ↦ A x + b` and fuses with its neighbours on either side, so the
*existing* left-to-right merge pass in `simplify(Composed)` collapses the whole run. No
second pass was needed.

## Composition, and the mistake it would be easy to make

With `a` applied first, `x ↦ A_b(A_a x + b_a) + b_b`, so the fused parts are
`(A_b A_a, A_b b_a + b_b)`. The offset is pushed **through** the second matrix. Simply
adding the two offsets agrees with the chain only when `A_b = I`, so there is a test that
pins the fused operator against a deliberately naive alternative and asserts they differ.

The tangent pushforward is its own dispatch rather than a delegation to the linear one.
A tangent sees only `A` — but on a non-flat chart the pulled-back Jacobian must be
anchored at the *image* of the base point, which is `A·at + b`, not `A·at`. Delegating
would have anchored it wrong. I did not spot that by reasoning; the `coordinaxs.astro`
phase-space tests failed and led me to it.

## What it refuses, and why that is the interesting part

These are refused because fusing them would be **wrong**, not merely unsupported:

| refused | reason |
| --- | --- |
| `semantic_kind` order ≥ 1 | a fibre kick shifts the tangent, not the point |
| `right_add=False` | a different map |
| non-Cartesian offset | `x + b` is componentwise only in Cartesian components |
| `Boost` | time-dependent: its offset grows with τ |

That last one **contradicts this issue's own acceptance criteria**, which list `Boost`
among the types to collapse. The proposal text says "static `AffineGroup` operators", and
a `Boost` is not static — `is_time_dependent` is `True`. Holding it would need a
τ-dependent offset, which is a different feature.

Same-type pairs are untouched: `Rotate | Rotate` is still a `Rotate`, not an `Affine`.

## Benchmarks (acceptance criterion 2)

4-op chain vs the fused operator, under `jit`:

| batch | chain | fused | speedup |
| ---: | ---: | ---: | ---: |
| 1 | 51.6 µs | 38.0 µs | 1.36× |
| 10 000 | 262.3 µs | 176.5 µs | 1.49× |
| 200 000 | 3214.1 µs | 1619.1 µs | 1.99× |

## One dispatch trap worth recording

The seven merge rules are registered as **explicit pairs**, not one
`Affine | AbstractLinearTransform | Translate` union on both sides. That union overlaps
`_merge(AbstractAdd, AbstractAdd)` on a `(Translate, Translate)` call without being
narrower than it — `Translate` is an `AbstractAdd`, `Affine` is not — so neither
signature dominates and every such call raised `AmbiguousLookupError`. Exactly the shape
that broke dispatch in GalacticDynamics/unxt#902. Recorded in a comment so it is not
reintroduced.

## Behaviour changes to review

`Rotate | Translate` used to stay a `Composed`. It now fuses, which updates one test and
three doctests — including the `coordinaxs.astro` frame-transition examples, where a
7-operator chain now prints as 3 (the two velocity kicks correctly stay outside the
`Affine`). In float64 one of those examples collapses further to a `Linear`, because the
two position offsets cancel exactly.

Full suite: **10796 passed**, 8 skipped, 1 xfailed. `ty` back to 6 diagnostics, same as
`main`.
