### PR TITLE
🐛 fix(transforms): `Composed`'s tangent act is the jet fold, so `at_jet` advances

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -66,6 +66,7 @@ Nearly every public function is a plum dispatch table, often with dozens of meth
 - **Check for an existing method before adding one.** `f.methods` at a REPL, or grep for `@plum.dispatch` above the name. A duplicate is an ambiguity, not an addition.
 - **Operators are `quax.register` on `lax` primitives, not dunders.** A PR adding `AbstractVector.__add__` is working against the design; the mixin from `quax-blocks` already routes to the registered handler.
 - **Does the dispatch honour everything it was given?** #707 found metric-level dispatches ignoring the metric they were handed — the signature took it, the body did not use it.
+- **A composite's `**kw`is not threading.**`Composed`folds over its sub-ops, and an anchor kwarg has to *advance* between steps, not ride along unchanged.`\*\*kw`passes the new keyword through and looks like it works — the result is silently wrong, since the last sub-op is anchored at the first one's input. #536 shipped`at_jet`this way:`at`/`at_vel`advanced,`at_jet`did not, and the two spellings of one anchor disagreed. A new kwarg on the generic funnel needs a`Composed` test that pins it against the single-op answer.
 
 ## Chart routing
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -66,7 +66,7 @@ Nearly every public function is a plum dispatch table, often with dozens of meth
 - **Check for an existing method before adding one.** `f.methods` at a REPL, or grep for `@plum.dispatch` above the name. A duplicate is an ambiguity, not an addition.
 - **Operators are `quax.register` on `lax` primitives, not dunders.** A PR adding `AbstractVector.__add__` is working against the design; the mixin from `quax-blocks` already routes to the registered handler.
 - **Does the dispatch honour everything it was given?** #707 found metric-level dispatches ignoring the metric they were handed — the signature took it, the body did not use it.
-- **A composite's `**kw`is not threading.**`Composed`folds over its sub-ops, and an anchor kwarg has to *advance* between steps, not ride along unchanged.`\*\*kw`passes the new keyword through and looks like it works — the result is silently wrong, since the last sub-op is anchored at the first one's input. #536 shipped`at_jet`this way:`at`/`at_vel`advanced,`at_jet`did not, and the two spellings of one anchor disagreed. A new kwarg on the generic funnel needs a`Composed` test that pins it against the single-op answer.
+- **Passing a kwarg through a composite is not threading it.** `Composed` folds over its sub-ops, and an anchor kwarg has to _advance_ between steps, not ride along unchanged. A catch-all `**kw` forwards the new keyword and looks like it works — the result is silently wrong, since the last sub-op is anchored at the first one's input. #536 shipped `at_jet` this way: `at` and `at_vel` advanced, `at_jet` did not, and the two spellings of one anchor disagreed with no error. A new anchor kwarg on the generic funnel needs a `Composed` test pinning it against the single-op answer.
 
 ## Chart routing
 

--- a/docs/guides/transforms.md
+++ b/docs/guides/transforms.md
@@ -470,7 +470,7 @@ Concretely:
 | `pushforward(op, tau, v, ..., at=q)` | Frozen-$\tau$ spatial differential $\partial_x\phi \cdot v$ | Displacements; the pure geometric map |
 | `act_jet(op, tau, jet, chart)` | Joint action on a whole jet `{0: q, 1: v, 2: a, ...}` | Phase-space states, arbitrary derivative order |
 
