### PR TITLE
🔧 ci: make Codecov wait for all six uploads before judging

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,9 @@
 # Codecov scores a commit as soon as it has *some* reports, not all of them.
-# Six uploads reach it per run:
+# Six uploads reach it per run, all from .github/workflows/ci.yml:
 #
-#   tests_linux     one per entry in ci.yml's PYTHON_VERSIONS  (currently 3)
-#   tests_nonlinux  macOS and Windows, on the edge version     (2)
-#   check_oldest    the resolved-oldest-dependency job         (1)
+#   tests_linux     one per entry in that file's PYTHON_VERSIONS  (currently 3)
+#   tests_nonlinux  macOS and Windows, on the edge version         (2)
+#   check_oldest    the resolved-oldest-dependency job             (1)
 #
 # tests_subprocess runs without `--cov` and uploads nothing.
 #
@@ -13,10 +13,10 @@
 # ones, and `codecov/project` failed on a PR whose coverage was fine. Waiting
 # for all six removes the race rather than papering over it with a threshold.
 #
-# ponytail: hardcoded count, coupled to PYTHON_VERSIONS in ci.yml. Adding a
-# version without bumping this brings the early verdict back; removing one
-# leaves Codecov waiting for an upload that never comes. Wire it to the matrix
-# only if that drift actually bites.
+# NOTE: the count below is hardcoded, and coupled to PYTHON_VERSIONS in
+# .github/workflows/ci.yml. Adding a version there without bumping it here
+# brings the early verdict back; removing one leaves Codecov waiting for an
+# upload that never comes. Wire it to the matrix only if that drift bites.
 codecov:
   notify:
     after_n_builds: 6

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+# Codecov scores a commit as soon as it has *some* reports, not all of them.
+# Six uploads reach it per run:
+#
+#   tests_linux     one per entry in ci.yml's PYTHON_VERSIONS  (currently 3)
+#   tests_nonlinux  macOS and Windows, on the edge version     (2)
+#   check_oldest    the resolved-oldest-dependency job         (1)
+#
+# tests_subprocess runs without `--cov` and uploads nothing.
+#
+# check_oldest takes ~17 min against 3-6 for the rest, so it is reliably last.
+# Judged without it, every line only it covers reads as a miss: #794 scored
+# -5.35% (-540 hits) on a diff that deleted 41 lines and added no uncovered
+# ones, and `codecov/project` failed on a PR whose coverage was fine. Waiting
+# for all six removes the race rather than papering over it with a threshold.
+#
+# ponytail: hardcoded count, coupled to PYTHON_VERSIONS in ci.yml. Adding a
+# version without bumping this brings the early verdict back; removing one
+# leaves Codecov waiting for an upload that never comes. Wire it to the matrix
+# only if that drift actually bites.
+codecov:
+  notify:
+    after_n_builds: 6
+
+comment:
+  after_n_builds: 6


### PR DESCRIPTION
Follow-up to the phantom coverage drop on #794.

## The bug

Codecov scores a commit as soon as it has *some* reports, not all of them. Six uploads reach it per run:

| Job | Uploads |
| --- | --- |
| `tests_linux` | one per `PYTHON_VERSIONS` entry (currently 3) |
| `tests_nonlinux` | macOS + Windows, edge version (2) |
| `check_oldest` | 1 |
| `tests_subprocess` | 0 — runs without `--cov` |

`check_oldest` resolves the oldest dependency set and takes **~17 min** against 3-6 for the rest, so it is reliably the last to report.

Judged without it, every line only that job covers reads as a miss. On #794 that produced:

```
- Coverage   96.87%   91.52%   -5.35%
  Files         270      267       -3
  Lines        9398     9357      -41
- Hits         9104     8564     -540
- Misses        294      793     +499
```

on a diff that deleted 41 lines and added no uncovered ones. `codecov/project` **failed** on a PR whose coverage was fine — while `codecov/patch` passed and the report itself said "All modified and coverable lines are covered by tests". Codecov even names the cause in its own comment: *"HEAD has 1 upload less than BASE."* The `-3` files corroborates it: the PR deletes no files, so those are files only `check_oldest` reports.

It went green on its own once that upload landed. That is the tell — the number was never about the code.

## The fix

`after_n_builds: 6` on both the status (`codecov.notify`) and the PR comment, so neither the verdict nor the posted table is computed against a partial set.

Waiting removes the race. The alternative — a `coverage.status.project.threshold` — would only hide it, and would have to be wide enough to hide real regressions too.

## The catch, stated in the file

The count is hardcoded and coupled to `PYTHON_VERSIONS` in `ci.yml`. Adding a Python version without bumping it brings the early verdict back; removing one leaves Codecov waiting for an upload that never comes. The comment in `codecov.yml` says so at the point someone would hit it. Wiring it to the matrix programmatically is more machinery than the drift has earned so far.

## Testing

Config only, no code. Validated against Codecov's own endpoint:

```bash
curl -s --data-binary @codecov.yml https://codecov.io/validate
```

→ `Valid!`, echoing back both keys as parsed. `prek run --all-files` green.

The real proof is this PR's own Codecov run: the comment and `codecov/project` should now appear only after all six uploads, i.e. not before `check_oldest` finishes.