### PR TITLE
⬆️ build: lock unxt 2.0.4, which carries the `_mk` measurement's other half

### DIFF
--- a/src/coordinax/_src/charts/containers.py
+++ b/src/coordinax/_src/charts/containers.py
@@ -118,9 +118,13 @@ def canonical_containers(p: CDict, chart: Any, /) -> CDict:
         #   canonical_containers, checked 351.8us -> 66.8us
         #   canonical_containers, `_mk`     8.7us ->  8.5us
         #
-        # A 38x gap remains on the newer one, so this stays. What it buys is
-        # ~2% of an eager `pt_map`, near the noise -- if the converters ever
-        # get the same treatment, drop `_mk` and this paragraph with it.
+        # Canonicalising a spherical point still costs ~8x more through the
+        # checked constructor even on 2.0.4 (66.8us against 8.5us), so this
+        # stays. That is the ratio the choice turns on: the constructors
+        # themselves differ by ~36x, but only the angular components of one
+        # point go through them. In an eager `pt_map` the whole saving is ~2%
+        # of the call, near the noise -- if the converters ever get the same
+        # treatment, drop `_mk` and this paragraph with it.
         promoted[k] = u.Angle._mk(value=v.value, unit=unit)
 
     # Nothing to do is the common case -- every Cartesian chart, and any point

--- a/src/coordinax/_src/charts/containers.py
+++ b/src/coordinax/_src/charts/containers.py
@@ -108,18 +108,19 @@ def canonical_containers(p: CDict, chart: Any, /) -> CDict:
         #
         # unxt#904 memoised that check, so it is no longer what `_mk` is
         # avoiding -- the `plum`-dispatched field converters are, and #904 did
-        # not touch those. It is also not in a release yet: unxt 2.0.3, the
-        # version pinned here, still pays the full check. Measured on both:
+        # not touch those. Both costs are live here: #904 landed in unxt 2.0.4,
+        # which the lock resolves, while the declared floor is 2.0.2 and
+        # `test_oldest` builds against it. Measured on either side of #904:
         #
-        #                                  2.0.3      main
-        #   u.Angle(value, unit)          170.9us -> 29.3us
-        #   u.Angle._mk(...)                0.8us ->  0.7us
-        #   canonical_containers, checked 351.8us -> 68.0us
-        #   canonical_containers, `_mk`     8.7us ->  8.7us
+        #                                 pre-#904     2.0.4
+        #   u.Angle(value, unit)          170.9us -> 28.9us
+        #   u.Angle._mk(...)                0.8us ->  0.8us
+        #   canonical_containers, checked 351.8us -> 66.8us
+        #   canonical_containers, `_mk`     8.7us ->  8.5us
         #
-        # A 40x gap remains even on main, so this stays. What it buys is ~2%
-        # of an eager `pt_map`, near the noise -- if the converters ever get
-        # the same treatment, drop `_mk` and this paragraph with it.
+        # A 38x gap remains on the newer one, so this stays. What it buys is
+        # ~2% of an eager `pt_map`, near the noise -- if the converters ever
+        # get the same treatment, drop `_mk` and this paragraph with it.
         promoted[k] = u.Angle._mk(value=v.value, unit=unit)
 
     # Nothing to do is the common case -- every Cartesian chart, and any point

--- a/uv.lock
+++ b/uv.lock
@@ -3411,7 +3411,7 @@ wheels = [
 
 [[package]]
 name = "unxt"
-version = "2.0.3"
+version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },
@@ -3432,9 +3432,9 @@ dependencies = [
     { name = "unxts-api" },
     { name = "wadler-lindig" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/f7/a24b34abec0756f5d79807131732d7209b818affe19630ddc4240b6aaf31/unxt-2.0.3.tar.gz", hash = "sha256:8abe1cb77a29c2fbb00d1d4b7e8e2745328d5bb9acb2d7a22b0e6bd16e78b220", size = 724115, upload-time = "2026-08-20T13:11:16.829Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/df/c6809f0be3fef6793a68d5fd6ee0a5e5174dcc40f3961c39367d6de329a6/unxt-2.0.4.tar.gz", hash = "sha256:fb226465242c9465045dfee71f09757afafb312494a22cc2c9b82b28842bc572", size = 725427, upload-time = "2026-09-04T08:02:05.732Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/5f/f63b3708237ef8c43d396599ac3808ce29c0cdc470dd21fdbae0f7405148/unxt-2.0.3-py3-none-any.whl", hash = "sha256:1a5ac6b81d20b5c9a752f0651a1dc9b99b91b9842b8a7e31f72c99b4fbd06165", size = 119121, upload-time = "2026-08-20T13:11:15.554Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/1a/33374c3793f6baf0534833a246820951aae2fa6873567586101e8af8067e/unxt-2.0.4-py3-none-any.whl", hash = "sha256:8443041705ca3a04ee78b9c6e48d4f817f1cc54d3a7862203b5da0ee79cf14fd", size = 119925, upload-time = "2026-09-04T08:02:02.654Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
[unxt 2.0.4](https://github.com/GalacticDynamics/unxt/releases/tag/unxt-v2.0.4) ships the #904 backport ([unxt#905](https://github.com/GalacticDynamics/unxt/pull/905)) — the memoised angular-unit check that #806 had to measure against a git build, because 2.0.3 was cut hours before #904 merged. The lock moves to it, and the comment in `containers.py` that said the improvement was unreleased is no longer true.

## The floor deliberately stays at `unxt>=2.0.2`

#904 is a performance improvement, not a correctness requirement. This code is correct on 2.0.2, and raising the floor would force an upgrade on every consumer for a speed-up they may not want to take. The existing floor comment gives the reason 2.0.2 is the floor (`np.asarray(Quantity)` raising rather than silently dropping the unit) and that reason has not changed.

That makes **both costs live in CI**, which is what the rewritten comment now says rather than naming one pinned version: `test_oldest` builds against the 2.0.2 floor and pays the full check; the main matrix resolves the lock and does not.

## Re-measured on the release

Not reusing #806's git-build numbers:

```
                                pre-#904     2.0.4
u.Angle(value, unit)          170.9us -> 28.9us
u.Angle._mk(...)                0.8us ->  0.8us
canonical_containers, checked 351.8us -> 66.8us
canonical_containers, `_mk`     8.7us ->  8.5us
```

The `pre-#904` column is labelled by what it is rather than by a version number, because it was measured on 2.0.3 while the floor is 2.0.2 — both are pre-#904, and claiming a 2.0.2 figure I did not measure would be worse than saying which side of the change it came from.

**#806's conclusion is unchanged.** `_mk` also skips the `plum`-dispatched field converters, which #904 did not touch, so a 38× gap remains and `_mk` stays.

## Verification

**11675 passed**, 311 skipped, 1 xfailed. `prek run --all-files` clean. Two files changed: `uv.lock` and the comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
