### PR TITLE
✨ feat(curveframes): `TubularChart`'s `pt_map` honours `usys`

### DIFF
--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/register_ptmap.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/register_ptmap.py
@@ -7,6 +7,8 @@ the solution by construction, which is exactly the stationarity condition.
 
 __all__: tuple[str, ...] = ()
 
+from typing import Any
+
 import jax.numpy as jnp
 import plum
 
@@ -18,6 +20,38 @@ from coordinaxs.api.custom_types import CDict
 
 from .chart import TubularChart
 from .nearest import nearest_tau
+
+_MSG_RAW_NEEDS_USYS = (
+    "coordinate {name!r} carries no unit, so it needs a `usys=` to say what "
+    "its numbers mean -- e.g. "
+    "`pt_map(p, ..., usys=u.unitsystem('km', 's', 'kg', 'rad'))`. This is the "
+    "raw-array route; pass `unxt.Quantity` coordinates instead to skip it."
+)
+
+
+def _usys_unit(usys: OptUSys, name: str, dimension: str, /) -> Any:
+    """``usys[dimension]``, or a message naming the coordinate that needed it.
+
+    The single place the unit system is indexed, so the "raw coordinate with
+    no `usys`" failure has exactly one wording and the type checker sees the
+    `None` ruled out once.
+    """
+    if usys is None:
+        raise ValueError(_MSG_RAW_NEEDS_USYS.format(name=name))
+    return usys[dimension]
+
+
+def _in_usys(value: Any, name: str, dimension: str, usys: OptUSys, /) -> Any:
+    """Interpret a raw coordinate through ``usys``; pass a `Quantity` through.
+
+    The raw-array route is the cheapest way in and carries no units, so the
+    unit system is what gives its numbers meaning -- the same bargain
+    `coordinax`'s own charts make (see `uconvert_to_rad`). A `Quantity` already
+    states its unit and is returned untouched, so a mixed dict works.
+    """
+    if u.unit_of(value) is not None:
+        return value
+    return u.Q(value, _usys_unit(usys, name, dimension))
 
 
 @plum.dispatch
