### PR TITLE
🔒 fix(ci): interpolate workflow inputs through `env`, never into shell

### DIFF
--- a/.github/actions/find-package-tag/action.yml
+++ b/.github/actions/find-package-tag/action.yml
@@ -19,11 +19,14 @@ runs:
   steps:
     - id: find_tag
       shell: bash
+      # Through `env`, not `${{ }}` inside `run`: a caller-supplied input
+      # containing a quote would otherwise close the literal and have the
+      # remainder run as shell.
+      env:
+        TAG_GLOB: ${{ inputs.tag_glob }}
+        COMMIT_SHA: ${{ inputs.commit_sha }}
       run: |
         set -euo pipefail
-
-        TAG_GLOB='${{ inputs.tag_glob }}'
-        COMMIT_SHA='${{ inputs.commit_sha }}'
 
         # Fetch tags to locate package-specific tags created by upstream workflow.
         git fetch --tags

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
         run: uv sync --no-default-groups --group nox --group test --locked
 
       - name: Test package
+        # Ubuntu-only job, so bash is already the default shell; the
+        # `tests_nonlinux` copy pins it explicitly because Windows is not.
+        #
         # `$EXCLUDE_ARGS` unquoted, from `env`: word splitting is wanted here
         # (it carries zero or more `--exclude-package` flags), but expansion
         # of a variable's *value* stops there -- bash does not re-parse it for
@@ -211,12 +214,20 @@ jobs:
         run: uv sync --no-default-groups --group nox --group test --locked
 
       - name: Test package
+        # `shell: bash` is load-bearing, not tidiness: this job also runs on
+        # `windows-latest`, whose default shell is PowerShell, where
+        # `$EXCLUDE_ARGS` names a *PowerShell* variable rather than the
+        # environment one. It would expand to nothing and the exclusions would
+        # vanish silently -- tests passing by running more than intended. The
+        # Linux job needs no pin because bash is already its default.
+        #
         # `$EXCLUDE_ARGS` unquoted, from `env`: word splitting is wanted here
         # (it carries zero or more `--exclude-package` flags), but expansion
         # of a variable's *value* stops there -- bash does not re-parse it for
         # quotes or metacharacters the way it would re-parse an interpolated
         # `${{ }}`. The args derive from changed file paths, which a fork PR
         # controls.
+        shell: bash
         env:
           EXCLUDE_ARGS: ${{ needs.prepare_test_matrix.outputs.exclude-args }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,16 @@ jobs:
         run: uv sync --no-default-groups --group nox --group test --locked
 
       - name: Test package
+        # `$EXCLUDE_ARGS` unquoted, from `env`: word splitting is wanted here
+        # (it carries zero or more `--exclude-package` flags), but expansion
+        # of a variable's *value* stops there -- bash does not re-parse it for
+        # quotes or metacharacters the way it would re-parse an interpolated
+        # `${{ }}`. The args derive from changed file paths, which a fork PR
+        # controls.
+        env:
+          EXCLUDE_ARGS: ${{ needs.prepare_test_matrix.outputs.exclude-args }}
         run: |
-          uv run --no-sync nox -s test -- ${{ needs.prepare_test_matrix.outputs.exclude-args }} --cov --cov-report=xml --cov-report=term --durations=20 --arraydiff -m"not slow and not subprocess_heavy"
+          uv run --no-sync nox -s test -- $EXCLUDE_ARGS --cov --cov-report=xml --cov-report=term --durations=20 --arraydiff -m"not slow and not subprocess_heavy"
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v7.0.0
@@ -203,8 +211,16 @@ jobs:
         run: uv sync --no-default-groups --group nox --group test --locked
 
       - name: Test package
+        # `$EXCLUDE_ARGS` unquoted, from `env`: word splitting is wanted here
+        # (it carries zero or more `--exclude-package` flags), but expansion
+        # of a variable's *value* stops there -- bash does not re-parse it for
+        # quotes or metacharacters the way it would re-parse an interpolated
+        # `${{ }}`. The args derive from changed file paths, which a fork PR
+        # controls.
+        env:
+          EXCLUDE_ARGS: ${{ needs.prepare_test_matrix.outputs.exclude-args }}
         run: |
-          uv run --no-sync nox -s test -- ${{ needs.prepare_test_matrix.outputs.exclude-args }} --cov --cov-report=xml --cov-report=term --durations=20 --arraydiff -m"not slow and not subprocess_heavy"
+          uv run --no-sync nox -s test -- $EXCLUDE_ARGS --cov --cov-report=xml --cov-report=term --durations=20 --arraydiff -m"not slow and not subprocess_heavy"
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v7.0.0

--- a/.github/workflows/create-package-tags.yml
+++ b/.github/workflows/create-package-tags.yml
@@ -38,10 +38,15 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Validate that this is a .0 release
+        # Through `env`, not `${{ }}` inside `run`: the tag name is
+        # attacker-supplied (anyone who can push `v*`), and interpolation
+        # happens before bash parses the line, so a crafted tag would break
+        # out of the quotes -- *before* the format check below could reject
+        # it. As an environment variable its content is never re-parsed.
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          VERSION="${{ steps.version.outputs.version }}"
-
           # Validate coordinator tag format: must be exactly vX.Y.0 (no suffixes like -rc1)
           if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.0$ ]]; then
             echo "ERROR: Coordinator tag must match pattern ^v[0-9]+\.[0-9]+\.0$ (e.g., v1.2.0)"
