### PR TITLE
🐛 fix(transforms): `Scale(matrix)` accepted a singular diagonal

### DIFF
--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -24,10 +24,16 @@ SMatrix: TypeAlias = Shaped[Array, " N N"]
 SFactors: TypeAlias = Shaped[Array, " N"]
 
 _MSG_SINGULAR: Final = "Scale matrix must be invertible: factors finite, non-zero."
+
 _MSG_NOT_DIAGONAL: Final = (
     "Scale requires a diagonal matrix -- it scales the axes, and nothing else. "
     "For a general linear map use `Linear`."
 )
+
+
+def _singular(s: Any, /) -> Any:
+    """Whether any factor makes the diagonal non-invertible."""
+    return jnp.any(jnp.isclose(s, 0) | ~jnp.isfinite(s))
 
 
 @final
@@ -103,6 +109,21 @@ class Scale(AbstractLinearTransform):
         S = self._validate_diagonal(self._validate_square(jnp.asarray(S)))
         object.__setattr__(self, "s", jnp.diagonal(S) if S.ndim == 2 else jnp.ravel(S))
 
+    def __check_init__(self) -> None:
+        """Refuse a singular diagonal, whichever constructor built it.
+
+        `_from_diagonal` goes around `__init__` and so around this, which is
+        the point: `inverse` and `_merge` produce factors that are valid by
+        construction, and re-checking them would cost a conditional and two
+        custom-calls apiece for nothing.
+
+        Store the checked value back so the guard survives jit (an unused
+        `error_if` result is dead-code-eliminated under trace).
+        """
+        object.__setattr__(
+            self, "s", eqx.error_if(self.s, _singular(self.s), _MSG_SINGULAR)
+        )
+
     @classmethod
     def _from_diagonal(cls, s: Any, /) -> "Scale":
         """Build directly from factors, skipping the matrix round-trip.
@@ -122,10 +143,10 @@ class Scale(AbstractLinearTransform):
         if s.ndim != 1:
             msg = f"Scale.from_factors requires a vector; got shape={s.shape!r}."
             raise ValueError(msg)
-        # Deferred so it survives jit, as in `Reflect.from_normal`. `inf` is the
-        # quiet failure: 1/inf = 0.0, so `inverse` came back finite and singular.
-        bad = jnp.isclose(s, 0) | ~jnp.isfinite(s)
-        s = eqx.error_if(s, jnp.any(bad), _MSG_SINGULAR)
+        # Checked here rather than by `__check_init__`, which `_from_diagonal`
+        # goes around. `inf` is the quiet failure: 1/inf = 0.0, so `inverse`
+        # came back finite and singular.
+        s = eqx.error_if(s, _singular(s), _MSG_SINGULAR)
         return cls._from_diagonal(s)
 
     @property
@@ -171,7 +192,12 @@ class Scale(AbstractLinearTransform):
         # matrix". Both shapes are the base's to report.
         if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
             return matrix
-        off = matrix - jnp.diag(jnp.diagonal(matrix))
+        # Selected, not subtracted: `matrix - jnp.diag(jnp.diagonal(matrix))`
+        # leaves `nan` where the diagonal holds `inf` or `nan`, and a `nan`
+        # residual is non-zero -- so a genuinely diagonal matrix with a
+        # non-finite factor was refused as non-diagonal, naming the wrong
+        # fault. `where` reads the entries instead of doing arithmetic on them.
+        off = jnp.where(jnp.eye(matrix.shape[0], dtype=bool), 0, matrix)
         return eqx.error_if(matrix, jnp.any(off != 0), _MSG_NOT_DIAGONAL)
 
 

--- a/src/coordinax/transforms/_src/actions/scale.py
+++ b/src/coordinax/transforms/_src/actions/scale.py
@@ -24,7 +24,6 @@ SMatrix: TypeAlias = Shaped[Array, " N N"]
 SFactors: TypeAlias = Shaped[Array, " N"]
 
 _MSG_SINGULAR: Final = "Scale matrix must be invertible: factors finite, non-zero."
-
 _MSG_NOT_DIAGONAL: Final = (
     "Scale requires a diagonal matrix -- it scales the axes, and nothing else. "
     "For a general linear map use `Linear`."
@@ -106,23 +105,13 @@ class Scale(AbstractLinearTransform):
         # The `ndim` branch reads a static shape, so it survives tracing; a
         # non-2D input has no diagonal to take and carries the square error
         # forward in its place.
+        #
+        # The singular check guards the stored value rather than the matrix, so
+        # it survives jit: an `error_if` whose result goes unused is
+        # dead-code-eliminated under trace.
         S = self._validate_diagonal(self._validate_square(jnp.asarray(S)))
-        object.__setattr__(self, "s", jnp.diagonal(S) if S.ndim == 2 else jnp.ravel(S))
-
-    def __check_init__(self) -> None:
-        """Refuse a singular diagonal, whichever constructor built it.
-
-        `_from_diagonal` goes around `__init__` and so around this, which is
-        the point: `inverse` and `_merge` produce factors that are valid by
-        construction, and re-checking them would cost a conditional and two
-        custom-calls apiece for nothing.
-
-        Store the checked value back so the guard survives jit (an unused
-        `error_if` result is dead-code-eliminated under trace).
-        """
-        object.__setattr__(
-            self, "s", eqx.error_if(self.s, _singular(self.s), _MSG_SINGULAR)
-        )
+        s = jnp.diagonal(S) if S.ndim == 2 else jnp.ravel(S)
+        object.__setattr__(self, "s", eqx.error_if(s, _singular(s), _MSG_SINGULAR))
 
     @classmethod
     def _from_diagonal(cls, s: Any, /) -> "Scale":
@@ -131,6 +120,11 @@ class Scale(AbstractLinearTransform):
         The diagonal is what the type stores, so every internal producer of one
         (`from_factors`, `inverse`, `_merge`) would otherwise inflate it to a
         matrix purely for `__init__` to take it apart again.
+
+        Going around `__init__` also goes around its singular check, which is
+        the point: `inverse` and `_merge` produce factors valid by
+        construction, and re-checking costs a conditional and two custom-calls
+        apiece.
         """
         obj = object.__new__(cls)
         object.__setattr__(obj, "s", jnp.asarray(s))
