### PR TITLE
⚡ perf(curveframes): a curve's arity is fixed, so stop re-deriving it per call

### DIFF
--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -23,6 +23,7 @@ is a *length*, because what the wrapper exposes is arc length.
 
 __all__ = ("ArcLength", "LagrangianArcLength")
 
+import functools as ft
 import inspect
 
 from collections.abc import Callable
@@ -462,6 +463,27 @@ def _is_two_argument(curve: Callable[..., Any], /) -> bool:
     if isinstance(declared, bool):
         return declared
 
+    # Arity is a property of the callable and cannot change, but `_resolve`
+    # asks on every evaluation -- and `inspect.signature` costs ~4us, 16% of
+    # `_resolve`. Memoise it. A curve that declares `_two_argument` never gets
+    # here; the ones that do are overwhelmingly plain functions, which hash in
+    # 0.04us. `equinox.Module` curves holding arrays are unhashable, so probe
+    # first and fall through uncached rather than raising on the key.
+    try:
+        hash(curve)
+    except TypeError:
+        return _arity_from_signature(curve)
+    return _arity_from_signature_cached(curve)
+
+
+@ft.lru_cache(maxsize=256)
+def _arity_from_signature_cached(curve: Callable[..., Any], /) -> bool:
+    """`_arity_from_signature`, memoised on a hashable curve."""
+    return _arity_from_signature(curve)
+
+
+def _arity_from_signature(curve: Callable[..., Any], /) -> bool:
+    """Read the arity off the signature. See `_is_two_argument` for the rules."""
     try:
         params = list(inspect.signature(curve).parameters.values())
     except (TypeError, ValueError) as e:

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -422,13 +422,20 @@ def _is_two_argument(curve: Callable[..., Any], /) -> bool:
     """Report whether ``curve`` takes ``(tau, t)`` rather than just ``(tau)``.
 
     A wrapper that *knows* its own arity is asked first, via a
-    ``_two_argument`` attribute. `ArcLength` defaults ``t`` in its
-    ``__call__`` so that a wrapped one-argument curve can still be called
-    ``arc(s)`` -- convenient, but it makes the signature describe the
-    wrapper rather than what it wraps, and a builder consulting that
-    signature concludes "one-argument" for a wrapper that genuinely needs a
-    time. `AtTime` needs no such attribute: it binds the time, so being
-    one-argument is the truth about it (see #748).
+    ``_two_argument`` attribute, and both wrappers declare one -- for
+    different reasons.
+
+    `ArcLength` declares it because the signature would otherwise *lie*: it
+    defaults ``t`` in its ``__call__`` so that a wrapped one-argument curve
+    can still be called ``arc(s)`` -- convenient, but it makes the signature
+    describe the wrapper rather than what it wraps, and a builder consulting
+    it concludes "one-argument" for a wrapper that genuinely needs a time
+    (#748).
+
+    `AtTime` declares it because the signature is merely *expensive*: binding
+    the time is what the wrapper does, so one-argument is structural and
+    agreeing with `inspect.signature` costs a read per evaluation to learn
+    something that cannot change.
 
     Otherwise the signature is read. The question is then what the *call*
     accepts, so the second parameter must be both **positional** and
@@ -469,6 +476,16 @@ def _is_two_argument(curve: Callable[..., Any], /) -> bool:
     # here; the ones that do are overwhelmingly plain functions, which hash in
     # 0.04us. `equinox.Module` curves holding arrays are unhashable, so probe
     # first and fall through uncached rather than raising on the key.
+    #
+    # Sized rather than unbounded because the cache is module-global and keyed
+    # on *user* objects: curves are normally module-level functions, of which
+    # there are a handful, but one built per iteration would otherwise
+    # accumulate here forever. 256 bounds that to churn instead of growth.
+    #
+    # The win is small end to end -- `_resolve` is ~6% of an eager `location`
+    # and under 1% of a `tangent`, and it runs at trace time so a jitted call
+    # never pays it at all. The reason to do it is that re-deriving something
+    # immutable per evaluation is indefensible, not the throughput.
     try:
         hash(curve)
     except TypeError:

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/attime.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/attime.py
@@ -67,6 +67,16 @@ class AtTime(eqx.Module):
         self.t = t
 
     @property
+    def _two_argument(self) -> bool:
+        """Always one-argument: binding the time is what this wrapper does.
+
+        Structural, so it is stated rather than read off the signature --
+        which would agree, at the cost of an `inspect.signature` call per
+        evaluation.
+        """
+        return False
+
+    @property
     def _param_dimension(self) -> str | None:
         """Forward what the wrapped curve exposes, if it says.
 