@@ -64,10 +69,10 @@ jobs:
 
       - name: Create and push package-specific tags
         id: create_tags
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          TAG="${{ steps.version.outputs.tag }}"
-
           # Configure git
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Closes #743.

## The reported file is already fixed; the class was not

The exact block #743 quotes was fixed by #744 (`5e3496296`), which moved `dispatch-package-cd`'s `github-script` step onto `env`/`process.env`. Verified — no `github-script` block in the repo still interpolates `${{ }}`.

But the same pattern survived in three other places, all `${{ }}` expanded directly into a `run:` script. GitHub substitutes the value *before* bash parses the line, so the value is read as source rather than data. Same vulnerability, different shell.

## What was found

| file | interpolated value | where it comes from |
| --- | --- | --- |
| `create-package-tags.yml` ×4 | `steps.version.outputs.tag` / `.version` | `${GITHUB_REF#refs/tags/}` — **the pushed tag's own name** |
| `find-package-tag/action.yml` ×2 | `inputs.tag_glob` / `inputs.commit_sha` | caller-supplied |
| `ci.yml` ×2 | `needs.prepare_test_matrix.outputs.exclude-args` | built from changed file paths |

The tag one is the interesting case. It expands as:

```bash
TAG="${{ steps.version.outputs.tag }}"
```

A tag name containing a quote closes the literal and the remainder runs as shell — and it does so **before** the `^v[0-9]+\.[0-9]+\.0$` check two lines below can reject it. The validation is positioned to guard a value the shell has already consumed, so it never sees it.

## The fix

All eight arrive as environment variables now. Bash expands a variable's value but never re-parses it, so quotes and metacharacters in the content stay content.

`ci.yml`'s stays deliberately **unquoted** (`$EXCLUDE_ARGS`, not `"$EXCLUDE_ARGS"`), because word splitting is the point there — it carries zero or more `--exclude-package` flags. Expansion still splits on whitespace; what it stops doing is honouring quotes and metacharacters from the value. Both halves checked:

```
EXCLUDE_ARGS='--exclude-package=a --exclude-package=b'  -> argc=7   (unchanged)
EXCLUDE_ARGS=''                                         -> argc=5   (unchanged)
EXCLUDE_ARGS='x"; echo PWNED; "'                        -> literal argv, no echo
```

## On severity — this is containment, not a public hole

Worth stating plainly rather than letting a security label imply more than is there:

- the tag path needs **push access** to create a `v*` tag
- `find-package-tag`'s inputs have only internal callers today
- `ci.yml` runs on `pull_request`, **not** `pull_request_target`, so a fork PR gets a read-only token and no secrets

So this bounds what a compromised or careless writer can reach — which is equally true of the report that prompted it. It is cheap, it is the documented GitHub hardening pattern, and it removes the class rather than one instance.

## Verification

- re-swept every `.github/**/*.yml` for `${{ }}` inside `run:`/`script:` blocks — none remain
- `Validate GitHub Workflows` and the rest of `prek run` clean on all three files
- argv behaviour of the one deliberately-unquoted site checked against the old semantics, as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
