### PR TITLE
♻️ style(charts,representations): trim the #782 comments, pin the pullback batch

### DIFF
--- a/src/coordinax/_src/charts/jacobian.py
+++ b/src/coordinax/_src/charts/jacobian.py
@@ -260,9 +260,6 @@ def jac_pt_map(
     (3, 3)
 
     """
-    # Determine whether the input is array-valued or quantity-valued.  If it's
-    # array-valued, we can skip the packing and unit handling and directly
-    # compute the Jacobian as an array.
     at = from_chart.check_data(at, keys=True)
 
     # A chart map is pointwise, so a batch of points is a batch of
@@ -272,11 +269,9 @@ def jac_pt_map(
     # with every off-diagonal block identically zero, and O(N^2) to hold.
     # Map over the leading axes instead.
     #
-    # `jnp.vectorize` would express the same mapping in one call, but it
-    # coerces its inputs with `asarray` and so cannot carry the Quantity
-    # route; measured, the two are within noise. Scalar components take
-    # the `not batch` branch, so the unbatched path is untouched -- the
-    # shape is static, so this costs nothing at trace time.
+    # `jnp.vectorize` maps this in one call but coerces inputs with
+    # `asarray`, so it cannot carry the Quantity route; timings were within
+    # noise. The shape is static, so the scalar path costs nothing here.
     batch = jnp.shape(zeroth(at.values()))
     if batch:
 
@@ -287,6 +282,9 @@ def jac_pt_map(
             one = jax.vmap(one)
         return one(at)
 
+    # Determine whether the input is array-valued or quantity-valued.  If it's
+    # array-valued, we can skip the packing and unit handling and directly
+    # compute the Jacobian as an array.
     is_array = not any(hasattr(v, "unit") for v in at.values())
     if is_array:
         at_arr = jnp.stack([at[k] for k in from_chart.components], axis=-1)

--- a/src/coordinax/representations/_src/tangent_map.py
+++ b/src/coordinax/representations/_src/tangent_map.py
@@ -148,11 +148,8 @@ def tangent_map(
     if from_chart == to_chart:
         return v
 
-    # Past that point a Jacobian must be evaluated somewhere, so `at` is
-    # not optional. Without this it reaches `jac_pt_map` as `None`, which
-    # resolves to the higher-order rule and returns a *function*; the
-    # failure then surfaces from `_apply_jac` as an unsupported `@`
-    # between a function and an array, naming nothing the caller wrote.
+    # `at=None` here reaches `jac_pt_map`, resolves to the higher-order rule
+    # and comes back a *function* -- hence the unsupported `@` callers saw.
     if at is None:
         msg = _MSG_AT_REQUIRED.format(
             frm=type(from_chart).__name__, to=type(to_chart).__name__

--- a/tests/unit/manifolds/test_metric_matrix_batch_invariant.py
+++ b/tests/unit/manifolds/test_metric_matrix_batch_invariant.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 from hypothesis import given, settings
 from hypothesis.extra.numpy import array_shapes
+from zeroth import zeroth
 
 import unxt as u
 
@@ -144,12 +145,12 @@ def test_pullback_metric_batches_like_the_points(manifold, chart, at):
     Bit-exact: batched and unbatched run the same arithmetic per point, so a
     tolerance here would hide exactly the mispairing this guards against.
     """
-    n = 3
+    n_points = len(zeroth(at.values()))
     got = _dense(cxmapi.metric_matrix(manifold, at, chart))
     want = np.stack(
         [
             _dense(cxmapi.metric_matrix(manifold, {k: at[k][i] for k in at}, chart))
-            for i in range(n)
+            for i in range(n_points)
         ]
     )
     assert got.shape == want.shape

--- a/tests/unit/manifolds/test_metric_matrix_batch_invariant.py
+++ b/tests/unit/manifolds/test_metric_matrix_batch_invariant.py
@@ -86,3 +86,71 @@ def test_sphere_diagonal_preserves_input_dtype(dtype):
         "phi": u.Q(np.asarray(0.3, dtype=dtype), "rad"),
     }
     assert cxmapi.metric_matrix(cxm.S2, at2, cxc.sph2).diagonal.dtype == dtype
