### PR TITLE
📝 docs(charts): re-measure the `_mk` reach-through against unxt

### DIFF
--- a/src/coordinax/_src/charts/containers.py
+++ b/src/coordinax/_src/charts/containers.py
@@ -105,6 +105,21 @@ def canonical_containers(p: CDict, chart: Any, /) -> CDict:
         # `v`, an `AbstractQuantity` that normalised them on its own
         # construction, and `_angular` above has just established the angular
         # dimension that `AbstractAngle.__check_init__` would re-derive.
+        #
+        # unxt#904 memoised that check, so it is no longer what `_mk` is
+        # avoiding -- the `plum`-dispatched field converters are, and #904 did
+        # not touch those. It is also not in a release yet: unxt 2.0.3, the
+        # version pinned here, still pays the full check. Measured on both:
+        #
+        #                                  2.0.3      main
+        #   u.Angle(value, unit)          170.9us -> 29.3us
+        #   u.Angle._mk(...)                0.8us ->  0.7us
+        #   canonical_containers, checked 351.8us -> 68.0us
+        #   canonical_containers, `_mk`     8.7us ->  8.7us
+        #
+        # A 40x gap remains even on main, so this stays. What it buys is ~2%
+        # of an eager `pt_map`, near the noise -- if the converters ever get
+        # the same treatment, drop `_mk` and this paragraph with it.
         promoted[k] = u.Angle._mk(value=v.value, unit=unit)
 
     # Nothing to do is the common case -- every Cartesian chart, and any point


### PR DESCRIPTION
[unxt#904](https://github.com/GalacticDynamics/unxt/pull/904) memoised `AbstractAngle.__check_init__` — the ~138 µs that #752's `canonical_containers` reached past the checked constructor to avoid, using `AbstractQuantity._mk`. The open question was whether the checked constructor is now cheap enough that `_mk` and its call-site theorem could go.

Measured, not assumed:

```
                                  2.0.3      main
u.Angle(value, unit)          170.9us -> 29.3us
u.Angle._mk(...)                0.8us ->  0.7us
canonical_containers, checked 351.8us -> 68.0us
canonical_containers, `_mk`     8.7us ->  8.7us
```

## The answer is no, and the reason has changed

#904 delivered exactly what it claimed: angle construction now costs what a plain `Quantity` does. But `_mk` skips *two* things — `__check_init__` **and** the `plum`-dispatched field converters — and #904 only removed the first. The residual 29 µs is the converters, so a **40x gap remains**. `canonical_containers` on a spherical point would go 8.7 µs → 68 µs.

So the code is unchanged; what was stale was the *justification*. The comment named `__check_init__` as what `_mk` avoids, which is no longer the live reason. It now names the converters, records both measurements, and states what would justify dropping `_mk`: the same treatment applied to the converters.

## Two things worth flagging

**#904 is not in a release.** `unxt-v2.0.3` was cut ~3 h before #904 merged, and coordinax pins 2.0.3 — so the version this repo actually runs against still pays the full 170.9 µs. The `main` column above required installing unxt from git.

**End-to-end, the gap is near the noise.** An eager `pt_map(cart3d -> sph3d)` is ~2.55 ms, so canonicalisation is ~2% of it — I could only separate `_mk` from checked by interleaving rounds to cancel drift:

```
_mk       median 2548.4 us   min 2500.7   max 2690.1
checked   median 2603.1 us   min 2559.3   max 2739.9
noop      median 2511.1 us   min 2447.4   max 2631.9
```

The ordering is consistent, but a single min-of-repeat run gets it backwards. The honest reading: `_mk` is cheap insurance on a function designed to be nearly free (#719 dispatch-bound, hot path), not a load-bearing 2x. If someone would rather have the simpler call site than the 2%, that is a defensible trade — this PR gives it a number instead of a guess.

## Verification

Comment-only change to `containers.py`. `tests/unit/charts` 758 passed; `prek run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
