### PR TITLE
🐛 fix(charts,representations): a batch of points is a batch of Jacobians

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -51,6 +51,8 @@ Treat as suspect, in metric/chart/vector code:
 - Indexing that assumes rank: `x[0]`, `x[..., 2]` mixed with `x[2]`, bare `len(...)`, `.shape[0]`.
 - Matrix assembly — `jnp.diag`, `jnp.stack`, `jnp.eye`, `reshape` to a fixed `(n, n)` — where the batch dimensions must lead. #613, #618, #621, and #751 were all metric matrices built as if unbatched.
 - `jnp.where`/arithmetic between a batched component and a scalar constant without an explicit broadcast (#653).
+- `jax.jacfwd`/`jacrev` applied to a function that already takes a batch. It does not error: it returns the `(*batch, n_out, *batch, n_in)` Jacobian of the batch as one map, block-diagonal with structurally-zero off-diagonal blocks, `O(N^2)` to hold, and wrong for any consumer expecting per-point matrices (#776). Write the function for one point and map it.
+- When one branch handles batches, check _which_ operand decides. #782 keyed the choice off the tangent vector, which broke a batched vector at a single base point; the base point is what needs one Jacobian each.
 
 The check that settles it: **is there a test that runs the changed function on a non-trivial batch shape and compares against the vmapped scalar?** #612 is the model — a property test asserting the batch invariant, not a second worked example. A batch-safety fix without such a test will regress.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1294,6 +1294,15 @@ The `coordinax.charts` module provides the chart-facing API for representing poi
         both to build the correct 2-D `UnitsMatrix` and returns
         `QuantityMatrix(J_arr, unit=unit_matrix)` of shape `(n_out, n_in)`.
 
+      - **Batched base points**: components may carry arbitrary leading batch
+        axes. A chart map is pointwise, so `N` points give `N` independent
+        Jacobians and the result is `(*batch, n_out, n_in)` — the per-point
+        matrices, not the Jacobian of the batch as one function. That larger
+        object, `(*batch, n_out, *batch, n_in)`, is what `jax.jacfwd` returns if
+        applied to a batched input directly: it is block-diagonal, every
+        off-diagonal block is identically zero, and it costs `O(N^2)` to hold.
+        Both branches map over the leading axes to avoid it (#776).
+
     **`usys` parameter:** required for the `None`-partial, curried, and plain-`Array`
     dispatches. Optional (`None`) for the `CDict` generic dispatch's quantity-valued
     branch, and for all analytical dispatches.
@@ -1885,7 +1894,7 @@ A representation is therefore **not** the same thing as a chart: the chart deter
 
     **Semantics by basis:**
 
-    - **`CoordinateBasis`**: delegates to `jac_pt_map(at, from_chart, to_chart)` to obtain the Jacobian $J^j{}_i = \partial\tilde{q}^j/\partial q^i$, then applies $\tilde{v}^j = J^j{}_i v^i$.
+    - **`CoordinateBasis`**: delegates to `jac_pt_map(at, from_chart, to_chart)` to obtain the Jacobian $J^j{}_i = \partial\tilde{q}^j/\partial q^i$, then applies $\tilde{v}^j = J^j{}_i v^i$. `at` is required whenever `from_chart != to_chart`, since the Jacobian is evaluated at a point; only the same-chart case, being the identity, may omit it. A batched `at` gives one Jacobian per point; a batched `v` at a single `at` shares the one Jacobian.
     - **`PhysicalBasis`**: fetch the orthonormal frame matrices $B_{\rm from}$ (columns = physical basis vectors in Cartesian) and $B_{\rm to}$ via `frame_cart`, compute $R = B_{\rm to}^T B_{\rm from}$, apply $\hat{v}' = R \hat{v}$.
 
     **Same-chart optimisation:** when `from_chart is to_chart`, returns `v` unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "quax-blocks>=0.5.0",
   "quaxed>=0.10.5",
   "typing-extensions>=4.13.2",
+  "zeroth>=1.2.0",
   # 2.0.2 makes `np.asarray(Quantity)` raise rather than silently drop the
   # unit. Relied upon: dropping a unit yields a number in the wrong dimension
   # that looks entirely plausible.

--- a/skills/coordinax/SKILL.md
+++ b/skills/coordinax/SKILL.md
@@ -304,6 +304,7 @@ Extend the dispatch API, not the internals. `coordinaxs.api` exists precisely so
 | Two vectors that should match compare `False` | `==` is strict on chart and frame. Use `equivalent` for the geometric question. |
 | A `Distance`/`Angle` came back as a plain `Q` | Deliberate degradation: the operation could not preserve the constraint. Reconstruct explicitly if you need the constrained type back. |
 | Velocity components are off by a factor of `r` or `r*sin(theta)` | `coord_basis` vs `phys_basis`. Convert with `change_basis(..., at=point)`. |
+| `tangent_map() needs the base point` | A chart change evaluates the Jacobian somewhere, so `at=` is required unless source and target charts are the same. Pass the point the vector sits at. |
 | Shape/broadcast error inside a metric or chart function | Scalar-first code given batched input. `vmap` the call; if it is a library function, that is a batch-safety bug worth reporting. |
 | Correct but ~100x slower than expected | A chart/representation is crossing the jit boundary as a traced arg, or pytrees are crossing per call. Close over the static objects. |
 | `jax.jacfwd`/`grad` over a batch returns a dense `(N, k, N, k)` array | Applied directly to a function that already takes a batch — this does not error, it silently computes every output point's derivative with respect to every input point. Write the function scalar (single point) and use `jax.vmap(jax.jacfwd(fn))`; `jac_pt_map` does exactly this. |

--- a/src/coordinax/_src/charts/jacobian.py
+++ b/src/coordinax/_src/charts/jacobian.py
@@ -46,6 +46,7 @@ from typing import Any
 import jax
 import jax.numpy as jnp
 import plum
+from zeroth import zeroth
 
 import quaxed.numpy as qnp
 import unxt as u
@@ -276,7 +277,7 @@ def jac_pt_map(
     # route; measured, the two are within noise. Scalar components take
     # the `not batch` branch, so the unbatched path is untouched -- the
     # shape is static, so this costs nothing at trace time.
-    batch = jnp.shape(next(iter(at.values())))
+    batch = jnp.shape(zeroth(at.values()))
     if batch:
 
         def one(at_i: CDict) -> Any:

--- a/src/coordinax/_src/charts/jacobian.py
+++ b/src/coordinax/_src/charts/jacobian.py
@@ -263,6 +263,25 @@ def jac_pt_map(
     # array-valued, we can skip the packing and unit handling and directly
     # compute the Jacobian as an array.
     at = from_chart.check_data(at, keys=True)
+
+    # A chart map is pointwise, so a batch of points is a batch of independent
+    # Jacobians. Differentiating the batch as one function would instead give
+    # the (*batch, n_out, *batch, n_in) Jacobian of R^(N*n) -> R^(N*n): correct
+    # for *that* function, but block-diagonal with every off-diagonal block
+    # identically zero, and O(N^2) to hold. Map over the leading axes instead.
+    #
+    # Scalar components take the `not batch` branch, so the unbatched path is
+    # unchanged -- the shape is static, so this costs nothing at trace time.
+    batch = jnp.shape(next(iter(at.values())))
+    if batch:
+
+        def one(at_i: CDict) -> Any:
+            return cxcapi.jac_pt_map(at_i, from_chart, to_chart, usys=usys)
+
+        for _ in batch:
+            one = jax.vmap(one)
+        return one(at)
+
     is_array = not any(hasattr(v, "unit") for v in at.values())
     if is_array:
         at_arr = jnp.stack([at[k] for k in from_chart.components], axis=-1)

--- a/src/coordinax/_src/charts/jacobian.py
+++ b/src/coordinax/_src/charts/jacobian.py
@@ -264,14 +264,18 @@ def jac_pt_map(
     # compute the Jacobian as an array.
     at = from_chart.check_data(at, keys=True)
 
-    # A chart map is pointwise, so a batch of points is a batch of independent
-    # Jacobians. Differentiating the batch as one function would instead give
-    # the (*batch, n_out, *batch, n_in) Jacobian of R^(N*n) -> R^(N*n): correct
-    # for *that* function, but block-diagonal with every off-diagonal block
-    # identically zero, and O(N^2) to hold. Map over the leading axes instead.
+    # A chart map is pointwise, so a batch of points is a batch of
+    # independent Jacobians. Differentiating the batch as one function
+    # would instead give the (*batch, n_out, *batch, n_in) Jacobian of
+    # R^(N*n) -> R^(N*n): correct for *that* function, but block-diagonal
+    # with every off-diagonal block identically zero, and O(N^2) to hold.
+    # Map over the leading axes instead.
     #
-    # Scalar components take the `not batch` branch, so the unbatched path is
-    # unchanged -- the shape is static, so this costs nothing at trace time.
+    # `jnp.vectorize` would express the same mapping in one call, but it
+    # coerces its inputs with `asarray` and so cannot carry the Quantity
+    # route; measured, the two are within noise. Scalar components take
+    # the `not batch` branch, so the unbatched path is untouched -- the
+    # shape is static, so this costs nothing at trace time.
     batch = jnp.shape(next(iter(at.values())))
     if batch:
 

--- a/src/coordinax/representations/_src/tangent_map.py
+++ b/src/coordinax/representations/_src/tangent_map.py
@@ -3,7 +3,7 @@
 __all__ = ("tangent_map",)
 
 from jaxtyping import Array
-from typing import Any
+from typing import Any, Final
 
 import jax
 import jax.numpy as jnp
@@ -46,7 +46,7 @@ def _check_linear_basis(rep: Representation, label: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-_MSG_AT_REQUIRED = (
+_MSG_AT_REQUIRED: Final = (
     "tangent_map() needs the base point: pushing a tangent vector from {frm} to "
     "{to} evaluates the Jacobian of the transition map somewhere, and the "
     "transition is not linear. Pass `at=` with the point the vector sits at. "
@@ -147,21 +147,21 @@ def tangent_map(
     if from_chart == to_chart:
         return v
 
-    # Past that point a Jacobian has to be evaluated somewhere, so `at` is not
-    # optional. Without this the base point reaches `jac_pt_map` as `None`,
-    # which resolves to the higher-order rule and returns a *function*; the
-    # failure then surfaces from `_apply_jac` as ``unsupported operand type(s)
-    # for @: 'function' and 'ArrayImpl'``, naming nothing the caller wrote.
+    # Past that point a Jacobian must be evaluated somewhere, so `at` is
+    # not optional. Without this it reaches `jac_pt_map` as `None`, which
+    # resolves to the higher-order rule and returns a *function*; the
+    # failure then surfaces from `_apply_jac` as an unsupported `@`
+    # between a function and an array, naming nothing the caller wrote.
     if at is None:
         msg = _MSG_AT_REQUIRED.format(
             frm=type(from_chart).__name__, to=type(to_chart).__name__
         )
         raise ValueError(msg)
 
-    # `_apply_jac` takes the 2-D Jacobian and the single tangent vector it
-    # documents, so a batch is mapped here rather than threaded through it and
-    # the unit handling inside. Scalar components skip this entirely: the shape
-    # is static, so the unbatched path is untouched.
+    # `_apply_jac` takes the 2-D Jacobian and single vector it documents,
+    # so a batch is mapped here rather than threaded through it and the
+    # unit handling inside. Scalar components skip this entirely: the
+    # shape is static, so the unbatched path is untouched.
     batch = jnp.shape(next(iter(v.values())))
     if batch:
 

--- a/src/coordinax/representations/_src/tangent_map.py
+++ b/src/coordinax/representations/_src/tangent_map.py
@@ -159,19 +159,26 @@ def tangent_map(
         )
         raise ValueError(msg)
 
-    # `_apply_jac` takes the 2-D Jacobian and single vector it documents,
-    # so a batch is mapped here rather than threaded through it and the
-    # unit handling inside. Scalar components skip this entirely: the
-    # shape is static, so the unbatched path is untouched.
-    batch = jnp.shape(zeroth(v.values()))
-    if batch:
+    # The *base point* decides this, not the vector: a batch of points needs
+    # one Jacobian each, whereas a batch of vectors at a single point shares
+    # one and `_apply_jac` already broadcasts it. So a scalar `at` keeps the
+    # unbatched path below, whatever shape `v` has.
+    #
+    # `_apply_jac` takes the 2-D Jacobian and single vector it documents, so
+    # the mapping happens here rather than being threaded through it and the
+    # unit handling inside.
+    at_batch = jnp.shape(zeroth(at.values()))
+    if at_batch:
+        # `v` rides along when it is batched too, pairing element with
+        # element; when it is not, every Jacobian acts on the same vector.
+        v_axis = 0 if jnp.shape(zeroth(v.values())) else None
 
         def one(v_i: CDict, at_i: CDict) -> CDict:
             J_i = cxc.jac_pt_map(at_i, from_chart, to_chart, usys=usys)
             return _apply_jac(J_i, from_chart.components, to_chart.components, v_i)
 
-        for _ in batch:
-            one = jax.vmap(one)
+        for _ in at_batch:
+            one = jax.vmap(one, in_axes=(v_axis, 0))
         return one(v, at)
 
     J = cxc.jac_pt_map(at, from_chart, to_chart, usys=usys)

--- a/src/coordinax/representations/_src/tangent_map.py
+++ b/src/coordinax/representations/_src/tangent_map.py
@@ -5,6 +5,7 @@ __all__ = ("tangent_map",)
 from jaxtyping import Array
 from typing import Any
 
+import jax
 import jax.numpy as jnp
 import plum
 
@@ -137,6 +138,21 @@ def tangent_map(
     # Same-chart optimization: identity transform
     if from_chart == to_chart:
         return v
+
+    # `_apply_jac` takes the 2-D Jacobian and the single tangent vector it
+    # documents, so a batch is mapped here rather than threaded through it and
+    # the unit handling inside. Scalar components skip this entirely: the shape
+    # is static, so the unbatched path is untouched.
+    batch = jnp.shape(next(iter(v.values())))
+    if batch:
+
+        def one(v_i: CDict, at_i: CDict) -> CDict:
+            J_i = cxc.jac_pt_map(at_i, from_chart, to_chart, usys=usys)
+            return _apply_jac(J_i, from_chart.components, to_chart.components, v_i)
+
+        for _ in batch:
+            one = jax.vmap(one)
+        return one(v, at)
 
     J = cxc.jac_pt_map(at, from_chart, to_chart, usys=usys)
     return _apply_jac(J, from_chart.components, to_chart.components, v)

--- a/src/coordinax/representations/_src/tangent_map.py
+++ b/src/coordinax/representations/_src/tangent_map.py
@@ -46,6 +46,14 @@ def _check_linear_basis(rep: Representation, label: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+_MSG_AT_REQUIRED = (
+    "tangent_map() needs the base point: pushing a tangent vector from {frm} to "
+    "{to} evaluates the Jacobian of the transition map somewhere, and the "
+    "transition is not linear. Pass `at=` with the point the vector sits at. "
+    "Only a same-chart conversion may omit it, being the identity."
+)
+
+
 def _apply_jac(
     J: Array | ul.QuantityMatrix,
     from_components: tuple[str, ...],
@@ -138,6 +146,17 @@ def tangent_map(
     # Same-chart optimization: identity transform
     if from_chart == to_chart:
         return v
+
+    # Past that point a Jacobian has to be evaluated somewhere, so `at` is not
+    # optional. Without this the base point reaches `jac_pt_map` as `None`,
+    # which resolves to the higher-order rule and returns a *function*; the
+    # failure then surfaces from `_apply_jac` as ``unsupported operand type(s)
+    # for @: 'function' and 'ArrayImpl'``, naming nothing the caller wrote.
+    if at is None:
+        msg = _MSG_AT_REQUIRED.format(
+            frm=type(from_chart).__name__, to=type(to_chart).__name__
+        )
+        raise ValueError(msg)
 
     # `_apply_jac` takes the 2-D Jacobian and the single tangent vector it
     # documents, so a batch is mapped here rather than threaded through it and

--- a/src/coordinax/representations/_src/tangent_map.py
+++ b/src/coordinax/representations/_src/tangent_map.py
@@ -8,6 +8,7 @@ from typing import Any, Final
 import jax
 import jax.numpy as jnp
 import plum
+from zeroth import zeroth
 
 import quaxed.numpy as qnp
 import unxt as u
@@ -162,7 +163,7 @@ def tangent_map(
     # so a batch is mapped here rather than threaded through it and the
     # unit handling inside. Scalar components skip this entirely: the
     # shape is static, so the unbatched path is untouched.
-    batch = jnp.shape(next(iter(v.values())))
+    batch = jnp.shape(zeroth(v.values()))
     if batch:
 
         def one(v_i: CDict, at_i: CDict) -> CDict:

--- a/tests/unit/charts/test_jacobian_pt_map.py
+++ b/tests/unit/charts/test_jacobian_pt_map.py
@@ -868,3 +868,70 @@ class TestJacobianPtMapAtExtremeScales:
 
         assert np.all(np.isfinite(got))
         assert_allclose(got, expected, rtol=1e-5)
+
+
+class TestJacobianOfABatchIsABatchOfJacobians:
+    """A chart map is pointwise, so N points give N independent Jacobians.
+
+    Differentiating the batch as one function instead gives the
+    ``(*batch, n_out, *batch, n_in)`` Jacobian of ``R^(N*n) -> R^(N*n)``:
+    correct for that function, but block-diagonal with every off-diagonal block
+    identically zero, and ``O(N^2)`` to hold. Consumers -- ``_apply_jac``,
+    ``metric_matrix`` -- read it as ``(*batch, n_out, n_in)``, so the mismatch
+    surfaced as silently wrong numbers rather than a shape error (#776).
+    """
+
+    N = 4
+    XS = (1.0, 2.0, 0.5, 3.0)
+    YS = (2.0, 1.0, -1.5, 0.5)
+    ZS = (3.0, 0.5, 2.0, 1.0)
+
+    def _batched(self, *, quantity):
+        wrap = (lambda a: u.Q(a, "m")) if quantity else (lambda a: a)
+        return {
+            "x": wrap(jnp.asarray(self.XS)),
+            "y": wrap(jnp.asarray(self.YS)),
+            "z": wrap(jnp.asarray(self.ZS)),
+        }
+
+    @staticmethod
+    def _value(j):
+        return np.asarray(j.value if hasattr(j, "value") else j)
+
+    @pytest.mark.parametrize("quantity", [True, False])
+    def test_it_matches_the_per_point_jacobians(self, quantity):
+        """Bit-exact, not merely close: these are the same computation."""
+        kw = {} if quantity else {"usys": u.unitsystems.si}
+        at = self._batched(quantity=quantity)
+        got = self._value(cxc.jac_pt_map(at, cxc.cart3d, cxc.sph3d, **kw))
+        want = np.stack(
+            [
+                self._value(
+                    cxc.jac_pt_map(
+                        {k: at[k][i] for k in at}, cxc.cart3d, cxc.sph3d, **kw
+                    )
+                )
+                for i in range(self.N)
+            ]
+        )
+        assert got.shape == (self.N, 3, 3)
+        assert_allclose(got, want, rtol=0, atol=0)
+
+    def test_a_scalar_point_still_gives_one_matrix(self):
+        """The unbatched shape is unchanged: no batch axis is invented."""
+        at = {k: u.Q(v, "m") for k, v in (("x", 1.0), ("y", 2.0), ("z", 3.0))}
+        assert self._value(cxc.jac_pt_map(at, cxc.cart3d, cxc.sph3d)).shape == (3, 3)
+
+    def test_several_leading_axes_are_all_mapped(self):
+        """Batch axes are arbitrary in number, not just one."""
+        rng = np.random.default_rng(0)
+        at = {k: u.Q(jnp.asarray(rng.uniform(1, 2, (2, 3))), "m") for k in "xyz"}
+        shape = self._value(cxc.jac_pt_map(at, cxc.cart3d, cxc.sph3d)).shape
+        assert shape == (2, 3, 3, 3)
+
+    def test_it_does_not_grow_with_the_square_of_the_batch(self):
+        """The old shape held N^2 blocks, all but N of them structurally zero."""
+        n = 64
+        at = {k: u.Q(jnp.ones(n), "m") for k in "xyz"}
+        size = self._value(cxc.jac_pt_map(at, cxc.cart3d, cxc.sph3d)).size
+        assert size == n * 3 * 3

--- a/tests/unit/representations/test_cconvert_tangent.py
+++ b/tests/unit/representations/test_cconvert_tangent.py
@@ -262,6 +262,69 @@ class TestTangentConversionOfABatch:
                     np.asarray(got[k])[i], np.asarray(one[k]), rtol=0, atol=0
                 )
 
+    def test_many_vectors_at_one_point_share_the_single_jacobian(self):
+        """A batched `v` with a scalar `at` must not take the mapped path.
+
+        The base point decides: one point needs one Jacobian, which
+        `_apply_jac` already broadcasts across the vectors. Keying the choice
+        off `v` instead broke this with a `vmap` rank error.
+        """
+        at_one = {k: self.AT[k][0] for k in self.AT}
+        got = cxr.cconvert(
+            self.V,
+            cxc.cart3d,
+            cxr.coord_vel,
+            cxc.sph3d,
+            cxr.coord_vel,
+            at=at_one,
+            usys=usys,
+        )
+        for k in got:
+            assert np.asarray(got[k]).shape == (self.N,)
+        for i in range(self.N):
+            one = cxr.cconvert(
+                {k: self.V[k][i] for k in self.V},
+                cxc.cart3d,
+                cxr.coord_vel,
+                cxc.sph3d,
+                cxr.coord_vel,
+                at=at_one,
+                usys=usys,
+            )
+            for k in got:
+                np.testing.assert_allclose(
+                    np.asarray(got[k])[i], np.asarray(one[k]), rtol=0, atol=1e-15
+                )
+
+    def test_one_vector_at_many_points_gives_one_result_each(self):
+        """The mirror case: a scalar `v` with a batched `at`."""
+        v_one = {k: self.V[k][0] for k in self.V}
+        got = cxr.cconvert(
+            v_one,
+            cxc.cart3d,
+            cxr.coord_vel,
+            cxc.sph3d,
+            cxr.coord_vel,
+            at=self.AT,
+            usys=usys,
+        )
+        for k in got:
+            assert np.asarray(got[k]).shape == (self.N,)
+        for i in range(self.N):
+            one = cxr.cconvert(
+                v_one,
+                cxc.cart3d,
+                cxr.coord_vel,
+                cxc.sph3d,
+                cxr.coord_vel,
+                at={k: self.AT[k][i] for k in self.AT},
+                usys=usys,
+            )
+            for k in got:
+                np.testing.assert_allclose(
+                    np.asarray(got[k])[i], np.asarray(one[k]), rtol=0, atol=0
+                )
+
     def test_the_batch_axis_leads_and_components_stay_separate(self):
         """Each component keeps the batch shape; nothing folds into it."""
         got = cxr.cconvert(

--- a/tests/unit/representations/test_cconvert_tangent.py
+++ b/tests/unit/representations/test_cconvert_tangent.py
@@ -2,6 +2,8 @@
 
 __all__: tuple[str, ...] = ()
 
+from typing import ClassVar
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -215,3 +217,61 @@ class TestAccelerationPushesForwardAsAVector:
         want = np.asarray(jax.jacfwd(_sph_of_t)(_T))
         got = _convert(_V, cxr.coord_vel)
         np.testing.assert_allclose(got, want, rtol=0, atol=1e-14)
+
+
+class TestTangentConversionOfABatch:
+    """A batch of tangent vectors converts element by element (#776).
+
+    `_apply_jac` takes the 2-D Jacobian and single vector it documents, so the
+    batch is mapped one level up rather than threaded through it and the unit
+    handling inside.
+    """
+
+    N = 4
+    AT: ClassVar = {
+        "x": jnp.asarray([1.0, 2.0, 0.5, 3.0]),
+        "y": jnp.asarray([2.0, 1.0, -1.5, 0.5]),
+        "z": jnp.asarray([3.0, 0.5, 2.0, 1.0]),
+    }
+    V: ClassVar = {
+        "x": jnp.asarray([1.0, 0.0, 0.0, 1.0]),
+        "y": jnp.asarray([0.0, 1.0, 0.0, 2.0]),
+        "z": jnp.asarray([0.0, 0.0, 1.0, 3.0]),
+    }
+
+    @pytest.mark.parametrize("kind_name", ["coord_disp", "coord_vel", "coord_acc"])
+    @pytest.mark.parametrize("to_chart", [cxc.sph3d, cxc.cyl3d])
+    def test_it_matches_element_by_element(self, kind_name, to_chart):
+        kind = getattr(cxr, kind_name)
+        got = cxr.cconvert(
+            self.V, cxc.cart3d, kind, to_chart, kind, at=self.AT, usys=usys
+        )
+        keys = tuple(got)
+        for i in range(self.N):
+            one = cxr.cconvert(
+                {k: self.V[k][i] for k in self.V},
+                cxc.cart3d,
+                kind,
+                to_chart,
+                kind,
+                at={k: self.AT[k][i] for k in self.AT},
+                usys=usys,
+            )
+            for k in keys:
+                np.testing.assert_allclose(
+                    np.asarray(got[k])[i], np.asarray(one[k]), rtol=0, atol=0
+                )
+
+    def test_the_batch_axis_leads_and_components_stay_separate(self):
+        """Each component keeps the batch shape; nothing folds into it."""
+        got = cxr.cconvert(
+            self.V,
+            cxc.cart3d,
+            cxr.coord_vel,
+            cxc.sph3d,
+            cxr.coord_vel,
+            at=self.AT,
+            usys=usys,
+        )
+        for k in got:
+            assert np.asarray(got[k]).shape == (self.N,)

--- a/tests/unit/representations/test_tangent_map.py
+++ b/tests/unit/representations/test_tangent_map.py
@@ -6,7 +6,7 @@ the Jacobian pushforward (CoordinateBasis) or frame matrix rotation (PhysicalBas
 
 __all__: tuple[str, ...] = ()
 
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 import jax
 import jax.numpy as jnp
@@ -361,3 +361,64 @@ class TestTangentMapMixedCDict:
         at = {"x": jnp.array(1.0), "y": jnp.array(0.0)}
         with pytest.raises(TypeError, match="mixed CDict"):
             cxr.tangent_map(v, cxc.cart2d, cxr.coord_disp, cxc.polar2d, at=at)
+
+
+class TestTheBasePointIsRequiredWhenTheChartChanges:
+    """`at=None` past the same-chart short-circuit used to fail unrecognisably.
+
+    `jac_pt_map(None, ...)` resolves to the higher-order rule and returns a
+    *function*, so the failure surfaced from `_apply_jac` as ``unsupported
+    operand type(s) for @: 'function' and 'ArrayImpl'`` -- naming nothing the
+    caller wrote. Pre-existing on the scalar path; the batched path added by
+    #776 inherited it.
+    """
+
+    V: ClassVar = {k: jnp.asarray(1.0) for k in "xyz"}
+    V_BATCH: ClassVar = {k: jnp.asarray([1.0, 2.0]) for k in "xyz"}
+
+    @pytest.mark.parametrize("basis", ["coord_basis", "phys_basis"])
+    def test_a_missing_base_point_is_named(self, basis):
+        with pytest.raises(ValueError, match="needs the base point"):
+            cxr.tangent_map(
+                self.V,
+                cxc.cart3d,
+                getattr(cxr, basis),
+                cxc.sph3d,
+                at=None,
+                usys=u.unitsystems.si,
+            )
+
+    def test_the_batched_path_refuses_it_too(self):
+        """The vmapped branch must not reach `jac_pt_map` with `None` either."""
+        with pytest.raises(ValueError, match="needs the base point"):
+            cxr.tangent_map(
+                self.V_BATCH,
+                cxc.cart3d,
+                cxr.coord_basis,
+                cxc.sph3d,
+                at=None,
+                usys=u.unitsystems.si,
+            )
+
+    def test_the_message_says_which_charts(self):
+        with pytest.raises(ValueError, match="Cart3D to Spherical3D"):
+            cxr.tangent_map(
+                self.V,
+                cxc.cart3d,
+                cxr.coord_basis,
+                cxc.sph3d,
+                at=None,
+                usys=u.unitsystems.si,
+            )
+
+    def test_a_same_chart_conversion_still_needs_no_base_point(self):
+        """It is the identity, so there is no Jacobian to evaluate anywhere."""
+        got = cxr.tangent_map(
+            self.V,
+            cxc.cart3d,
+            cxr.coord_basis,
+            cxc.cart3d,
+            at=None,
+            usys=u.unitsystems.si,
+        )
+        assert {k: float(got[k]) for k in got} == {"x": 1.0, "y": 1.0, "z": 1.0}

--- a/uv.lock
+++ b/uv.lock
@@ -471,6 +471,7 @@ dependencies = [
     { name = "unxts-linalg" },
     { name = "wadler-lindig" },
     { name = "xmmutablemap" },
+    { name = "zeroth" },
 ]
 
 [package.optional-dependencies]
@@ -633,6 +634,7 @@ requires-dist = [
     { name = "unxts-parametric", marker = "extra == 'parametric'", specifier = ">=2.0" },
     { name = "wadler-lindig", specifier = ">=0.1.6" },
     { name = "xmmutablemap", specifier = ">=0.1" },
+    { name = "zeroth", specifier = ">=1.2.0" },
 ]
 provides-extras = ["astro", "benchmark", "curveframes", "interop-astropy", "parametric", "workspace"]
 
@@ -3731,6 +3733,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/a6/c4043eb00f297956a5447109985f41fabb0adbbf80786a21c2949f798ba4/xmmutablemap-0.2.1.tar.gz", hash = "sha256:38a881b0fcc54352e2751628d11519d023bc6677e978483736f8f51b45c7147f", size = 97896, upload-time = "2025-10-22T01:22:00.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/89/4628be42c56e0063b2158a468fc0de3e21285800f8cab07f2d3be684c763/xmmutablemap-0.2.1-py3-none-any.whl", hash = "sha256:002f97986e1cc343d362e38eae62a0a51ca7b76bd3b1de0f70a8f05dbe2b8c5c", size = 7584, upload-time = "2025-10-22T01:21:58.821Z" },
+]
+
+[[package]]
+name = "zeroth"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/d3/e1cb496be02859e42763dd351e834f537a214e8deaebf0af247bbc2809f2/zeroth-1.2.0.tar.gz", hash = "sha256:9d484a5f70800ab44189b5252401d18e9ce537c917081ee4e87dd86871d6b77f", size = 115154, upload-time = "2026-05-12T19:02:21.102Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/66/3400e437c761dcfdc355d24620ae57d71fb29be0c339380864260069068e/zeroth-1.2.0-py3-none-any.whl", hash = "sha256:5eb008cd02eb6e44a2387b5d5421d39a86a8abfc5eae8d1ca8d09b97f572a075", size = 4664, upload-time = "2026-05-12T19:02:19.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #776.

Batch-aware, per the discussion on the issue — with the scalar path left alone, which was the open worry.

## The change

`jac_pt_map` differentiated a batched `CDict` as one function $\mathbb{R}^{N\times n} \to \mathbb{R}^{N\times n}$. Its Jacobian is `(*batch, n_out, *batch, n_in)` — correct for *that* function, but a chart map is pointwise, so the induced map is block-diagonal with every off-diagonal block identically zero. Consumers read the result as `(*batch, n_out, n_in)`, and the mismatch surfaced as silently wrong numbers out of `cconvert` on tangent data, and a raw `dot_general` shape error in 2-D.

Mapped over the leading axes in two places:

- **`jac_pt_map`'s `CDict` entry point** — fixes every direct caller, plus the Jacobian-pullback branch of `metric_matrix`.
- **`tangent_map`** — so `_apply_jac` keeps receiving the 2-D Jacobian and single vector its docstring promises. Its unit handling is untouched, which was the fiddly half.

## The scalar path costs nothing

The batch check reads a *static* shape, so an unbatched call takes the branch it always did. Dispatch counts per eager call, before and after — the deterministic measure #769 established:

```
jac_pt_map            168 -> 168
cconvert (tangent)    223 -> 223
```

Identical. Timing agreed but is dispatch-dominated at ~16 ms/call and too noisy to be evidence on its own, so the counts are the claim.

## Nothing is discarded

The per-point Jacobians are exactly the batch-diagonal blocks; the remainder is exactly zero — verified, not bounded:

```
diagonal blocks == per-element Jacobians :  maxdiff  = 0.0
off-diagonal blocks are exactly zero     :  max|off| = 0.0
```

So the new tests assert `rtol=0, atol=0` rather than a tolerance: these are the same computation, not merely close.

## And an O(N²) blow-up goes away

| N | before | after |
| --- | --- | --- |
| 200 | 360,000 elements, 2.7 MiB | 1,800 elements, 0.01 MiB |
| 800 | 5,760,000 elements, 43.9 MiB | 7,200 elements, 0.05 MiB |
| 5000 | ~1.8 GiB | 0.34 MiB |

All but N of those N² blocks were structurally zero, so batched dicts would have OOM'd at modest sizes even with correct numbers.

## Verification

- 26/26 cases in the tangent sweep now match element-by-element at `0.0`, across `coord_disp`/`coord_vel`/`coord_acc` and six chart pairs, both directions.
- Multi-axis batches work: a `(2, 3)` batch gives `J` of `(2, 3, 3, 3)`, and element `[1, 2]` equals the scalar call exactly.
- Both the `Quantity` and bare-array routes are covered, parametrised.
- Full suite: **11267 passed**, 311 skipped, 1 xfailed, 0 failures. `prek` clean.

## Note for the perf guide (#769)

`vmap` was already exact and remains the recommended way to batch. But the guide's "prefer raw arrays at the boundary" pointed at the one route that failed *silently* — the `Quantity` route at least raised. That is no longer a trap either way; if you want, the guide could gain a line saying batched dicts and `vmap` now agree.