@@ -52,15 +86,38 @@ def pt_map(
     >>> cxc.pt_map(p, chart.M, chart, chart.M, cxc.cart3d)
     {'x': Q(1.1, 'km'), 'y': Q(0., 'km'), 'z': Q(0., 'km')}
 
+    Raw coordinates take the same route, given a ``usys`` to say what their
+    numbers mean, and come back raw:
+
+    >>> usys = u.unitsystem("km", "s", "kg", "rad")
+    >>> p = {"tau": 0.0, "n1": 0.1, "n2": 0.0}
+    >>> cxc.pt_map(p, chart.M, chart, chart.M, cxc.cart3d, usys=usys)
+    {'x': Array(1.1, dtype=float64...),
+     'y': Array(0., dtype=float64...),
+     'z': Array(0., dtype=float64...)}
+
     """
-    del to_M, usys
+    del to_M
     assert from_M == from_chart.M  # noqa: S101
     b = from_chart.builder
-    tau = p["tau"]
+
+    # Raw in -> raw out, as everywhere else in `pt_map`: the caller who came
+    # in on the array route wants to leave on it, not be handed Quantities.
+    tau_dim = from_chart.coord_dimensions[0]
+    raw = u.unit_of(p["tau"]) is None
+    tau = _in_usys(p["tau"], "tau", tau_dim, usys)
+    n1 = _in_usys(p["n1"], "n1", "length", usys)
+    n2 = _in_usys(p["n2"], "n2", "length", usys)
+
     R = b.rotation_matrix(tau)
     g = b.location(tau)
-    unit = g.unit
-    xyz = g.ustrip(unit) + p["n1"].ustrip(unit) * R[1] + p["n2"].ustrip(unit) * R[2]
+    # Read the output unit from the system, not from `n1`: in a mixed dict
+    # `n1` may be a `Quantity` the caller supplied in some other unit (100 m
+    # rather than 0.1 km), and the raw output is defined by the system.
+    unit = _usys_unit(usys, "n1", "length") if raw else g.unit
+    xyz = g.ustrip(unit) + n1.ustrip(unit) * R[1] + n2.ustrip(unit) * R[2]
+    if raw:
+        return dict(zip(("x", "y", "z"), xyz, strict=True))
     return {k: u.Q(xyz[i], unit) for i, k in enumerate(("x", "y", "z"))}
 
 
@@ -108,20 +165,31 @@ def pt_map(
     True
 
     """
-    del from_M, usys
+    del from_M
     assert to_M == to_chart.M  # noqa: S101
     b = to_chart.builder
+
+    raw = u.unit_of(p["x"]) is None
+    xyz = [_in_usys(p[k], k, "length", usys) for k in ("x", "y", "z")]
+
     unit = b.location(to_chart.tau_bounds[0]).unit
-    x = u.Q(jnp.stack([p[k].ustrip(unit) for k in ("x", "y", "z")]), unit)
+    x = u.Q(jnp.stack([c.ustrip(unit) for c in xyz]), unit)
 
     tau = nearest_tau(b, x, bounds=to_chart.tau_bounds, n_seed=to_chart.n_seed)
     R = b.rotation_matrix(tau)
     d = x.ustrip(unit) - b.location(tau).ustrip(unit)
-    return {
-        "tau": tau,
-        "n1": u.Q(jnp.dot(d, R[1]), unit),
-        "n2": u.Q(jnp.dot(d, R[2]), unit),
-    }
+    n1, n2 = jnp.dot(d, R[1]), jnp.dot(d, R[2])
+    if raw:
+        # `tau` comes back from `nearest_tau` as a `Quantity` in the bounds'
+        # unit; strip it to the unit system so the dict is uniformly raw.
+        tau_unit = _usys_unit(usys, "tau", to_chart.coord_dimensions[0])
+        per_length = u.Q(1.0, unit).ustrip(_usys_unit(usys, "n1", "length"))
+        return {
+            "tau": tau.ustrip(tau_unit),
+            "n1": n1 * per_length,
+            "n2": n2 * per_length,
+        }
+    return {"tau": tau, "n1": u.Q(n1, unit), "n2": u.Q(n2, unit)}
 
 
 @plum.dispatch

--- a/packages/coordinaxs.curveframes/tests/unit/test_tubular_usys.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_tubular_usys.py
@@ -82,3 +82,33 @@ def test_quantities_and_raw_values_can_be_mixed(chart) -> None:
     want = cxc.pt_map(allraw, chart.M, chart, chart.M, cxc.cart3d, usys=USYS)
     for k in ("x", "y", "z"):
         assert jnp.allclose(got[k], want[k]), k
+
+
+def test_raw_tau_bounds_are_where_the_raw_route_stops() -> None:
+    """`tau_bounds` states the chart's own tau range, so it must carry a unit.
+
+    A `usys` interprets the coordinates of a *call*; `tau_bounds` is
+    structural -- read by `coord_dimensions` with no call in sight, so there
+    is no `usys` in scope to consult. The raw route stops here, with the
+    builder's own message rather than an `AttributeError`.
+
+    Worth pinning now that raw coordinates work everywhere else in this
+    chart: passing raw bounds too is the natural next assumption.
+
+    `nearest_tau` is deliberately not exercised here -- its ``bounds`` is
+    annotated `tuple[AbstractQuantity, AbstractQuantity]`, so beartype
+    rejects a raw pair before any of this runs. `TubularChart.tau_bounds` is
+    `tuple[Any, Any]`, which is why the chart is the path that reaches it.
+    """
+    chart = cxfc.TubularChart(
+        cxfc.BishopBuilder(circle),  # inferring, so nothing declared
+        tau_bounds=(0.0, 2 * jnp.pi),
+    )
+    with pytest.raises(TypeError, match="carries no unit"):
+        _ = chart.coord_dimensions
+
+    # Declaring the unit is the way through, exactly as for a raw parameter.
+    declared = cxfc.TubularChart(
+        cxfc.BishopBuilder(circle, "s"), tau_bounds=(0.0, 2 * jnp.pi)
+    )
+    assert declared.coord_dimensions == ("time", "length", "length")

--- a/packages/coordinaxs.curveframes/tests/unit/test_tubular_usys.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_tubular_usys.py
@@ -1,0 +1,84 @@
+"""The raw-array route through `TubularChart`'s `pt_map`.
+
+`pt_map` accepts three shapes of coordinate throughout `coordinax`: a
+`unxt.Quantity`, a raw array interpreted through a `usys`, and mixtures of
+the two. `TubularChart` advertised the same signature but opened its body
+with ``del usys`` and then called ``p["n1"].ustrip(...)``, so a raw
+coordinate died on the missing method rather than being interpreted.
+
+Raw in gives raw out, matching every other chart: a caller who came in on
+the cheap route wants to leave on it.
+"""
+
+import jax.numpy as jnp
+import pytest
+
+import coordinax.charts as cxc
+import unxt as u
+
+import coordinaxs.curveframes as cxfc
+
+USYS = u.unitsystem("km", "s", "kg", "rad")
+
+
+def circle(tau: u.AbstractQuantity) -> u.AbstractQuantity:
+    t = tau.ustrip("s")
+    return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), jnp.zeros_like(t)]), "km")
+
+
+@pytest.fixture
+def chart() -> cxfc.TubularChart:
+    return cxfc.TubularChart(
+        cxfc.BishopBuilder(circle, "s"),
+        tau_bounds=(u.Q(0.0, "s"), u.Q(2 * jnp.pi, "s")),
+    )
+
+
+def test_the_raw_route_agrees_with_the_quantity_route(chart) -> None:
+    """Same numbers either way; only the wrapper differs."""
+    pq = {"tau": u.Q(0.5, "s"), "n1": u.Q(0.1, "km"), "n2": u.Q(0.0, "km")}
+    pa = {"tau": jnp.asarray(0.5), "n1": jnp.asarray(0.1), "n2": jnp.asarray(0.0)}
+
+    fq = cxc.pt_map(pq, chart.M, chart, chart.M, cxc.cart3d)
+    fa = cxc.pt_map(pa, chart.M, chart, chart.M, cxc.cart3d, usys=USYS)
+
+    for k in ("x", "y", "z"):
+        assert u.unit_of(fa[k]) is None, f"{k} came back wrapped"
+        assert jnp.allclose(fq[k].ustrip("km"), fa[k]), k
+
+
+def test_the_raw_route_round_trips(chart) -> None:
+    """Cart3D -> Tubular -> Cart3D returns the coordinates it was given."""
+    pa = {"tau": jnp.asarray(0.5), "n1": jnp.asarray(0.1), "n2": jnp.asarray(0.0)}
+    fwd = cxc.pt_map(pa, chart.M, chart, chart.M, cxc.cart3d, usys=USYS)
+    back = cxc.pt_map(fwd, chart.M, cxc.cart3d, chart.M, chart, usys=USYS)
+
+    for k, want in pa.items():
+        assert u.unit_of(back[k]) is None, f"{k} came back wrapped"
+        assert jnp.allclose(back[k], want, atol=1e-5), (k, back[k], want)
+
+
+def test_a_raw_coordinate_without_a_usys_says_what_is_missing(chart) -> None:
+    """The one unserveable combination, named rather than crashed into.
+
+    Without a `usys` the numbers mean nothing, and before this the failure was
+    an `AttributeError` on a missing `ustrip`, several frames down.
+    """
+    pa = {"tau": jnp.asarray(0.5), "n1": jnp.asarray(0.1), "n2": jnp.asarray(0.0)}
+    with pytest.raises(ValueError, match="needs a `usys=`"):
+        cxc.pt_map(pa, chart.M, chart, chart.M, cxc.cart3d)
+
+
+def test_quantities_and_raw_values_can_be_mixed(chart) -> None:
+    """A `Quantity` states its own unit, so it is passed through untouched.
+
+    Which means a partly-wrapped dict works, and a `Quantity` in a unit the
+    `usys` does not use is still honoured -- 100 m rather than 0.1 km.
+    """
+    mixed = {"tau": jnp.asarray(0.5), "n1": u.Q(100.0, "m"), "n2": jnp.asarray(0.0)}
+    allraw = {"tau": jnp.asarray(0.5), "n1": jnp.asarray(0.1), "n2": jnp.asarray(0.0)}
+
+    got = cxc.pt_map(mixed, chart.M, chart, chart.M, cxc.cart3d, usys=USYS)
+    want = cxc.pt_map(allraw, chart.M, chart, chart.M, cxc.cart3d, usys=USYS)
+    for k in ("x", "y", "z"):
+        assert jnp.allclose(got[k], want[k]), k


