### PR TITLE
✨ feat(curveframes): `velocity` reports the frame's own motion

### DIFF
--- a/packages/coordinaxs.curveframes/docs/curve-charts.md
+++ b/packages/coordinaxs.curveframes/docs/curve-charts.md
@@ -274,6 +274,57 @@ Q([1.5, 0. , 0. ], 'km')
 
 Which of the two readings a frame is built on is not a setting on the chart or the builder. The velocity of the frame origin at label $s$ is $\partial\gamma/\partial t$ at fixed $s$, taken on whatever curve the builder was handed: a bare $\gamma(\sigma, t)$ gives the velocity of the material point $\sigma$; `ArcLength` adds the advection term that holds the label at fixed arc length; `LagrangianArcLength` removes it again. The parametrisation supplies the reading, and nothing downstream overrides it.
 
+### The Frame Velocity
+
+`velocity` returns that $\partial\gamma/\partial t$ — the ADM shift $\boldsymbol\beta$, the rate at which the frame origin moves. It reports what the curve says and never chooses a reading:
+
+```{code-block} python
+>>> def stretching(sigma, t):
+...     sv, tv = sigma.ustrip("km"), t.ustrip("s")
+...     z = jnp.zeros_like(sv)
+...     return u.Q(jnp.stack([sv * (1 + 0.5 * tv), 0.1 * tv * sv**2, z]), "km")
+
+>>> worldtube = cxfc.BishopBuilder(stretching, "km", station=u.Q(1.3, "km"))
+>>> worldtube.velocity(u.Q(1.0, "s")).round(3)
+Q([0.65 , 0.169, 0.   ], 'km / s')
+
+```
+
+Its argument means what `location`'s does on the same builder: the evaluation time when a station is pinned, the station otherwise. The two sections agree where they cross, so binding the slice with `AtTime` gives the same answer at the same event:
+
+```{code-block} python
+>>> slice_ = cxfc.BishopBuilder(cxfc.AtTime(stretching, u.Q(1.0, "s")), "km")
+>>> slice_.velocity(u.Q(1.3, "km")).round(3)
+Q([0.65 , 0.169, 0.   ], 'km / s')
+
+```
+
+A curve with no time in it has a frame that does not move, so `velocity` is zero. It is reported per second; the choice is immaterial rather than arbitrary, because zero converts to zero in any time unit.
+
+Only `AtTime` is seen. A curve that binds its own time — `lambda tau: gamma(tau, my_t)` — is indistinguishable from a static one and reports zero.
+
+#### Transporting A Velocity
+
+Do not build a velocity transform out of $\boldsymbol\beta$ by hand. `coordinax.transforms.TimeDep` takes a curve-frame builder directly, and its prolongation differentiates the whole map:
+
+```{code-block} python
+>>> import coordinax.transforms as cxfm
+>>> op = cxfm.TimeDep(worldtube)
+>>> op.is_time_dependent
+True
+
+```
+
+The closed form $R(v - \boldsymbol\beta)$ is exact only _on_ the curve axis. Off it, the neglected $\dot R\,\mathbf{n}$ term — the triad rotating an off-axis point out from under itself — grows with the offset:
+
+| point | truth | $R(v-\boldsymbol\beta)$ | error |
+| --- | --- | --- | --- |
+| on the curve | `[0.316, -0.226, 0]` | `[0.316, -0.226, 0]` | 0 |
+| $n = 0.5\,\mathrm{km}$ | `[0.371, -0.236, 0]` | `[0.316, -0.226, 0]` | 0.056 |
+| $n = 2\,\mathrm{km}$ | `[0.537, -0.265, 0]` | `[0.316, -0.226, 0]` | 0.224 |
+
+A tubular chart exists to describe points off the axis, so the closed form is wrong exactly where the chart is used. `TimeDep` is right everywhere, and the Coriolis and centrifugal terms fall out of the same prolongation — see the {doc}`co-rotating frames tutorial <coordinax:tutorials/corotating_frames>`.
+
 ### Four Curve Shapes
 
 A curve is not always handed to `ArcLength` to be reparametrised — it can also arrive already arc-length parametrised, in one of a few shapes. This section walks through each.

