### PR TITLE
✅ test(curveframes): pin what unit a two-argument curve's time carries

### DIFF
--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/base.py
@@ -260,6 +260,19 @@ class AbstractCurveFrameBuilder(eqx.Module):
         Returning the builder rather than mutating keeps this usable from
         `__call__`, `location` and `tangent` alike, and keeps the two-argument
         path a routing decision made in exactly one place.
+
+        Whether that time carries a unit is the *curve's* business, and
+        nothing here settles it: `tau_unit` describes the pinned station, not
+        this parameter. A curve reading the time with `ustrip` wants a
+        `Quantity`; one reading it as a plain number wants a bare value, which
+        is the time-side counterpart of the array fastpath. Both work, and the
+        mismatched pairing fails from inside the curve -- an `AttributeError`
+        on `ustrip` one way, a `UnitConversionError` the other.
+
+        So a bare time is not rejected here. It looks rejectable from the
+        `ustrip` side, and rejecting it would break the raw-reading curve.
+        Note the consequence for `velocity`, which is a rate per the unit it
+        was given: a bare time makes it `km` rather than `km / s`.
         """
         if _is_two_argument(self.curve):
             return dataclasses.replace(

--- a/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
@@ -481,3 +481,75 @@ def test_the_dimension_guard_still_fires_on_an_inferred_unit() -> None:
     with pytest.raises(ValueError, match="dimension length"):
         b.tangent(u.Q(1.0, "s"))
     b.tangent(u.Q(1.0, "km"))  # a length is what it wants, and needs no declaring
+
+
+# --------------------------------------------------------------------------
+# What unit the *time* carries is the curve's business, not the builder's.
+
+
+def _ustrips_the_time(sigma, t):
+    """Reads the time by converting: needs a `Quantity`."""
+    sv, tv = sigma.ustrip("km"), t.ustrip("s")
+    return u.Q(
+        jnp.stack([sv * (1 + 0.5 * tv), 0.1 * tv * sv**2, jnp.zeros_like(sv)]), "km"
+    )
+
+
+def _reads_the_time_raw(sigma, t):
+    """Reads the time as a plain number: needs a bare one."""
+    sv = sigma.ustrip("km")
+    return u.Q(
+        jnp.stack([sv * (1 + 0.5 * t), 0.1 * t * sv**2, jnp.zeros_like(sv)]), "km"
+    )
+
+
+@pytest.mark.parametrize(
+    ("curve", "time", "rate_unit"),
+    [(_ustrips_the_time, u.Q(1.0, "s"), "km / s"), (_reads_the_time_raw, 1.0, "km")],
+    ids=["converting-curve-takes-a-quantity", "raw-curve-takes-a-bare-number"],
+)
+def test_the_curve_decides_whether_the_time_carries_a_unit(
+    curve, time, rate_unit
+) -> None:
+    """Both forms work, and `tau_unit` settles neither.
+
+    On a pinned-station builder the call-time parameter is the *time*, and
+    `tau_unit` describes the station -- so nothing on the builder states the
+    time's unit, and nothing needs to: a curve that converts wants a
+    `Quantity`, one that reads the number wants a bare value.
+
+    Pinned because the asymmetry looks like a bug from either side. Passing a
+    bare time to a converting curve raises `AttributeError: 'float' object has
+    no attribute 'ustrip'` from inside the curve, which invites "reject bare
+    times" -- and that would break the raw-reading curve, which is the
+    time-side analogue of the array fastpath.
+    """
+    b = cxfc.BishopBuilder(curve, "km", station=u.Q(1.3, "km"))
+
+    assert jnp.allclose(
+        b.location(time).ustrip("km"), jnp.array([1.95, 0.169, 0.0]), atol=1e-5
+    )
+
+    # `velocity` is a rate *per the unit of the parameter it was given*, so a
+    # bare time makes it `km` rather than `km / s`. Dimensionally different,
+    # and self-consistent: the curve took its time as a plain number, so the
+    # derivative is per plain number. Asserted rather than normalised away --
+    # it is the visible consequence of the choice this test exists to pin.
+    vel = b.velocity(time)
+    assert str(u.unit_of(vel)) == rate_unit
+    assert jnp.allclose(vel.ustrip(rate_unit), jnp.array([0.65, 0.169, 0.0]), atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    ("curve", "time", "err"),
+    [
+        (_ustrips_the_time, 1.0, AttributeError),
+        (_reads_the_time_raw, u.Q(1.0, "s"), Exception),
+    ],
+    ids=["converting-curve-given-bare", "raw-curve-given-quantity"],
+)
+def test_the_mismatched_form_fails(curve, time, err) -> None:
+    """The other pairing is the curve's own error, surfacing from the curve."""
+    b = cxfc.BishopBuilder(curve, "km", station=u.Q(1.3, "km"))
+    with pytest.raises(err):
+        b.location(time)

