### PR TITLE
💥 fix(charts): `ProlateSpheroidal3D.Delta` must be a length

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1543,6 +1543,7 @@ The `coordinax.charts` module provides the chart-facing API for representing poi
     - `ProlateSpheroidal3D` is the final concrete chart type for prolate spheroidal coordinates $(\mu, \nu, \phi)$.
     - Components: `("mu", "nu", "phi")` with dimensions `("area", "area", "angle")`.
     - Carries a required field `Delta` (focal half-length, an `AbstractQuantity["length"]` with `Delta > 0`). A `StaticQuantity` contributes no pytree leaves; a `Quantity` contributes one and is differentiable.
+    - The two rules are checked in different places, because only one of them can be checked at construction. The *dimension* is: a unit is static, so `__post_init__` raises `ValueError` for a `Delta` that is not a length, under `jit` as well as outside it. *Positivity* is not: `Delta.value` is a tracer under `jit`, so it is enforced by `check_data` through `eqx.error_if`, like every other value check.
     - Validity constraints: $\mu \ge \Delta^2$, $|\nu| \le \Delta^2$.
     - Unlike many other charts, `ProlateSpheroidal3D` instances are not interchangeable: two instances with different `Delta` are distinct charts.
     - No pre-defined instance (requires `Delta` parameter).

--- a/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/chart_kwargs.py
+++ b/packages/coordinaxs.hypothesis/src/coordinaxs/hypothesis/charts/_src/chart_kwargs.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import hypothesis.strategies as st
 import plum
+import unxt as u
+import unxts.hypothesis as ust
 
 import coordinax.charts as cxc
 