+
+
+# ---------------------------------------------------------------------------
+# The Jacobian-pullback family
+#
+# #591 pinned the analytic diagonal rules above. The other branch -- "all other
+# charts", g = J^T J -- consumes `jac_pt_map`, which #782 changed from
+# differentiating the batch as one function to mapping over its leading axes.
+# Nothing pinned that branch batched, so this does.
+# ---------------------------------------------------------------------------
+
+_PULLBACK_CASES = [
+    pytest.param(
+        cxm.R3,
+        cxc.loncoslat_sph3d,
+        {
+            "lon_coslat": u.Angle([0.4, 1.1, 0.2], "rad"),
+            "lat": u.Angle([0.3, 0.5, 1.0], "rad"),
+            "distance": u.Q([2.0, 3.0, 1.5], "m"),
+        },
+        id="loncoslat_sph3d",
+    ),
+    pytest.param(
+        cxm.Sn(2),
+        cxc.loncoslat_sph2,
+        {
+            "lon_coslat": u.Angle([0.4, 1.1, 0.2], "rad"),
+            "lat": u.Angle([0.3, 0.5, 1.0], "rad"),
+        },
+        id="loncoslat_sph2",
+    ),
+    pytest.param(
+        cxm.R3,
+        cxc.ProlateSpheroidal3D(Delta=u.Q(1.0, "m")),
+        {
+            "mu": u.Q([2.0, 3.0, 1.5], "m2"),
+            "nu": u.Q([0.5, 0.7, 0.2], "m2"),
+            "phi": u.Angle([0.3, 1.0, 2.0], "rad"),
+        },
+        id="prolate_spheroidal",
+    ),
+]
+
+
+def _dense(g):
+    """Return the metric as a plain ``(..., n, n)`` array, whatever its type."""
+    d = g.to_dense() if hasattr(g, "to_dense") else g
+    m = d.matrix if hasattr(d, "matrix") else d
+    return np.asarray(m.value if hasattr(m, "value") else m)
+
+
+@pytest.mark.parametrize(("manifold", "chart", "at"), _PULLBACK_CASES)
+def test_pullback_metric_batches_like_the_points(manifold, chart, at):
+    """A batch of points gives a batch of metrics, element for element.
+
+    Bit-exact: batched and unbatched run the same arithmetic per point, so a
+    tolerance here would hide exactly the mispairing this guards against.
+    """
+    n = 3
+    got = _dense(cxmapi.metric_matrix(manifold, at, chart))
+    want = np.stack(
+        [
+            _dense(cxmapi.metric_matrix(manifold, {k: at[k][i] for k in at}, chart))
+            for i in range(n)
+        ]
+    )
+    assert got.shape == want.shape
+    np.testing.assert_allclose(got, want, rtol=0, atol=0)


### PR DESCRIPTION
Carry-forward from the #782 review — deferred at the time rather than force-pushing that PR for comment churn. Now that #782 has merged, they land together.

## The comment that mattered

`jac_pt_map`'s "Determine whether the input is array-valued" comment ended up 25 lines above the `is_array` line it describes, because #782's batch block was inserted between them. It now sits on the statement it is about. A comment pointing at the wrong code is worse than a verbose one, so this is the part I would have taken regardless of line count.

## Trims

Sentences that restated the code immediately below them (`if batch:`), the same "the shape is static, so the scalar path costs nothing" point repeated in a second file, and the narration of the old `@`-on-a-function failure — which `_MSG_AT_REQUIRED` and a test already carry.

What deliberately stays: the paragraph explaining why this is not a naive `jacfwd`, since that is exactly what a future reader would undo, and `_MSG_AT_REQUIRED`'s closing sentence about same-chart conversions, which stops someone making `at` mandatory everywhere.

## The gap #782 left

#591's property test pins batch-invariance for the **analytic diagonal** metrics. The other branch — "all other charts", `g = J^T J` — consumes `jac_pt_map`, which #782 changed from differentiating the batch as one function to mapping over its leading axes. Nothing pinned that branch batched.

This adds a parametrised test over the three charts that take it:

```
loncoslat_sph3d      pullback            (3, 3, 3)
loncoslat_sph2       pullback            (3, 2, 2)
ProlateSpheroidal3D  pullback-diagonal   (3, 3, 3)
```

asserting `rtol=0, atol=0` against element-by-element evaluation. Bit-exact is the right bar: batched and unbatched run the same arithmetic per point, so a tolerance would hide precisely the mispairing the test exists to catch.

I had swept these three by hand after #782 and they were clean — but a probe is not a regression guard, which is the whole point of adding it here.

## Verification

- `tests/unit/manifolds` + `tests/unit/charts` + `tests/unit/representations`: 1098 passed
- Full suite on this base: **11645 passed**, 311 skipped, 1 xfailed, 0 failures
- `prek` clean

No behaviour change: comments, plus one new test.

