### PR TITLE
♻️ refactor(curveframes): drop single-use aliases in the arc-length calls

### DIFF
--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -676,9 +676,6 @@ class ArcLength(eqx.Module):
         Array([1., 0., 0.], dtype=float64)
 
         """
-        tau_unit = self.tau_unit
-        tau_0 = self.tau_0
-
         # Bind `t` into a one-argument curve for a time-dependent wrapped
         # curve; otherwise use it as-is. See `_two_argument`'s docstring for
         # why this is a static-field branch rather than a per-call one.
@@ -686,15 +683,15 @@ class ArcLength(eqx.Module):
             # Without this the omission surfaces as an `AttributeError` on
             # `None` from inside the ODE, nowhere near the call that caused it.
             raise TypeError(_MSG_MISSING_TIME)
-        curve = self.curve if not self._two_argument else AtTime(self.curve, t)
+        curve = AtTime(self.curve, t) if self._two_argument else self.curve
 
         tau = _tau_of_s(
             curve,
-            tau_0,
+            self.tau_0,
             s,
             self._interp,
             self.s_max,
-            tau_unit=tau_unit,
+            tau_unit=self.tau_unit,
             diffeqsolver=self.diffeqsolver,
         )
         return curve(tau)
@@ -864,19 +861,16 @@ class LagrangianArcLength(eqx.Module):
         Q([1., 0., 0.], 'km')
 
         """
-        tau_unit = self.tau_unit
-        tau_0 = self.tau_0
-
         # Speed is always measured on the fixed slice t0 -- never on the
         # supplied t -- which is what makes this reading Lagrangian.
         curve_t0 = AtTime(self.curve, self.t0)
         tau = _tau_of_s(
             curve_t0,
-            tau_0,
+            self.tau_0,
             s,
             self._interp,
             self.s_max,
-            tau_unit=tau_unit,
+            tau_unit=self.tau_unit,
             diffeqsolver=self.diffeqsolver,
         )
 


### PR DESCRIPTION
Both `ArcLength.__call__` and `LagrangianArcLength.__call__` bound `self.tau_unit` and `self.tau_0` to locals used exactly once each, and `ArcLength` picked its curve through a negated ternary (`self.curve if not self._two_argument else ...`). +5/-11 on one file.

## Second purpose: exercising the CI stall path

This PR touches `packages/coordinaxs.curveframes/`, which is the point. #796 made `--exclude-package` work, and every green run since has been one where `curveframes` was excluded — so the stall that has been killing ubuntu runners has not actually been exercised since #801 armed `faulthandler_timeout`. `detect-changed-packages` will keep the package in here, the ubuntu jobs will run the heavy tail, and we get a real trial of the instrumentation.

If it stalls, the log now names the stuck test instead of going silent, and the job dies in ~30 min rather than burning a runner for an hour. If it passes, that is a data point too, though I would want more than one before calling the stall gone.

## On the size of the cleanup

`curveframes` is in good shape and there is little left to cut. Several candidates turned out to be things that should *not* change, which is worth recording:

- **`_tau_of_s_jvp` reads as unused** — it is registered by `@_tau_of_s.def_jvp`, referenced by decorator rather than by name. Deleting it would silently break gradients.
- **`_DIFFEQSOLVER` is byte-identical in `arclength.py` and `bishop.py`** — but they are independent defaults for two different ODEs (reparametrisation vs parallel transport) that happen to coincide today. Merging them would couple the two, so tuning Bishop's tolerance would silently retune ArcLength's. Left alone deliberately.
- **The `ArcLength` / `LagrangianArcLength` field blocks are 27 of 31 lines identical** — real duplication, but the fix is a shared base class: ~27 lines removed against ~31 added, plus an inheritance layer. Not worth it.

No TODOs, no debt markers, no dead code, no unused imports; all three `noqa`s justified.

## Verification

- Full `curveframes` suite: 1458 passed, 1 xfailed in 3:07
- `prek run --all-files` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)