@@ -167,3 +169,58 @@ def chart_init_kwargs(
 
     # Delegate to the non-strategy version for the actual kwargs generation
     return draw(chart_init_kwargs(chart_class, ndim=ndim))
+
+
+@plum.dispatch
+@ft.lru_cache(maxsize=128, typed=True)
+@strip_return_annotation
+@st.composite
+def chart_init_kwargs(
+    draw: st.DrawFn,
+    chart_class: type[cxc.ProlateSpheroidal3D],
+    /,
+    *,
+    ndim: int | None | st.SearchStrategy = None,
+) -> dict[str, Any]:
+    """`Delta` is a focal *length*, which its annotation cannot say.
+
+    The generic version reads each parameter's jaxtyping annotation, and
+    `Delta`'s pins the container and shape but not the dimension -- it cannot,
+    without narrowing to one quantity type and losing the
+    `Quantity`/`StaticQuantity` choice that makes differentiability opt-in.
+    Drawing from the annotation alone gives seconds as readily as parsecs, and
+    `ProlateSpheroidal3D` rejects those at construction.
+
+    Both containers are drawn, because which one is used is a real distinction
+    for this chart: a `StaticQuantity` contributes no pytree leaves and a
+    `Quantity` contributes one.
+
+    The magnitude is kept modest. `Delta` is squared to bound `mu`, so a draw
+    near the float ceiling squares to infinity -- representable as a chart,
+    but not as the domain the strategies then draw points from. The limits are
+    powers of two so that they are exact at float32, which `floats(width=32)`
+    requires of its bounds.
+
+    >>> import coordinax.charts as cxc
+    >>> import coordinaxs.hypothesis.main as cxst
+    >>> from hypothesis import given
+    >>> import unxt as u
+
+    >>> @given(kwargs=cxst.chart_init_kwargs(cxc.ProlateSpheroidal3D))
+    ... def test_delta_is_a_length(kwargs):
+    ...     assert u.dimension_of(kwargs["Delta"]) == u.dimension("length")
+    ...     cxc.ProlateSpheroidal3D(**kwargs)
+
+    """
+    unit = draw(ust.units(u.dimension("length")))
+    value = draw(
+        st.floats(
+            min_value=0.125,
+            max_value=1024.0,
+            allow_nan=False,
+            allow_infinity=False,
+            width=32,
+        )
+    )
+    container = draw(st.sampled_from([u.Q, u.quantity.StaticQuantity]))
+    return {"Delta": container(value, unit)}

--- a/src/coordinax/_src/charts/d3.py
+++ b/src/coordinax/_src/charts/d3.py
@@ -19,6 +19,7 @@ __all__ = (
 )
 
 import dataclasses
+import functools as ft
 
 from jaxtyping import Real
 from typing import Annotated, Any, Final, Literal as L, Self, override  # noqa: N817
@@ -437,6 +438,22 @@ ProlateSpheroidalKeys = tuple[L["mu"], L["nu"], L["phi"]]
 ProlateSpheroidal3DDims = tuple[L["area"], L["area"], Ang]
 
 
+@ft.lru_cache(maxsize=128)
+def _is_length(unit: Any, /) -> bool:
+    """Whether *unit* is a length, answered once per unit.
+
+    `unxt.is_unit_convertible` costs ~21us, against ~10us for building the
+    whole chart -- it walks astropy's unit graph on every call. Memoising it
+    per unit brings that to ~0.1us, because the answer depends only on the
+    unit and a program uses very few of them.
+
+    Comparing dimensions instead is not the cheaper route it looks like:
+    ``dimension_of(unit) == dimension("length")`` measured ~69us, and
+    ``dimension_of(quantity)`` ~134us.
+    """
+    return bool(u.is_unit_convertible("m", unit))
+
+
 @EuclideanAtlas.register
 class ProlateSpheroidal3D(
     Abstract3D,
@@ -510,7 +527,7 @@ class ProlateSpheroidal3D(
         type -- which would cost the `Quantity`/`StaticQuantity` choice that
         makes differentiability opt-in.
         """
-        if not u.is_unit_convertible("m", self.Delta.unit):
+        if not _is_length(self.Delta.unit):
             msg = (
                 "ProlateSpheroidal3D.Delta is the focal length and must have "
                 f"dimensions of length, got {self.Delta.unit!s} "

--- a/src/coordinax/_src/charts/d3.py
+++ b/src/coordinax/_src/charts/d3.py
@@ -491,9 +491,32 @@ class ProlateSpheroidal3D(
         Real[u.quantity.AbstractQuantity, ""],  # Quantity (dynamic) or StaticQuantity
         Is[lambda x: x.value > 0],
     ]
-    """Focal length of the coordinate system."""
+    """Focal length of the coordinate system. Must have dimensions of length."""
 
     M: MT = R3  # ty: ignore[invalid-assignment]
+
+    def __post_init__(self) -> None:
+        """Reject a `Delta` that is not a length.
+
+        The components are declared ``('area', 'area', 'angle')`` and the
+        bounds `check_data` enforces are ``Delta**2``, so only a length closes
+        the loop: a `Delta` in seconds gives a bound in ``s2`` that no `mu` in
+        ``m2`` can be compared against, and `check_data` would then validate
+        ``s2`` data against an ``area`` chart without complaint.
+
+        The jaxtyping annotation cannot carry this. It pins the container and
+        the shape, but nothing enforces it at construction, and the dimension
+        is not expressible there without narrowing `Delta` to one quantity
+        type -- which would cost the `Quantity`/`StaticQuantity` choice that
+        makes differentiability opt-in.
+        """
+        if not u.is_unit_convertible("m", self.Delta.unit):
+            msg = (
+                "ProlateSpheroidal3D.Delta is the focal length and must have "
+                f"dimensions of length, got {self.Delta.unit!s} "
+                f"({u.dimension_of(self.Delta)})."
+            )
+            raise ValueError(msg)
 
     def check_data(self, data: CDictT, /, *, values: bool = False, **kw: Any) -> CDictT:
         super().check_data(data, **kw)  # call base check

--- a/src/coordinax/_src/charts/register_domains.py
+++ b/src/coordinax/_src/charts/register_domains.py
@@ -113,20 +113,15 @@ def component_domains(chart: ProlateSpheroidal3D, /) -> dict[str, Interval]:
     so cannot be read under `jax.jit`. Nothing on the construction path calls
     it -- `check_data` compares quantities directly, and stays traceable.
     """
-    # `Delta` is constrained to be positive and scalar, but not to be a length
-    # and not to be of any particular size, so `Delta**2` is not always a
-    # usable bound: seconds give a bound in ``s2`` that no `mu` in ``m2`` can
-    # be compared against, and a `Delta` near the float ceiling squares to
-    # infinity. Neither is declarable, so such a chart declares nothing for
-    # `mu` and `nu` -- the same answer as any other chart with no bound to
-    # state, rather than an unconvertible or infinite one.
+    # `Delta` is a length and positive, so `Delta**2` is always an area -- but
+    # not always a finite one: a `Delta` near the float ceiling squares to
+    # infinity, which is not a bound. Such a chart declares nothing for `mu`
+    # and `nu`, the same answer as any other chart with no bound to state.
     with np.errstate(over="ignore"):
         delta_sq = chart.Delta**2
     unit = str(delta_sq.unit)
     bound = float(u.ustrip(delta_sq.unit, delta_sq))
-    if not u.is_unit_convertible(delta_sq.unit, u.unit("m2")) or not math.isfinite(
-        bound
-    ):
+    if not math.isfinite(bound):
         return {"mu": FREE, "nu": FREE, "phi": AZIMUTH}
 
     return {

--- a/tests/unit/charts/test_domain_agreement.py
+++ b/tests/unit/charts/test_domain_agreement.py
@@ -148,23 +148,15 @@ def test_every_enforced_bound_is_declared() -> None:
         chart.check_data(point, keys=False, values=True)
 
 
-@pytest.mark.parametrize(
-    ("delta", "reason"),
-    [
-        (u.StaticQuantity(2.0, "s"), "not convertible to the components' area"),
-        (u.StaticQuantity(1e200, "m"), "squares past the float ceiling"),
-    ],
-)
-def test_prolate_spheroidal_declares_nothing_for_an_unusable_delta(
-    delta, reason
-) -> None:
-    """`Delta` is only constrained positive and scalar, so it can be unusable.
+def test_prolate_spheroidal_declares_nothing_for_an_infinite_bound() -> None:
+    """`Delta` is a length, but not necessarily one that survives squaring.
 
-    A non-length `Delta` gives a bound in a unit `mu` cannot be compared
-    against, and an enormous one squares to infinity. Neither is a bound, so
-    neither is declared -- the alternative is a domain a caller cannot convert
-    or a generator cannot draw from.
+    ``1e200 m`` squares past the float ceiling, and infinity is not a bound,
+    so nothing is declared -- a domain no generator could draw from. The other
+    way a bound could be unusable, a `Delta` in the wrong dimension, is now
+    refused by the chart itself (`test_prolate_delta_dimension.py`).
     """
-    domains = component_domains(cxc.ProlateSpheroidal3D(Delta=delta))
-    assert domains["mu"].unit is None, reason
-    assert domains["nu"].unit is None, reason
+    chart = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(1e200, "m"))
+    domains = component_domains(chart)
+    assert domains["mu"].unit is None
+    assert domains["nu"].unit is None

--- a/tests/unit/charts/test_prolate_delta_dimension.py
+++ b/tests/unit/charts/test_prolate_delta_dimension.py
@@ -1,0 +1,46 @@
+"""`ProlateSpheroidal3D.Delta` is a focal length, and only a length."""
+
+import jax
+import pytest
+
+import unxt as u
+
+import coordinax.charts as cxc
+
+
+@pytest.mark.parametrize("unit", ["m", "kpc", "AU"])
+@pytest.mark.parametrize("container", [u.Q, u.quantity.StaticQuantity])
+def test_a_length_is_accepted_in_either_container(container, unit) -> None:
+    """Both quantity types stay available: differentiability is opt-in."""
+    chart = cxc.ProlateSpheroidal3D(Delta=container(2.0, unit))
+    assert u.dimension_of(chart.Delta) == u.dimension("length")
+
+
+@pytest.mark.parametrize("unit", ["s", "kpc2", "", "km/s"])
+def test_a_non_length_is_rejected(unit) -> None:
+    """The hole this closes.
+
+    `check_data` compares `mu` against ``Delta**2``, so seconds gave a bound
+    in ``s2`` and the chart then validated ``s2`` data while declaring its
+    components ``area``. Rejecting at construction is what makes the declared
+    dimensions mean anything.
+    """
+    with pytest.raises(ValueError, match="must have dimensions of length"):
+        cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, unit))
+
+
+def test_the_error_names_the_dimension_it_got() -> None:
+    """A bare "invalid Delta" would not say which of the two rules was broken."""
+    with pytest.raises(ValueError, match=r"got s \(time\)"):
+        cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "s"))
+
+
+def test_a_dynamic_delta_still_traces() -> None:
+    """The check reads the unit, which is static, so it survives `jit`.
+
+    A check that touched `Delta.value` would not: that is a tracer under
+    `jit`, and the chart is built inside traced code by every `pt_map` that
+    takes one as an argument.
+    """
+    build = jax.jit(lambda d: cxc.ProlateSpheroidal3D(Delta=d).Delta)
+    assert u.dimension_of(build(u.Q(2.0, "kpc"))) == u.dimension("length")

--- a/tests/unit/charts/test_prolate_delta_dimension.py
+++ b/tests/unit/charts/test_prolate_delta_dimension.py
@@ -44,3 +44,52 @@ def test_a_dynamic_delta_still_traces() -> None:
     """
     build = jax.jit(lambda d: cxc.ProlateSpheroidal3D(Delta=d).Delta)
     assert u.dimension_of(build(u.Q(2.0, "kpc"))) == u.dimension("length")
+
+
+def test_the_check_stays_off_the_hot_paths() -> None:
+    """`__post_init__` must not re-run when the chart is rebuilt from its pytree.
+
+    This is what keeps the check a per-construction cost rather than a
+    per-call one: `jit` flattens and unflattens a chart argument on every
+    boundary crossing, and equinox rebuilds a `Module` without calling
+    `__init__`. If that ever changed, the cost would move onto the traced
+    path, where it does not belong -- and nothing else would go red.
+    """
+    chart = cxc.ProlateSpheroidal3D(Delta=u.Q(2.0, "kpc"))
+    leaves, treedef = jax.tree.flatten(chart)
+
+    calls = 0
+    original = type(chart).__post_init__
+
+    def counting(self: object) -> None:
+        nonlocal calls
+        calls += 1
+        original(self)
+
+    type(chart).__post_init__ = counting  # type: ignore[method-assign]
+    try:
+        jax.tree.unflatten(treedef, leaves)
+        jax.jit(lambda c: c.Delta)(chart)
+    finally:
+        type(chart).__post_init__ = original  # type: ignore[method-assign]
+
+    assert calls == 0
+
+
+def test_the_unit_check_is_memoised() -> None:
+    """The check is answered once per unit, not once per construction.
+
+    `unxt.is_unit_convertible` walks astropy's unit graph and costs about
+    twice what building the whole chart does. Uncached it dominated
+    construction; the cache is what makes the check affordable at all.
+    """
+    from coordinax._src.charts.d3 import _is_length
+
+    _is_length.cache_clear()
+    unit = u.unit("kpc")
+    _is_length(unit)
+    before = _is_length.cache_info().misses
+    for _ in range(100):
+        _is_length(unit)
+    assert _is_length.cache_info().misses == before
+    assert _is_length.cache_info().hits >= 100


### PR DESCRIPTION
The spec has said so since it was written:

> Carries a required field `Delta` (focal half-length, an `AbstractQuantity["length"]` with `Delta > 0`).

Nothing enforced it. `check_data` compares `mu` against `Delta**2` and never asks what dimension that is, so:

```pycon
>>> chart = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "s"))
>>> chart.coord_dimensions
('area', 'area', 'angle')
>>> chart.check_data({"mu": u.Q(9.0, "s2"), ...}, values=True)   # accepted
```

A chart that declares `area` and validates `s2`. #807 worked around it — `component_domains` declares nothing for a `Delta` it cannot use — but the hole is in the chart, so this closes it there.

## Where each rule is enforced, and why they differ

`__post_init__` raises `ValueError` naming the dimension it got:

```
ProlateSpheroidal3D.Delta is the focal length and must have dimensions of
length, got s (time).
```

**Positivity stays in `check_data`, deliberately.** A unit is static and readable under `jit`; `Delta.value` is a tracer, so `> 0` cannot be branched on at construction. The chart is built inside traced code by every `pt_map` that takes one as an argument, so the dimension check had to be tracer-safe — it is, and there's a test pinning that.

The jaxtyping annotation cannot carry this either. It is not enforced at construction (a non-scalar `Delta` is accepted today despite `Real[..., ""]`), and the dimension is not expressible there without narrowing `Delta` to a single quantity type — which would cost the `Quantity`/`StaticQuantity` choice that makes differentiability opt-in per instance.

## ⚠️ Breaking

A `Delta` in any other dimension now raises at construction. Such a chart was already broken — its `mu` bound could not be meaningfully compared against the `area` its own components declare — so this surfaces existing bugs rather than rejecting working code. No in-repo caller passed a non-length `Delta`.

## Fallout

**The strategies were the real users of the looseness.** `chart_init_kwargs` builds parameters from each field's annotation, and `Delta`'s pins no dimension, so it drew seconds as readily as parsecs — **28 tests** constructed such charts. There is already a `plum` dispatch seam for per-chart overrides; this adds the first one, drawing a length in both quantity containers (which one is used is a real distinction here: `StaticQuantity` contributes no pytree leaves, `Quantity` contributes one). Magnitude is kept modest and its bounds are powers of two, since `Delta` is squared to bound `mu` and `floats(width=32)` requires exactly-representable bounds.

**It also deletes a guard from #807.** `component_domains` no longer asks whether `Delta**2` is convertible to an area — a length squared always is. Only the overflow check remains, for a `Delta` near the float ceiling.

## Verification

**11691 passed**, 311 skipped, 1 xfailed. `prek run --all-files` clean; `nox -s docs` succeeds. New tests cover both containers across three length units, four rejected dimensions, the error naming the dimension, and that a dynamic `Delta` still traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
