### PR TITLE
ci: allow coverage artifact overwrite on reruns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
         with:
           name: coverage-python-${{ github.run_id }}
           path: coverage.xml
+          overwrite: true
 
   # These tests spawn their own interpreter, which has to cold-import the whole
   # JAX stack. Doing that beside xdist workers cold-importing the same stack


### PR DESCRIPTION
Follow-up to the Copilot review comment on #809, which merged before the fix landed.

The coverage artifact name is keyed on `github.run_id`, which is stable across re-run attempts, so "Re-run jobs" hits an existing artifact and `upload-artifact` errors. `overwrite: true` makes reruns replace it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)