@@ -143,9 +137,8 @@ class Scale(AbstractLinearTransform):
         if s.ndim != 1:
             msg = f"Scale.from_factors requires a vector; got shape={s.shape!r}."
             raise ValueError(msg)
-        # Checked here rather than by `__check_init__`, which `_from_diagonal`
-        # goes around. `inf` is the quiet failure: 1/inf = 0.0, so `inverse`
-        # came back finite and singular.
+        # Its own check: this reaches `_from_diagonal`, not `__init__`. `inf`
+        # is the quiet one -- 1/inf = 0.0, so `inverse` came back singular.
         s = eqx.error_if(s, _singular(s), _MSG_SINGULAR)
         return cls._from_diagonal(s)
 
@@ -192,11 +185,9 @@ class Scale(AbstractLinearTransform):
         # matrix". Both shapes are the base's to report.
         if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
             return matrix
-        # Selected, not subtracted: `matrix - jnp.diag(jnp.diagonal(matrix))`
-        # leaves `nan` where the diagonal holds `inf` or `nan`, and a `nan`
-        # residual is non-zero -- so a genuinely diagonal matrix with a
-        # non-finite factor was refused as non-diagonal, naming the wrong
-        # fault. `where` reads the entries instead of doing arithmetic on them.
+        # Selected, not subtracted: `inf - inf` is `nan` and `nan != 0`, so
+        # subtracting the diagonal refused a genuinely diagonal matrix holding
+        # a non-finite factor, naming the wrong fault.
         off = jnp.where(jnp.eye(matrix.shape[0], dtype=bool), 0, matrix)
         return eqx.error_if(matrix, jnp.any(off != 0), _MSG_NOT_DIAGONAL)
 

