### PR TITLE
✅ bench(curveframes): pin the builder's input-route costs

### DIFF
--- a/tests/benchmark/test_input_routes.py
+++ b/tests/benchmark/test_input_routes.py
@@ -1,0 +1,100 @@
+"""Input-route costs for the curve-frame builders.
+
+`coordinaxs.curveframes` accepts a curve parameter three ways: a
+`unxt.Quantity`, a raw array given meaning by a declared ``tau_unit``, and
+(through `pt_map`) a raw array given meaning by a `unxt.AbstractUnitSystem`.
+A raw route is normally the cheap one, so these pin what it actually costs
+here.
+
+The answer is that it costs the same, and these exist to keep that honest
+rather than to celebrate it. A raw parameter is wrapped into a `Quantity` at
+`_param` and the identical computation follows, so the routes converge almost
+immediately. Measured medians on the helix below:
+
+===================  ==========  ==========
+call                 quantity    raw
+===================  ==========  ==========
+``location`` eager   423 us      456 us
+``tangent``  eager   3434 us     3136 us
+``tangent``  jitted  36.7 us     34.8 us
+===================  ==========  ==========
+
+The eager pair disagree in *opposite directions*, and the run-to-run spread
+(210-310 us on ``tangent``) is larger than the gap between them: that is two
+routes indistinguishable from each other, not one winning.
+
+What dominates is neither the wrapper nor the units: it is eager JAX op
+dispatch inside the user's curve. ``curve(tau)`` alone accounted for roughly
+340 us of ``location``'s ~425, and ``jacfwd``'s call for roughly 2250 us of
+``tangent``'s ~3400. Against that the parameter's wrapper is noise -- as is
+the per-call arity check, `inspect.signature`, an obvious suspect that
+measured 4.2 us, under 0.1% of a ``tangent`` call.
+
+The lever is `jax.jit`, not the input type: it takes ``tangent`` from ~3400
+us to ~36, a ~95x, and it does so equally for both routes. A raw route that
+is genuinely faster would have to stay unitless end to end, which means the
+*curve* must accept magnitudes -- a change to the curve protocol, not to the
+builders, and not one these benchmarks assume.
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import unxt as u
+
+pytest.importorskip("pytest_benchmark")
+cxfc = pytest.importorskip("coordinaxs.curveframes")
+
+import equinox as eqx  # noqa: E402
+
+
+def _helix(tau):
+    """Same helix as ``test_curveframes.py``, for comparable numbers."""
+    t = tau.ustrip("s")
+    return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), 0.3 * t]), "km")
+
+
+TAU_Q = u.Q(0.7, "s")
+TAU_RAW = jnp.asarray(0.7)
+
+
+@pytest.fixture
+def builder():
+    """Frenet-Serret, not Bishop: closed form, so no ODE solve per call.
+
+    The same reason ``test_curveframes.py`` gives -- one Bishop call is a
+    `diffrax` solve and would bury the difference these benchmarks measure
+    under two orders of magnitude of integrator.
+    """
+    return cxfc.FrenetSerretBuilder(_helix, "s")
+
+
+class TestEagerInputRoutes:
+    """Eager per-call cost, by how the parameter arrived."""
+
+    @pytest.mark.parametrize("tau", [TAU_Q, TAU_RAW], ids=["quantity", "raw"])
+    def test_eager_location(self, benchmark, builder, tau):
+        """`location` -- one curve evaluation, no derivative."""
+        builder.location(tau)
+        benchmark(lambda: jax.block_until_ready(builder.location(tau)))
+
+    @pytest.mark.parametrize("tau", [TAU_Q, TAU_RAW], ids=["quantity", "raw"])
+    def test_eager_tangent(self, benchmark, builder, tau):
+        """`tangent` -- adds the `jacfwd` that dominates the call."""
+        builder.tangent(tau)
+        benchmark(lambda: jax.block_until_ready(builder.tangent(tau)))
+
+
+class TestJittedInputRoutes:
+    """Jitted steady state: the wrap traces away, so both routes converge.
+
+    A regression here means the raw route stopped being traced away -- i.e.
+    something started branching on the parameter's type at runtime.
+    """
+
+    @pytest.mark.parametrize("tau", [TAU_Q, TAU_RAW], ids=["quantity", "raw"])
+    def test_jit_tangent(self, benchmark, builder, tau):
+        f = eqx.filter_jit(lambda b, t: b.tangent(t))
+        jax.block_until_ready(f(builder, tau))  # compile
+        benchmark(lambda: jax.block_until_ready(f(builder, tau)))

--- a/tests/benchmark/test_input_routes.py
+++ b/tests/benchmark/test_input_routes.py
@@ -9,14 +9,16 @@ here.
 The answer is that it is not a fastpath, and these exist to keep that honest
 rather than to celebrate it. A raw parameter is wrapped into a `Quantity` at
 `_param` and the identical computation follows, so the routes converge almost
-immediately. Medians over three runs:
+immediately. Medians over four runs on one developer machine -- indicative
+of the *relationship* between the routes, not absolute numbers; CodSpeed
+tracks the real trend:
 
 ===================  ================  ================
 call                 quantity          raw
 ===================  ================  ================
-``location`` eager   424-452 us        456-487 us
-``tangent``  eager   3627-3769 us      3136-3918 us
-``tangent``  jitted  36.6-40.5 us      34.8-37.3 us
+``location`` eager   424-459 us        456-487 us
+``tangent``  eager   3492-3769 us      3136-3918 us
+``tangent``  jitted  36.6-40.8 us      34.8-37.7 us
 ===================  ================  ================
 
 Read that as three different answers, none of them "raw is faster":

--- a/tests/benchmark/test_input_routes.py
+++ b/tests/benchmark/test_input_routes.py
@@ -6,33 +6,38 @@
 A raw route is normally the cheap one, so these pin what it actually costs
 here.
 
-The answer is that it costs the same, and these exist to keep that honest
+The answer is that it is not a fastpath, and these exist to keep that honest
 rather than to celebrate it. A raw parameter is wrapped into a `Quantity` at
 `_param` and the identical computation follows, so the routes converge almost
-immediately. Measured medians on the helix below:
+immediately. Medians over three runs:
 
-===================  ==========  ==========
-call                 quantity    raw
-===================  ==========  ==========
-``location`` eager   423 us      456 us
-``tangent``  eager   3434 us     3136 us
-``tangent``  jitted  36.7 us     34.8 us
-===================  ==========  ==========
+===================  ================  ================
+call                 quantity          raw
+===================  ================  ================
+``location`` eager   424-452 us        456-487 us
+``tangent``  eager   3627-3769 us      3136-3918 us
+``tangent``  jitted  36.6-40.5 us      34.8-37.3 us
+===================  ================  ================
 
-The eager pair disagree in *opposite directions*, and the run-to-run spread
-(210-310 us on ``tangent``) is larger than the gap between them: that is two
-routes indistinguishable from each other, not one winning.
+Read that as three different answers, none of them "raw is faster":
+
+* ``location`` eager consistently favours the `Quantity` by ~7%, which is the
+  wrap being paid for and is the honest cost of the raw route.
+* ``tangent`` jitted consistently favours raw by ~6% -- one pytree node fewer
+  crossing the `jax.jit` boundary.
+* ``tangent`` eager **flipped ordering between runs**, and its spread is
+  larger than the gap. There is no answer there to report.
 
 What dominates is neither the wrapper nor the units: it is eager JAX op
 dispatch inside the user's curve. ``curve(tau)`` alone accounted for roughly
 340 us of ``location``'s ~425, and ``jacfwd``'s call for roughly 2250 us of
-``tangent``'s ~3400. Against that the parameter's wrapper is noise -- as is
-the per-call arity check, `inspect.signature`, an obvious suspect that
-measured 4.2 us, under 0.1% of a ``tangent`` call.
+``tangent``'s ~3400. Against that the parameter's wrapper is a rounding error
+-- as is the per-call arity check, `inspect.signature`, an obvious suspect
+that measured 4.2 us, under 0.1% of a ``tangent`` call.
 
-The lever is `jax.jit`, not the input type: it takes ``tangent`` from ~3400
-us to ~36, a ~95x, and it does so equally for both routes. A raw route that
-is genuinely faster would have to stay unitless end to end, which means the
+The lever is `jax.jit`, not the input type: it takes ``tangent`` from ~3700
+us to ~37, a ~100x, and it does so for both routes alike. A raw route that is
+genuinely faster would have to stay unitless end to end, which means the
 *curve* must accept magnitudes -- a change to the curve protocol, not to the
 builders, and not one these benchmarks assume.
 """