--- a/packages/coordinaxs.curveframes/docs/curve-charts.md
+++ b/packages/coordinaxs.curveframes/docs/curve-charts.md
@@ -323,7 +323,7 @@ The closed form $R(v - \boldsymbol\beta)$ is exact only _on_ the curve axis. Off
 | $n = 0.5\,\mathrm{km}$ | `[0.371, -0.236, 0]` | `[0.316, -0.226, 0]` | 0.056 |
 | $n = 2\,\mathrm{km}$ | `[0.537, -0.265, 0]` | `[0.316, -0.226, 0]` | 0.224 |
 
-A tubular chart exists to describe points off the axis, so the closed form is wrong exactly where the chart is used. `TimeDep` is right everywhere, and the Coriolis and centrifugal terms fall out of the same prolongation — see the {doc}`co-rotating frames tutorial <coordinax:tutorials/corotating_frames>`.
+A tubular chart exists to describe points off the axis, so the closed form is wrong exactly where the chart is used. `TimeDep` is right everywhere, and the Coriolis and centrifugal terms fall out of the same prolongation — see the [co-rotating frames tutorial](../../../docs/tutorials/corotating_frames.md).
 
 ### Four Curve Shapes
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -464,13 +464,16 @@ class AbstractCurveFrameBuilder(eqx.Module):
         >>> slice_.velocity(u.Q(1.3, "km")).round(3)
         Q([0.65 , 0.169, 0.   ], 'km / s')
 
-        A curve with no time in it has a frame that does not move:
+        A curve taking no *second* argument has nothing to differentiate
+        against, so its frame does not move. Note this is not the same as the
+        curve having no derivative: it has a fine one, and that is the
+        `tangent`.
 
-        >>> def circle(tau: u.Q) -> u.Q:
-        ...     t = tau.ustrip("s")
-        ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), jnp.zeros_like(t)]), "km")
+        >>> def circle(arc: u.Q) -> u.Q:
+        ...     a = arc.ustrip("km")
+        ...     return u.Q(jnp.stack([jnp.cos(a), jnp.sin(a), jnp.zeros_like(a)]), "km")
 
-        >>> cxfc.BishopBuilder(circle, "s").velocity(u.Q(0.0, "s"))
+        >>> cxfc.BishopBuilder(circle, "km").velocity(u.Q(0.0, "km"))
         Q([0., 0., 0.], 'km / s')
 
         Notes

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -22,6 +22,7 @@ from typing import Any, cast
 from typing_extensions import TypeVar
 
 import equinox as eqx
+import jax.numpy as jnp
 
 import coordinax.charts as cxc
 import coordinax.frames as cxf
@@ -424,3 +425,93 @@ class AbstractCurveFrameBuilder(eqx.Module):
         b, p = self._resolve(tau)
         R = b.rotation_matrix(p.astype(float))
         return u.Q(R[0], "")