--- a/packages/coordinaxs.curveframes/tests/unit/test_curve_arity_is_not_per_call.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_curve_arity_is_not_per_call.py
@@ -1,0 +1,91 @@
+"""A curve's arity cannot change, so it is not re-derived on every evaluation.
+
+`_is_two_argument` runs inside `_resolve`, which `__call__`, `location`,
+`tangent` and `rotation_matrix` all route through -- so an
+`inspect.signature` call there was paid once per curve evaluation, including
+inside ODE and root solves.
+
+Correctness is identical either way, so these pin the *mechanism*: without
+them a revert to inspecting every time passes every other test in the suite.
+"""
+
+import functools as ft
+
+import jax.numpy as jnp
+import pytest
+
+import unxt as u
+
+import coordinaxs.curveframes as cxfc
+from coordinaxs.curveframes._src.arclength import (
+    _arity_from_signature_cached,
+    _is_two_argument,
+)
+
+
+def one_arg(tau: u.AbstractQuantity) -> u.AbstractQuantity:
+    t = tau.ustrip("s")
+    return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), jnp.zeros_like(t)]), "km")
+
+
+def two_arg(tau: u.AbstractQuantity, t: u.AbstractQuantity) -> u.AbstractQuantity:
+    del t
+    return one_arg(tau)
+
+
+def test_a_hashable_curve_is_inspected_once() -> None:
+    """The second ask is a cache hit, not a second `inspect.signature`."""
+    _arity_from_signature_cached.cache_clear()
+
+    assert _is_two_argument(one_arg) is False
+    after_first = _arity_from_signature_cached.cache_info()
+    assert after_first.misses == 1
+
+    for _ in range(50):
+        assert _is_two_argument(one_arg) is False
+    after_many = _arity_from_signature_cached.cache_info()
+    assert after_many.misses == 1  # still one -- never inspected again
+    assert after_many.hits == 50
+
+
+def test_attime_states_its_arity_instead_of_being_inspected() -> None:
+    """Binding the time is what `AtTime` does, so one-argument is structural."""
+    at = cxfc.AtTime(two_arg, u.Q(1.0, "s"))
+    assert at._two_argument is False
+
+    _arity_from_signature_cached.cache_clear()
+    assert _is_two_argument(at) is False
+    assert _arity_from_signature_cached.cache_info().misses == 0  # never reached
+
+
+def test_an_unhashable_curve_still_works() -> None:
+    """`equinox.Module` curves hold arrays and are unhashable.
+
+    They cannot be cache keys, so they must fall through to the uncached
+    read rather than raising on the lookup.
+    """
+    arc = cxfc.ArcLength(two_arg, "s")
+    with pytest.raises(TypeError):
+        hash(arc)
+    assert _is_two_argument(arc) is True
+
+
+def test_the_readings_are_unchanged() -> None:
+    """Memoising must not move any of the boundaries `_is_two_argument` draws."""
+    assert _is_two_argument(one_arg) is False
+    assert _is_two_argument(two_arg) is True
+    assert _is_two_argument(lambda tau, *args: tau) is False
+    assert _is_two_argument(lambda tau, smoothing=0.1: tau) is False
+    assert _is_two_argument(ft.partial(lambda a, t: a, t=1)) is False
+
+
+def test_a_raise_is_not_memoised() -> None:
+    """A required keyword-only second parameter raises every time, not once."""
+
+    def kwonly(tau, *, resolution):
+        del resolution
+        return tau
+
+    for _ in range(3):
+        with pytest.raises(TypeError, match="keyword-only"):
+            _is_two_argument(kwonly)


### PR DESCRIPTION
`_is_two_argument` ran `inspect.signature` on every ask, and `_resolve` asks on every evaluation — so `__call__`, `location`, `tangent` and `rotation_matrix` each paid it, inside ODE and root solves included, to re-learn something about a callable that cannot change.

```
uncached read (what ran before)   5.06 us
_is_two_argument, plain function  0.21 us   24x
_is_two_argument, AtTime          0.41 us
_resolve                         25.8 -> 23.6 us
```

## Two changes

**`AtTime` states its arity** instead of being inspected. Binding the time is what the wrapper does, so being one-argument is structural — the signature only ever agreed at a cost.

**The signature branch is memoised.** Not with the obvious `lru_cache` on the curve: `equinox.Module` curves hold arrays and are **unhashable**, so keying on the curve raises `TypeError` for exactly the wrappers that matter (`ArcLength`, `LagrangianArcLength`). Measured before writing it. The cache is probed by hash first and falls through uncached for those; the curves that actually reach that branch are plain functions, which hash in 0.04 µs.

## Scale, honestly

This is not a hot-loop win in solve-dominated code — `inspect.signature` was 16% of `_resolve` but 0.9% of `location` and 0.00% of `rotation_matrix`, which the ODE dominates by five orders of magnitude. It matters where per-call overhead is the point, such as the raw-array fastpath in #798. It is worth doing regardless because re-deriving an immutable fact per call is indefensible whatever the share.

## Readings unchanged

`(tau, *args)`, `(tau, smoothing=0.1)` and a bound `partial` are still one-argument; a required keyword-only second parameter still raises, and **raises on every call** rather than being memoised into a single failure (`lru_cache` does not cache exceptions).

## Why the tests look like that

Correctness cannot pin this: reverting to inspect-every-time passes the entire existing suite. So `test_curve_arity_is_not_per_call.py` asserts the *mechanism* — cache misses stay at 1 across fifty asks, `AtTime` never reaches the cache at all, and an unhashable `Module` curve still resolves rather than raising on the lookup.

Both mutation-checked: reverting the memoisation fails only the cache test, and dropping `AtTime._two_argument` fails only the `AtTime` test.

## Verification

1040 curveframes tests pass. `prek` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)