### PR TITLE
🐛 fix(ci): make `--exclude-package` actually exclude

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -6,6 +6,7 @@
 
 import argparse
 import shutil
+import tomllib
 from enum import Enum
 from pathlib import Path
 
@@ -129,15 +130,31 @@ def test(s: nox.Session, /) -> None:
     parser.add_argument("--exclude-package", action="append", default=[])
     args, posargs = parser.parse_known_args(s.posargs)
 
-    ignore_paths: list[str] = []
+    excluded: set[str] = set()
     for raw in args.exclude_package:
         try:
             package = PackageEnum[raw]
         except KeyError:
             s.error(f"Unknown --exclude-package value: {raw!r}")
-        ignore_paths.extend(package.paths)
+        excluded.update(path.rstrip("/") for path in package.paths)
 
-    ignore_args = [f"--ignore={path}" for path in dict.fromkeys(ignore_paths)]
+    # Select by naming the paths that survive rather than by `--ignore`.
+    # `testpaths` lists these package directories explicitly, and pytest does
+    # not apply `--ignore` to an initial argument it was handed directly, so
+    # every `--ignore` here was a no-op: the jobs that asked to skip a package
+    # still ran the whole suite.
+    path_args: list[str] = []
+    if excluded:
+        cfg = tomllib.loads((DIR / "pyproject.toml").read_text(encoding="utf-8"))
+        testpaths: list[str] = cfg["tool"]["pytest"]["ini_options"]["testpaths"]
+        path_args = [p for p in testpaths if p.rstrip("/") not in excluded]
+        # Excluding nothing is never what the caller meant, and quietly running
+        # everything is how this went unnoticed. Fail instead.
+        if len(path_args) == len(testpaths):
+            s.error(
+                f"--exclude-package matched no testpaths: {sorted(excluded)} "
+                f"against {testpaths}"
+            )
 
     # -n logical: parallelize across cores. --dist=loadfile: keep each file's
     # tests on one worker -- Sybil doctests share sequential state across
@@ -152,7 +169,7 @@ def test(s: nox.Session, /) -> None:
     s.run(
         "pytest",
         *xdist_args,
-        *ignore_args,
+        *path_args,
         *posargs,
         env={"COORDINAX_REQUIRE_INTEROP_TESTS": "1"},
     )


### PR DESCRIPTION
## The bug

`nox -s test -- --exclude-package astro` emitted `--ignore=packages/coordinaxs.astro/`, and that did nothing.

`testpaths` in `pyproject.toml` names those package directories explicitly, and pytest does not apply `--ignore` to an initial argument it was handed directly. So every exclusion was a silent no-op: a CI job told to skip a package still collected the whole suite.

Visible in the *passing* 3.12 job of run [32852597055](https://github.com/GalacticDynamics/coordinax/actions/runs/32852597055) — it ran with `--exclude-package astro --exclude-package curveframes`, and its `--durations=20` table is full of `coordinaxs.astro` and `coordinaxs.curveframes` tests, led by an 80s `curveframes` case. 11577 tests, 19:11.

## The fix

Name the paths that survive instead of trying to ignore the ones that don't, taking `testpaths` from `pyproject.toml` so there is one source of truth.

Excluding nothing is never what the caller meant, and quietly running everything is exactly how this went unnoticed, so a no-op exclusion now aborts the session naming both sides.

## Verification

Collected counts, baseline 11889:

| `--exclude-package` | before | after |
|---|---|---|
| `coordinax` | 11889 | 3012 |
| `api` | 11889 | 11639 |
| `astro` | 11889 | 11473 |
| `curveframes` | 11889 | 10861 |
| `hypothesis` | 11889 | 11003 |
| *(none)* | 11889 | 11889 |

- Full run with the CI-style exclusions: **10135 passed, 313 skipped, 1 xfailed in 1:44** — against ~6:00 for the same command before, when the exclusions did nothing.
- No-exclusion path unchanged, still 11889.
- Drift guard mutation-tested: renaming a `testpaths` entry aborts with `--exclude-package matched no testpaths: ['packages/coordinaxs.api'] against [...]`.
- `prek run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)