-Acting a time-dependent transform on a _lone_ velocity or acceleration needs the lower jet slots (the $\dot R x$ term acts on the position); pass `at=` / `at_vel=`, or — simpler — act on a `coordinax.Coordinate` bundle, which supplies the whole jet automatically:
+Acting a time-dependent transform on a _lone_ velocity or acceleration needs the lower jet slots (the $\dot R x$ term acts on the position); pass `at_jet={0: q, 1: v, ...}`, or its `at=` / `at_vel=` shorthand for slots 0 and 1, or — simpler — act on a `coordinax.Coordinate` bundle, which supplies the whole jet automatically:
 
 ```python
 import coordinax as cx

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -27,8 +27,8 @@ from .composite import AbstractCompositeTransform
 from .custom_types import CDict
 from .identity import Identity, identity
 from .prolong import (
-    _MSG_AT_JET_CONFLICT,
     _MSG_JET_SLOT0_MISSING,
+    _merge_slot0,
     _slot_jet,
     prolong_jet,
     pushforward_generic,
@@ -567,14 +567,7 @@ def act(
     # The ladder needs only the base point, but it has to accept it in either
     # spelling: `at_jet` is the general anchor form, so a caller who passes
     # `at_jet={0: at}` and omits `at=` must not hit a downstream "pass 'at'".
-    # Given both, raise rather than pick one -- silently preferring `at=` would
-    # hide a wrong anchor, and the generic path already refuses the same way.
-    if at_jet is not None and 0 in at_jet:
-        if at is not None:
-            raise TypeError(
-                _MSG_AT_JET_CONFLICT.format(op=type(op).__name__, k=0, alias="at")
-            )
-        at = at_jet[0]
+    at = _merge_slot0(op, at, at_jet)
     return _ladder_act(op, op0, k, tau, m, x, chart, rep, at=at, usys=usys, **kw)
 
 

--- a/src/coordinax/transforms/_src/actions/add.py
+++ b/src/coordinax/transforms/_src/actions/add.py
@@ -28,6 +28,7 @@ from .custom_types import CDict
 from .identity import Identity, identity
 from .prolong import (
     _MSG_JET_SLOT0_MISSING,
+    AnchorJet,
     _merge_slot0,
     _slot_jet,
     prolong_jet,
@@ -493,7 +494,7 @@ def act(
     *,
     at: CDict | None = None,
     at_vel: CDict | None = None,
-    at_jet: dict[int, CDict] | None = None,
+    at_jet: AnchorJet | None = None,
     usys: Any = None,
     **kw: Any,
 ) -> CDict:

--- a/src/coordinax/transforms/_src/actions/composed.py
+++ b/src/coordinax/transforms/_src/actions/composed.py
@@ -16,10 +16,11 @@ import unxt as u
 import coordinax.charts as cxc
 import coordinax.representations as cxr
 import coordinaxs.api.transforms as cxfmapi
-from .base import AbstractTransform
+from .base import AbstractTransform, is_time_dependent
 from .composite import AbstractCompositeTransform
-from .custom_types import CDict
+from .custom_types import CDict, OptUSys
 from .identity import Identity, identity
+from .prolong import JetDict, _merge_slot0, prolong_slot
 from coordinax.transforms._src import groups
 
 Ts = TypeVarTuple("Ts")
@@ -278,33 +279,56 @@ def act(
     {'x': Q(1, 'km'), 'y': Q(2, 'km'), 'z': Q(3, 'km')}
 
     """
-    # 'at' / 'at_vel' track the evolving jet slots (base point and velocity)
-    # for tangent transformations: advance them after each sub-op so the next
-    # step evaluates at the correct anchor. Whether each anchor is provided is
-    # loop-invariant, so the step kwargs dict is built once and updated.
-    current_at = kw.get("at")
-    current_at_vel = kw.get("at_vel")
-    kw_rest = {k: v for k, v in kw.items() if k not in ("at", "at_vel")}
+    # Tangent data of order >= 1 under a time-dependent pipeline is a
+    # prolongation, and jets compose by the chain rule -- so the prolongation
+    # of a composition IS the composition of the prolongations, which is the
+    # `act_jet` fold further down this module. Hand it the assembled anchor
+    # jet and let it fold.
+    #
+    # This used to be a hand-rolled shadow 2-jet instead: `at` and `at_vel`
+    # threaded through the per-sub-op `act` fold and advanced after each step
+    # (velocity first, since it needed the old base point). Two implementations
+    # of one semantics, and only one of them generalised -- the shadow knew
+    # about exactly two anchors, so `at_jet` rode through *unadvanced* and came
+    # out with a different, wrong answer, silently. See gh#536.
+    #
+    # A point rep has no ladder order at all (`None`, not 0), and this is the
+    # ungated 5-argument dispatch, so the geometry check has to come first.
+    m = (
+        rep.semantic_kind.order
+        if isinstance(rep.geom_kind, cxr.TangentGeometry)
+        else None
+    )
+    if m is not None and m >= 1 and is_time_dependent(op):
+        return prolong_slot(
+            op,
+            tau,
+            x,
+            chart,
+            m,
+            at=cast("CDict | None", kw.get("at")),
+            at_vel=cast("CDict | None", kw.get("at_vel")),
+            at_jet=cast("JetDict | None", kw.get("at_jet")),
+            usys=cast("OptUSys", kw.get("usys")),
+        )
+
+    # Everything else -- points, displacements, and tangent data under a
+    # time-independent pipeline -- folds sub-op by sub-op. Only the base point
+    # travels with it: these paths all end in the frozen-tau pushforward, which
+    # anchors on slot 0 alone, so there is no shadow jet left to keep in step.
+    current_at = _merge_slot0(op, kw.get("at"), kw.get("at_jet"))
+    kw_rest = {k: v for k, v in kw.items() if k not in ("at", "at_vel", "at_jet")}
     step_kw = dict(kw_rest)
-    at_kw = {"at": current_at} if current_at is not None else {}
     result = x
     last = len(op.transforms) - 1
     for i, sub_op in enumerate(op.transforms):
         if current_at is not None:
             step_kw["at"] = current_at
-            at_kw["at"] = current_at
-        if current_at_vel is not None:
-            step_kw["at_vel"] = current_at_vel
         result = cxfmapi.act(sub_op, tau, result, chart, rep, **step_kw)
         if i == last:
-            # The advanced anchors would never be read — skip the (eager-mode)
-            # dead work of transforming them through the final sub-op.
+            # The advanced anchor would never be read — skip the (eager-mode)
+            # dead work of transforming it through the final sub-op.
             break
-        # Advance the anchor jet (velocity first: it needs the old base point).
-        if current_at_vel is not None:
-            current_at_vel = cxfmapi.act(
-                sub_op, tau, current_at_vel, chart, cxr.coord_vel, **kw_rest, **at_kw
-            )
         if current_at is not None:
             current_at = cxfmapi.act(
                 sub_op, tau, current_at, chart, cxr.point, **kw_rest

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -686,6 +686,10 @@ def act(
     m = rep.semantic_kind.order
 
     if m == 0 or not is_time_dependent(op):
+        # No prolongation here, just the frozen-tau pushforward -- but it still
+        # needs the base point, and `at_jet` is the general anchor form, so
+        # slot 0 must reach it as surely as `at=` does.
+        at = _merge_slot0(op, at, at_jet)
         return cast(
             "CDict", cxfmapi.pushforward(op, tau, x, chart, rep, at=at, usys=usys)
         )
@@ -693,6 +697,25 @@ def act(
     return prolong_slot(
         op, tau, x, chart, m, at=at, at_vel=at_vel, at_jet=at_jet, usys=usys
     )
+
+
+def _merge_slot0(
+    op: AbstractTransform, at: CDict | None, at_jet: JetDict | None, /
+) -> CDict | None:
+    """Resolve the base point from ``at`` or ``at_jet[0]``, refusing both at once.
+
+    For the paths that need only slot 0 (the frozen-tau pushforward, the fibre
+    ladder, a `Composed` fold's travelling anchor). Giving one slot twice
+    raises rather than silently preferring one: a wrong anchor is a wrong
+    answer, not a lesser convenience.
+    """
+    if at_jet is None or 0 not in at_jet:
+        return at
+    if at is not None:
+        raise TypeError(
+            _MSG_AT_JET_CONFLICT.format(op=type(op).__name__, k=0, alias="at")
+        )
+    return at_jet[0]
 
 
 def _slot_jet(

--- a/src/coordinax/transforms/_src/actions/prolong.py
+++ b/src/coordinax/transforms/_src/actions/prolong.py
@@ -33,6 +33,7 @@ Two related verbs are distinguished:
 """
 
 __all__ = (
+    "AnchorJet",
     "JetDict",
     "prolong_jet",
     "prolong_slot",
@@ -72,6 +73,16 @@ All-integer keys keep the jet a valid JAX pytree (jit/vmap-safe).
 Note the distinction from the tangent semantic-kind ladder: `Displacement`
 (ladder order 0) is a same-$\tau$ point difference, *not* a curve derivative,
 so it is never a jet slot — displacement fibres transform by ``pushforward``.
+"""
+
+AnchorJet: TypeAlias = dict[int, CDict | None]
+"""Anchor slots as a *caller* supplies them, via the ``at_jet=`` keyword.
+
+Distinct from `JetDict`, which is engine data: an actual jet has a value in
+every slot it names. An anchor dict is assembled by the caller, often
+programmatically, so a slot may come out empty — and `None` there means "not
+given", exactly as ``at=None`` does. `_live_slots` drops those, and is the one
+place the caller-facing form becomes a `JetDict`.
 """
 
 _MSG_TAU_REQUIRED = (
@@ -642,7 +653,7 @@ def act(
     *,
     at: CDict | None = None,
     at_vel: CDict | None = None,
-    at_jet: JetDict | None = None,
+    at_jet: AnchorJet | None = None,
     usys: OptUSys = None,
     **kw: Any,
 ) -> CDict:
@@ -699,8 +710,27 @@ def act(
     )
 
 
+def _live_slots(at_jet: AnchorJet | None, /) -> JetDict:
+    """Keep the slots actually supplied, dropping the empty ones.
+
+    Both validators below test slot *presence by key*, so a `None` value would
+    sail past a missing-slot check and fail far downstream about a slot that
+    looks supplied. The runtime typechecker is not a gate here: beartype
+    samples one entry per container, so ``{0: q, 1: None}`` is caught only on
+    the draws that happen to pick slot 1.
+
+    Normalizing in the two functions every entrypoint routes through — rather
+    than at each entrypoint — is what makes ``at_jet={0: None}`` read as
+    ``at=None`` does: on the funnel, through `Composed`, and on ``add.py``'s
+    `TimeDep` rule alike.
+    """
+    if at_jet is None:
+        return {}
+    return {k: v for k, v in at_jet.items() if v is not None}
+
+
 def _merge_slot0(
-    op: AbstractTransform, at: CDict | None, at_jet: JetDict | None, /
+    op: AbstractTransform, at: CDict | None, at_jet: AnchorJet | None, /
 ) -> CDict | None:
     """Resolve the base point from ``at`` or ``at_jet[0]``, refusing both at once.
 
@@ -709,13 +739,14 @@ def _merge_slot0(
     raises rather than silently preferring one: a wrong anchor is a wrong
     answer, not a lesser convenience.
     """
-    if at_jet is None or 0 not in at_jet:
+    slots = _live_slots(at_jet)
+    if 0 not in slots:
         return at
     if at is not None:
         raise TypeError(
             _MSG_AT_JET_CONFLICT.format(op=type(op).__name__, k=0, alias="at")
         )
-    return at_jet[0]
+    return slots[0]
 
 
 def _slot_jet(
@@ -727,7 +758,7 @@ def _slot_jet(
     *,
     at: CDict | None,
     at_vel: CDict | None,
-    at_jet: JetDict | None = None,
+    at_jet: AnchorJet | None = None,
 ) -> JetDict:
     """Validate the lower jet slots and assemble the jet for an order-``m`` slot.
 
@@ -742,7 +773,7 @@ def _slot_jet(
     # `at`/`at_vel` are sugar for slots 0 and 1; `at_jet` is the general form,
     # and the only way to reach slots >= 2. Missing-slot checks come *after*
     # the merge, so supplying slot 0 through `at_jet` alone is enough.
-    slots: JetDict = dict(at_jet or {})
+    slots: JetDict = _live_slots(at_jet)
     for k, (alias, value) in enumerate((("at", at), ("at_vel", at_vel))):
         if value is None:
             continue
@@ -781,7 +812,7 @@ def prolong_slot(
     at: CDict | None,
     at_vel: CDict | None,
     usys: OptUSys,
-    at_jet: JetDict | None = None,
+    at_jet: AnchorJet | None = None,
 ) -> CDict:
     """Apply the m-th prolongation to a single order-``m`` slot.
 

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -567,9 +567,14 @@ def act(
     if at_vel_data is not None:
         kw["at_vel"] = at_vel_data
     if at_jet is not None:
-        kw["at_jet"] = {
+        slots = {
             k: _unwrap_anchor(v, x.chart, f"at_jet[{k}]") for k, v in at_jet.items()
         }
+        # A `None` slot means "not given", exactly as `at=None` does. Keeping
+        # the key would sail past the engine's presence check -- which tests
+        # keys, not values -- and fail further down about a slot that looks
+        # supplied, naming neither the slot nor the caller's mistake.
+        kw["at_jet"] = {k: v for k, v in slots.items() if v is not None}
     data = cxfmapi.act(op, tau, x.data, x.chart, x.rep, **kw)
     return replace(x, data=data)
 

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -567,14 +567,12 @@ def act(
     if at_vel_data is not None:
         kw["at_vel"] = at_vel_data
     if at_jet is not None:
-        slots = {
+        # Unwrap only. Empty slots are dropped by the engine, for every
+        # entrypoint at once (`prolong._live_slots`); filtering here as well
+        # would be a second place to keep in step with it.
+        kw["at_jet"] = {
             k: _unwrap_anchor(v, x.chart, f"at_jet[{k}]") for k, v in at_jet.items()
         }
-        # A `None` slot means "not given", exactly as `at=None` does. Keeping
-        # the key would sail past the engine's presence check -- which tests
-        # keys, not values -- and fail further down about a slot that looks
-        # supplied, naming neither the slot nor the caller's mistake.
-        kw["at_jet"] = {k: v for k, v in slots.items() if v is not None}
     data = cxfmapi.act(op, tau, x.data, x.chart, x.rep, **kw)
     return replace(x, data=data)
 

--- a/src/coordinax/vectors/_src/register_cx.py
+++ b/src/coordinax/vectors/_src/register_cx.py
@@ -529,6 +529,7 @@ def act(
     *,
     at: Any = None,
     at_vel: Any = None,
+    at_jet: dict[int, Any] | None = None,
     **kw: Any,
 ) -> Tangent:
     """Act a frame transform on a tangent Tangent.
@@ -536,8 +537,11 @@ def act(
     ``at`` (the base point) and ``at_vel`` (the velocity at the base point)
     anchor the transformation when it is needed — for Jacobian pushforwards in
     non-Cartesian charts and for the kinematic prolongation under
-    time-dependent transforms. They may be `Point`/`Tangent` instances (whose
-    ``.data`` is used, after a chart check) or raw ``CDict`` data.
+    time-dependent transforms. ``at_jet`` is the general form of the same
+    thing, a dict keyed by jet slot, and the only spelling that reaches slot 2
+    and above. They may be `Point`/`Tangent` instances (whose ``.data`` is
+    used, after a chart check) or raw ``CDict`` data — ``at_jet``'s values
+    included, slot by slot.
 
     >>> import jax.numpy as jnp
     >>> import unxt as u
@@ -562,6 +566,10 @@ def act(
         kw["at"] = at_data
     if at_vel_data is not None:
         kw["at_vel"] = at_vel_data
+    if at_jet is not None:
+        kw["at_jet"] = {
+            k: _unwrap_anchor(v, x.chart, f"at_jet[{k}]") for k, v in at_jet.items()
+        }
     data = cxfmapi.act(op, tau, x.data, x.chart, x.rep, **kw)
     return replace(x, data=data)
 

--- a/tests/unit/transforms/test_composed_jet_fold.py
+++ b/tests/unit/transforms/test_composed_jet_fold.py
@@ -1,0 +1,195 @@
+"""`Composed`'s tangent `act` is the `act_jet` fold (#536, second half).
+
+`Composed` used to hand-roll a shadow 2-jet: it threaded `at`/`at_vel` through
+the per-sub-op `act` fold, advancing each anchor after every step (velocity
+first, since it needs the old base point). That duplicated the `act_jet` fold
+sitting in the same module, and only one of the two generalised -- the shadow
+knew about exactly two anchors, so `at_jet` was passed through *unadvanced* and
+came out with a different, wrong answer, and no error.
+"""
+
+__all__: tuple[str, ...] = ()
+
+import dataclasses
+
+import jax.numpy as jnp
+import pytest
+
+import unxt as u
+
+import coordinax as cx
+import coordinax.charts as cxc
+import coordinax.representations as cxr
+import coordinax.transforms as cxfm
+from coordinax.representations._src.semantics import (
+    _TANGENT_TIME_ORDER_LADDER as _LADDER,
+    AbstractTangentSemanticKind,
+)
+
+_ZHAT = jnp.asarray([0.0, 0.0, 1.0])
+_TAU = u.Q(0.0, "s")
+_ACC_REP = cxr.Representation(cxr.tangent_geom, cxr.coord_basis, cxr.acc)
+
+_AT = {"x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+_VEL = {"x": u.Q(0.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")}
+_ACC = {"x": u.Q(0.0, "m/s2"), "y": u.Q(0.0, "m/s2"), "z": u.Q(0.0, "m/s2")}
+
+
+def _pipe() -> cxfm.Composed:
+    r"""Translate 10 m along x, then spin at 1 rad/s about z.
+
+    The translation is what makes the anchor advance observable: the rotation's
+    centripetal term is $-\omega^2 r$, so it reports the base point it saw.
+    An anchor left at the pipeline's *input* point reports r = 1 m instead of
+    the 11 m the rotation actually acts at.
+    """
+    return cxfm.Composed(
+        (
+            cxfm.Translate.from_([10.0, 0.0, 0.0], "m"),
+            cxfm.TimeDep(
+                cxfm.builders.RotationAboutAxis(u.Q(1.0, "rad/s"), axis=_ZHAT)
+            ),
+        )
+    )
+
+
+def _x(cdict: dict) -> float:
+    return float(u.ustrip("m/s2", cdict["x"]))
+
+
+def test_at_jet_matches_the_sugar_through_a_pipeline() -> None:
+    """The regression: `at_jet` used to skip the anchor advance and give -1."""
+    pipe = _pipe()
+    via_sugar = cxfm.act(pipe, _TAU, _ACC, cxc.cart3d, _ACC_REP, at=_AT, at_vel=_VEL)
+    via_jet = cxfm.act(pipe, _TAU, _ACC, cxc.cart3d, _ACC_REP, at_jet={0: _AT, 1: _VEL})
+    assert _x(via_sugar) == pytest.approx(_x(via_jet))
+
+
+def test_both_spellings_match_the_act_jet_fold() -> None:
+    """`act_jet` on the full jet is the reference: -omega^2 * 11 m."""
+    pipe = _pipe()
+    reference = cxfm.act_jet(pipe, _TAU, {0: _AT, 1: _VEL, 2: _ACC}, cxc.cart3d)[2]
+    assert _x(reference) == pytest.approx(-11.0)
+
+    for kw in ({"at": _AT, "at_vel": _VEL}, {"at_jet": {0: _AT, 1: _VEL}}):
+        out = cxfm.act(pipe, _TAU, _ACC, cxc.cart3d, _ACC_REP, **kw)
+        assert _x(out) == pytest.approx(-11.0)
+
+
+def test_a_time_independent_pipeline_takes_at_jet_slot_zero() -> None:
+    """No prolongation here -- just the pushforward, anchored on `at_jet[0]`.
+
+    A curved chart is what makes the base point matter: the Jacobian of the
+    spherical->spherical map depends on where it is evaluated.
+    """
+    pipe = cxfm.Composed(
+        (
+            cxfm.Rotate.from_euler("z", u.Q(90, "deg")),
+            cxfm.Rotate.from_euler("x", u.Q(30, "deg")),
+        )
+    )
+    at = {"r": u.Q(2.0, "m"), "theta": u.Q(1.0, "rad"), "phi": u.Q(0.5, "rad")}
+    v = {"r": u.Q(1.0, "m/s"), "theta": u.Q(0.1, "rad/s"), "phi": u.Q(0.2, "rad/s")}
+    rep = cxr.Representation(cxr.tangent_geom, cxr.coord_basis, cxr.vel)
+
+    via_at = cxfm.act(pipe, None, v, cxc.sph3d, rep, at=at)
+    via_jet = cxfm.act(pipe, None, v, cxc.sph3d, rep, at_jet={0: at})
+    for k in via_at:
+        assert jnp.allclose(
+            u.ustrip(u.unit_of(via_at[k]), via_at[k]),
+            u.ustrip(u.unit_of(via_at[k]), via_jet[k]),
+        )
+
+
+def test_the_doubly_given_base_point_is_refused_through_a_pipeline() -> None:
+    """`Composed` refuses the same way every other path does."""
+    with pytest.raises(TypeError, match="given twice"):
+        cxfm.act(
+            _pipe(), _TAU, _ACC, cxc.cart3d, _ACC_REP, at=_AT, at_jet={0: _AT, 1: _VEL}
+        )
+
+
+def test_a_pipeline_reaches_order_three() -> None:
+    """The order ceiling is gone through `Composed` too, not just a bare op.
+
+    The kind is registered here and popped again: the time-order ladder is
+    global and other tests assert it holds exactly the three shipped kinds.
+    """
+    import jax.tree_util as jtu
+
+    @jtu.register_static
+    @dataclasses.dataclass(frozen=True, slots=True, repr=False)
+    class Snap(AbstractTangentSemanticKind):
+        order = 3
+
+    try:
+        rep = cxr.Representation(cxr.tangent_geom, cxr.coord_basis, Snap())
+        pipe = _pipe()
+        jerk = {"x": u.Q(1.0, "m/s3"), "y": u.Q(0.0, "m/s3"), "z": u.Q(0.0, "m/s3")}
+        slots = {0: _AT, 1: _VEL, 2: _ACC}
+
+        out = cxfm.act(pipe, _TAU, jerk, cxc.cart3d, rep, at_jet=slots)
+        reference = cxfm.act_jet(pipe, _TAU, {**slots, 3: jerk}, cxc.cart3d)[3]
+        for k in ("x", "y", "z"):
+            assert jnp.allclose(
+                u.ustrip("m/s3", out[k]), u.ustrip("m/s3", reference[k]), atol=1e-6
+            )
+    finally:
+        _LADDER.pop(3, None)
+
+
+def test_the_coordinate_bundle_route_still_agrees() -> None:
+    """The bundle path already folded jets; it must not have moved."""
+    pipe = _pipe()
+    pv = cx.Coordinate(
+        point=cx.Point.from_([1.0, 0.0, 0.0], "m"),
+        velocity=cx.Tangent.from_([0.0, 0.0, 0.0], "m/s"),
+    )
+    out = cxfm.act(pipe, _TAU, pv)
+    lone = cxfm.act(
+        pipe,
+        _TAU,
+        dict(pv["velocity"].data),
+        cxc.cart3d,
+        cxr.Representation(cxr.tangent_geom, cxr.coord_basis, cxr.vel),
+        at_jet={0: dict(pv.point.data)},
+    )
+    for k in ("x", "y", "z"):
+        assert jnp.allclose(
+            u.ustrip("m/s", out["velocity"].data[k]),
+            u.ustrip("m/s", lone[k]),
+            atol=1e-6,
+        )
+
+
+def test_at_jet_slots_accept_point_and_tangent_bundles() -> None:
+    """`at=` took a `Point`; `at_jet={0: Point}` has to as well.
+
+    The public `Tangent` wrapper unwrapped (and chart-checked) `at`/`at_vel`
+    only, so a `Point` in an `at_jet` slot reached the engine as a vector
+    object and died on a component mismatch it could not explain.
+    """
+    op = cxfm.TimeDep(cxfm.builders.RotationAboutAxis(u.Q(1.0, "rad/s"), axis=_ZHAT))
+    at = cx.Point.from_([1.0, 0.0, 0.0], "m")
+    v = cx.Tangent.from_([0.0, 0.0, 0.0], "m/s")
+
+    via_at = cx.act(op, _TAU, v, at=at)
+    via_jet = cx.act(op, _TAU, v, at_jet={0: at})
+    for k in ("x", "y", "z"):
+        assert jnp.allclose(
+            u.ustrip("m/s", via_at.data[k]), u.ustrip("m/s", via_jet.data[k])
+        )
+    # and the anchor was actually read: the omega x r term is 1 m/s along y
+    assert float(u.ustrip("m/s", via_jet.data["y"])) == pytest.approx(1.0)
+
+
+def test_a_mismatched_chart_in_an_at_jet_slot_says_which_slot() -> None:
+    """The chart check travels with the unwrap, and names the slot it failed on."""
+    op = cxfm.TimeDep(cxfm.builders.RotationAboutAxis(u.Q(1.0, "rad/s"), axis=_ZHAT))
+    v = cx.Tangent.from_([0.0, 0.0, 0.0], "m/s")
+    wrong = cx.Point.from_(
+        {"r": u.Q(1.0, "m"), "theta": u.Q(0.5, "rad"), "phi": u.Q(0.2, "rad")},
+        cxc.sph3d,
+    )
+    with pytest.raises(ValueError, match=r"at_jet\[0\]"):
+        cx.act(op, _TAU, v, at_jet={0: wrong})

--- a/tests/unit/transforms/test_composed_jet_fold.py
+++ b/tests/unit/transforms/test_composed_jet_fold.py
@@ -193,3 +193,23 @@ def test_a_mismatched_chart_in_an_at_jet_slot_says_which_slot() -> None:
     )
     with pytest.raises(ValueError, match=r"at_jet\[0\]"):
         cx.act(op, _TAU, v, at_jet={0: wrong})
+
+
+def test_a_none_slot_reads_as_not_given() -> None:
+    """`at_jet={0: None}` is "not given", exactly as `at=None` is.
+
+    The engine tests slot *presence by key*, so a kept `None` would sail past
+    the check and fail further down about a slot that looks supplied. Dropping
+    it instead yields the engine's own missing-slot message, which names the
+    slot and offers both spellings.
+    """
+    op = cxfm.TimeDep(cxfm.builders.RotationAboutAxis(u.Q(1.0, "rad/s"), axis=_ZHAT))
+    v = cx.Tangent.from_([0.0, 0.0, 0.0], "m/s")
+
+    with pytest.raises(TypeError, match=r"'at'.*or as slot 0 of 'at_jet'"):
+        cx.act(op, _TAU, v, at_jet={0: None})
+
+    # and a `None` alongside a real slot does not shadow it
+    at = cx.Point.from_([1.0, 0.0, 0.0], "m")
+    out = cx.act(op, _TAU, v, at_jet={0: at, 1: None})
+    assert float(u.ustrip("m/s", out.data["y"])) == pytest.approx(1.0)

--- a/tests/unit/transforms/test_composed_jet_fold.py
+++ b/tests/unit/transforms/test_composed_jet_fold.py
@@ -213,3 +213,52 @@ def test_a_none_slot_reads_as_not_given() -> None:
     at = cx.Point.from_([1.0, 0.0, 0.0], "m")
     out = cx.act(op, _TAU, v, at_jet={0: at, 1: None})
     assert float(u.ustrip("m/s", out.data["y"])) == pytest.approx(1.0)
+
+
+# --- `None` anchor slots, at the engine layer -----------------------------
+#
+# `at_jet` is caller-supplied input, so a slot can come out empty. The drop
+# lives in the engine's two validators rather than in any one entrypoint, and
+# these go in below the `cx.Tangent` wrapper to pin that. The runtime
+# typechecker is not the gate: beartype samples one entry per container, so
+# `{0: q, 1: None}` is only caught on the draws that pick slot 1.
+
+
+def test_a_none_slot_reads_as_not_given_on_the_prolongation_path() -> None:
+    """`_slot_jet`: the missing-slot error names the slot that came in `None`."""
+    op = cxfm.TimeDep(cxfm.builders.RotationAboutAxis(u.Q(1.0, "rad/s"), axis=_ZHAT))
+    with pytest.raises(TypeError, match=r"'at_vel'.*or as slot 1 of 'at_jet'"):
+        cxfm.act(op, _TAU, _ACC, cxc.cart3d, _ACC_REP, at_jet={0: _AT, 1: None})
+
+
+def test_a_none_slot_reads_as_not_given_on_the_pushforward_path() -> None:
+    """`_merge_slot0`: no prolongation, but slot 0 still has to read as absent.
+
+    A curved chart is what makes it observable -- the Jacobian pushforward
+    refuses without a base point rather than quietly using the origin.
+    """
+    op = cxfm.Rotate.from_euler("z", u.Q(90, "deg"))
+    v = {"r": u.Q(1.0, "m/s"), "theta": u.Q(0.1, "rad/s"), "phi": u.Q(0.2, "rad/s")}
+    rep = cxr.Representation(cxr.tangent_geom, cxr.coord_basis, cxr.vel)
+    with pytest.raises(TypeError, match="requires 'at'"):
+        cxfm.act(op, None, v, cxc.sph3d, rep, at_jet={0: None})
+
+
+def test_a_none_slot_reads_as_not_given_through_a_pipeline() -> None:
+    """`Composed` routes to the same validators, so it inherits this."""
+    with pytest.raises(TypeError, match=r"'at'.*or as slot 0 of 'at_jet'"):
+        cxfm.act(_pipe(), _TAU, _ACC, cxc.cart3d, _ACC_REP, at_jet={0: None, 1: _VEL})
+
+
+def test_a_none_slot_does_not_shadow_a_real_one() -> None:
+    """Dropping the empty slots must not take the supplied ones with them."""
+    op = cxfm.TimeDep(cxfm.builders.RotationAboutAxis(u.Q(1.0, "rad/s"), axis=_ZHAT))
+    vel = {"x": u.Q(0.0, "m/s"), "y": u.Q(0.0, "m/s"), "z": u.Q(0.0, "m/s")}
+    rep = cxr.Representation(cxr.tangent_geom, cxr.coord_basis, cxr.vel)
+
+    out = cxfm.act(op, _TAU, vel, cxc.cart3d, rep, at_jet={0: _AT, 1: None})
+    reference = cxfm.act(op, _TAU, vel, cxc.cart3d, rep, at=_AT)
+    for k in ("x", "y", "z"):
+        assert jnp.allclose(u.ustrip("m/s", out[k]), u.ustrip("m/s", reference[k]))
+    # and the anchor was read: the omega x r term is 1 m/s along y
+    assert float(u.ustrip("m/s", out["y"])) == pytest.approx(1.0)


### PR DESCRIPTION
Closes #536 — the **second** of its two halves, after #781.

## The bug the refactor was hiding

`Composed`'s tangent `act` hand-rolled a shadow 2-jet: `at`/`at_vel` threaded
through the per-sub-op `act` fold and advanced after each step (velocity first,
since it needs the old base point). #536 already called that out as two
implementations of one semantics, with only one of them generalising.

It generalised worse than "not at all". `at_jet` — the anchor spelling #781
introduced *as the general form* — is not one of the two names the shadow knew,
so it rode through `**kw` unadvanced, anchoring every sub-op at the pipeline's
input point:

```python
pipe = Translate([10, 0, 0] m) | TimeDep(RotationAboutAxis(1 rad/s))

