### PR TITLE
✅ test(curveframes): the frame velocity comes from the curve

### DIFF
--- a/packages/coordinaxs.curveframes/docs/curve-charts.md
+++ b/packages/coordinaxs.curveframes/docs/curve-charts.md
@@ -253,6 +253,8 @@ Q([1.5, 0. , 0. ], 'km')
 
 `AtTime(curve, t)` binds the evaluation time of a two-argument curve, turning it into a one-argument one; it is what makes `ArcLength`'s otherwise-two-argument result callable with `s` alone above. Where `AtTime` sits relative to `ArcLength` changes what is being asked: `ArcLength(AtTime(curve, t))` binds `t` first, so `ArcLength` sees a one-argument curve and freezes arc length to that one slice permanently — there is no Eulerian/Lagrangian distinction left to make. `AtTime(ArcLength(curve), t)`, used above, keeps `ArcLength` two-argument and only fixes which slice a given call reads; a later call with a different `t` re-measures on that slice instead.
 
+Which of the two readings a frame is built on is not a setting on the chart or the builder. The velocity of the frame origin at label $s$ is $\partial\gamma/\partial t$ at fixed $s$, taken on whatever curve the builder was handed: a bare $\gamma(\sigma, t)$ gives the velocity of the material point $\sigma$; `ArcLength` adds the advection term that holds the label at fixed arc length; `LagrangianArcLength` removes it again. The parametrisation supplies the reading, and nothing downstream overrides it.
+
 ### Four Curve Shapes
 
 A curve is not always handed to `ArcLength` to be reparametrised — it can also arrive already arc-length parametrised, in one of a few shapes. This section walks through each.

--- a/packages/coordinaxs.curveframes/tests/unit/test_frame_velocity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_frame_velocity.py
@@ -1,0 +1,65 @@
+r"""The frame velocity comes from the curve, and only from the curve.
+
+A time-dependent curve frame's connection is $\partial\gamma/\partial t$ at
+fixed first argument. Nothing in the library selects the Eulerian or the
+Lagrangian reading; the parametrisation the caller hands in already fixes it,
+and these tests pin that the library never overrides it.
+"""
+
+import jax
+import jax.numpy as jnp
+
+import unxt as u
+
+import coordinaxs.curveframes as cxfc
+
+S0 = 1.3
+T0 = 1.0
+
+
+def stretch_and_bend(
+    sigma: u.AbstractQuantity, t: u.AbstractQuantity
+) -> u.AbstractQuantity:
+    """gamma(sigma, t) = (sigma (1 + t/2), t sigma^2 / 10, 0).
+
+    `sigma` is a *material* label: it names the same piece of the curve on
+    every slice. The curve both stretches and bends, so arc length is not a
+    reparametrisation-invariant relabelling of it.
+    """
+    sv, tv = sigma.ustrip("km"), t.ustrip("s")
+    x = sv * (1.0 + 0.5 * tv)
+    y = 0.1 * tv * sv**2
+    return u.Q(jnp.stack([x, y, jnp.zeros_like(x)]), "km")
+
+
+#: d/dt of `stretch_and_bend` at fixed `sigma`, in km/s.
+MATERIAL_VELOCITY = jnp.array([0.5 * S0, 0.1 * S0**2, 0.0])
+
+
+def dt_at_fixed_label(curve, label: float, t: float) -> jax.Array:
+    """d(curve)/dt holding the first argument fixed -- whatever it labels."""
+
+    def f(tv: float) -> jax.Array:
+        return curve(u.Q(label, "km"), u.Q(tv, "s")).ustrip("km")
+
+    return jax.jacfwd(f)(t)
+
+
+def test_plain_curve_is_material() -> None:
+    """An unwrapped curve's first argument is whatever the caller made it."""
+    got = dt_at_fixed_label(stretch_and_bend, S0, T0)
+    assert jnp.allclose(got, MATERIAL_VELOCITY)
+
+
+def test_arclength_is_eulerian() -> None:
+    """Wrapping in `ArcLength` re-measures per slice, so the label advects."""
+    arc = cxfc.ArcLength(stretch_and_bend, "km")
+    got = dt_at_fixed_label(arc, S0, T0)
+    assert not jnp.allclose(got, MATERIAL_VELOCITY)
+
+
+def test_lagrangian_arclength_restores_the_material_velocity() -> None:
+    """`LagrangianArcLength`'s label names a material point, so it does not."""
+    lag = cxfc.LagrangianArcLength(stretch_and_bend, u.Q(0.0, "s"), "km")
+    got = dt_at_fixed_label(lag, S0, T0)
+    assert jnp.allclose(got, MATERIAL_VELOCITY, atol=1e-6)

--- a/packages/coordinaxs.curveframes/tests/unit/test_frame_velocity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_frame_velocity.py
@@ -8,6 +8,7 @@ and these tests pin that the library never overrides it.
 
 import jax
 import jax.numpy as jnp
+import pytest
 
 import unxt as u
 
@@ -52,10 +53,18 @@ def test_plain_curve_is_material() -> None:
 
 
 def test_arclength_is_eulerian() -> None:
-    """Wrapping in `ArcLength` re-measures per slice, so the label advects."""
+    """Wrapping in `ArcLength` re-measures per slice, so the label advects.
+
+    Asserted as the size of the departure rather than as `not allclose`: a NaN
+    compares False against everything, so the negative form alone would pass
+    on an all-NaN result -- the exact failure mode the guards in this package
+    exist to prevent.
+    """
     arc = cxfc.ArcLength(stretch_and_bend, "km")
     got = dt_at_fixed_label(arc, S0, T0)
-    assert not jnp.allclose(got, MATERIAL_VELOCITY)
+    assert jnp.isfinite(got).all()
+    advection = float(jnp.linalg.norm(got - MATERIAL_VELOCITY))
+    assert advection == pytest.approx(0.6677, abs=1e-3)
 
 
 def test_lagrangian_arclength_restores_the_material_velocity() -> None:


### PR DESCRIPTION
A time-dependent curve frame's origin at label `s` moves at $\partial\gamma/\partial t$ holding the first argument fixed. Which reading that is — Eulerian or Lagrangian — follows entirely from the curve the caller hands in. No setting on the chart or the builder selects it, and none should: the curve already carries the answer.

Measured on one curve that both stretches and bends, $\gamma(\sigma, t) = (\sigma(1+t/2),\ t\sigma^2/10,\ 0)$, at $\sigma = 1.3\,\mathrm{km}$, $t = 1\,\mathrm{s}$:

| curve handed to the frame | $\partial\gamma/\partial t$ at fixed label | reading |
| --- | --- | --- |
| bare `gamma(sigma, t)` | `[0.65, 0.169, 0]` — the closed-form material velocity | Lagrangian |
| `ArcLength(gamma)` | `[-0.0019, 0.0247, 0]` | Eulerian |
| `LagrangianArcLength(gamma, t0)` | `[0.65, 0.169, 0]` | Lagrangian |

Nothing pinned this. A reparametrisation added inside a chart — the kind of thing a "sensible default" looks like while building the bundle chart — would have broken no test and no doctest. Three assertions now cover the three rows; each was mutation-checked to fail when its own row is broken.

The docs change states the consequence in the section that already explains the distinction, which stopped short of saying what it means for a frame built on the curve.

No source changes: the behaviour is already correct. The interface constraint this implies for the Layer 4 bundle chart is recorded in #779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)