### PR TITLE
🐛 fix(ci): run the oldest-dependency tests through nox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,10 +204,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install
+        run: uv sync --no-default-groups --group nox --locked
+
       - name: Test package
         run: >-
-          uv run --group test-all --extra workspace --resolution lowest-direct pytest -n logical
-          --dist=loadfile --cov --cov-report=xml --cov-report=term --durations=20
+          uv run --no-sync nox -s test_oldest --
+          --cov --cov-report=xml --cov-report=term --durations=20
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v7.0.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -176,6 +176,66 @@ def test(s: nox.Session, /) -> None:
     # s.notify("pytest_benchmark", posargs=s.posargs)
 
 
+#: Where `test_oldest` builds its downgraded environment. Kept out of the
+#: project's own `.venv`, which every other session and a developer's shell
+#: share: resolving the oldest dependencies into it would silently downgrade
+#: the environment they are all using.
+_OLDEST_ENV = {"UV_PROJECT_ENVIRONMENT": str(DIR / ".nox" / "oldest")}
+
+
+@nox.session(venv_backend="none", default=False)
+def test_oldest(s: nox.Session, /) -> None:
+    """Run the tests against the oldest supported direct dependencies.
+
+    `uv run --resolution lowest-direct` resolves as it runs, so unlike `test`
+    there is no environment for nox to build up front -- hence no venv backend.
+
+    Selection mirrors the `test` session because it has to: these tests spawn
+    children that cold-import the whole JAX stack, and beside xdist workers
+    importing the same stack the children starve. CI used to call pytest
+    directly here and so inherited none of that.
+    """
+    uv = [
+        "uv",
+        "run",
+        "--group=test-all",
+        "--extra=workspace",
+        "--resolution=lowest-direct",
+        "pytest",
+    ]
+    # Resolving downwards rewrites `uv.lock`, which matters here in a way it
+    # never did in CI, where the checkout is thrown away. Do not "fix" that
+    # with `--frozen`: it leaves the lock alone by declining to re-resolve at
+    # all, so the session installs the current pins and passes while testing
+    # nothing. Measured: with `--frozen`, unxt 2.0.3 and jax 0.10.0; without
+    # it, unxt 2.0.2 and jax 0.7.2, which is the floor this session guards.
+    lockfile = DIR / "uv.lock"
+    saved = lockfile.read_bytes()
+    try:
+        s.run(
+            *uv,
+            "-n",
+            "logical",
+            "--dist=loadfile",
+            "-mnot subprocess_heavy",
+            *s.posargs,
+            env=_OLDEST_ENV,
+            external=True,
+        )
+        # Serial, and after the parallel run, so nothing competes for cores.
+        s.run(
+            *uv,
+            "-msubprocess_heavy",
+            "-n0",
+            "--no-cov",
+            "-q",
+            env={**_OLDEST_ENV, "COORDINAX_REQUIRE_INTEROP_TESTS": "1"},
+            external=True,
+        )
+    finally:
+        lockfile.write_bytes(saved)
+
+
 @session(uv_groups=["test"], uv_extras=["workspace"], reuse_venv=True)
 @nox.parametrize("package", list(PackageEnum))
 def pytest(s: nox.Session, /, package: PackageEnum) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -180,7 +180,12 @@ def test(s: nox.Session, /) -> None:
 #: project's own `.venv`, which every other session and a developer's shell
 #: share: resolving the oldest dependencies into it would silently downgrade
 #: the environment they are all using.
-_OLDEST_ENV = {"UV_PROJECT_ENVIRONMENT": str(DIR / ".nox" / "oldest")}
+_OLDEST_ENV = {
+    "UV_PROJECT_ENVIRONMENT": str(DIR / ".nox" / "oldest"),
+    # As in `test`: with the workspace extra installed, a missing interop
+    # package is a hard error rather than a silent skip.
+    "COORDINAX_REQUIRE_INTEROP_TESTS": "1",
+}
 
 
 @nox.session(venv_backend="none", default=False)
@@ -203,6 +208,11 @@ def test_oldest(s: nox.Session, /) -> None:
         "--resolution=lowest-direct",
         "pytest",
     ]
