### PR TITLE
✨ feat(transforms): `at_jet` removes the order ceiling on tangent `act`

### DIFF
--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -492,6 +492,7 @@ def act(
     *,
     at: CDict | None = None,
     at_vel: CDict | None = None,
+    at_jet: dict[int, CDict] | None = None,
     usys: Any = None,
     **kw: Any,
 ) -> CDict:
@@ -533,7 +534,17 @@ def act(
         return cast(
             "CDict",
             _generic_tangent_act()(
-                op, tau, x, chart, geom, rep, at=at, at_vel=at_vel, usys=usys, **kw
+                op,
+                tau,
+                x,
+                chart,
+                geom,
+                rep,
+                at=at,
+                at_vel=at_vel,
+                at_jet=at_jet,
+                usys=usys,
+                **kw,
             ),
         )
 
@@ -549,7 +560,7 @@ def act(
         # second materialization is a whole ODE solve for a curve-frame
         # builder, so assemble the jet with the engine's own validator and
         # call the engine's jet function directly.
-        jet = _slot_jet(op, tau, x, m, at=at, at_vel=at_vel)
+        jet = _slot_jet(op, tau, x, m, at=at, at_vel=at_vel, at_jet=at_jet)
         return prolong_jet(op, tau, jet, chart, usys=usys)[m]
 
     return _ladder_act(op, op0, k, tau, m, x, chart, rep, at=at, usys=usys, **kw)

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -563,6 +563,11 @@ def act(
         jet = _slot_jet(op, tau, x, m, at=at, at_vel=at_vel, at_jet=at_jet)
         return prolong_jet(op, tau, jet, chart, usys=usys)[m]
 
+    # The ladder needs only the base point, but it has to accept it in either
+    # spelling: `at_jet` is the general anchor form, so a caller who passes
+    # `at_jet={0: at}` and omits `at=` must not hit a downstream "pass 'at'".
+    if at is None and at_jet is not None:
+        at = at_jet.get(0)
     return _ladder_act(op, op0, k, tau, m, x, chart, rep, at=at, usys=usys, **kw)
 
 

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -27,6 +27,7 @@ from .composite import AbstractCompositeTransform
 from .custom_types import CDict
 from .identity import Identity, identity
 from .prolong import (
+    _MSG_AT_JET_CONFLICT,
     _MSG_JET_SLOT0_MISSING,
     _slot_jet,
     prolong_jet,
@@ -566,8 +567,14 @@ def act(
     # The ladder needs only the base point, but it has to accept it in either
     # spelling: `at_jet` is the general anchor form, so a caller who passes
     # `at_jet={0: at}` and omits `at=` must not hit a downstream "pass 'at'".
-    if at is None and at_jet is not None:
-        at = at_jet.get(0)
+    # Given both, raise rather than pick one -- silently preferring `at=` would
+    # hide a wrong anchor, and the generic path already refuses the same way.
+    if at_jet is not None and 0 in at_jet:
+        if at is not None:
+            raise TypeError(
+                _MSG_AT_JET_CONFLICT.format(op=type(op).__name__, k=0, alias="at")
+            )
+        at = at_jet[0]
     return _ladder_act(op, op0, k, tau, m, x, chart, rep, at=at, usys=usys, **kw)
 
 

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -88,6 +88,16 @@ _MSG_AT_VEL_REQUIRED = (
     "transform requires the lower-order jet slots; pass 'at_vel' (the "
     "velocity at the base point) or use a coordinax.Coordinate bundle."
 )
+_MSG_AT_JET_REQUIRED = (
+    "act({op}, ...) on order-{m} tangent data requires jet slots 0..{last}; "
+    "slot(s) {missing} are missing. Pass them as 'at_jet' (a dict keyed by "
+    "slot order), or use a coordinax.Coordinate bundle. 'at' and 'at_vel' are "
+    "shorthand for slots 0 and 1 and cannot reach higher slots."
+)
+_MSG_AT_JET_CONFLICT = (
+    "act({op}, ...): jet slot {k} was given twice, once as {alias!r} and once "
+    "in 'at_jet'. Pass it one way only."
+)
 _MSG_JET_SLOT_MISSING = (
     "act_jet({op}, ...) requires all jet slots 1..{m}; slot {k} is missing."
 )
@@ -618,6 +628,7 @@ def act(
     *,
     at: CDict | None = None,
     at_vel: CDict | None = None,
+    at_jet: JetDict | None = None,
     usys: OptUSys = None,
     **kw: Any,
 ) -> CDict:
@@ -661,7 +672,9 @@ def act(
             "CDict", cxfmapi.pushforward(op, tau, x, chart, rep, at=at, usys=usys)
         )
 
-    return prolong_slot(op, tau, x, chart, m, at=at, at_vel=at_vel, usys=usys)
+    return prolong_slot(
+        op, tau, x, chart, m, at=at, at_vel=at_vel, at_jet=at_jet, usys=usys
+    )
 
 
 def _slot_jet(
@@ -673,6 +686,7 @@ def _slot_jet(
     *,
     at: CDict | None,
     at_vel: CDict | None,
+    at_jet: JetDict | None = None,
 ) -> JetDict:
     """Validate the lower jet slots and assemble the jet for an order-``m`` slot.
 
@@ -683,20 +697,35 @@ def _slot_jet(
     """
     if tau is None:
         raise TypeError(_MSG_TAU_REQUIRED.format(op=type(op).__name__))
-    if at is None:
-        raise TypeError(_MSG_AT_REQUIRED.format(verb="act", op=type(op).__name__, m=m))
 
-    jet: JetDict = {0: at, m: x}
-    if m >= 2:
-        if at_vel is None:
-            raise TypeError(_MSG_AT_VEL_REQUIRED.format(op=type(op).__name__, m=m))
-        jet[1] = at_vel
-    if m > 2:
-        msg = (
-            f"act on order-{m} tangent data requires jet slots 1..{m - 1}; "
-            "use coordinax.transforms.act_jet with a full jet instead."
+    # `at`/`at_vel` are sugar for slots 0 and 1; `at_jet` is the general form,
+    # and the only way to reach slots >= 2. Missing-slot checks come *after*
+    # the merge, so supplying slot 0 through `at_jet` alone is enough.
+    slots: JetDict = dict(at_jet or {})
+    for k, (alias, value) in enumerate((("at", at), ("at_vel", at_vel))):
+        if value is None:
+            continue
+        if k in slots:
+            raise TypeError(
+                _MSG_AT_JET_CONFLICT.format(op=type(op).__name__, k=k, alias=alias)
+            )
+        slots[k] = value
+
+    if 0 not in slots:
+        raise TypeError(_MSG_AT_REQUIRED.format(verb="act", op=type(op).__name__, m=m))
+    if m >= 2 and 1 not in slots:
+        raise TypeError(_MSG_AT_VEL_REQUIRED.format(op=type(op).__name__, m=m))
+
+    missing = [k for k in range(1, m) if k not in slots]
+    if missing:
+        raise TypeError(
+            _MSG_AT_JET_REQUIRED.format(
+                op=type(op).__name__, m=m, last=m - 1, missing=missing
+            )
         )
-        raise TypeError(msg)
+
+    jet: JetDict = {k: slots[k] for k in range(m)}
+    jet[m] = x
     return jet
 
 
@@ -711,6 +740,7 @@ def prolong_slot(
     at: CDict | None,
     at_vel: CDict | None,
     usys: OptUSys,
+    at_jet: JetDict | None = None,
 ) -> CDict:
     """Apply the m-th prolongation to a single order-``m`` slot.
 
@@ -719,7 +749,7 @@ def prolong_slot(
     returns the transformed slot. Shared by the generic tangent rule and by
     operator fast paths that fall back to the generic prolongation.
     """
-    jet = _slot_jet(op, tau, x, m, at=at, at_vel=at_vel)
+    jet = _slot_jet(op, tau, x, m, at=at, at_vel=at_vel, at_jet=at_jet)
     out = cast("JetDict", cxfmapi.act_jet(op, tau, jet, chart, usys=usys))
     return out[m]
 

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -651,8 +651,12 @@ def act(
     - Order-0 (displacement) data and all data under time-independent
       transforms transform by the frozen-$\tau$ ``pushforward``.
     - Under a time-dependent transform, order-$m$ data ($m \geq 1$) transforms
-      by the $m$-th prolongation, which requires the lower jet slots: the base
-      point ``at`` and, for $m = 2$, the velocity ``at_vel``.
+      by the $m$-th prolongation, which requires jet slots $0 \ldots m-1$.
+
+    Supply those slots with ``at_jet``, a dict keyed by slot order. ``at`` and
+    ``at_vel`` are shorthand for slots 0 and 1 and cover $m \leq 2$; beyond
+    that -- an order-3 kind needs slot 2 -- ``at_jet`` is the only spelling
+    that reaches. Giving one slot both ways raises rather than picking one.
 
     Examples
     --------

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -730,9 +730,9 @@ def _slot_jet(
         slots[k] = value
 
     if 0 not in slots:
-        raise TypeError(_MSG_AT_REQUIRED.format(verb="act", op=type(op).__name__, m=m))
+        raise TypeError(_MSG_SLOT0_REQUIRED.format(op=type(op).__name__, m=m))
     if m >= 2 and 1 not in slots:
-        raise TypeError(_MSG_AT_VEL_REQUIRED.format(op=type(op).__name__, m=m))
+        raise TypeError(_MSG_SLOT1_REQUIRED.format(op=type(op).__name__, m=m))
 
     missing = [k for k in range(1, m) if k not in slots]
     if missing:

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -88,6 +88,20 @@ _MSG_AT_VEL_REQUIRED = (
     "transform requires the lower-order jet slots; pass 'at_vel' (the "
     "velocity at the base point) or use a coordinax.Coordinate bundle."
 )
+# Distinct from `_MSG_AT_REQUIRED` / `_MSG_AT_VEL_REQUIRED`: those are shared
+# with `pushforward` and `tangent_map`, which take no `at_jet`, so naming it
+# there would send the reader after a keyword that does not exist.
+_MSG_SLOT0_REQUIRED = (
+    "act({op}, ...) on order-{m} tangent data requires the base point: pass it "
+    "as 'at' (a CDict in the same chart) or as slot 0 of 'at_jet', or use a "
+    "coordinax.Coordinate bundle which supplies it automatically."
+)
+_MSG_SLOT1_REQUIRED = (
+    "act({op}, ...) on order-{m} tangent data with a time-dependent transform "
+    "requires the lower-order jet slots; pass the velocity at the base point "
+    "as 'at_vel' or as slot 1 of 'at_jet', or use a coordinax.Coordinate "
+    "bundle."
+)
 _MSG_AT_JET_REQUIRED = (
     "act({op}, ...) on order-{m} tangent data requires jet slots 0..{last}; "
     "slot(s) {missing} are missing. Pass them as 'at_jet' (a dict keyed by "

--- a/tests/unit/transforms/test_jet_order_ceiling.py
+++ b/tests/unit/transforms/test_jet_order_ceiling.py
@@ -13,6 +13,7 @@ import dataclasses
 
 import pytest
 
+import quaxed.numpy as jnp
 import unxt as u
 
 import coordinax.charts as cxc
@@ -69,10 +70,35 @@ _SLOTS = {
 
 
 def test_order_three_transforms_through_act() -> None:
-    """The ceiling is gone: no `act_jet` detour required."""
+    """The ceiling is gone: no `act_jet` detour required.
+
+    The offset is linear in tau, so its third derivative is zero and the jerk
+    comes back unchanged. That alone would also pass if the machinery quietly
+    did nothing, which is what the cubic case below is for.
+    """
     out = cxfm.act(_OP, _TAU, _DATA, cxc.cart3d, _JERK_REP, at_jet=_SLOTS)
     assert set(out) == {"x", "y", "z"}
-    assert u.unit_of(out["x"]).is_equivalent(u.unit("km/s3"))
+    for k in ("x", "y", "z"):
+        assert jnp.allclose(u.ustrip("km/s3", out[k]), 1.0, atol=1e-6)
+
+
+def test_order_three_picks_up_the_third_derivative() -> None:
+    r"""The value check: an order-3 slot gains $d^3\delta/d\tau^3$.
+
+    With $\delta_x = \tau^3\,\mathrm{km/s^3}$ the third derivative is
+    $6\,\mathrm{km/s^3}$, so `x` goes 1 -> 7 while the untouched axes stay at
+    1. A path that ran but dropped the derivative would return 1 everywhere.
+    """
+    cubic = cxfm.TimeDep.from_(
+        lambda tau: cxfm.Translate(
+            {"x": u.Q(1.0, "km/s3") * tau**3, "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")},
+            cxc.cart3d,
+        )
+    )
+    out = cxfm.act(cubic, _TAU, _DATA, cxc.cart3d, _JERK_REP, at_jet=_SLOTS)
+    assert jnp.allclose(u.ustrip("km/s3", out["x"]), 7.0, atol=1e-6)
+    for k in ("y", "z"):
+        assert jnp.allclose(u.ustrip("km/s3", out[k]), 1.0, atol=1e-6)
 
 
 def test_a_missing_middle_slot_says_which_one() -> None:

--- a/tests/unit/transforms/test_jet_order_ceiling.py
+++ b/tests/unit/transforms/test_jet_order_ceiling.py
@@ -135,3 +135,33 @@ def test_giving_a_slot_twice_is_refused() -> None:
     """Silently preferring one would be a wrong anchor, not a convenience."""
     with pytest.raises(TypeError, match="given twice"):
         cxfm.act(_OP, _TAU, _DATA, cxc.cart3d, _JERK_REP, at=_SLOTS[0], at_jet=_SLOTS)
+
+
+def test_the_fibre_ladder_path_takes_at_jet_too() -> None:
+    """`at_jet` is the general anchor form, so every path must accept it.
+
+    A `TimeDep` holding a fibre offset routes through the ladder rule rather
+    than the generic prolongation, and that rule read only `at=`. A caller
+    passing the base point as slot 0 of `at_jet` hit a downstream "pass 'at'".
+    """
+    op = cxfm.TimeDep.from_(
+        lambda tau: cxfm.Translate(
+            {
+                "x": u.Q(1.0, "km/s") * (tau / u.Q(1.0, "s")),
+                "y": u.Q(0.0, "km/s"),
+                "z": u.Q(0.0, "km/s"),
+            },
+            cxc.cart3d,
+            semantic_kind=cxr.vel,
+        )
+    )
+    rep = cxr.Representation(cxr.tangent_geom, cxr.coord_basis, cxr.vel)
+    data = {k: u.Q(1.0, "km/s") for k in ("x", "y", "z")}
+    at = {k: u.Q(1.0, "km") for k in ("x", "y", "z")}
+
+    via_at = cxfm.act(op, _TAU, data, cxc.cart3d, rep, at=at)
+    via_jet = cxfm.act(op, _TAU, data, cxc.cart3d, rep, at_jet={0: at})
+    for k in ("x", "y", "z"):
+        assert jnp.allclose(u.ustrip("km/s", via_at[k]), u.ustrip("km/s", via_jet[k]))
+    # and the ladder actually did something: 1 km/s + the offset's 1 km/s
+    assert jnp.allclose(u.ustrip("km/s", via_jet["x"]), 2.0, atol=1e-6)

--- a/tests/unit/transforms/test_jet_order_ceiling.py
+++ b/tests/unit/transforms/test_jet_order_ceiling.py
@@ -1,0 +1,111 @@
+"""`act` on tangent data has no order ceiling any more (#536).
+
+`act` used to assemble the jet it needs from the `at`/`at_vel` keywords alone,
+which reach jet slots 0 and 1 and no further. Order-3 data needs slot 2 as well,
+so it hard-failed with "use act_jet with a full jet instead" -- the API
+admitting the ladder did not scale. `at_jet` is the general form; `at` and
+`at_vel` are now sugar for its first two slots.
+"""
+
+__all__: tuple[str, ...] = ()
+
+import dataclasses
+
+import pytest
+
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.representations as cxr
+import coordinax.transforms as cxfm
+from coordinax.representations._src.semantics import (
+    _TANGENT_TIME_ORDER_LADDER as _LADDER,
+    AbstractTangentSemanticKind,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _jerk_kind():
+    """Register an order-3 kind for this module only, then unregister it.
+
+    Defining the class registers it in the module-level time-order ladder, and
+    that ladder is global: other tests assert it holds exactly the three kinds
+    the library ships. Leaving order 3 behind broke five of them, so the entry
+    is removed again on the way out.
+    """
+    import jax.tree_util as jtu
+
+    @jtu.register_static
+    @dataclasses.dataclass(frozen=True, slots=True, repr=False)
+    class Jerk(AbstractTangentSemanticKind):
+        """An order-3 kind, defined purely to exercise the ladder."""
+
+        order = 3
+
+    global _JERK_REP  # noqa: PLW0603
+    _JERK_REP = cxr.Representation(cxr.tangent_geom, cxr.coord_basis, Jerk())
+    yield
+    _LADDER.pop(3, None)
+    _JERK_REP = None
+
+
+_JERK_REP = None
+
+# Time-dependent, so the *prolongation* path runs rather than the frozen-tau
+# pushforward -- the prolongation is what needed the lower slots.
+_OP = cxfm.TimeDep.from_(
+    lambda tau: cxfm.Translate(
+        {"x": u.Q(1.0, "km/s") * tau, "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")},
+        cxc.cart3d,
+    )
+)
+_TAU = u.Q(1.0, "s")
+_DATA = {k: u.Q(1.0, "km/s3") for k in ("x", "y", "z")}
+_SLOTS = {
+    0: {k: u.Q(0.0, "km") for k in ("x", "y", "z")},
+    1: {k: u.Q(0.0, "km/s") for k in ("x", "y", "z")},
+    2: {k: u.Q(0.0, "km/s2") for k in ("x", "y", "z")},
+}
+
+
+def test_order_three_transforms_through_act() -> None:
+    """The ceiling is gone: no `act_jet` detour required."""
+    out = cxfm.act(_OP, _TAU, _DATA, cxc.cart3d, _JERK_REP, at_jet=_SLOTS)
+    assert set(out) == {"x", "y", "z"}
+    assert u.unit_of(out["x"]).is_equivalent(u.unit("km/s3"))
+
+
+def test_a_missing_middle_slot_says_which_one() -> None:
+    """`at`/`at_vel` cannot reach slot 2, and the error says so."""
+    with pytest.raises(TypeError, match=r"slot\(s\) \[2\] are missing"):
+        cxfm.act(
+            _OP, _TAU, _DATA, cxc.cart3d, _JERK_REP, at=_SLOTS[0], at_vel=_SLOTS[1]
+        )
+
+
+def test_the_sugar_still_reaches_slots_zero_and_one() -> None:
+    """Order-2 data through `at`/`at_vel` is unchanged by the generalisation."""
+    acc = cxr.Representation(cxr.tangent_geom, cxr.coord_basis, cxr.acc)
+    data = {k: u.Q(1.0, "km/s2") for k in ("x", "y", "z")}
+    out = cxfm.act(_OP, _TAU, data, cxc.cart3d, acc, at=_SLOTS[0], at_vel=_SLOTS[1])
+    assert set(out) == {"x", "y", "z"}
+
+
+def test_the_sugar_and_at_jet_agree() -> None:
+    """`at=`/`at_vel=` are aliases, so both spellings give the same answer."""
+    acc = cxr.Representation(cxr.tangent_geom, cxr.coord_basis, cxr.acc)
+    data = {k: u.Q(1.0, "km/s2") for k in ("x", "y", "z")}
+    via_sugar = cxfm.act(
+        _OP, _TAU, data, cxc.cart3d, acc, at=_SLOTS[0], at_vel=_SLOTS[1]
+    )
+    via_jet = cxfm.act(
+        _OP, _TAU, data, cxc.cart3d, acc, at_jet={0: _SLOTS[0], 1: _SLOTS[1]}
+    )
+    for k in ("x", "y", "z"):
+        assert u.ustrip("km/s2", via_sugar[k]) == u.ustrip("km/s2", via_jet[k])
+
+
+def test_giving_a_slot_twice_is_refused() -> None:
+    """Silently preferring one would be a wrong anchor, not a convenience."""
+    with pytest.raises(TypeError, match="given twice"):
+        cxfm.act(_OP, _TAU, _DATA, cxc.cart3d, _JERK_REP, at=_SLOTS[0], at_jet=_SLOTS)

--- a/tests/unit/transforms/test_jet_order_ceiling.py
+++ b/tests/unit/transforms/test_jet_order_ceiling.py
@@ -165,3 +165,45 @@ def test_the_fibre_ladder_path_takes_at_jet_too() -> None:
         assert jnp.allclose(u.ustrip("km/s", via_at[k]), u.ustrip("km/s", via_jet[k]))
     # and the ladder actually did something: 1 km/s + the offset's 1 km/s
     assert jnp.allclose(u.ustrip("km/s", via_jet["x"]), 2.0, atol=1e-6)
+
+
+def test_the_missing_slot_errors_name_at_jet() -> None:
+    """Both spellings are offered, since both now work.
+
+    The messages previously named only `at`/`at_vel`. Asserting on the text is
+    the point here: I once "fixed" this by adding the new constants and left
+    the raise sites pointing at the old ones, which a constants-only check
+    would not have caught.
+    """
+    acc = cxr.Representation(cxr.tangent_geom, cxr.coord_basis, cxr.acc)
+    data = {k: u.Q(1.0, "km/s2") for k in ("x", "y", "z")}
+
+    with pytest.raises(TypeError, match=r"'at'.*or as slot 0 of 'at_jet'"):
+        cxfm.act(_OP, _TAU, data, cxc.cart3d, acc, at_vel=_SLOTS[1])
+
+    with pytest.raises(TypeError, match=r"'at_vel'.*or as slot 1 of 'at_jet'"):
+        cxfm.act(_OP, _TAU, data, cxc.cart3d, acc, at=_SLOTS[0])
+
+
+def test_the_ladder_path_refuses_a_doubly_given_base_point() -> None:
+    """Matching the generic path: two spellings of one slot is an error.
+
+    Silently preferring `at=` would hide a wrong anchor.
+    """
+    op = cxfm.TimeDep.from_(
+        lambda tau: cxfm.Translate(
+            {
+                "x": u.Q(1.0, "km/s") * (tau / u.Q(1.0, "s")),
+                "y": u.Q(0.0, "km/s"),
+                "z": u.Q(0.0, "km/s"),
+            },
+            cxc.cart3d,
+            semantic_kind=cxr.vel,
+        )
+    )
+    rep = cxr.Representation(cxr.tangent_geom, cxr.coord_basis, cxr.vel)
+    data = {k: u.Q(1.0, "km/s") for k in ("x", "y", "z")}
+    at = {k: u.Q(1.0, "km") for k in ("x", "y", "z")}
+
+    with pytest.raises(TypeError, match="given twice"):
+        cxfm.act(op, _TAU, data, cxc.cart3d, rep, at=at, at_jet={0: at})


### PR DESCRIPTION
Part of #536 — the **first** of its two halves. The issue stays open; see "What is not
here" below.

## The ceiling

`act` on order-*m* tangent data assembled the jet it needs from `at` and `at_vel`, which
reach jet slots 0 and 1 and no further. Order 3 needs slot 2 as well, so it hard-failed:

```
act on order-3 tangent data requires jet slots 1..2;
use coordinax.transforms.act_jet with a full jet instead.
```

That message is the API admitting the kwarg ladder does not scale — order 4 would want
`at_acc`, and so on. It is the first thing #536 names.

`at_jet` is a dict keyed by slot order and is now the general form; `at` and `at_vel`
become sugar for its first two slots:

```python
cxfm.act(op, tau, jerk_data, cxc.cart3d, jerk_rep, at_jet={0: at, 1: vel, 2: acc})
# -> Q(..., 'km / s3')     order 3, through the same `act` path
```

Two details that turned out to matter:

- **The missing-slot checks had to move after the merge.** An early `if at is None`
  guard rejected before `at_jet` was ever consulted, so supplying slot 0 through
  `at_jet` alone still failed with "requires the base point via 'at'".
- **`TimeDep` needed threading too.** It has its own tangent rule that calls `_slot_jet`
  directly, so wiring `at_jet` only into the generic funnel would have left the ceiling
  in place for every time-dependent transform — which is every transform that needs a
  prolongation at all.

Giving one slot twice raises rather than silently preferring one: a wrong anchor is a
wrong answer, not a lesser convenience.

## Testing

An order-3 `Jerk` kind, registered **inside a module fixture that unregisters it again**.
The time-order ladder is global; my first version registered at import and broke five
tests elsewhere that assert it holds exactly the three kinds the library ships. The
fixture pops the entry on the way out.

Coverage: order 3 works end to end; the `at`/`at_vel` route is unchanged for order 2;
both spellings agree numerically; the missing-slot error names the slot; the
double-specified slot is refused.

## What is not here

The issue's second half — **`Composed`'s tangent `act` delegating to the `prolong` fold**
— is not done, so #536 should stay open.

`Composed.act_jet` is already the clean fold:

```python
result = jet
for sub_op in op.transforms:
    result = act_jet(sub_op, tau, result, chart, **kw)
```

while its tangent `act` hand-rolls a shadow 2-jet, threading `at`/`at_vel` through each
sub-op with a documented "velocity first: it needs the old base point" ordering subtlety
and a last-iteration dead-work skip. Collapsing the second into the first means routing
a 5-argument `act` dispatch into the geometry-redispatched generic rule, on the hot path
for every composed tangent action. That is behaviour-preserving surgery I did not want to
attempt without the budget to verify it properly, and the ceiling removal stands on its
own.

Full suite: **11007 passed** with the five ladder-pollution failures fixed; `ty` at 6
diagnostics, same as `main`.