### PR DESCRIPTION
Stacked on #771 (its two commits are included below; review that first). Splitting out one of the two gaps found while checking that the raw-array route survives #771.

## The bug

`pt_map` accepts coordinates three ways across `coordinax` — a `unxt.Quantity`, a raw array interpreted through a `usys`, or a mix. `TubularChart` advertised exactly that signature:

```python
def pt_map(p: CDict, from_M, from_chart: TubularChart, to_M, to_chart: cxc.Cart3D, /, *, usys: OptUSys = None) -> CDict:
    del to_M, usys                       # <-- discarded
    ...
    xyz = g.ustrip(unit) + p["n1"].ustrip(unit) * R[1] + ...   # <-- assumes Quantity
```

So the raw route was reachable in principle and unusable in practice:

```
pt_map({"tau": jnp.asarray(0.5), ...}, chart.M, chart, chart.M, cxc.cart3d, usys=usys)
→ NotFoundLookupError: `ustrip(Unit("s"), Array(0.5, dtype=float64))` could not be resolved
```

Pre-existing — both `del usys` lines predate #756 and #771.

## The change

Both directions interpret raw coordinates through the unit system, and **return raw when given raw**, matching every other chart: a caller who came in on the cheap route wants to leave on it.

```python
>>> usys = u.unitsystem("km", "s", "kg", "rad")
>>> p = {"tau": 0.0, "n1": 0.1, "n2": 0.0}
>>> cxc.pt_map(p, chart.M, chart, chart.M, cxc.cart3d, usys=usys)
{'x': Array(1.1, ...), 'y': Array(0., ...), 'z': Array(0., ...)}
```

Three details worth review:

- **`tau` is read in the chart's own `coord_dimensions[0]`**, not an assumed time, so a builder over an arc-length curve gets a length from the system rather than a `KeyError` or a wrong unit.
- **Mixed dicts work**, because a `Quantity` states its own unit and passes through untouched. `Q(100.0, "m")` stays 100 m even when the system's length is km — the output unit comes from the *system*, never from whichever coordinate happened to be wrapped. That distinction was a real bug in an intermediate version of this patch and is now pinned by a test.
- **The unserveable case names itself.** A raw coordinate with no `usys` raises `ValueError` saying which coordinate and what to pass, instead of `AttributeError` on a missing `ustrip`.

`_usys_unit` is the single place the system is indexed, so that message has one wording and the `OptUSys` `None` is ruled out once.

## What this is not

It does not make the raw route *faster* — see the sibling PR for the measurements. It makes it work. At this layer both routes converge on the same computation almost immediately.

## Verification

- 984 `coordinaxs.curveframes` tests pass (4 new)
- `prek run` clean on touched files, including `ty`
- new tests pin: raw ≡ quantity numerically; raw round-trips Cart3D → Tubular → Cart3D; mixed dicts; the missing-`usys` message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