+    # As in `test`: xdist breaks --pdb/--trace, so drop it when either is asked
+    # for rather than making the caller also pass `-n0`.
+    debugging = any(arg == "--trace" or arg.startswith("--pdb") for arg in s.posargs)
+    xdist_args = [] if debugging else ["-n", "logical", "--dist=loadfile"]
+
     # Resolving downwards rewrites `uv.lock`, which matters here in a way it
     # never did in CI, where the checkout is thrown away. Do not "fix" that
     # with `--frozen`: it leaves the lock alone by declining to re-resolve at
@@ -212,24 +222,22 @@ def test_oldest(s: nox.Session, /) -> None:
     lockfile = DIR / "uv.lock"
     saved = lockfile.read_bytes()
     try:
+        # First and alone: these spawn children that cold-import the whole JAX
+        # stack, which is what starves them beside xdist workers importing the
+        # same stack. Running them before the parallel pass keeps them off a
+        # busy machine just as running them after would, and it lets the pass
+        # below append to their coverage rather than the other way round.
+        s.run(
+            *uv, "-msubprocess_heavy", "-n0", *s.posargs, env=_OLDEST_ENV, external=True
+        )
+        # `--cov-append`, so the report the caller asked for covers both runs.
         s.run(
             *uv,
-            "-n",
-            "logical",
-            "--dist=loadfile",
+            *xdist_args,
             "-mnot subprocess_heavy",
+            "--cov-append",
             *s.posargs,
             env=_OLDEST_ENV,
-            external=True,
-        )
-        # Serial, and after the parallel run, so nothing competes for cores.
-        s.run(
-            *uv,
-            "-msubprocess_heavy",
-            "-n0",
-            "--no-cov",
-            "-q",
-            env={**_OLDEST_ENV, "COORDINAX_REQUIRE_INTEROP_TESTS": "1"},
             external=True,
         )
     finally:


### PR DESCRIPTION
`check_oldest` called pytest directly rather than through the `test` session, so it inherited none of that session's selection. After #795 it became the only job still running the two subprocess-spawning test files under `-n logical` — the starvation that cost several runners today, including one lost outright with no log. It also runs the full suite with no `--exclude-package`, which is why it is the slowest job in the workflow at 13–19 minutes.

A `test_oldest` session removes the bypass, so the two cannot drift apart again.

## Behaviour

- `-m"not subprocess_heavy"` for the parallel run, then a serial `-m"subprocess_heavy" -n0` step. Their oldest-dependency coverage is kept rather than dropped, for ~22s.
- `COORDINAX_REQUIRE_INTEROP_TESTS=1` matches the `test` session: with the workspace extra installed, a missing interop package is a hard error, not a silent skip.
- `default=False`, so a bare `nox` does not re-resolve the oldest dependencies.
- `UV_PROJECT_ENVIRONMENT` points at `.nox/oldest`, keeping the downgraded install out of the shared `.venv`.
- `slow` tests still run here, as before — that scope is unchanged.

## Two traps, both recorded in comments

**`uv.lock` is rewritten** by `--resolution lowest-direct` — 2254 lines. Invisible in CI's throwaway checkout, but a nox session is meant to be run locally, where it silently downgrades your lockfile. It surfaced immediately: `prek`'s `ty` hook re-syncs `.venv` from the lock, and `ty check` began failing with `Non-generic class Quantity cannot be specialized`. The session snapshots and restores the lock.

**`--frozen` is not the fix.** It leaves the lock alone by declining to re-resolve at all, so the job installs the current pins and passes while testing nothing:

| | unxt | jax |
|---|---|---|
| `--resolution lowest-direct` | 2.0.2 | **0.7.2** |
| `+ --frozen` | 2.0.3 | 0.10.0 |

0.7.2 is the floor this job exists to guard, so `--frozen` would have made it green and worthless.

## Verification

Full session locally, both steps:

- parallel: 11543 passed, 315 skipped, 1 xfailed in 5:09
- serial subprocess step: 8 passed in 22.17s
- `uv.lock` clean afterwards
- `prek run --all-files` clean, including actionlint

🤖 Generated with [Claude Code](https://claude.com/claude-code)