### PR TITLE
🐛 fix(curveframes): validate `tau_bounds` where the field can still be named

### DIFF
--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
@@ -39,6 +39,29 @@ _MSG_BARE_TIME_BOUNDS = (
     "dimension."
 )
 
+#: Both messages name `tau_bounds`, which is the whole point of raising here:
+#: left to `nearest_tau`, the same mistakes surface as a bare
+#: `UnitConversionError` or `AttributeError` from inside the scan setup, with
+#: nothing to say which field was wrong (measured, both cases).
+_MSG_BOUNDS_DISAGREE = (
+    "`TubularChart.tau_bounds` must state one dimension, but the lower bound "
+    "is {lo} and the upper is {hi}. The scan strips both ends to the lower "
+    "bound's unit, which a different dimension cannot convert to."
+)
+
+_MSG_BOUNDS_HALF_BARE = (
+    "`TubularChart.tau_bounds` must be both `Quantity` or both bare, but got "
+    "{lo} and {hi}. A bare bound takes its unit from the builder's declared "
+    "`tau_unit` and a `Quantity` one carries its own, so a mixed pair has no "
+    "single answer to what the bounds mean."
+)
+
+
+def _bounds_dimension(bound: Any, /) -> str | None:
+    """Return the dimension ``bound`` states, or `None` if it is bare."""
+    unit = u.unit_of(bound)
+    return None if unit is None else str(u.dimension_of(unit))
+
 
 @final
 class TubularChart(AbstractParameterizedChart):
@@ -106,6 +129,42 @@ class TubularChart(AbstractParameterizedChart):
         """The ambient manifold, always flat 3-space regardless of the curve."""
         return cxm.R3
 
+    def __check_init__(self) -> None:
+        """Require `tau_bounds` to state one dimension, and to state it at all.
+
+        `tau_bounds[0]` alone is what the unit is read from -- it labels the
+        coordinate, and `nearest_tau` strips both ends to it -- so a
+        disagreeing `tau_bounds[1]` is not caught until the inverse solve
+        runs, and not named when it is. Measured on an unguarded chart:
+        ``(Q(0, "s"), Q(2, "km"))`` builds, reports `('time', ...)`, and dies
+        in the scan with `UnitConversionError`; a mixed bare/`Quantity` pair
+        dies with ``'float' object has no attribute 'ustrip'``. Neither
+        mentions `tau_bounds`, and neither fires until someone maps a point.
+
+        A *converting* pair is fine and stays fine -- ``(Q(0, "s"), Q(2000,
+        "ms"))`` strips to 2 s -- so this checks the dimension, not the unit.
+
+        Bare bounds are the array fastpath and stay legal on the static
+        branch, where the builder's declared `tau_unit` says what the numbers
+        mean. On a **worldtube** they never are: `tau_unit` describes the
+        pinned station, so nothing states this coordinate's dimension (see
+        `_tau_unit`). That was `coord_dimensions`' own check until it moved
+        here -- it is a pure function of the builder's curve, knowable the
+        moment the chart is built, and leaving it downstream is the shape
+        this method exists to remove. Reading the arity again costs nothing:
+        `AbstractCurveFrameBuilder.__check_init__` already inspected the same
+        curve, and the result is cached.
+        """
+        lo, hi = (_bounds_dimension(b) for b in self.tau_bounds)
+        if lo != hi:
+            msg = _MSG_BOUNDS_HALF_BARE if None in (lo, hi) else _MSG_BOUNDS_DISAGREE
+            raise ValueError(msg.format(lo=lo or "bare", hi=hi or "bare"))
+        # `TypeError`, matching the sibling in `base.py`: a missing unit is
+        # the wrong *kind* of value, where two disagreeing ones above are the
+        # wrong value. `_tau_unit` raised this same message from the property.
+        if lo is None and self.is_time_dependent:
+            raise TypeError(_MSG_BARE_TIME_BOUNDS)
+
     @property
     def components(self) -> tuple[str, str, str]:
         return ("tau", "n1", "n2")
@@ -130,12 +189,12 @@ class TubularChart(AbstractParameterizedChart):
         handed to it -- but a pinned station makes `tau` the time, and
         `tau_unit` describes the station. Asking the builder therefore labels
         a time coordinate `length`, and strips a time in kilometres.
+
+        Bare bounds cannot reach the worldtube branch: `__check_init__`
+        rejects that pair, so the `unit_of` below is never `None` there.
         """
         if self.is_time_dependent:
-            tau_unit = u.unit_of(self.tau_bounds[0])
-            if tau_unit is None:
-                raise TypeError(_MSG_BARE_TIME_BOUNDS)
-            return cast("u.AbstractUnit", tau_unit)
+            return cast("u.AbstractUnit", u.unit_of(self.tau_bounds[0]))
         return self.builder._tau_unit_at(self.tau_bounds[0])
 
     @property

--- a/packages/coordinaxs.curveframes/tests/unit/test_tubular_chart.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_tubular_chart.py
@@ -93,10 +93,12 @@ def test_a_worldtube_needs_its_time_bounds_to_carry_a_unit() -> None:
     On the static branch a bare `tau_bounds` falls back to the builder's
     declared `tau_unit`. A worldtube has no such fallback: `tau_unit` is the
     station's.
+
+    Raised at construction rather than from `coord_dimensions`: the builder's
+    curve arity settles it, so the chart never needs to exist in this state.
     """
