### PR TITLE
🐛 fix(ci): a skipped coverage upload failed the gate on every fork PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,3 +300,10 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
+          # `upload-coverage-python` does not run for a pull request from a
+          # fork -- it needs `code-quality: write`, which a fork's token does
+          # not carry. Without this it is a required job that is skipped, and
+          # a skipped required job fails the gate, so every fork PR went red
+          # with all seven real jobs green. `allowed-skips` excuses the skip
+          # only: if the job runs and fails, this still fails.
+          allowed-skips: upload-coverage-python


### PR DESCRIPTION
`CI Pass` has been failing on every pull request from a fork, with all seven real jobs green:

```
📝 upload-coverage-python → ⬜ skipped [required to succeed]
```

## Why

`upload-coverage-python` needs `code-quality: write`, which a fork's token does not carry, so it is correctly gated:

```yaml
if: ${{ ... && (github.event_name != 'pull_request'
                || github.event.pull_request.head.repo.full_name == github.repository) }}
```

But it is listed unconditionally in the gate's `needs`, and `alls-green` counts a **skipped** required job as a failure. The two are individually right and wrong together.

Nothing was wrong with the coverage job or with the PRs. #812 merged showing `FAILURE` on a run where format, smoke, tests_linux, tests_nonlinux, tests_subprocess, check_oldest and docs all passed, and #813 is sitting on the same red now. That is the real cost here: a gate that is always red stops carrying information about the runs that do matter, and a genuine failure would look identical.

## The fix

`allowed-skips: upload-coverage-python` — one line, and it excuses the skip and nothing else.

The job **stays in `needs`**, so on a same-repo push, where it does run, a failure still fails the gate. `allowed-failures` was the wrong knob for exactly that reason: it would have excused a genuine upload failure too. Verified against the action's `action.yml` at the pinned SHA rather than from memory — both inputs exist and the semantics differ as described.

The other seven required jobs carry no `if:`, so `upload-coverage-python` is the only one that can skip; this is the whole fix, not one instance of a pattern.

## Verification

`prek run --all-files` clean, including the workflow-schema hook. Parsed the result to confirm the gate still requires the job while excusing only its skip, and that no `allowed-failures` crept in. The behaviour this changes is only observable in CI: this PR is itself a fork PR, so its own `CI Pass` is the test — red before, green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