@@ -76,13 +81,21 @@ class TestEagerInputRoutes:
     @pytest.mark.parametrize("tau", [TAU_Q, TAU_RAW], ids=["quantity", "raw"])
     def test_eager_location(self, benchmark, builder, tau):
         """`location` -- one curve evaluation, no derivative."""
-        builder.location(tau)
+        # Blocked: JAX dispatch is async, so an unblocked warm-up can still be
+        # in flight when the first measured iteration starts. Tracing and
+        # compilation finish synchronously either way, but the device compute
+        # would overlap the first round.
+        jax.block_until_ready(builder.location(tau))
         benchmark(lambda: jax.block_until_ready(builder.location(tau)))
 
     @pytest.mark.parametrize("tau", [TAU_Q, TAU_RAW], ids=["quantity", "raw"])
     def test_eager_tangent(self, benchmark, builder, tau):
         """`tangent` -- adds the `jacfwd` that dominates the call."""
-        builder.tangent(tau)
+        # Blocked: JAX dispatch is async, so an unblocked warm-up can still be
+        # in flight when the first measured iteration starts. Tracing and
+        # compilation finish synchronously either way, but the device compute
+        # would overlap the first round.
+        jax.block_until_ready(builder.tangent(tau))
         benchmark(lambda: jax.block_until_ready(builder.tangent(tau)))
 
 