--- a/tests/unit/transforms/test_spatial_linear_transforms.py
+++ b/tests/unit/transforms/test_spatial_linear_transforms.py
@@ -42,11 +42,9 @@ def test_scale_matrix_constructor_rejects_a_singular_diagonal(bad: float) -> Non
 
 
 def test_the_singular_check_survives_jit() -> None:
-    """`__check_init__` stores the checked value back, so the guard is not DCE'd.
+    """`error_if`'s result is what gets stored, so the guard is not DCE'd.
 
-    An `error_if` whose result is discarded is dead-code-eliminated under
-    trace: it raises eagerly and vanishes under `jit`. Fails if the
-    `object.__setattr__` goes away.
+    A discarded one raises eagerly and vanishes under `jit`.
     """
     build = eqx.filter_jit(lambda m: cxfm.Scale(m).s)
     with pytest.raises(eqx.EquinoxRuntimeError, match="invertible"):
@@ -54,7 +52,7 @@ def test_the_singular_check_survives_jit() -> None:
 
 
 def test_the_algebra_paths_are_not_re_checked() -> None:
-    """`inverse` and `_merge` go around `__check_init__`, deliberately.
+    """`inverse` and `_merge` go around `__init__`, deliberately.
 
     A factor `from_factors` would refuse as singular can still be *produced*
     by inverting a large one. Re-checking there would cost a conditional per

--- a/tests/unit/transforms/test_spatial_linear_transforms.py
+++ b/tests/unit/transforms/test_spatial_linear_transforms.py
@@ -30,6 +30,42 @@ def test_scale_from_factors_singular_raises_under_jit(bad: float) -> None:
         jax.block_until_ready(build(jnp.asarray([2.0, bad, 4.0])).s)
 
 
+@pytest.mark.parametrize("bad", [0.0, jnp.nan, jnp.inf], ids=["zero", "nan", "inf"])
+def test_scale_matrix_constructor_rejects_a_singular_diagonal(bad: float) -> None:
+    """`Scale(matrix)` went around `from_factors`' check and built a singular map.
+
+    Its `inverse` then came back `[0.5, inf]`, composing to `diag(1, nan)`
+    rather than the identity.
+    """
+    with pytest.raises(eqx.EquinoxRuntimeError, match="invertible"):
+        cxfm.Scale(jnp.diag(jnp.asarray([2.0, bad])))
+
+
+def test_the_singular_check_survives_jit() -> None:
+    """`__check_init__` stores the checked value back, so the guard is not DCE'd.
+
+    An `error_if` whose result is discarded is dead-code-eliminated under
+    trace: it raises eagerly and vanishes under `jit`. Fails if the
+    `object.__setattr__` goes away.
+    """
+    build = eqx.filter_jit(lambda m: cxfm.Scale(m).s)
+    with pytest.raises(eqx.EquinoxRuntimeError, match="invertible"):
+        jax.block_until_ready(build(jnp.diag(jnp.asarray([2.0, 0.0]))))
+
+
+def test_the_algebra_paths_are_not_re_checked() -> None:
+    """`inverse` and `_merge` go around `__check_init__`, deliberately.
+
+    A factor `from_factors` would refuse as singular can still be *produced*
+    by inverting a large one. Re-checking there would cost a conditional per
+    operation to catch a case the caller asked for.
+    """
+    big = cxfm.Scale.from_factors(jnp.asarray([2.0, 1e9]))
+    assert float(big.inverse.s[1]) == pytest.approx(1e-9)
+    with pytest.raises(eqx.EquinoxRuntimeError, match="invertible"):
+        cxfm.Scale.from_factors(jnp.asarray([2.0, 1e-9]))
+
+
 def test_scale_from_factors_nonsingular_jits() -> None:
     """A valid Scale builds cleanly under jit."""
     op = eqx.filter_jit(cxfm.Scale.from_factors)(jnp.asarray([2.0, 3.0, 4.0]))


### PR DESCRIPTION
Follows #773, now merged; rebased onto main.

`Scale`'s invertibility check lived only in `from_factors`. `__init__` does not route through it: it validates square and diagonal, then sets `s` directly. So the matrix constructor built a map whose `inverse` was quietly wrong.

```
Scale(jnp.diag([2., 0.]))     ->  [2. 0.]     no error
  .inverse.s                  ->  [0.5 inf]
  composed with the original   ->  [1. nan]    should be [1, 1]
from_factors([2., 0.])        ->  RAISES
```

Two constructors, opposite verdicts on the same matrix.

## Where the check goes

Onto the diagonal as `__init__` extracts it. That is where setting belongs, and the guard has to set — see the `jit` hazard below.

`_from_diagonal` bypasses `__init__` with `object.__new__`, the same escape `AbstractDistance._make` already relies on, so `inverse` and `_merge` stay unchecked. That is deliberate: they produce factors valid by construction, and re-checking costs a conditional plus two custom-calls apiece. `dataclasses.replace` does route through `__init__`, and does raise.

`__post_init__` is not available here: Python skips it whenever a class defines its own `__init__`, and equinox warns as much at class-definition time, pointing invariant checks at `__check_init__`. But `__check_init__` is for checking, not assigning, so the guard lives with the assignment instead.

## Why not `_from_diagonal`

That was the obvious-looking spot, and it is wrong twice over. Measured, µs/call, best of 7×2000:

| path | before | in `__check_init__` | in `_from_diagonal` |
| --- | --- | --- | --- |
| `Scale(matrix)` eager | 185–193 | **260** | 189 |
| `.inverse` eager | 19.4–19.8 | 18.9 | **100**  (5.1×) |
| `_merge` eager | 28.9–30.0 | 27.4 | **113**  (3.8×) |
| anything under `jit` | 22.9–27.9 | unchanged | unchanged |
| **closes the hole?** | — | **yes** | **no** |

It does not close the hole because `__init__` never calls `_from_diagonal`. It would tax the two hot paths 4–5× and leave the bug.

Run-to-run spread on the baseline is ~4%; the cost lands entirely on eager matrix construction, which already pays for two `error_if` validations, and does not scale with `n` (n=64: 211 → 282).

## The `jit` hazard

`error_if`'s result is what gets stored, because a discarded one is dead-code-eliminated under trace — it raises eagerly and vanishes under `jit`, which is the worst possible failure for a guard. Measured directly:

```
discarded error_if, eager       RAISES
discarded error_if, inside jit  NO RAISE   <-- check was lost
threaded back,      inside jit  RAISES
```

`test_the_singular_check_survives_jit` fails if the stored value ever stops being the checked one.

## A second bug, found by writing the test

`_validate_diagonal` isolated the off-diagonal by subtracting the diagonal — and `inf - inf` is `nan`, which is non-zero. A genuinely diagonal matrix holding `inf` or `nan` was refused as **non-diagonal**, naming the wrong fault:

```
Scale(jnp.diag([2., inf]))  ->  "Scale requires a diagonal matrix"
```

It now selects with `jnp.where` instead of doing arithmetic on the entries, so the diagnosis matches the actual fault.

## Not changed

`isclose(s, 0)` reduces to `|s| <= 1e-8` absolute, so `[2, 1e-9]` is refused while `[2, 1e9]` is accepted and inverts to `1e-9`. Same conditioning, opposite verdicts. That asymmetry is pre-existing and is now pinned by `test_the_algebra_paths_are_not_re_checked` rather than silently relied on.

## Verification

8534 passed / 309 skipped across `tests/`, `docs/`, and `src/coordinax`. Each new test mutation-checked:

- store the raw `s` instead of the checked one → only the `jit` test fails
- revert `_validate_diagonal` to subtraction → only the `nan`/`inf` cases fail
- remove the check from `__init__` → all four constructor cases fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)