### PR TITLE
♻️ refactor(curveframes): resolve the curve parameter and its unit together

### DIFF
--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -301,8 +301,13 @@ class AbstractCurveFrameBuilder(eqx.Module):
         check_param_dimension(self.curve, tau_unit)
         return tau_unit
 
-    def _param(self, tau: Any, /) -> Any:
-        r"""Return the curve parameter as a `Quantity`: ``tau``, or the station.
+    def _param(self, tau: Any, /) -> tuple[Any, u.AbstractUnit]:
+        r"""Return the curve parameter as a `Quantity`, and its unit.
+
+        Both, because every caller that evaluates the curve needs both, and
+        resolving them apart is what let them disagree: `rotation_matrices`
+        used to re-derive the unit with a comment reading "same resolution
+        `_solve_U1` performs", which is a duplication documenting itself.
 
         A raw (unitless) parameter is the **array fastpath**: bare arrays
         carrying no unit, which is the cheapest way in and the reason
@@ -316,16 +321,20 @@ class AbstractCurveFrameBuilder(eqx.Module):
         from here, so none of them has to know whether it arrived wrapped.
 
         A raw parameter with no declared unit is the one combination that
-        cannot be served -- nothing anywhere states the unit -- and raises.
+        cannot be served -- nothing anywhere states the unit -- and raises,
+        naming *which* value is bare, since a pinned `station` is what the
+        builder evaluates at and a `Quantity` at call time will not rescue it.
         """
         pinned = self.station is not None
         param = self.station if pinned else tau
-        if u.unit_of(param) is not None:
-            return param
-        if self.tau_unit is None:
-            source, fix = _SOURCE_STATION if pinned else _SOURCE_TAU
-            raise TypeError(_MSG_TAU_UNIT_UNINFERABLE.format(source=source, fix=fix))
-        return u.Q(param, self.tau_unit)
+        if u.unit_of(param) is None:
+            if self.tau_unit is None:
+                source, fix = _SOURCE_STATION if pinned else _SOURCE_TAU
+                raise TypeError(
+                    _MSG_TAU_UNIT_UNINFERABLE.format(source=source, fix=fix)
+                )
+            param = u.Q(param, self.tau_unit)
+        return param, self._tau_unit_at(param)
 
     @abc.abstractmethod
     def rotation_matrix(self, tau: Any, /) -> Array:
@@ -362,7 +371,7 @@ class AbstractCurveFrameBuilder(eqx.Module):
         """
         b, p = self._resolve(tau)
         cart = cxc.cart3d
-        g = b._param(p)
+        g, _ = b._param(p)
         translate = cxfm.Translate(cxc.cdict(-b.curve(g), cart), chart=cart)
         return translate | cxfm.Rotate(b.rotation_matrix(p))
 
@@ -389,7 +398,8 @@ class AbstractCurveFrameBuilder(eqx.Module):
 
         """
         b, p = self._resolve(tau)
-        return b.curve(b._param(p))
+        g, _ = b._param(p)
+        return b.curve(g)
 
     def tangent(self, tau: Any, /) -> u.Q:
         r"""Return the unit tangent vector $\mathbf{T}$ (row 0 of R).

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/bishop.py
@@ -403,6 +403,11 @@ class BishopBuilder(AbstractCurveFrameBuilder):
 
     def _tangent_at(self, g: Any, /) -> u.AbstractQuantity:
         r"""Compute unit tangent $\mathbf{T} = \gamma'/\|\gamma'\|$."""
+        # Reads the unit off `g` rather than being handed it: this is passed
+        # whole to `unxt.experimental.jacfwd`, whose `units=` tuple must match
+        # the positional arity, so a second parameter cannot be added without
+        # a `functools.partial` at every call. `g` always arrives from
+        # `_param`, so the read is a `unit_of` on a `Quantity` and cannot fail.
         dcurve = u.experimental.jacfwd(self.curve, units=(self._tau_unit_at(g),))
         return _normalize(dcurve(g.astype(float)))
 