-    ch = _worldtube(tau_bounds=(0.0, 2.0))
     with pytest.raises(TypeError, match="must carry a unit"):
-        _ = ch.coord_dimensions
+        _worldtube(tau_bounds=(0.0, 2.0))
 
 
 def test_the_two_sections_meet() -> None:
@@ -183,6 +185,55 @@ def test_static_bounds_drop_their_leaves() -> None:
         tau_bounds=(u.StaticQuantity(-1.0, "s"), u.StaticQuantity(7.0, "s")),
     )
     assert len(jax.tree.leaves(ch)) == 2  # builder only
+
+
+def test_bounds_of_two_dimensions_are_rejected() -> None:
+    """Caught at construction, where the field can still be named.
+
+    Unguarded, this chart builds and reports `('time', ...)`; the mistake
+    only surfaces when someone maps a point, as a `UnitConversionError`
+    raised inside `nearest_tau`'s scan setup that says nothing about
+    `tau_bounds`.
+    """
+    with pytest.raises(ValueError, match="must state one dimension"):
+        cxfc.TubularChart(
+            cxfc.BishopBuilder(circle, "s"), tau_bounds=(u.Q(0.0, "s"), u.Q(2.0, "km"))
+        )
+
+
+def test_bounds_may_not_be_half_bare() -> None:
+    """A bare bound and a `Quantity` one take their unit from different places.
+
+    Bare bounds are legal -- they fall back to the builder's declared
+    `tau_unit` -- and so are `Quantity` ones, which carry their own. A mixed
+    pair has no single answer, and unguarded it reaches `nearest_tau` to fail
+    as ``'float' object has no attribute 'ustrip'``.
+    """
+    with pytest.raises(ValueError, match="both `Quantity` or both bare"):
+        cxfc.TubularChart(
+            cxfc.BishopBuilder(circle, "s"), tau_bounds=(0.0, u.Q(2.0, "s"))
+        )
+
+
+def test_bare_bounds_are_still_allowed() -> None:
+    """The guard is about disagreement, not about requiring units.
+
+    Both-bare is the array fastpath: the builder's declared `tau_unit` states
+    what the numbers mean, so there is nothing for the two ends to disagree
+    about.
+    """
+    ch = cxfc.TubularChart(cxfc.BishopBuilder(circle, "s"), tau_bounds=(0.0, 2.0))
+    assert ch.coord_dimensions == ("time", "length", "length")
+
+
+def test_bounds_in_different_units_of_one_dimension_still_work() -> None:
+    """The check is on the dimension, not the unit: `ms` converts to `s`."""
+    ch = cxfc.TubularChart(
+        cxfc.BishopBuilder(circle, "s"), tau_bounds=(u.Q(0.0, "s"), u.Q(2000.0, "ms"))
+    )
+    p = {"x": u.Q(0.5, "km"), "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")}
+    got = cxc.pt_map(p, ch.M, cxc.cart3d, ch.M, ch)
+    assert 0.0 <= float(got["tau"].ustrip("s")) <= 2.0
 
 
 def test_inside_the_reach_the_jacobian_factor_is_positive() -> None:


### PR DESCRIPTION
Follow-up to #814, which noted this but left it out of scope. Independent of it — this branch is off `main`.

## The gap

`tau_bounds[0]` alone is what the unit is read from: it labels the coordinate, and `nearest_tau` strips both ends to it. So nothing ever looks at whether the two ends agree, and a disagreeing pair constructs fine.

Measured on an unguarded chart:

| `tau_bounds` | constructs? | `coord_dimensions` | first `pt_map` into the chart |
| --- | --- | --- | --- |
| `(Q(0, "s"), Q(2, "km"))` | yes | `('time', 'length', 'length')` | `UnitConversionError: 'km' (length) and 's' (time) are not convertible` |
| `(0.0, Q(2, "s"))` | yes | `('time', 'length', 'length')` | `AttributeError: 'float' object has no attribute 'ustrip'` |

Both are loud, eventually. Neither names `tau_bounds`, and neither fires until someone maps a point — the traceback lands in `nearest_tau`'s scan setup, several frames from the field that was wrong.

## The fix

`__check_init__`, the pattern `AbstractCurveFrameBuilder` already uses for `tau_unit`. Two required bounds that contradict each other are exactly what a construction-time check is for.

It checks the **dimension**, not the unit, so nothing that worked stops working:

- `(Q(0, "s"), Q(2000, "ms"))` — still legal, still scans zero to two seconds. Tested.
- `(0.0, 2.0)` — still legal. That is the array fastpath: the builder's declared `tau_unit` states what the numbers mean, so there is nothing for the two ends to disagree about. Tested.
- a mixed bare/`Quantity` pair gets its own message, since the two halves take their unit from different places and there is no single reading to pick.

## Verification

1188 tests across `packages/coordinaxs.curveframes/tests` + `tests/unit/charts` + `tests/unit/product`, 152 curveframes doctests, all pre-commit hooks. The three new tests fail without the guard (construction succeeds instead of raising); the two negative-control tests pass either way and pin that the guard did not overreach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)