### PR TITLE
🔧 ci: make the recurring test stall diagnosable and bounded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,10 @@ jobs:
     name: Check Python ${{ matrix.python-version }} on ubuntu-latest
     runs-on: ubuntu-latest
     needs: [prepare_test_matrix]
+    # Well above a real run (4-16 min), and far below the 6h default. A stall
+    # here has cost a runner for the better part of an hour more than once;
+    # this bounds it, and `faulthandler_timeout` names the test before it hits.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -145,6 +149,9 @@ jobs:
     name: Subprocess-heavy tests (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     needs: [prepare_test_matrix]
+    # ~1 min in practice; these spawn children, so a stall is exactly the
+    # failure mode this job exists to keep away from the parallel runs.
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -169,6 +176,7 @@ jobs:
     name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
     needs: [prepare_test_matrix]
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
@@ -199,6 +207,8 @@ jobs:
     name: Check Oldest Dependencies
     runs-on: ${{ matrix.runs-on }}
     needs: [format, smoke]
+    # The slowest job at ~20 min: it resolves downwards and excludes nothing.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/packages/coordinaxs.hypothesis/tests/unit/utils/annotations/test_jax_dtypes.py
+++ b/packages/coordinaxs.hypothesis/tests/unit/utils/annotations/test_jax_dtypes.py
@@ -91,25 +91,12 @@ print("\\n".join(bad[:3]))
 
 #: Wall-clock ceiling for the subprocess below.
 #:
-#: The work costs ~3.4s on an idle machine and ~4.4s with all ten logical cores
-#: saturated, so this is a ~130x margin, not a tight bound. It has nonetheless
-#: been hit on CI -- on several PRs at once, including ones touching neither
-#: `charts()` nor anything it imports, which is what marks it as a flake rather
-#: than a regression.
-#:
-#: Ruled out, each by measurement rather than reasoning:
-#:
-#: - CPU contention from `-n logical` (#788). Saturating every core costs ~30%,
-#:   not the ~130x a timeout would need.
-#: - JAX persistent-compilation-cache locking between workers. No cache is
-#:   configured, so there is no lock to contend for.
-#: - Memory exhaustion. The child peaks at ~290MB and a pytest worker at
-#:   ~297MB, so a four-worker runner sits near 1.5GB against 7GB+ available.
-#:
-#: The cause is still unknown. Raising the ceiling further would only make the
-#: eventual failure slower to arrive, so it stays where it is and the handler
-#: below makes the next occurrence say something useful instead.
-_X32_TIMEOUT_S = 600
+#: The work costs ~3.4s idle. It used to be 600s, sized for a child starved by
+#: xdist workers cold-importing the same JAX stack; that is no longer the
+#: shape of the run, because the test has a serial job to itself and takes
+#: ~22s there end to end. A ceiling far above the real cost only makes a stall
+#: slower to report, so this is sized against the job it actually runs in.
+_X32_TIMEOUT_S = 120
 
 
 #: Environment for the child, beyond turning x64 off.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -318,6 +318,13 @@ filterwarnings = [
   # subclasses) so the filter loads even where pyparsing is not installed.
   "ignore:'\\w+' deprecated - use '\\w+':DeprecationWarning:matplotlib\\..*",
 ]
+# Dump every thread's traceback for any test still running after 5 minutes,
+# naming the file, line and test, then let the run continue. CI has repeatedly
+# lost ubuntu runners to a stall that goes silent at 99% and produces no
+# output at all, so there has been nothing to act on; the slowest legitimate
+# test is ~80s, so this can only fire on a genuine stall. Works under xdist:
+# the stuck worker dumps, the others carry on.
+faulthandler_timeout = 300
 log_level = "INFO"
 markers = [
   "network: marks tests that require a network connection (deselect with '-m not network')",


### PR DESCRIPTION
**This diagnoses the stall; it does not fix it.** The cause is still unidentified, and I would rather ship the instrument than another guess — four successive hypotheses have each been overturned by the next measurement.

## The failure

Run [32933371589](https://github.com/GalacticDynamics/coordinax/actions/runs/32933371589) on `main`, `Check Python 3.14 on ubuntu-latest`:

```
05:25:21  [ 99%]
05:27:33  ##[error]The runner has received a shutdown signal.
```

Same signature as earlier failures: reaches 99%, goes completely silent, loses the runner. On one earlier job the silence lasted **28 minutes**; on another the runner vanished with **no log at all**.

#796 did not fix this — it removed `coordinaxs.curveframes` from jobs that do not touch it, and every green run since has been one of those. #770 touched `packages/coordinaxs.curveframes/_src/register_ptmap.py`, the detector correctly kept the package in, and the stall returned. So CI is currently reliable only for PRs that happen to miss the heaviest package.

## Why I am not guessing again

Measured, and each ruled out what came before:

- **Not memory.** Peak RSS across four workers is 3.93 GiB against 16 GB.
- **Not the x32 or interop subprocess tests.** Both are isolated in their own job, green, and deselected from these runs.
- **Not simply a slow tail.** `curveframes` is 714 CPU-seconds against 257s wall at `-n 4`, ~70% parallel efficiency. Its heaviest file holds 128 tests, so a worker grinding through it emits a dot per test — it cannot go silent for 28 minutes. That is one test stuck, not a slow file.
- **Not reproducible locally.** `curveframes` alone 4:17, full suite 4:56, both clean.

Nothing in any CI log names a test, because a stalled run produces no output at all.

## What this adds

`faulthandler_timeout = 300` dumps every thread's traceback for a test still running after 5 minutes, naming file, line and test, then lets the run continue. Verified under the exact CI configuration:

```
$ pytest -n 2 --dist=loadfile -o faulthandler_timeout=10
.Timeout (0:00:10)!
  File "/tmp/fh2/test_stall.py", line 3 in test_stalls
```

The slowest legitimate test is ~80s, so it can only fire on a genuine stall. Applied to the 3.12 failure, its 28 minutes of silence would instead have produced a named test after 5.

`timeout-minutes` on each test job, comfortably above observed durations:

| Job | Observed | Cap |
|---|---|---|
| `tests_linux` | 4-16 min | 30 |
| `tests_subprocess` | ~1 min | 15 |
| `tests_nonlinux` | ~14 min | 40 |
| `check_oldest` | ~20 min | 45 |

A stall now costs minutes instead of the 57 one job burned.

Also drops `_X32_TIMEOUT_S` from 600s to 120s. 600 was sized for a child starved beside xdist workers; that test now has a serial job to itself and finishes in ~22s, so the old ceiling only delayed reporting. Its comment claiming the cause is unknown is rewritten, since it is not.

## Verification

- Full suite: 11589 passed, 315 skipped, 1 xfailed in 4:56, **no faulthandler dumps** — nothing legitimate approaches the threshold.
- Subprocess job with the 120s ceiling: 8 passed in 21.44s.
- `prek run --all-files` clean, including actionlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)