### PR TITLE
📝 docs(distances,astro): say why the guard assigns from `__check_init__`

### DIFF
--- a/packages/coordinaxs.astro/src/coordinaxs/astro/_src/parallax.py
+++ b/packages/coordinaxs.astro/src/coordinaxs/astro/_src/parallax.py
@@ -71,8 +71,16 @@ class Parallax(cxd.AbstractDistance):
             raise ValueError(msg)
 
         if self.check_negative:
-            # Store the checked value back so the guard survives jit (an
-            # unused `error_if` result is dead-code-eliminated under trace).
+            # `object.__setattr__` because equinox forbids assigning here --
+            # and this guard must assign: an unused `error_if` result is
+            # dead-code-eliminated under trace, so the checked array has to be
+            # the one the field holds. Neither alternative works.
+            # `__post_init__` runs before equinox applies the converters, so
+            # it sees the raw constructor argument: `error_if` then has no
+            # array to thread the error onto unless the caller happened to pass
+            # one, which would make the guard work or not by input type. And a
+            # `converter=` guard, the idiomatic home, cannot read
+            # `check_negative` -- a converter is passed only its own value.
             checked = eqx.error_if(
                 self.value,
                 jnp.any(jnp.less(self.value, 0)),

--- a/src/coordinax/distances/_src/measures.py
+++ b/src/coordinax/distances/_src/measures.py
@@ -57,8 +57,16 @@ class Distance(AbstractDistance):
             raise ValueError(msg)
 
         if self.check_negative:
-            # Store the checked value back so the guard survives jit (an
-            # unused `error_if` result is dead-code-eliminated under trace).
+            # `object.__setattr__` because equinox forbids assigning here --
+            # and this guard must assign: an unused `error_if` result is
+            # dead-code-eliminated under trace, so the checked array has to be
+            # the one the field holds. Neither alternative works.
+            # `__post_init__` runs before equinox applies the converters, so
+            # it sees the raw constructor argument: `error_if` then has no
+            # array to thread the error onto unless the caller happened to pass
+            # one, which would make the guard work or not by input type. And a
+            # `converter=` guard, the idiomatic home, cannot read
+            # `check_negative` -- a converter is passed only its own value.
             checked = eqx.error_if(
                 self.value,
                 jnp.any(jnp.less(self.value, 0)),


### PR DESCRIPTION
`Distance` and `Parallax` guard non-negativity from `__check_init__`, and assign there through `object.__setattr__`. That looks wrong, and by equinox's contract it is: the docs say assignment in `__check_init__` is *"disallowed to prevent unexpected behavior"*, and `self.foo = 1` raises. `object.__setattr__` bypasses that ban.

It has to assign. An `error_if` whose result goes unused is dead-code-eliminated under trace, so the checked array must be the one the field holds — otherwise the guard passes eagerly and vanishes under `jit`, which is the failure mode #773 and #805 were about.

I tried both escapes. Neither works, and the reasons are worth recording rather than rediscovering.

## `__post_init__` runs too early

Converters are applied in `_ModuleMeta.__call__` *after* `super().__call__()` returns:

```python
self = super().__call__(*args, **kwargs)              # __init__, incl. __post_init__
for f in fields:
    object.__setattr__(self, f.name, converter(...))  # converters, here
for parent_cls in cls.__mro__:
    check_init(self)                                  # __check_init__, here
```

So nothing inside `__init__` sees a converted field:

```
in __post_init__ :  value=int          unit=str
in __check_init__:  value=ArrayImpl    unit=PrefixUnit
```

`error_if` on a plain `int` fails with `ValueError: No arrays to thread error on to.`, so even a valid `Distance(10, "km")` raises. Calling `__post_init__` by hand from a custom `__init__` does not change this — the ordering is in the metaclass, not in who calls it.

## A `converter=` guard would be idiomatic, but can't see `check_negative`

This is the clean answer in principle: the converter's return value is what gets stored, so nothing is eliminated, no checker assigns, and `_make` bypasses it already. Verified working, including under `jit`:

```
valid eager -> ok      neg eager  -> RAISES
valid jit   -> ok      neg in jit -> RAISES
```

But a converter is passed only its own value, and this guard is conditional on `check_negative` — a sibling field that is public, documented, tested, and propagated through arithmetic dispatch (`register_primitives.py:107`, so an opted-out `Distance` stays opted out).

## Defining `__check_init__` is not the cost

The MRO walk in `_ModuleMeta.__call__` is unconditional — it runs whether or not the method exists, so defining it turns a failed dict lookup into a successful one:

| | µs/construction |
| --- | --- |
| no `__check_init__` | 30.65 |
| empty `__check_init__` | 30.84 |
| `__check_init__` with the guard | 85.66 |

The 55 µs is the `error_if`, and it would cost that wherever it lived. There is no walk to avoid.

## Result

The status quo is the least-bad option, so both sites now state all three constraints instead of leaving the escape hatch looking like an oversight.

The one real alternative is a design change, not a cleanup: drop `check_negative` in favour of `_make` — whose docstring already argues it is *cheaper* than `check_negative=False` — which would unblock the converter route and remove the `object.__setattr__` entirely. That is a public API removal and is deliberately not done here.

Comments only; no behaviour change. 395 passed / 2 skipped across `tests/unit/distances`, the `coordinax.distances` doctests, and the astro package's suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)