@@ -415,11 +420,7 @@ class BishopBuilder(AbstractCurveFrameBuilder):
         solve rather than whichever convertible one it was given in.
         """
         tau_0_in = self.tau_0
-        tau_0 = (
-            u.Q(0.0, tau_unit)
-            if tau_0_in is None
-            else u.Q(tau_0_in.ustrip(tau_unit), tau_unit)
-        )
+        tau_0 = u.Q(0.0 if tau_0_in is None else tau_0_in.ustrip(tau_unit), tau_unit)
 
         T0_val = self._tangent_at(tau_0).value
         if self.initial_normal is not None:
@@ -451,7 +452,7 @@ class BishopBuilder(AbstractCurveFrameBuilder):
 
         return ode_rhs
 
-    def _solve_U1(self, g: Any, /) -> Array:
+    def _solve_U1(self, g: Any, tau_unit: Any, /) -> Array:
         r"""Compute $\mathbf{U}_1$ via ODE integration from $\tau_0$.
 
         Solves the parallel-transport ODE $d\mathbf{U}_1/d\tau = -(\mathbf{U}_1
@@ -470,7 +471,6 @@ class BishopBuilder(AbstractCurveFrameBuilder):
         derivative survives.  Both signs of $\Delta$ are handled by the same
         expression -- no forward-only workaround is needed.
         """
-        tau_unit = self._tau_unit_at(g)
         _, tau_0_val, U1_0_val, dTangent_fn = self._transport_start(tau_unit)
         dtau = _float(g.ustrip(tau_unit)) - tau_0_val
         ode_rhs = self._transport_rhs(tau_0_val, dtau, tau_unit, dTangent_fn)
@@ -513,9 +513,9 @@ class BishopBuilder(AbstractCurveFrameBuilder):
         # For a two-argument curve `tau` is the time: transport runs along
         # that time slice, at the pinned station. See `_resolve`.
         b, p = self._resolve(tau)
-        g = b._param(p)
+        g, tau_unit = b._param(p)
         T_val = b._tangent_at(g).value
-        U1_val = b._solve_U1(g)
+        U1_val = b._solve_U1(g, tau_unit)
         U2_val = jnp.cross(T_val, U1_val)
         return jnp.stack([T_val, U1_val, U2_val])
 
@@ -575,9 +575,10 @@ class BishopBuilder(AbstractCurveFrameBuilder):
         if _is_two_argument(self.curve):
             raise ValueError(_MSG_BATCH_TWO_ARGUMENT)
 
-        # Same resolution `_solve_U1` performs: infer the unit from the
-        # parameter (#771) rather than assuming `tau_unit` was declared, and
-        # restate `tau_0` in it so the nested `_tangent_at` infers the same one.
+        # Resolved here rather than taken from `_param`: this is the batched
+        # entry, and `taus` is a whole array of parameters instead of the one
+        # a station could stand in for. `_transport_start` then restates
+        # `tau_0` in the same unit, exactly as it does for `_solve_U1`.
         tau_unit = self._tau_unit_at(taus)
         taus_val = _float(u.ustrip(tau_unit, taus))
 
@@ -668,7 +669,8 @@ class BishopBuilder(AbstractCurveFrameBuilder):
 
         """
         b, p = self._resolve(tau)
-        return u.Q(b._tangent_at(b._param(p)).value, "")
+        g, _ = b._param(p)
+        return u.Q(b._tangent_at(g).value, "")
 
     def normal1(self, tau: Any, /) -> u.Q:
         r"""First parallel-transported normal $\mathbf{U}_1(\tau)$ (row 1 of R).

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/frenetserret.py
@@ -173,13 +173,11 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
         b, p = self._resolve(tau)
 
         # Unit-aware first and second derivatives via unxt. `g` is built
-        # first: it is what the parameter unit is read off when undeclared.
-        # Resolve the unit *before* `.astype`: a unitless parameter has no
-        # `.astype`, so doing it the other way round reports the accident
-        # (`AttributeError`) instead of the cause (`_tau_unit_at`'s message,
-        # which names both ways to fix it).
-        g = b._param(p)
-        tau_unit = b._tau_unit_at(g)
+        # `_param` resolves the parameter and its unit together, and raises
+        # for a bare one before anything reaches `.astype` -- which a unitless
+        # parameter does not have, so the other order reported the accident
+        # rather than the cause.
+        g, tau_unit = b._param(p)
         g = g.astype(float)
         dcurve = u.experimental.jacfwd(b.curve, units=(tau_unit,))
         d2curve = u.experimental.jacfwd(dcurve, units=(tau_unit,))
@@ -225,10 +223,9 @@ class FrenetSerretBuilder(AbstractCurveFrameBuilder):
 
         """
         b, p = self._resolve(tau)
-        g = b._param(p)
-        dcurve = u.experimental.jacfwd(b.curve, units=(b._tau_unit_at(g),))
-        g = g.astype(float)
-        return u.Q(_normalize(dcurve(g)).value, "")
+        g, tau_unit = b._param(p)
+        dcurve = u.experimental.jacfwd(b.curve, units=(tau_unit,))
+        return u.Q(_normalize(dcurve(g.astype(float))).value, "")
 
     def normal(self, tau: Any, /) -> u.Q:
         r"""Return the unit normal vector $\mathbf{N}(\tau)$ (row 1 of R).

--- a/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
@@ -481,10 +481,3 @@ def test_the_dimension_guard_still_fires_on_an_inferred_unit() -> None:
     with pytest.raises(ValueError, match="dimension length"):
         b.tangent(u.Q(1.0, "s"))
     b.tangent(u.Q(1.0, "km"))  # a length is what it wants, and needs no declaring
-
-
-def test_declaring_the_unit_is_still_accepted() -> None:
-    """The explicit form is unchanged -- inference is a default, not a removal."""
-    cxfc.BishopBuilder(curve1, "s")
-    cxfc.BishopBuilder(curve1, "Gyr")
-    cxfc.FrenetSerretBuilder(curve1, "s")


### PR DESCRIPTION
Cleanup of the `tau_unit` machinery landed by #771, from a follow-up review of the merged code.

## The duplication

`_param` and `_tau_unit_at` were called back to back on the same value by every accessor that evaluates the curve, so *"which value is this, and what unit does it carry"* was decided twice per call:

```python
g = b._param(p)            # unitless? -> wrap with the declared unit, or raise
tau_unit = b._tau_unit_at(g)   # declared? -> else read it back off g
```

Deciding it in two places is what let the two answers drift. `rotation_matrices` re-derived the unit under a comment reading:

> `# Same resolution _solve_U1 performs: infer the unit from the parameter (#771) ...`

which is a duplication documenting itself. It is also the pattern behind three of the review findings on #771 — including the one where the "pass a `Quantity` parameter" advice was wrong for a pinned `station`, because the two sites needed separately-worded messages for the same condition.

## The change

`_param` returns the parameter **and** its unit; `_solve_U1` takes the unit rather than re-deriving it. Callers wanting only the parameter discard the unit.

Two deliberate hold-outs, both now documented in place rather than left looking inconsistent:

- **`rotation_matrices` still resolves its own.** It is the batched entry — `taus` is an array of parameters, not the single one a station can stand in for — so it has no `_param` call to take the unit from. Its comment now says that instead of pointing at `_solve_U1`.
- **`_tangent_at` still reads the unit off its argument.** It is handed whole to `unxt.experimental.jacfwd`, whose `units=` tuple must match the positional arity, so a second parameter would need a `functools.partial` at every call site — machinery added to remove a read that `jit` makes static anyway. `g` always arrives from `_param`, so that read is a `unit_of` on a `Quantity` and cannot fail.

Also here: a test that constructed builders and asserted nothing (every other test in the file already constructs with a declared unit), and `tau_0`'s restatement in two lines rather than five.

## On size

**Net is about neutral: roughly −1 executable line, +4 comment lines.** I estimated −16 when I first flagged this, before `_transport_start`/`rotation_matrices` landed on main; on the evolved code the removable duplication is narrower than that, and the hold-outs above need explaining. The point is one decision point rather than two, not a shorter file — flagging it plainly so the diff is not mistaken for a size win.

## Not changed

`_SOURCE_VALUE`, the third message wording, stays. I had it down for deletion as unreachable, but #783 added a test that reaches it — raw `tau_bounds` read structurally by `coord_dimensions`, where no `usys` is in scope — so it is live and covered.

## Verification

- 1027 `coordinaxs.curveframes` tests pass
- `prek run` clean on touched files, including `ty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
