### PR TITLE
🐛 fix(curveframes): a worldtube's `tau_bounds` must be times

### DIFF
--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
@@ -49,6 +49,14 @@ _MSG_BOUNDS_DISAGREE = (
     "bound's unit, which a different dimension cannot convert to."
 )
 
+_MSG_WORLDTUBE_BOUNDS_NOT_TIME = (
+    "`TubularChart.tau_bounds` must be times when the builder pins a station, "
+    "but they are {lo}. `tau` is the evaluation time on this branch, so "
+    "bounds of another dimension label the coordinate one way while the "
+    "builder evaluates it the other -- leaving no value the chart both "
+    "declares and accepts."
+)
+
 _MSG_BOUNDS_HALF_BARE = (
     "`TubularChart.tau_bounds` must be both `Quantity` or both bare, but got "
     "{lo} and {hi}. A bare bound takes its unit from the builder's declared "
@@ -130,7 +138,7 @@ class TubularChart(AbstractParameterizedChart):
         return cxm.R3
 
     def __check_init__(self) -> None:
-        """Require `tau_bounds` to state one dimension, and to state it at all.
+        """Require `tau_bounds` to state one dimension, state it, and mean it.
 
         `tau_bounds[0]` alone is what the unit is read from -- it labels the
         coordinate, and `nearest_tau` strips both ends to it -- so a
@@ -154,6 +162,18 @@ class TubularChart(AbstractParameterizedChart):
         this method exists to remove. Reading the arity again costs nothing:
         `AbstractCurveFrameBuilder.__check_init__` already inspected the same
         curve, and the result is cached.
+
+        Carrying a unit is still not enough on that branch: it has to be a
+        *time*. Length bounds on a worldtube built a chart that declared
+        `('length', 'length', 'length')` and accepted only `time` -- its own
+        `check_data` refused a `tau` in `s`, and a `tau` in `km` died in the
+        scan with `UnitConversionError`. No value satisfied both (#820).
+
+        Rejecting the bounds rather than reconciling the label with the
+        runtime, because the library reserves a two-argument curve's second
+        argument for the time: `AtTime` binds it, `GalileanCT` refuses a chart
+        that has one, and `TimeDep` sends every other parameter to a builder
+        field rather than a call-time argument.
         """
         lo, hi = (_bounds_dimension(b) for b in self.tau_bounds)
         if lo != hi:
@@ -164,6 +184,12 @@ class TubularChart(AbstractParameterizedChart):
         # wrong value. `_tau_unit` raised this same message from the property.
         if lo is None and self.is_time_dependent:
             raise TypeError(_MSG_BARE_TIME_BOUNDS)
+        # And having a unit is not enough: it has to be a *time*. `_tau_unit`
+        # labels this coordinate from the bounds while `_resolve` evaluates it
+        # as the time regardless, so any other dimension leaves the two
+        # disagreeing with no value satisfying both (see #820).
+        if self.is_time_dependent and lo != "time":
+            raise ValueError(_MSG_WORLDTUBE_BOUNDS_NOT_TIME.format(lo=lo))
 
     @property
     def components(self) -> tuple[str, str, str]:

--- a/packages/coordinaxs.curveframes/tests/unit/test_tubular_chart.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_tubular_chart.py
@@ -101,6 +101,25 @@ def test_a_worldtube_needs_its_time_bounds_to_carry_a_unit() -> None:
         _worldtube(tau_bounds=(0.0, 2.0))
 
 
+def test_a_worldtubes_bounds_must_be_times() -> None:
+    """Bounds of the wrong dimension made the chart contradict itself.
+
+    `_tau_unit` labels the coordinate from `tau_bounds`, while `_resolve`
+    reads the builder's argument as the time regardless -- so length bounds
+    on a worldtube declared `length` and accepted only `time`. Measured
+    before this guard: `coord_dimensions` gave three lengths, a `tau` in `s`
+    was refused by the chart's own `check_data`, and a `tau` in `km` died in
+    the scan with `UnitConversionError`. No input satisfied both.
+
+    Rejecting the input rather than reconciling the two: the library reserves
+    a two-argument curve's second argument for the time -- `AtTime` binds it,
+    `GalileanCT` refuses a chart that has one, and `TimeDep` directs every
+    other parameter to a builder field rather than a call-time argument.
+    """
+    with pytest.raises(ValueError, match="must be times"):
+        _worldtube(tau_bounds=(u.Q(0.0, "km"), u.Q(2.0, "km")))
+
+
 def test_the_two_sections_meet() -> None:
     r"""The worldtube and the spatial slice are two cuts of one 4-D object.
 


### PR DESCRIPTION
Closes #820.

## The state before

Length bounds on a pinned-station builder produced a chart that contradicted itself. Reproduced on `20abbdb6a`:

| | result |
| --- | --- |
| construction | succeeds |
| `is_time_dependent` | `True` |
| `coord_dimensions` | `('length', 'length', 'length')` |
| `check_data({"tau": Q(1.0, "s")}, values=True)` | `ValueError: ... time != length` |
| `pt_map(tau=Q(1.0, "km"))` | `UnitConversionError: 'km' (length) and 's' (time)` |

Every value the declaration invites fails in the solve; the one value that works is refused by the chart's own validator. No input satisfies both.

`_tau_unit` labels the coordinate from `tau_bounds`, while `_resolve` reads the builder's argument as the time regardless. Nothing reconciled them.

## The call

#820 left this blocked on whether *"the second argument of every two-argument curve is a time"* is intended. It is, and there is a citation the issue did not use — `TimeDep`'s own docstring:

> "Extra parameters (e.g. an affine curve parameter γ) are builder fields, not call-time arguments."

So the library already reserves the call-time second argument for the time and directs everything else to a builder field. `AtTime` binds it, `_resolve` reads it unconditionally, `is_time_dependent`'s docstring asserts it, and `GalileanCT` refuses a chart that has one. Four places assume it; one states the alternative.

So the fix is to reject the input, not to reconcile the label with the runtime.

## The change

One clause, beside the two #818 added, in the same method and at the same cost — `is_time_dependent` is a pure function of the builder, known at construction, cached since #816:

```python
if self.is_time_dependent and lo != "time":
    raise ValueError(_MSG_WORLDTUBE_BOUNDS_NOT_TIME.format(lo=lo))
```

## Scope, verified rather than argued

| case | result |
| --- | --- |
| worldtube, time bounds | ok |
| worldtube, **length** bounds | rejected |
| worldtube, `(s, ms)` | ok — converting pairs still convert |
| static, length bounds | ok |
| static, bare bounds | ok — array fastpath intact |
| `AtTime` slice, length bounds | ok |

The last row is the one that could have gone wrong: the ADM spatial slice is `is_time_dependent=False`, so it legitimately takes length bounds and the guard must not reach it.

## Verification

1053 curveframes tests pass. `prek` clean.

Mutation-checked in both directions:

- removing the guard → fails only the new test
- dropping the `is_time_dependent` condition (over-catching) → fails three *existing* tests, so the suite independently pins the static branch against over-reach

🤖 Generated with [Claude Code](https://claude.com/claude-code)