### PR DESCRIPTION
Now that #771 has merged this is a standalone one-file change. The second of the two gaps found while checking that the raw-array route survives #771 — and the one where the answer turned out to be "measure it, don't build it."

## What you asked for vs what the numbers say

The premise was that the array-only route is generally the fastest, so it deserves a real fastpath. At this layer it isn't, and this PR pins that instead of building something that cannot pay off.

A raw parameter is wrapped into a `Quantity` at `_param` and the identical computation follows, so the two routes converge almost immediately. Measured medians (`pytest-benchmark`, same helix as `test_curveframes.py`):

| call | quantity | raw |
| --- | --- | --- |
| `location` eager | 424–459 µs | 456–487 µs |
| `tangent` eager | 3492–3769 µs | 3136–3918 µs |
| `tangent` jitted | 36.6–40.8 µs | 34.8–37.7 µs |

Medians over four runs on one developer machine — indicative of the *relationship* between the routes, not absolute numbers; CodSpeed tracks the real trend. Read that as three different answers, none of them "raw is faster":

- **`location` eager consistently favours the `Quantity` by ~7%** — that is the wrap being paid for, and it is the honest cost of the raw route.
- **`tangent` jitted consistently favours raw by ~6%** — one pytree node fewer crossing the `jax.jit` boundary.
- **`tangent` eager flipped ordering between runs**, with a spread wider than the gap. There is no answer there to report, and an earlier draft of this PR pinned one run's numbers as though there were.

## Where the time actually goes

Neither the wrapper nor the units:

- `curve(tau)` alone — the user's own `jnp.cos`/`jnp.stack`/`ustrip` — is roughly **340 µs of `location`'s ~425**
- `jacfwd`'s call is roughly **2250 µs of `tangent`'s ~3400**
- `inspect.signature`, run per call by the arity check and the obvious suspect I went in expecting to find, measures **4.2 µs — under 0.1%** of a `tangent` call

That last one is worth stating plainly: caching the arity on the builder looked like an easy win and would have bought nothing. `ArcLength` already caches it, which made the asymmetry look like an oversight rather than a non-issue.

**The lever is `jax.jit`** — ~3400 µs → ~36 µs on `tangent`, a ~95x, and it applies equally to both routes.

## What would make a raw route genuinely faster

It would have to stay unitless end to end. The cost is eager op dispatch *inside the curve*, and the curve is user code written against `Quantity` (`tau.ustrip("s")`). Skipping `Quantity` in the builder while the curve still constructs them moves the work, it doesn't remove it. A real fastpath therefore needs the **curve protocol** to admit magnitudes — a much larger change, and deliberately not attempted here.

I'd rather land the measurement and let the protocol question be decided on evidence than ship a speculative fastpath that the numbers say would be flat.

## Contents

Six benchmarks under the existing CodSpeed setup: eager `location` and `tangent`, and jitted `tangent`, each parametrised over both input routes. The jitted pair double as a guard — a regression there means the wrap stopped being traced away, i.e. something started branching on the parameter's type at runtime.

## Verification

- 20 benchmarks pass under `pytest tests/benchmark`
- `prek run` clean, including `ty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