act(..., at=q, at_vel=v)              # -> -11 m/s2   correct
act(..., at_jet={0: q, 1: v})         # ->  -1 m/s2   silently wrong
act_jet(pipe, tau, {0:q, 1:v, 2:a})   # -> -11 m/s2   the reference
```

No exception — just a different number. `test_the_sugar_and_at_jet_agree` pins
the two spellings together, but only for a bare `TimeDep`; nothing pinned them
through a pipeline.

## The fix

Tangent data of order $\geq 1$ under a time-dependent pipeline now assembles
its anchor jet with the engine's own validator and hands it to `act_jet`, which
*is* the composition of the prolongations the chain rule says it is. The shadow
jet is deleted, along with its velocity-first ordering subtlety and its
last-iteration dead-work skip. Order 3+ reaches through `Composed` for free.

The remaining fold is the honest half of the old one: points, displacements,
and tangent data under a *time-independent* pipeline all end in the frozen-$\tau$
pushforward, which anchors on slot 0 alone — so only the base point travels,
and there is no shadow jet left to keep in step.

## Two supporting fixes

Both are the same defect class — `at_jet` not yet being a peer of `at`:

- **The funnel's pushforward branch read `at` only.** `at_jet={0: q}` on a
  time-independent op pushed forward unanchored, or raised `requires 'at'` in a
  curved chart. Slot 0 is now resolved once in `_merge_slot0`, which `add.py`'s
  ladder path also stops open-coding.
- **The public `Tangent` act unwrapped `Point`/`Tangent` anchors for `at` and
  `at_vel` but not for `at_jet`'s slots**, so `at_jet={0: cx.Point(...)}` died
  on a component mismatch it could not explain. The chart check now travels
  with the unwrap and names the slot it failed on.

## Testing

New `tests/unit/transforms/test_composed_jet_fold.py`, 8 tests. The first one
fails on `main` with exactly `-11.0 != -1.0`. Coverage: both spellings agree
through a pipeline and both match the `act_jet` reference; a time-independent
pipeline in a curved chart takes `at_jet[0]`; the doubly-given base point is
refused through a pipeline too; order 3 reaches through `Composed`; the
`Coordinate` bundle route is unmoved; `at_jet` slots take `Point`/`Tangent`
bundles and name the slot on a chart mismatch.

Full suite serial: **11361 passed**, 311 skipped, 1 xfailed. `ty` at 6
diagnostics, same as `main`. `prek` clean.

## Performance

`test_eager_composed_anchored_velocity` benches this exact path. Sub-ops now
prolong through the generic AD `act_jet` rather than their own `act` fast paths
— the design #536 asks for — so it was worth measuring rather than assuming:

| | median (µs) | vs `test_eager_td_translate_velocity` |
| --- | --- | --- |
| `main` | 12.43 | 1.42× |
| this PR | 11.92 | 1.42× |

Same ratio, and the absolute difference is inside run-to-run noise.

## On `at_vel`

This does not remove it. `at_vel` is now a pure slot-1 alias in `prolong.py`
with no other consumer, so deleting it is a ~10-line breaking change that buys
one loop iteration — `at` has to stay regardless (`pushforward` and
`tangent_map` need a base point and have no jet), so the `at`-vs-`at_jet`
conflict machinery survives either way. Worth doing on its own terms, not
bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