+
+    def velocity(self, tau: Any, /) -> u.Q:
+        r"""Return the frame origin's velocity, $\partial\gamma/\partial t$.
+
+        The ADM shift $\boldsymbol\beta$: how fast the curve point this frame
+        rides on is moving, holding the curve's *first* argument fixed. It is
+        read off the curve rather than chosen -- which of the Eulerian and
+        Lagrangian readings you get is whatever the parametrisation you handed
+        in already says, and this never overrides it.
+
+        ``tau`` means what it means for `location` on the same builder: the
+        evaluation time when a station is pinned, the station otherwise. The
+        two branches therefore take arguments of different *dimension*.
+
+        Examples
+        --------
+        >>> import jax.numpy as jnp
+        >>> import unxt as u
+        >>> import coordinaxs.curveframes as cxfc
+
+        >>> def stretching(sigma: u.Q, t: u.Q) -> u.Q:
+        ...     sv, tv = sigma.ustrip("km"), t.ustrip("s")
+        ...     z = jnp.zeros_like(sv)
+        ...     return u.Q(jnp.stack([sv * (1 + 0.5 * tv), 0.1 * tv * sv**2, z]), "km")
+
+        A pinned station is one material point's history, so ``tau`` is the
+        time:
+
+        >>> worldtube = cxfc.BishopBuilder(stretching, "km", station=u.Q(1.3, "km"))
+        >>> worldtube.velocity(u.Q(1.0, "s")).round(3)
+        Q([0.65 , 0.169, 0.   ], 'km / s')
+
+        `AtTime` fixes the slice instead, so ``tau`` is the station -- and the
+        answer is the same, because it is the same event either way:
+
+        >>> slice_ = cxfc.BishopBuilder(cxfc.AtTime(stretching, u.Q(1.0, "s")), "km")
+        >>> slice_.velocity(u.Q(1.3, "km")).round(3)
+        Q([0.65 , 0.169, 0.   ], 'km / s')
+
+        A curve with no time in it has a frame that does not move:
+
+        >>> def circle(tau: u.Q) -> u.Q:
+        ...     t = tau.ustrip("s")
+        ...     return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), jnp.zeros_like(t)]), "km")
+
+        >>> cxfc.BishopBuilder(circle, "s").velocity(u.Q(0.0, "s"))
+        Q([0., 0., 0.], 'km / s')
+
+        Notes
+        -----
+        Do **not** build a velocity transform out of this by hand.
+        $R(v-\boldsymbol\beta)$ is exact only *on* the curve axis; off it the
+        neglected $\dot R\,\mathbf{n}$ term grows with the offset, and a
+        tubular chart exists to describe points off the axis.
+        `coordinax.transforms.TimeDep` wraps a builder directly and gets this
+        right everywhere, by differentiating the whole map.
+
+        A static curve's zero is reported per **second**. The choice is
+        immaterial rather than arbitrary: zero converts to zero in any time
+        unit.
+
+        A curve that binds its own time -- ``lambda tau: gamma(tau, my_t)``
+        rather than `AtTime` -- is indistinguishable from a static one and so
+        reports zero. Wrap the time with `AtTime` for it to be seen.
+
+        """
+        curve = self.curve
+        if _is_two_argument(curve):
+            # Station pinned: `tau` is the time, and the station is the field.
+            station, t, inner = self.station, tau, curve
+        elif isinstance(curve, AtTime) and _is_two_argument(curve.curve):
+            # A bound slice: `tau` is the station, and the time is the wrapper's.
+            station, t, inner = tau, curve.t, curve.curve
+        else:
+            # Nothing to differentiate. Taking the shape and unit from the
+            # curve keeps this the same kind of thing as the other branches.
+            loc = self.location(tau)
+            per_time = cast("u.AbstractUnit", u.unit_of(loc)) / u.unit("s")
+            return u.Q(jnp.zeros_like(loc.value), per_time)
+
+        # `cast`: on the branches that reach here `inner` is the *two*-argument
+        # curve, which the `curve` field's one-argument annotation does not
+        # describe -- `_is_two_argument` is the check, and it is not one a type
+        # checker can follow.
+        two_arg = cast("Callable[[Any, Any], Any]", inner)
+
+        def at(t_: Any) -> Any:
+            return two_arg(station, t_)
+
+        return u.experimental.jacfwd(at, units=(u.unit_of(t),))(t)

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -492,12 +492,20 @@ class AbstractCurveFrameBuilder(eqx.Module):
 
         """
         curve = self.curve
+        # `_param` for the station on both branches, not the raw field: it is
+        # what wraps a bare one with the declared `tau_unit`, so the array
+        # fastpath reaches the curve as a `Quantity` here exactly as it does
+        # through `location`. Skipping it handed a curve a bare float, which
+        # died in the curve's own `ustrip` with nothing to say why.
         if _is_two_argument(curve):
-            # Station pinned: `tau` is the time, and the station is the field.
-            station, t, inner = self.station, tau, curve
+            # Station pinned: `tau` is the time, and `_param` returns the field.
+            station, _ = self._param(tau)
+            t, inner = tau, curve
         elif isinstance(curve, AtTime) and _is_two_argument(curve.curve):
-            # A bound slice: `tau` is the station, and the time is the wrapper's.
-            station, t, inner = tau, curve.t, curve.curve
+            # A bound slice: `_param` returns `tau` itself, the station, and
+            # the time is the wrapper's.
+            station, _ = self._param(tau)
+            t, inner = curve.t, curve.curve
         else:
             # Nothing to differentiate. Taking the shape and unit from the
             # curve keeps this the same kind of thing as the other branches.

--- a/packages/coordinaxs.curveframes/tests/unit/test_frame_velocity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_frame_velocity.py
@@ -111,6 +111,28 @@ def test_the_attime_slice_is_not_the_tangent() -> None:
     assert not jnp.allclose(got, tangent, atol=1e-3)
 
 
+@pytest.mark.parametrize("bare", [True, False], ids=["bare", "quantity"])
+def test_the_array_fastpath_reaches_velocity(bare: bool) -> None:
+    """A bare station is wrapped by `_param`, exactly as `location` wraps it.
+
+    Bare parameters plus a declared `tau_unit` are the array fastpath. Reading
+    the `station` field directly instead of going through the funnel handed
+    the curve a raw float, which died inside the curve's own `ustrip` with
+    nothing to say why.
+    """
+    station = S0 if bare else u.Q(S0, "km")
+    worldtube = cxfc.BishopBuilder(stretch_and_bend, "km", station=station)
+    assert jnp.allclose(
+        worldtube.velocity(u.Q(T0, "s")).ustrip("km/s"), MATERIAL_VELOCITY, atol=1e-5
+    )
+
+    tau = S0 if bare else u.Q(S0, "km")
+    slice_ = cxfc.BishopBuilder(cxfc.AtTime(stretch_and_bend, u.Q(T0, "s")), "km")
+    assert jnp.allclose(
+        slice_.velocity(tau).ustrip("km/s"), MATERIAL_VELOCITY, atol=1e-5
+    )
+
+
 def test_a_static_curve_has_a_frame_that_does_not_move() -> None:
     """No time in the curve, so no frame velocity -- zero, per second."""
 

--- a/packages/coordinaxs.curveframes/tests/unit/test_frame_velocity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_frame_velocity.py
@@ -133,14 +133,21 @@ def test_the_array_fastpath_reaches_velocity(bare: bool) -> None:
     )
 
 
-def test_a_static_curve_has_a_frame_that_does_not_move() -> None:
-    """No time in the curve, so no frame velocity -- zero, per second."""
+def test_a_one_argument_curve_has_a_frame_that_does_not_move() -> None:
+    r"""No *second* argument, so there is no time to differentiate against.
 