--- a/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_builder_curve_arity.py
@@ -541,15 +541,26 @@ def test_the_curve_decides_whether_the_time_carries_a_unit(
 
 
 @pytest.mark.parametrize(
-    ("curve", "time", "err"),
+    ("curve", "time", "err", "match"),
     [
-        (_ustrips_the_time, 1.0, AttributeError),
-        (_reads_the_time_raw, u.Q(1.0, "s"), Exception),
+        (_ustrips_the_time, 1.0, AttributeError, "has no attribute 'ustrip'"),
+        (
+            _reads_the_time_raw,
+            u.Q(1.0, "s"),
+            apyu.UnitConversionError,
+            "not convertible",
+        ),
     ],
     ids=["converting-curve-given-bare", "raw-curve-given-quantity"],
 )
-def test_the_mismatched_form_fails(curve, time, err) -> None:
-    """The other pairing is the curve's own error, surfacing from the curve."""
+def test_the_mismatched_form_fails(curve, time, err, match) -> None:
+    """The other pairing is the curve's own error, surfacing from the curve.
+
+    Named exactly, not as a bare `Exception`: each mismatch has one failure
+    that belongs to it -- the converting curve cannot `ustrip` a float, and
+    the raw-reading curve cannot mix a time into a dimensionless expression.
+    A broad catch would pass on an unrelated error and hide the regression.
+    """
     b = cxfc.BishopBuilder(curve, "km", station=u.Q(1.3, "km"))
-    with pytest.raises(err):
+    with pytest.raises(err, match=match):
         b.location(time)


### PR DESCRIPTION
## This was reported as a bug. It is not one.

I raised it in the #823 review: a *bare* time on a pinned-station builder fails in `location`, `tangent` and `velocity` alike, with an `AttributeError` thrown from inside the user's curve. That reads like a missing guard.

Investigating it says otherwise. A bare time is a **working, intended usage**, and the two forms are complementary — the *curve* decides, and `tau_unit` settles neither, because it describes the pinned station rather than this parameter:

| curve reads the time as | bare time | `Quantity` time |
| --- | --- | --- |
| `t.ustrip("s")` | `AttributeError` | works |
| raw `t` | **works** | `UnitConversionError` |

The `ustrip` side is the one usually met, which is exactly why this is worth pinning: from there the fix looks like "reject bare times", and that would break the raw-reading curve — the time-side counterpart of the array fastpath.

## What is here

Four parametrised tests in `test_builder_curve_arity.py` covering both working pairings and both mismatches, and the contract written down in `_resolve`, which is where the two-argument path reads its parameter as the time.

No behaviour change.

## A dimensional consequence, asserted rather than smoothed over

`velocity` is a rate *per the unit of the parameter it was given*. A bare time therefore makes it `km`, not `km / s`:

```
converting curve, Quantity time  ->  km / s
raw curve,        bare time      ->  km
```

Self-consistent — the curve took its time as a plain number, so the derivative is per plain number — but a real difference, and the first version of this test asserted `km / s` on both branches and failed. It is asserted per branch now, because it is the visible consequence of the choice the test exists to pin.

## Verification

1085 curveframes tests pass. `prek` clean including `ty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)