### PR TITLE
✅ test(hypothesis): make the x32 subprocess timeout say something

### DIFF
--- a/packages/coordinaxs.hypothesis/tests/unit/utils/annotations/test_jax_dtypes.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/utils/annotations/test_jax_dtypes.py
@@ -5,6 +5,7 @@ __all__: tuple[str, ...] = ()
 import os
 import subprocess
 import sys
+import time
 
 from typing import Any
 
@@ -70,10 +71,35 @@ def run(d):
     except InvalidArgument as exc:
         bad.append(str(exc)[:120])
 
+import sys as _sys
+print("imported", file=_sys.stderr, flush=True)
 run()
 print(len(bad))
 print("\\n".join(bad[:3]))
 """
+
+
+#: Wall-clock ceiling for the subprocess below.
+#:
+#: The work costs ~3.4s on an idle machine and ~4.4s with all ten logical cores
+#: saturated, so this is a ~130x margin, not a tight bound. It has nonetheless
+#: been hit on CI -- on several PRs at once, including ones touching neither
+#: `charts()` nor anything it imports, which is what marks it as a flake rather
+#: than a regression.
+#:
+#: Ruled out, each by measurement rather than reasoning:
+#:
+#: - CPU contention from `-n logical` (#788). Saturating every core costs ~30%,
+#:   not the ~130x a timeout would need.
+#: - JAX persistent-compilation-cache locking between workers. No cache is
+#:   configured, so there is no lock to contend for.
+#: - Memory exhaustion. The child peaks at ~290MB and a pytest worker at
+#:   ~297MB, so a four-worker runner sits near 1.5GB against 7GB+ available.
+#:
+#: The cause is still unknown. Raising the ceiling further would only make the
+#: eventual failure slower to arrive, so it stays where it is and the handler
+#: below makes the next occurrence say something useful instead.
+_X32_TIMEOUT_S = 600
 
 
 def test_charts_draws_without_x64() -> None:
@@ -82,14 +108,46 @@ def test_charts_draws_without_x64() -> None:
     Guards the wiring rather than the helper: dropping `honoured_dtypes` from the
     dtype defaults leaves the unit test above passing while this fails.
     """
-    proc = subprocess.run(  # noqa: S603  # fixed literal script, this interpreter
-        [sys.executable, "-c", _X32_SCRIPT],
-        env={**os.environ, "JAX_ENABLE_X64": "0"},
-        capture_output=True,
-        text=True,
-        timeout=600,
-        check=False,
-    )
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(  # noqa: S603  # fixed literal script, this interpreter
+            [sys.executable, "-c", _X32_SCRIPT],
+            env={**os.environ, "JAX_ENABLE_X64": "0"},
+            capture_output=True,
+            text=True,
+            timeout=_X32_TIMEOUT_S,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:  # pragma: no cover  - CI-only flake
+        # `subprocess.run` raises before the assert below, so a timeout used to
+        # surface as a bare `TimeoutExpired` carrying a 600-line repr of the
+        # script and nothing about what the child was doing. Re-raise as a
+        # failure that says how far it got.
+        out = (
+            (exc.stdout or b"").decode(errors="replace")
+            if isinstance(exc.stdout, bytes)
+            else (exc.stdout or "")
+        )
+        err = (
+            (exc.stderr or b"").decode(errors="replace")
+            if isinstance(exc.stderr, bytes)
+            else (exc.stderr or "")
+        )
+        stage = (
+            "while drawing charts()"
+            if "imported" in err
+            else "before importing jax/coordinaxs"
+        )
+        msg = (
+            f"the x32 subprocess exceeded {_X32_TIMEOUT_S}s, {stage}.\n"
+            f"It costs ~3.4s idle and ~4.4s with every core saturated, so a "
+            f"timeout here is a stall, not slow work -- see the note above "
+            f"`_X32_TIMEOUT_S` for what has already been ruled out.\n"
+            f"elapsed={time.monotonic() - started:.1f}s\n"
+            f"child stdout: {out[-1000:]!r}\n"
+            f"child stderr: {err[-2000:]!r}"
+        )
+        raise AssertionError(msg) from exc
     assert proc.returncode == 0, proc.stderr[-3000:]
     n_bad, _, detail = proc.stdout.strip().partition("\n")
     assert int(n_bad) == 0, f"{n_bad} InvalidArgument draws:\n{detail}"


### PR DESCRIPTION
`test_charts_draws_without_x64` has been timing out on CI across several PRs at once. This does **not** fix the cause — I could not reproduce it — it fixes the reason nobody has diagnosed it.

## The defect

When the timeout fires, every diagnostic is destroyed:

```python
proc = subprocess.run(..., timeout=600, check=False)
assert proc.returncode == 0, proc.stderr[-3000:]   # never reached
```

`subprocess.run(timeout=...)` raises `TimeoutExpired` *before* the assert written to diagnose it. So CI gets a bare exception carrying a 600-character repr of the script and nothing about what the child was doing — not whether it stalled importing JAX or drawing charts, not how far it got, not a line of its output.

## What this changes

- the child prints a marker to **stderr** once its imports finish, so a timeout can say *where* it stalled (stdout is untouched — the test parses its first line as a count, which my first attempt broke);
- the timeout is caught and re-raised naming the stage, elapsed time, captured output, and the local baseline;
- `_X32_TIMEOUT_S` is named, with the measurements recorded beside it.

Verified by forcing a 1-second ceiling:

```
AssertionError: the x32 subprocess exceeded 1s, before importing jax/coordinaxs.
It costs ~3.4s idle and ~4.4s with every core saturated, so a timeout here is a
stall, not slow work -- see the note above `_X32_TIMEOUT_S` for what has already
been ruled out.
elapsed=1.0s
```

## What was ruled out, by measurement

| suspected cause | measured | verdict |
| --- | --- | --- |
| CPU contention from `-n logical` (#788) | 3.4 s idle → **4.4 s with all 10 logical cores saturated** | ~30%, not the ~130× a timeout needs |
| JAX compilation-cache lock contention | no persistent cache is configured | no lock to contend for |
| Memory exhaustion | child ~290 MB, pytest worker ~297 MB → ~1.5 GB on a 4-worker runner | against 7 GB+ available |

Main's own CI also passes **after** #788 landed, so it is not a deterministic regression.

Seen concurrently on #780, #787 and #781 — the last touching neither `charts()` nor anything it imports, which is what marks it a flake rather than any one branch's fault.

## On the ceiling

Left at 600 s. Against a 3.4 s workload that is already a ~130× margin; raising it would only make the eventual failure slower to arrive, and would bury the signal further.

## Verification

- Full suite: **11353 passed**, 311 skipped, 1 xfailed
- `prek run --all-files` clean, including `ty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