-    def circle(tau: u.AbstractQuantity) -> u.AbstractQuantity:
-        t = tau.ustrip("s")
-        return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), jnp.zeros_like(t)]), "km")
+    Parametrised by arc length rather than by anything time-like, because the
+    distinction being tested is easy to blur: this curve has a perfectly good
+    `d(gamma)/d(arc)`, and it is the **tangent**. The frame velocity is
+    $\partial\gamma/\partial t$ at fixed label, and with no `t` in the
+    signature there is nothing for it to be but zero.
+    """
 
-    got = cxfc.BishopBuilder(circle, "s").velocity(u.Q(0.3, "s"))
+    def circle(arc: u.AbstractQuantity) -> u.AbstractQuantity:
+        a = arc.ustrip("km")
+        return u.Q(jnp.stack([jnp.cos(a), jnp.sin(a), jnp.zeros_like(a)]), "km")
+
+    got = cxfc.BishopBuilder(circle, "km").velocity(u.Q(0.3, "km"))
     assert str(u.unit_of(got)) == "km / s"
     assert jnp.allclose(got.ustrip("km/s"), jnp.zeros(3))
 

--- a/packages/coordinaxs.curveframes/tests/unit/test_frame_velocity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_frame_velocity.py
@@ -72,3 +72,118 @@ def test_lagrangian_arclength_restores_the_material_velocity() -> None:
     lag = cxfc.LagrangianArcLength(stretch_and_bend, u.Q(0.0, "s"), "km")
     got = dt_at_fixed_label(lag, S0, T0)
     assert jnp.allclose(got, MATERIAL_VELOCITY, atol=1e-6)
+
+
+# --------------------------------------------------------------------------
+# `builder.velocity` reports that connection, on whichever section it is given.
+
+
+def test_a_worldtube_reports_the_material_velocity() -> None:
+    """A pinned station makes `tau` the time, so `velocity` differentiates it."""
+    b = cxfc.BishopBuilder(stretch_and_bend, "km", station=u.Q(S0, "km"))
+    got = b.velocity(u.Q(T0, "s"))
+    assert str(u.unit_of(got)) == "km / s"
+    assert jnp.allclose(got.ustrip("km/s"), MATERIAL_VELOCITY, atol=1e-5)
+
+
+def test_an_attime_slice_reports_the_same_velocity() -> None:
+    """The two sections are cuts of one object, so they agree where they cross."""
+    b = cxfc.BishopBuilder(cxfc.AtTime(stretch_and_bend, u.Q(T0, "s")), "km")
+    got = b.velocity(u.Q(S0, "km"))
+    assert jnp.allclose(got.ustrip("km/s"), MATERIAL_VELOCITY, atol=1e-5)
+
+
+def test_the_attime_slice_is_not_the_tangent() -> None:
+    """The trap this accessor exists to avoid.
+
+    On the `AtTime` branch `location` takes the *station*, so differentiating
+    it with respect to its argument gives the tangent -- same shape, same
+    units, entirely plausible, and wrong. Asserted against both values so an
+    implementation written as "differentiate `location`" fails here rather
+    than passing quietly.
+    """
+    b = cxfc.BishopBuilder(cxfc.AtTime(stretch_and_bend, u.Q(T0, "s")), "km")
+    tangent = jax.jacfwd(lambda sv: b.location(u.Q(sv, "km")).ustrip("km"))(S0)
+
+    assert not jnp.allclose(tangent, MATERIAL_VELOCITY, atol=1e-3)  # they differ
+    got = b.velocity(u.Q(S0, "km")).ustrip("km/s")
+    assert jnp.allclose(got, MATERIAL_VELOCITY, atol=1e-5)
+    assert not jnp.allclose(got, tangent, atol=1e-3)
+
+
+def test_a_static_curve_has_a_frame_that_does_not_move() -> None:
+    """No time in the curve, so no frame velocity -- zero, per second."""
+
+    def circle(tau: u.AbstractQuantity) -> u.AbstractQuantity:
+        t = tau.ustrip("s")
+        return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), jnp.zeros_like(t)]), "km")
+
+    got = cxfc.BishopBuilder(circle, "s").velocity(u.Q(0.3, "s"))
+    assert str(u.unit_of(got)) == "km / s"
+    assert jnp.allclose(got.ustrip("km/s"), jnp.zeros(3))
+
+
+def test_the_reading_follows_the_curve_not_the_accessor() -> None:
+    """`velocity` reports; it never chooses Eulerian or Lagrangian.
+
+    The same underlying curve, wrapped two ways, gives two different answers
+    -- which is the whole point of #779.
+    """
+    eulerian = cxfc.BishopBuilder(
+        cxfc.AtTime(cxfc.ArcLength(stretch_and_bend, "km"), u.Q(T0, "s")), "km"
+    ).velocity(u.Q(S0, "km"))
+    lagrangian = cxfc.BishopBuilder(
+        cxfc.AtTime(stretch_and_bend, u.Q(T0, "s")), "km"
+    ).velocity(u.Q(S0, "km"))
+
+    assert jnp.allclose(lagrangian.ustrip("km/s"), MATERIAL_VELOCITY, atol=1e-5)
+    assert not jnp.allclose(eulerian.ustrip("km/s"), MATERIAL_VELOCITY, atol=1e-3)
+
+
+# --------------------------------------------------------------------------
+# Transporting a velocity is `TimeDep`'s job, and it already does it.
+
+
+def _ground_truth(op, x0: jnp.ndarray, v_lab: jnp.ndarray) -> jax.Array:
+    """d/dt of the lab trajectory pushed through the frame map at that same t."""
+
+    def mapped(tv: float) -> jax.Array:
+        x = x0 + v_lab * (tv - T0)
+        q = {k: u.Q(x[i], "km") for i, k in enumerate("xyz")}
+        out = op(u.Q(tv, "s"), q)
+        return jnp.stack([out[k].ustrip("km") for k in "xyz"])
+
+    return jax.jacfwd(mapped)(T0)
+
+
+@pytest.mark.parametrize("offset", [0.0, 0.5, 2.0], ids=["on-axis", "n=0.5", "n=2"])
+def test_timedep_transports_a_velocity_correctly_off_axis(offset: float) -> None:
+    r"""`TimeDep` wraps a curve-frame builder unmodified, and is right everywhere.
+
+    This is why there is no hand-rolled `relative_velocity`. The closed form
+    $R(v-\beta)$ is exact only *on* the axis; off it the neglected
+    $\dot R\,\mathbf{n}$ term grows with the offset. A tubular chart exists to
+    describe points off the axis, so the closed form would be wrong exactly
+    where the chart is used. Differentiating the whole map is not.
+    """
+    import coordinax.transforms as cxfm
+
+    b = cxfc.BishopBuilder(stretch_and_bend, "km", station=u.Q(S0, "km"))
+    op = cxfm.TimeDep(b)
+
+    beta = b.velocity(u.Q(T0, "s")).ustrip("km/s")
+    rot = jnp.asarray(b.rotation_matrix(u.Q(T0, "s")))
+    gamma = b.location(u.Q(T0, "s")).ustrip("km")
+
+    v_lab = jnp.array([1.0, 0.0, 0.0])
+    x0 = gamma + jnp.array([0.0, offset, 0.0])
+
+    truth = _ground_truth(op, x0, v_lab)
+    closed_form = rot @ (v_lab - beta)
+
+    assert jnp.allclose(truth, _ground_truth(op, x0, v_lab))  # deterministic
+    if offset == 0.0:
+        assert jnp.allclose(truth, closed_form, atol=1e-4)
+    else:
+        # the closed form drifts, and further the further out you go
+        assert not jnp.allclose(truth, closed_form, atol=1e-2)


### PR DESCRIPTION
Layer 4 of #779. `AbstractCurveFrameBuilder.velocity(tau)` returns the ADM shift $\boldsymbol\beta$ — the rate at which the frame origin moves, $\partial\gamma/\partial t$ at fixed first argument.

```pycon
>>> worldtube.velocity(u.Q(1.0, "s")).round(3)
Q([0.65 , 0.169, 0.   ], 'km / s')
```

## It reports; it never chooses

The Eulerian/Lagrangian reading is settled by the parametrisation the caller handed in, before the builder sees anything — a bare $\gamma(\sigma,t)$ gives the material velocity, `ArcLength` adds the advection term, `LagrangianArcLength` removes it again. Pinned by #778 and restated here as a test: the same curve wrapped two ways gives two answers, and `velocity` reports whichever it was given.

## Three branches

The 4-D tube $(t, \sigma, n_1, n_2)$ has two natural 3-D sections, and they reach the same quantity differently:

| curve handed to the builder | how | |
| --- | --- | --- |
| station pinned | the argument *is* the time, so differentiate the curve | `[0.65, 0.169, 0]` |
| `AtTime` slice | the argument is the station; the time is the wrapper's | `[0.65, 0.169, 0]` |
| plain one-argument | zero — nothing moves in time | |

The first two agree because they are cuts of one object through the same event.

### The trap the middle branch sets

On the `AtTime` branch — the one ADM actually uses — differentiating `location` with respect to its argument gives `[1.5, 0.26, 0]`. That is the **tangent**, not $\boldsymbol\beta$. Same shape, same units, entirely plausible.

`test_the_attime_slice_is_not_the_tangent` asserts against *both* values, so an implementation written as "differentiate `location`" fails rather than passing quietly. Mutation-checked: writing it that way fails three tests.

## No `relative_velocity`

The intended convenience was $R^{\mathsf T}(v-\boldsymbol\beta)$. Measurement killed it twice over — the transpose was backwards, and the closed form is exact only *on* the axis:

| point | truth | $R(v-\boldsymbol\beta)$ | error |
| --- | --- | --- | --- |
| on the curve | `[0.316, -0.226, 0]` | `[0.316, -0.226, 0]` | 0 |
| $n = 0.5$ km | `[0.371, -0.236, 0]` | `[0.316, -0.226, 0]` | 0.056 |
| $n = 2$ km | `[0.537, -0.265, 0]` | `[0.316, -0.226, 0]` | 0.224 |

The residual is the neglected $\dot R\,\mathbf n$ term. A tubular chart exists to describe points *off* the axis, so the closed form would be wrong exactly where the chart is used.

`coordinax.transforms.TimeDep` already takes a curve-frame builder unmodified — same `Callable[[Any], AbstractTransform]` contract as `RotationAboutAxis`, and `station` is precisely the "builder field, not call-time argument" its docstring describes. Its prolongation matches finite-differenced ground truth everywhere tested. That composition was undocumented and untested; both are fixed here.

## Two documented limitations

A static curve's zero is reported **per second**. Immaterial rather than arbitrary: zero converts to zero in any time unit.

A curve that binds its own time — `lambda tau: gamma(tau, my_t)` rather than `AtTime` — is indistinguishable from a static one and reports zero. Documented rather than detected, because detection would be a guess.

## Also not here

No 4-D chart: Galilean spacetime's metric structure is degenerate — a temporal 1-form plus a spatial 3-metric — so time enters through the shift and `TubularChart` stays 3-D. No lapse field: $\alpha \equiv 1$ under absolute time, and a later Lorentzian pass can add it without changing this signature.

## Verification

11 new tests, 260 `src` doctests, 129 `curve-charts.md` doctests, `prek` clean including `ty`. Three mutations each fail exactly their own tests: dropping the `AtTime` branch, implementing it as "differentiate `location`", and returning the wrong unit on the static branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)