### PR TITLE
✅ test(curveframes): pin the ADM structure the metric already has

### DIFF
--- a/packages/coordinaxs.curveframes/docs/curve-charts.md
+++ b/packages/coordinaxs.curveframes/docs/curve-charts.md
@@ -314,8 +314,8 @@ On a worldtube the chart's coordinates are $(t, n_1, n_2)$ — one time and two 
 ...     worldtube, tau_bounds=(u.Q(0.0, "s"), u.Q(2.0, "s"))
 ... )
 >>> at = {"tau": u.Q(1.0, "s"), "n1": u.Q(0.2, "km"), "n2": u.Q(0.1, "km")}
->>> print(metric_matrix(tube.M, at, tube).matrix.unit)
-UnitsMatrix("((km2 / s2, km / s, km / s), (km / s, , ), (km / s, , ))")
+>>> print(metric_matrix(tube.M, at, tube).matrix.unit.to_string())
+((km2 / s2, km / s, km / s), (km / s, , ), (km / s, , ))
 
 ```
 

--- a/packages/coordinaxs.curveframes/docs/curve-charts.md
+++ b/packages/coordinaxs.curveframes/docs/curve-charts.md
@@ -303,6 +303,38 @@ A curve with no time in it has a frame that does not move, so `velocity` is zero
 
 Only `AtTime` is seen. A curve that binds its own time — `lambda tau: gamma(tau, my_t)` — is indistinguishable from a static one and reports zero.
 
+#### The Metric Already Carries It
+
+On a worldtube the chart's coordinates are $(t, n_1, n_2)$ — one time and two lengths — and the generic Jacobian pullback of {ref}`The Metric <the-metric>` produces the ADM block structure on its own. Nothing was written to make it do so; it follows from what the coordinates are. The units say it before the numbers do:
+
+```{code-block} python
+>>> from coordinaxs.api.manifolds import metric_matrix
+
+>>> tube = cxfc.TubularChart(
+...     worldtube, tau_bounds=(u.Q(0.0, "s"), u.Q(2.0, "s"))
+... )
+>>> at = {"tau": u.Q(1.0, "s"), "n1": u.Q(0.2, "km"), "n2": u.Q(0.1, "km")}
+>>> print(metric_matrix(tube.M, at, tube).matrix.unit)
+UnitsMatrix("((km2 / s2, km / s, km / s), (km / s, , ), (km / s, , ))")
+
+```
+
+A speed squared, a speed, and a dimensionless spatial block:
+
+$$
+g_{00} = \lvert \boldsymbol\beta + \dot R\,\mathbf{n} \rvert^2, \qquad
+   g_{0i} = (R\boldsymbol\beta)_i, \qquad
+   g_{ij} = \delta_{ij}.
+$$
+
+$g_{0i}$ **is** the shift, in the triad's normal directions — the pullback and `velocity` reach it by different routes and agree exactly. $g_{ij}$ is the identity because $\mathbf{U}_1$ and $\mathbf{U}_2$ are orthonormal.
+
+$g_{00}$ is the squared speed of the point _at that offset_, not of the frame origin: it equals $\lvert\boldsymbol\beta\rvert^2$ on the axis and departs from it off-axis, because $\partial\mathbf{x}/\partial t$ at fixed $\mathbf{n}$ is $\boldsymbol\beta + \dot R\,\mathbf{n}$. That is the same $\dot R\,\mathbf{n}$ term that makes a hand-written $R(v-\boldsymbol\beta)$ wrong off the axis; here the pullback carries it correctly.
+
+The spatial slice has no time coordinate, so it has no shift block: three length coordinates in one unit give a wholly dimensionless metric.
+
+This is a 3-metric on one section, not a 4-metric. Galilean spacetime has a temporal 1-form and a spatial 3-metric rather than a single non-degenerate $g_{\mu\nu}$, so $(\gamma_{ij}, \beta^i)$ is the container — there is no 4×4 to assemble. What is _not_ provided is the extrinsic curvature $K_{ij}$, which an evolution would need: $\partial_t\gamma_{ij}$ is differentiable straight through the chart, but $D_i\beta_j$ is not supplied.
+
 #### Transporting A Velocity
 
 Do not build a velocity transform out of $\boldsymbol\beta$ by hand. `coordinax.transforms.TimeDep` takes a curve-frame builder directly, and its prolongation differentiates the whole map:

--- a/packages/coordinaxs.curveframes/docs/curve-charts.md
+++ b/packages/coordinaxs.curveframes/docs/curve-charts.md
@@ -305,7 +305,7 @@ Only `AtTime` is seen. A curve that binds its own time — `lambda tau: gamma(ta
 
 #### The Metric Already Carries It
 
-On a worldtube the chart's coordinates are $(t, n_1, n_2)$ — one time and two lengths — and the generic Jacobian pullback of {ref}`The Metric <the-metric>` produces the ADM block structure on its own. Nothing was written to make it do so; it follows from what the coordinates are. The units say it before the numbers do:
+On a worldtube the chart's coordinates are $(t, n_1, n_2)$ — one time and two lengths — and the generic Jacobian pullback of [The Metric](#the-metric) produces the ADM block structure on its own. Nothing was written to make it do so; it follows from what the coordinates are. The units say it before the numbers do:
 
 ```{code-block} python
 >>> from coordinaxs.api.manifolds import metric_matrix

--- a/packages/coordinaxs.curveframes/tests/unit/test_adm_structure.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_adm_structure.py
@@ -118,7 +118,9 @@ def test_the_spatial_slice_is_three_lengths(n1: float) -> None:
 
     pt = {"tau": u.Q(S0, "km"), "n1": u.Q(n1, "km"), "n2": u.Q(0.0, "km")}
     g = metric_matrix(ch.M, pt, ch)
-    # three length coordinates in one unit, so every entry is dimensionless
-    assert g.matrix.unit.is_uniform
-    assert g.matrix.unit.to_tuple()[0][0] == u.unit("")
+    # three length coordinates in one unit, so every entry is dimensionless.
+    # Spelt as a whole-matrix comparison rather than with `is_uniform`, which
+    # postdates the oldest supported `unxts-linalg`.
+    none = u.unit("")
+    assert g.matrix.unit == ul.UnitsMatrix(((none,) * 3,) * 3)
     assert np.allclose(np.asarray(g.matrix.value)[1:, 1:], np.eye(2), atol=1e-5)

--- a/packages/coordinaxs.curveframes/tests/unit/test_adm_structure.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_adm_structure.py
@@ -1,0 +1,121 @@
+r"""The worldtube's metric is already an ADM decomposition.
+
+Nobody built it that way. `metric_matrix` falls through to the generic
+Jacobian pullback, and on a pinned-station chart -- whose coordinates are
+$(t, n_1, n_2)$, one time and two lengths -- that pullback produces the ADM
+block structure on its own:
+
+$$ g_{00} = |\boldsymbol\beta + \dot R\,\mathbf{n}|^2, \qquad
+   g_{0i} = (R\boldsymbol\beta)_i, \qquad
+   g_{ij} = \delta_{ij}. $$
+
+Emergent structure is the kind that breaks silently: one refactor of the
+pullback and $g_{0i}$ stops being the shift, with nothing to notice. These
+pin it.
+
+Galilean spacetime has no non-degenerate 4-metric -- a temporal 1-form and a
+spatial 3-metric, not a single $g_{\mu\nu}$ -- so this is a 3-metric on one
+section, not a 4-metric. `(gamma_ij, beta^i)` is the container; see #779.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from coordinaxs.api.manifolds import metric_matrix
+
+import unxt as u
+
+import coordinaxs.curveframes as cxfc
+
+S0 = 1.3
+T0 = 1.0
+
+
+def stretch_and_bend(
+    sigma: u.AbstractQuantity, t: u.AbstractQuantity
+) -> u.AbstractQuantity:
+    """The #778 curve: stretches *and* bends, so the triad genuinely rotates."""
+    sv, tv = sigma.ustrip("km"), t.ustrip("s")
+    x = sv * (1.0 + 0.5 * tv)
+    y = 0.1 * tv * sv**2
+    return u.Q(jnp.stack([x, y, jnp.zeros_like(x)]), "km")
+
+
+def _worldtube():
+    b = cxfc.BishopBuilder(stretch_and_bend, "km", station=u.Q(S0, "km"))
+    ch = cxfc.TubularChart(b, tau_bounds=(u.Q(0.0, "s"), u.Q(2.0, "s")))
+    return b, ch
+
+
+def _g(ch, n1: float, n2: float) -> np.ndarray:
+    pt = {"tau": u.Q(T0, "s"), "n1": u.Q(n1, "km"), "n2": u.Q(n2, "km")}
+    return np.asarray(metric_matrix(ch.M, pt, ch).matrix.value)
+
+
+def test_the_blocks_carry_the_adm_units() -> None:
+    """A speed squared, a speed, and a dimensionless spatial block."""
+    _, ch = _worldtube()
+    pt = {"tau": u.Q(T0, "s"), "n1": u.Q(0.2, "km"), "n2": u.Q(0.1, "km")}
+    unit_str = str(metric_matrix(ch.M, pt, ch).matrix.unit)
+
+    assert "km2 / s2" in unit_str  # g_00, a speed squared
+    assert "km / s" in unit_str  # g_0i, a speed
+
+
+def test_the_off_diagonal_block_is_the_shift() -> None:
+    r"""$g_{0i}$ *is* $\boldsymbol\beta$, in the triad's normal directions.
+
+    Not approximately, and not by construction -- the pullback and
+    `velocity` reach it by different routes and agree.
+    """
+    b, ch = _worldtube()
+    beta = np.asarray(b.velocity(u.Q(T0, "s")).ustrip("km/s"))
+    rot = np.asarray(b.rotation_matrix(u.Q(T0, "s")))
+    in_triad = rot @ beta  # (T, U1, U2) components
+
+    g = _g(ch, 0.2, 0.1)
+    assert np.allclose([g[0, 1], g[0, 2]], in_triad[1:], atol=1e-5)
+    assert np.allclose(g[0, 1], g[1, 0], atol=1e-6)  # symmetric
+
+
+def test_the_spatial_block_is_the_orthonormal_triad() -> None:
+    """`U1` and `U2` are unit and orthogonal, so the normal block is the identity."""
+    _, ch = _worldtube()
+    g = _g(ch, 0.4, -0.3)
+    assert np.allclose(g[1:, 1:], np.eye(2), atol=1e-5)
+
+
+def test_g00_is_the_squared_speed_of_the_point_at_that_offset() -> None:
+    r"""On the axis it is $|\boldsymbol\beta|^2$; off it, $\dot R\,\mathbf n$ enters.
+
+    The same $\dot R\,\mathbf n$ term that makes a closed-form
+    $R(v-\boldsymbol\beta)$ wrong off-axis (see `velocity`'s notes). Here the
+    pullback carries it correctly, which is worth pinning rather than
+    trusting.
+    """
+    b, ch = _worldtube()
+    beta = np.asarray(b.velocity(u.Q(T0, "s")).ustrip("km/s"))
+    drot = np.asarray(jax.jacfwd(lambda tv: b.rotation_matrix(u.Q(tv, "s")))(T0))
+
+    assert np.allclose(_g(ch, 0.0, 0.0)[0, 0], beta @ beta, atol=1e-5)
+
+    for n1, n2 in [(0.2, 0.0), (0.5, 0.3), (1.0, -0.4)]:
+        speed = beta + n1 * drot[1] + n2 * drot[2]
+        assert np.allclose(_g(ch, n1, n2)[0, 0], speed @ speed, atol=1e-4)
+
+
+@pytest.mark.parametrize("n1", [0.0, 0.5], ids=["on-axis", "off-axis"])
+def test_the_spatial_slice_is_three_lengths(n1: float) -> None:
+    """`AtTime` gives the other section: no time coordinate, so no shift block."""
+    ch = cxfc.TubularChart(
+        cxfc.BishopBuilder(cxfc.AtTime(stretch_and_bend, u.Q(T0, "s")), "km"),
+        tau_bounds=(u.Q(0.0, "km"), u.Q(3.0, "km")),
+    )
+    assert ch.coord_dimensions == ("length", "length", "length")
+
+    pt = {"tau": u.Q(S0, "km"), "n1": u.Q(n1, "km"), "n2": u.Q(0.0, "km")}
+    g = metric_matrix(ch.M, pt, ch)
+    # three length coordinates in one unit, so every entry is dimensionless
+    assert "km" not in str(g.matrix.unit)
+    assert np.allclose(np.asarray(g.matrix.value)[1:, 1:], np.eye(2), atol=1e-5)

--- a/packages/coordinaxs.curveframes/tests/unit/test_adm_structure.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_adm_structure.py
@@ -22,6 +22,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+import unxts.linalg as ul
 from coordinaxs.api.manifolds import metric_matrix
 
 import unxt as u
@@ -57,10 +58,11 @@ def test_the_blocks_carry_the_adm_units() -> None:
     """A speed squared, a speed, and a dimensionless spatial block."""
     _, ch = _worldtube()
     pt = {"tau": u.Q(T0, "s"), "n1": u.Q(0.2, "km"), "n2": u.Q(0.1, "km")}
-    unit_str = str(metric_matrix(ch.M, pt, ch).matrix.unit)
 
-    assert "km2 / s2" in unit_str  # g_00, a speed squared
-    assert "km / s" in unit_str  # g_0i, a speed
+    speed_sq, speed, none = u.unit("km2 / s2"), u.unit("km / s"), u.unit("")
+    assert metric_matrix(ch.M, pt, ch).matrix.unit == ul.UnitsMatrix(
+        ((speed_sq, speed, speed), (speed, none, none), (speed, none, none))
+    )
 
 
 def test_the_off_diagonal_block_is_the_shift() -> None:
@@ -117,5 +119,6 @@ def test_the_spatial_slice_is_three_lengths(n1: float) -> None:
     pt = {"tau": u.Q(S0, "km"), "n1": u.Q(n1, "km"), "n2": u.Q(0.0, "km")}
     g = metric_matrix(ch.M, pt, ch)
     # three length coordinates in one unit, so every entry is dimensionless
-    assert "km" not in str(g.matrix.unit)
+    assert g.matrix.unit.is_uniform
+    assert g.matrix.unit.to_tuple()[0][0] == u.unit("")
     assert np.allclose(np.asarray(g.matrix.value)[1:, 1:], np.eye(2), atol=1e-5)


### PR DESCRIPTION
Step 1 of the metric assembly for #779. No behaviour change — this pins and documents structure that already exists.

## The finding

On a worldtube the chart's coordinates are $(t, n_1, n_2)$ — one time and two lengths — and the generic Jacobian pullback produces the ADM block structure **on its own**. Nothing was written to make it do so; it follows from what the coordinates are. The units say it before the numbers do:

```
((km2 / s2, km / s, km / s), (km / s, , ), (km / s, , ))
```

A speed squared, a speed, and a dimensionless spatial block:

$$ g_{00} = \lvert\boldsymbol\beta + \dot R\,\mathbf{n}\rvert^2, \qquad g_{0i} = (R\boldsymbol\beta)_i, \qquad g_{ij} = \delta_{ij}. $$

$g_{0i}$ **is** the shift. The pullback and `velocity` reach it by different routes and agree exactly — `0.05551` both ways.

## Why pin it

Emergent structure breaks silently. One refactor of the generic pullback and $g_{0i}$ stops being the shift, with nothing to notice. Same shape as `TimeDep` composing with curve frames: already true, nowhere stated.

The tests are a genuine cross-check, not a restatement — doubling `velocity` while leaving the pullback untouched fails two of them.

## $g_{00}$, verified rather than inferred

It is the squared speed of the point *at that offset*, not of the frame origin — $\lvert\boldsymbol\beta\rvert^2$ on the axis, departing off it because $\partial\mathbf{x}/\partial t$ at fixed $\mathbf{n}$ is $\boldsymbol\beta + \dot R\,\mathbf{n}$:

| offset | $g_{00}$ | $\lvert d\mathbf{x}/dt\rvert^2$ |
| --- | --- | --- |
| `n=0` | 0.45106 | 0.45106 |
| `n=0.2` | 0.42153 | 0.42153 |
| `n=0.5` | 0.37912 | 0.37912 |
| `n=1.0` | 0.31347 | 0.31347 |

and the decomposition itself checked at three offsets including a two-component one. That is the same $\dot R\,\mathbf{n}$ term that makes a hand-written $R(v-\boldsymbol\beta)$ wrong off-axis (see `velocity`'s notes, #823); here the pullback carries it correctly.

## What the docs now also record as *absent*

- **No 4×4 to assemble.** Galilean spacetime has a temporal 1-form and a spatial 3-metric rather than a non-degenerate $g_{\mu\nu}$, so $(\gamma_{ij}, \beta^i)$ is the container. The worldtube metric is a 3-metric on one section; the spatial slice is the other.
- **No extrinsic curvature $K_{ij}$**, which an evolution would need. $\partial_t\gamma_{ij}$ differentiates straight through the chart; $D_i\beta_j$ is not supplied. That is step 2.

## Verification

6 new tests, 139 doctests including `curve-charts.md`, `nox -s docs` clean, `prek` clean including `ty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)