### PR TITLE
🐛 fix(curveframes): a worldtube's `tau` is a time, and said it was a length

### DIFF
--- a/packages/coordinaxs.curveframes/docs/curve-charts.md
+++ b/packages/coordinaxs.curveframes/docs/curve-charts.md
@@ -81,6 +81,25 @@ That is a categorical difference, not a stylistic one. A frame transform has no 
 
 ```
 
+The exception is a builder over a **two-argument** curve with a pinned `station`. There the builder's call-time parameter is the time, so the chart's $\tau$ is a time as well and `tau_bounds` are times — a _worldtube_, one material point's history, rather than a slice of space:
+
+```{code-block} python
+>>> def stretching(s, t):
+...     sv, tv = s.ustrip("km"), t.ustrip("s")
+...     z = jnp.zeros_like(sv)
+...     return u.Q(jnp.stack([sv * (1 + 0.5 * tv), 0.1 * tv * sv**2, z]), "km")
+
+>>> ch_tube = cxfc.TubularChart(
+...     cxfc.BishopBuilder(stretching, "km", station=u.Q(1.3, "km")),
+...     tau_bounds=(u.Q(0.0, "s"), u.Q(2.0, "s")),
+... )
+>>> ch_tube.coord_dimensions
+('time', 'length', 'length')
+
+```
+
+`tau_bounds` is the only statement of that unit — the builder's `tau_unit` describes the _station_ here — so bare (unitless) bounds raise on this branch rather than falling back to it.
+
 `tau_bounds` sets the scan range the inverse solve seeds from (below); it must cover the $\tau$ values you intend to query. For a curve that closes on itself, it must also cover **no more than one period** — see [Limitations](#limitations).
 
 ## Both Directions

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
@@ -32,6 +32,13 @@ from coordinax._src.base import AbstractParameterizedChart
 from .arclength import _is_two_argument
 from .base import AbstractCurveFrameBuilder
 
+_MSG_BARE_TIME_BOUNDS = (
+    "`TubularChart.tau_bounds` must carry a unit when the builder pins a "
+    "station: `tau` is then the evaluation time, and the builder's `tau_unit` "
+    "describes the station instead, so nothing else states this coordinate's "
+    "dimension."
+)
+
 
 @final
 class TubularChart(AbstractParameterizedChart):
@@ -112,7 +119,18 @@ class TubularChart(AbstractParameterizedChart):
         # field holding the tau range as a `Quantity`, so it carries the unit
         # structurally -- which is what this property needs and an inferring
         # builder, having no call parameter here, cannot supply.
-        tau_unit = self.builder._tau_unit_at(self.tau_bounds[0])
+        #
+        # On a worldtube it is the *only* source. `_tau_unit_at` resolves the
+        # curve *parameter*, and prefers a declared `tau_unit` over the value
+        # handed to it -- but a pinned station makes `tau` the time, and
+        # `tau_unit` describes the station, so asking the builder labels a time
+        # coordinate `length`.
+        if self.is_time_dependent:
+            tau_unit = u.unit_of(self.tau_bounds[0])
+            if tau_unit is None:
+                raise TypeError(_MSG_BARE_TIME_BOUNDS)
+        else:
+            tau_unit = self.builder._tau_unit_at(self.tau_bounds[0])
         return (str(u.dimension_of(tau_unit)), "length", "length")
 
     @property

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
@@ -18,7 +18,7 @@ __all__ = ("TubularChart",)
 
 import dataclasses
 
-from typing import Any, ClassVar, final, override
+from typing import Any, ClassVar, cast, final, override
 
 import equinox as eqx
 import jax
@@ -111,27 +111,38 @@ class TubularChart(AbstractParameterizedChart):
         return ("tau", "n1", "n2")
 
     @property
-    def coord_dimensions(self) -> tuple[str, str, str]:
-        # The first coordinate inherits whatever the curve is parameterised by,
-        # so this cannot be a class-level tuple the way most charts declare it.
-        #
-        # `tau_bounds` is the source rather than the builder: it is a required
-        # field holding the tau range as a `Quantity`, so it carries the unit
-        # structurally -- which is what this property needs and an inferring
-        # builder, having no call parameter here, cannot supply.
-        #
-        # On a worldtube it is the *only* source. `_tau_unit_at` resolves the
-        # curve *parameter*, and prefers a declared `tau_unit` over the value
-        # handed to it -- but a pinned station makes `tau` the time, and
-        # `tau_unit` describes the station, so asking the builder labels a time
-        # coordinate `length`.
+    def _tau_unit(self) -> u.AbstractUnit:
+        """The unit of *this chart's* ``tau``, which is not the builder's.
+
+        The two coincide on the static branch and part on a worldtube, which
+        is the whole of what this property exists to say. Everything the chart
+        does with ``tau`` -- label it, strip it, seed a scan over it -- routes
+        through here rather than the builder, or it gets the curve
+        *parameter's* unit where this *coordinate's* was wanted.
+
+        `tau_bounds` is the source rather than the builder: it is a required
+        field holding the tau range as a `Quantity`, so it carries the unit
+        structurally -- which is what this needs, and an inferring builder,
+        having no call parameter here, cannot supply.
+
+        On a worldtube it is the *only* source. `_tau_unit_at` resolves the
+        curve *parameter*, and prefers a declared `tau_unit` over the value
+        handed to it -- but a pinned station makes `tau` the time, and
+        `tau_unit` describes the station. Asking the builder therefore labels
+        a time coordinate `length`, and strips a time in kilometres.
+        """
         if self.is_time_dependent:
             tau_unit = u.unit_of(self.tau_bounds[0])
             if tau_unit is None:
                 raise TypeError(_MSG_BARE_TIME_BOUNDS)
-        else:
-            tau_unit = self.builder._tau_unit_at(self.tau_bounds[0])
-        return (str(u.dimension_of(tau_unit)), "length", "length")
+            return cast("u.AbstractUnit", tau_unit)
+        return self.builder._tau_unit_at(self.tau_bounds[0])
+
+    @property
+    def coord_dimensions(self) -> tuple[str, str, str]:
+        # The first coordinate inherits whatever the curve is parameterised by,
+        # so this cannot be a class-level tuple the way most charts declare it.
+        return (str(u.dimension_of(self._tau_unit)), "length", "length")
 
     @property
     def cartesian(self) -> cxc.Cart3D:
@@ -198,7 +209,10 @@ class TubularChart(AbstractParameterizedChart):
         matters.
         """
         tau, n1, n2 = data["tau"], data["n1"], data["n2"]
-        unit = self.builder._tau_unit_at(tau)
+        # The chart's `tau`, not the builder's curve parameter: on a worldtube
+        # those are a time and a station respectively, and asking the builder
+        # strips seconds in kilometres. See `_tau_unit`.
+        unit = self._tau_unit
         # Derive the unit from the curve (as ``nearest.py`` and
         # ``register_ptmap.py`` do), not hardcode `"km"`: the scale cancels in
         # `dot(dx,T)/speed`, but a hardcoded unit raises `UnitConversionError`

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/nearest.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/nearest.py
@@ -97,8 +97,14 @@ def nearest_tau(
 
     """
     # The bounds are the tau range, so they carry tau's unit themselves -- no
-    # need to consult the builder, which may not have one declared.
-    unit = builder._tau_unit_at(bounds[0])
+    # need to consult the builder, which may not have one declared. Reading
+    # them is not merely a shortcut: `_tau_unit_at` prefers a *declared*
+    # `tau_unit`, and on a pinned-station builder that describes the station
+    # while these bounds are times, so consulting it scans seconds in
+    # kilometres. The builder is the fallback for bare (unitless) bounds only.
+    unit = u.unit_of(bounds[0])
+    if unit is None:
+        unit = builder._tau_unit_at(bounds[0])
     # `jnp.asarray` narrows only here: `ustrip` is typed as a broad union, and
     # `ty` rejects `hi - lo` between two of them. Everywhere else the bare
     # `ustrip` is enough.

--- a/packages/coordinaxs.curveframes/tests/unit/test_tubular_chart.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_tubular_chart.py
@@ -52,6 +52,48 @@ def test_dimension_follows_the_curve_parameter() -> None:
     assert ch.coord_dimensions == ("length", "length", "length")
 
 
+def test_a_worldtube_reports_its_tau_as_a_time() -> None:
+    """A pinned station makes `tau` the *time*, so it is not a length.
+
+    `_resolve` reads the builder's argument as a time and takes the station
+    from `builder.station`, so `tau_unit` describes the station rather than
+    this coordinate. Asking the builder therefore labels a time coordinate
+    with the station's dimension.
+    """
+
+    def moving(sigma: u.AbstractQuantity, t: u.AbstractQuantity) -> u.AbstractQuantity:
+        sv, tv = sigma.ustrip("km"), t.ustrip("s")
+        z = jnp.zeros_like(sv)
+        return u.Q(jnp.stack([sv * (1.0 + 0.5 * tv), 0.1 * tv * sv**2, z]), "km")
+
+    ch = cxfc.TubularChart(
+        cxfc.BishopBuilder(moving, "km", station=u.Q(1.3, "km")),
+        tau_bounds=(u.Q(0.0, "s"), u.Q(2.0, "s")),
+    )
+    assert ch.is_time_dependent
+    assert ch.coord_dimensions == ("time", "length", "length")
+
+
+def test_a_worldtube_needs_its_time_bounds_to_carry_a_unit() -> None:
+    """Nothing else states the time coordinate's dimension.
+
+    On the static branch a bare `tau_bounds` falls back to the builder's
+    declared `tau_unit`. A worldtube has no such fallback: `tau_unit` is the
+    station's.
+    """
+
+    def moving(sigma: u.AbstractQuantity, t: u.AbstractQuantity) -> u.AbstractQuantity:
+        sv, tv = sigma.ustrip("km"), t.ustrip("s")
+        z = jnp.zeros_like(sv)
+        return u.Q(jnp.stack([sv * (1.0 + 0.5 * tv), 0.1 * tv * sv**2, z]), "km")
+
+    ch = cxfc.TubularChart(
+        cxfc.BishopBuilder(moving, "km", station=u.Q(1.3, "km")), tau_bounds=(0.0, 2.0)
+    )
+    with pytest.raises(TypeError, match="must carry a unit"):
+        _ = ch.coord_dimensions
+
+
 def test_cartesian_is_cart3d() -> None:
     assert isinstance(_chart().cartesian, cxc.Cart3D)
 

--- a/packages/coordinaxs.curveframes/tests/unit/test_tubular_chart.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_tubular_chart.py
@@ -29,6 +29,28 @@ def _chart(**kw):
     return cxfc.TubularChart(cxfc.BishopBuilder(circle, "s"), tau_bounds=BOUNDS, **kw)
 
 
+def stretching(s: u.AbstractQuantity, t: u.AbstractQuantity) -> u.AbstractQuantity:
+    """The two-argument curve of the guide's "A Station on a Curve That Moves"."""
+    sv, tv = s.ustrip("km"), t.ustrip("s")
+    z = jnp.zeros_like(sv)
+    return u.Q(jnp.stack([sv * (1.0 + 0.5 * tv), 0.1 * tv * sv**2, z]), "km")
+
+
+#: The station the worldtube is pinned at, and the time the spatial slice is
+#: taken at -- the two sections meet at this pair, which is what
+#: `test_the_two_sections_meet` checks.
+STATION = u.Q(1.3, "km")
+AT_TIME = u.Q(1.0, "s")
+TIME_BOUNDS = (u.Q(0.0, "s"), u.Q(2.0, "s"))
+
+
+def _worldtube(tau_bounds=TIME_BOUNDS):
+    """The tube at a fixed station, swept through time: coordinates (t, n1, n2)."""
+    return cxfc.TubularChart(
+        cxfc.BishopBuilder(stretching, "km", station=STATION), tau_bounds=tau_bounds
+    )
+
+
 def test_is_on_the_parameterized_branch() -> None:
     assert issubclass(cxfc.TubularChart, AbstractParameterizedChart)
 
@@ -60,16 +82,7 @@ def test_a_worldtube_reports_its_tau_as_a_time() -> None:
     this coordinate. Asking the builder therefore labels a time coordinate
     with the station's dimension.
     """
-
-    def moving(sigma: u.AbstractQuantity, t: u.AbstractQuantity) -> u.AbstractQuantity:
-        sv, tv = sigma.ustrip("km"), t.ustrip("s")
-        z = jnp.zeros_like(sv)
-        return u.Q(jnp.stack([sv * (1.0 + 0.5 * tv), 0.1 * tv * sv**2, z]), "km")
-
-    ch = cxfc.TubularChart(
-        cxfc.BishopBuilder(moving, "km", station=u.Q(1.3, "km")),
-        tau_bounds=(u.Q(0.0, "s"), u.Q(2.0, "s")),
-    )
+    ch = _worldtube()
     assert ch.is_time_dependent
     assert ch.coord_dimensions == ("time", "length", "length")
 
@@ -81,17 +94,69 @@ def test_a_worldtube_needs_its_time_bounds_to_carry_a_unit() -> None:
     declared `tau_unit`. A worldtube has no such fallback: `tau_unit` is the
     station's.
     """
-
-    def moving(sigma: u.AbstractQuantity, t: u.AbstractQuantity) -> u.AbstractQuantity:
-        sv, tv = sigma.ustrip("km"), t.ustrip("s")
-        z = jnp.zeros_like(sv)
-        return u.Q(jnp.stack([sv * (1.0 + 0.5 * tv), 0.1 * tv * sv**2, z]), "km")
-
-    ch = cxfc.TubularChart(
-        cxfc.BishopBuilder(moving, "km", station=u.Q(1.3, "km")), tau_bounds=(0.0, 2.0)
-    )
+    ch = _worldtube(tau_bounds=(0.0, 2.0))
     with pytest.raises(TypeError, match="must carry a unit"):
         _ = ch.coord_dimensions
+
+
+def test_the_two_sections_meet() -> None:
+    r"""The worldtube and the spatial slice are two cuts of one 4-D object.
+
+    $(t, \sigma, n_1, n_2)$ is a tube swept through time. Pinning the station
+    gives one material point's history -- a *time* and two lengths -- and
+    binding the time with `AtTime` gives the tube at one instant, three
+    lengths. They are the same object iff they agree where they cross, which
+    is what makes the differing `coord_dimensions` two readings rather than a
+    contradiction.
+    """
+    slice_ch = cxfc.TubularChart(
+        cxfc.BishopBuilder(cxfc.AtTime(stretching, AT_TIME), "km"),
+        tau_bounds=(u.Q(0.0, "km"), u.Q(2.0, "km")),
+    )
+    assert slice_ch.coord_dimensions == ("length", "length", "length")
+    assert _worldtube().coord_dimensions == ("time", "length", "length")
+
+    zero = {"n1": u.Q(0.0, "km"), "n2": u.Q(0.0, "km")}
+    on_slice = cxc.pt_map(
+        {"tau": STATION, **zero}, slice_ch.M, slice_ch, slice_ch.M, cxc.cart3d
+    )
+    tube = _worldtube()
+    on_tube = cxc.pt_map({"tau": AT_TIME, **zero}, tube.M, tube, tube.M, cxc.cart3d)
+    for k in ("x", "y", "z"):
+        assert jnp.allclose(
+            on_tube[k].ustrip("km"), on_slice[k].ustrip("km"), atol=1e-6
+        )
+
+
+def test_a_worldtube_round_trips_through_cartesian() -> None:
+    """The inverse solve scans in the bounds' unit, so it scans a *time*.
+
+    Resolving `tau`'s unit through the builder hands `nearest_tau` the pinned
+    station's `km`, and the scan raises rather than converging. Both
+    directions have to agree on which coordinate `tau` is.
+    """
+    ch = _worldtube()
+    p = {"tau": AT_TIME, "n1": u.Q(0.02, "km"), "n2": u.Q(0.0, "km")}
+    xyz = cxc.pt_map(p, ch.M, ch, ch.M, cxc.cart3d)
+    back = cxc.pt_map(xyz, ch.M, cxc.cart3d, ch.M, ch)
+
+    assert jnp.allclose(back["tau"].ustrip("s"), AT_TIME.ustrip("s"), atol=1e-3)
+    assert jnp.allclose(back["n1"].ustrip("km"), 0.02, atol=1e-5)
+    assert jnp.allclose(back["n2"].ustrip("km"), 0.0, atol=1e-5)
+
+
+def test_a_worldtubes_reach_check_runs() -> None:
+    """`check_data(values=True)` strips `tau` to evaluate the Jacobian factor.
+
+    Stripping through the builder's `tau_unit` asks a time for kilometres, so
+    the check could not run at all on a worldtube -- the point on the curve,
+    which is unambiguously inside the reach, raised `UnitConversionError`
+    instead of passing.
+    """
+    ch = _worldtube()
+    p = {"tau": AT_TIME, "n1": u.Q(0.0, "km"), "n2": u.Q(0.0, "km")}
+    assert ch.check_data(dict(p), values=True) is not None
+    assert float(ch.jacobian_factor(p)) > 0.0
 
 
 def test_cartesian_is_cart3d() -> None:


### PR DESCRIPTION
Groundwork for #779. Found while working out what the time+space story actually is for a time-dependent tubular chart, and worth landing on its own.

## The bug

`TubularChart.coord_dimensions` reported three lengths for a chart whose first coordinate must be handed **seconds**:

```
CASE 1 (station pinned)  components=('tau','n1','n2')  coord_dimensions=('length','length','length')  is_time_dependent=True
CASE 2 (time pinned)     components=('tau','n1','n2')  coord_dimensions=('length','length','length')  is_time_dependent=False
```

Case 1 is called with a time. The two are indistinguishable from the chart's declared interface, and one of the declarations is wrong.

The property's own comment already said `tau_bounds` was the source *"rather than the builder"* — but it routed through `_tau_unit_at`, whose first rule is *"a declared `tau_unit` wins"*. The stated intent was defeated by the resolver's precedence, and `tau_unit` describes the **station**, not this coordinate.

## The geometry it was obscuring

The real object is 4D — `(t, σ, n₁, n₂)`, a tube swept through time — and each of these is one 3D section of it:

| section | fixed by | coordinates | what it is |
| --- | --- | --- | --- |
| spatial slice | `AtTime(γ, t₀)` | `(σ, n₁, n₂)` | the tube at one instant — three lengths |
| worldtube | `station=σ₀` | `(t, n₁, n₂)` | one material point's history — a **time** and two lengths |

Both sections evaluate to the same point `[1.95, 0.169, 0]` at `σ=1.3 km, t=1 s`, which is the check that they are two cuts through one object rather than two objects.

This is also what made `GalileanCT`'s refusal read as arbitrary: it appears to decline a "spatial" chart of three lengths. It is declining a *worldtube*, exactly as its message says, and now the dimensions agree with the message.

## The fix

On the worldtube branch the unit comes straight off `tau_bounds`, which is the only statement of it there — and bare bounds raise, since the builder's fallback describes the station instead. The static branch is untouched.

## Verification

1036 curveframes tests, 760 across `tests/unit/charts` + `tests/unit/product`, 139 including the `curve-charts.md` doctests. Reverting the branch fails only the new test, so nothing depended on the old label. The new error path is reachable and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)