### PR TITLE
💥 refactor(frames): Bob is a Lorentz boost; Carol inherits the velocity kick

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5866,35 +5866,38 @@ A **reference frame** is an abstract label used to identify a coordinate descrip
 
 !!! info `Bob` and `bob`
 
-    An example inertial reference frame in uniform motion relative to `Alice`.
-
-    `Bob` is a **non-rotating** observer moving at constant velocity with respect to Alice. His frame is characterised by two parameters:
+    A **relativistic** example frame: an inertial observer moving at 0.9 c
+    relative to `Alice`.
 
     - **Spatial offset** from Alice's origin: $[\,100\,000\ \text{km},\; 10\,000\ \text{km},\; 0\,]$.
-    - **Velocity** relative to Alice: $\approx 269\,813\ \text{km\,s}^{-1}$ ($\approx 0.9\,c$) along Alice's $x$-axis.
+    - **Velocity** relative to Alice: $0.9\,c$ along Alice's $x$-axis.
 
-    Because Bob is non-rotating, the Alice → Bob transformation requires only a spatial `Translate` followed by a velocity kick (`Translate(semantic_kind=vel)` — a fibre-only offset; contrast with `Boost`, the Galilean boost, whose point action moves positions by $\Delta v\,\tau$ and therefore requires a time). No rotation is needed.
+    At that speed the transformation must be a **Lorentz boost**, so Bob acts
+    on spacetime — `minkowskict`, components $(ct, x, y, z)$ — not on a 3-D
+    spatial chart. A Galilean velocity kick would simply add velocities: a
+    particle already moving at $0.3\,c$ in Alice's frame comes out at
+    $1.2\,c$, which is not merely imprecise but impossible. Composing the two
+    relativistically gives $0.9449\,c$. `Carol` is the slow frame where the
+    kick *is* the right physics.
 
     **Frame transition table:**
 
     | From → To     | Transform                          |
     |---------------|------------------------------------|
     | `Bob → Bob`   | `Identity()`                       |
-    | `Alice → Bob` | `Translate([100 000, 10 000, 0] km) \| Translate([269 813 212.2, 0, 0] m/s, semantic_kind=vel)` |
-    | `Bob → Alice` | inverse of Alice → Bob: `Translate([−269 813 212.2, 0, 0] m/s, semantic_kind=vel) \| Translate([−100 000, −10 000, 0] km)` |
+    | `Alice → Bob` | `Translate([0, 1e8, 1e7, 0] m, chart=minkowskict) \| LorentzBoost([0.9, 0, 0])` |
+    | `Bob → Alice` | inverse of Alice → Bob             |
 
-    **Semantic behaviour** (per representation):
+    **Semantic behaviour.** A boost mixes $ct$ into the spatial components, so
+    unlike a velocity kick it moves *events*, not only rates. Purely spatial
+    input is refused — a 3-D point has no time component to boost — rather
+    than being silently treated as though it had one.
 
-    | Representation semantic | Effect of Alice → Bob transform |
-    |-------------------------|---------------------------------|
-    | `Point` / `Location`    | position shifted by `[100 000, 10 000, 0] km` (unitful Quantities act as positions; bare unitless arrays are rejected — the velocity kick cannot tell a position array from a velocity array) |
-    | `Displacement`          | unchanged (both offsets are identity on displacements) |
-    | `Velocity`              | velocity shifted by `[269 813 212.2, 0, 0] m/s` |
-    | `Acceleration`          | unchanged (a constant velocity kick is identity on accelerations) |
+    **Invariant.** The boost preserves the Minkowski interval, and a null
+    separation stays null. That is the property being bought at $0.9\,c$, and
+    exactly what the Galilean kick fails to provide.
 
-    **Pre-defined instance:**
-
-    - `bob` is the canonical `Bob()` singleton.
+    **Pre-defined instance:** `bob` is the canonical `Bob()` singleton.
 
     **Examples:**
 
@@ -5905,9 +5908,58 @@ A **reference frame** is an abstract label used to identify a coordinate descrip
     Identity()
 
     >>> op = cxf.frame_transition(cxf.alice, cxf.bob)
-    >>> type(op).__name__
-    'Composed'
+    >>> [type(t).__name__ for t in op.transforms]
+    ['Translate', 'LorentzBoost']
+    ```
 
+(software-spec-carol)=
+
+!!! info `Carol` and `carol`
+
+    An example inertial frame in *slow* uniform motion relative to `Alice` —
+    the Galilean counterpart to `Bob`, and the frame that carries the
+    translate-plus-velocity-kick example.
+
+    - **Spatial offset** from Alice's origin: $[\,100\,000\ \text{km},\; 10\,000\ \text{km},\; 0\,]$.
+    - **Velocity** relative to Alice: $30\ \text{km\,s}^{-1}$ (Earth's orbital
+      speed, $10^{-4}\,c$) along Alice's $x$-axis.
+
+    Because Carol is non-rotating and slow, the Alice → Carol transformation
+    needs only a spatial `Translate` followed by a velocity kick
+    (`Translate(semantic_kind=vel)` — a fibre-only offset; contrast with
+    `Boost`, the Galilean boost, whose point action moves positions by
+    $\Delta v\,\tau$ and therefore requires a time). At $10^{-4}\,c$ the
+    relativistic correction is one part in $10^{8}$, so adding velocities is
+    correct and ordinary 3-D charts suffice.
+
+    **Frame transition table:**
+
+    | From → To       | Transform                          |
+    |-----------------|------------------------------------|
+    | `Carol → Carol` | `Identity()`                       |
+    | `Alice → Carol` | `Translate([100 000, 10 000, 0] km) \| Translate([30, 0, 0] km/s, semantic_kind=vel)` |
+    | `Carol → Alice` | inverse of Alice → Carol           |
+
+    **Semantic behaviour** (per representation):
+
+    | Representation semantic | Effect of Alice → Carol transform |
+    |-------------------------|-----------------------------------|
+    | `Point` / `Location`    | position shifted by `[100 000, 10 000, 0] km` (unitful Quantities act as positions; bare unitless arrays are rejected — the velocity kick cannot tell a position array from a velocity array) |
+    | `Displacement`          | unchanged (both offsets are identity on displacements) |
+    | `Velocity`              | velocity shifted by `[30, 0, 0] km/s` |
+    | `Acceleration`          | unchanged (a constant velocity kick is identity on accelerations) |
+
+    **Pre-defined instance:** `carol` is the canonical `Carol()` singleton.
+
+    **Examples:**
+
+    ```pycon
+    >>> import coordinax.frames as cxf
+
+    >>> cxf.frame_transition(cxf.carol, cxf.carol)
+    Identity()
+
+    >>> op = cxf.frame_transition(cxf.alice, cxf.carol)
     >>> import coordinax as cx
     >>> import unxt as u
     >>> d = cx.cdict(u.Q([0.0, 0.0, 0.0], "km"))

--- a/src/coordinax/frames/__init__.py
+++ b/src/coordinax/frames/__init__.py
@@ -71,7 +71,9 @@ __all__: tuple[str, ...] = (
     "Alex",
     "alex",
     "Bob",
+    "Carol",
     "bob",
+    "carol",
 )
 
 with install_import_hook("coordinax.frames"):
@@ -81,12 +83,14 @@ with install_import_hook("coordinax.frames"):
         Alex,
         Alice,
         Bob,
+        Carol,
         FrameTransformError,
         NoFrame,
         TransformedReferenceFrame,
         alex,
         alice,
         bob,
+        carol,
         noframe,
     )
     from coordinaxs.api.frames import frame_transition

--- a/src/coordinax/frames/_src/example.py
+++ b/src/coordinax/frames/_src/example.py
@@ -1,6 +1,6 @@
 """Base implementation of coordinate frames."""
 
-__all__ = ("Alice", "alice", "Alex", "alex", "Bob", "bob")
+__all__ = ("Alice", "alice", "Alex", "alex", "Bob", "bob", "Carol", "carol")
 
 
 from typing import cast, final
@@ -14,6 +14,20 @@ import coordinax.representations as cxr
 import coordinax.transforms as cxfm
 import coordinaxs.api.frames as cxfapi
 from .base import AbstractReferenceFrame
+
+BOB_BETA = 0.9
+"""Bob's speed relative to Alice, as a fraction of ``c``.
+
+Relativistic on purpose: at this speed a Galilean velocity kick gives answers
+that exceed ``c``, which is what makes Bob the frame that has to be Lorentz.
+"""
+
+CAROL_SPEED = u.Q([30.0, 0.0, 0.0], "km/s")
+"""Carol's velocity relative to Alice -- Earth's orbital speed, 1e-4 c.
+
+Slow on purpose: this is where a Galilean velocity kick *is* the right physics,
+and the correction Lorentz would add is one part in 1e8.
+"""
 
 
 @final
@@ -29,9 +43,10 @@ class Alice(AbstractReferenceFrame):
 
     * **Alice → Alex**: translate +10 m along Alice's x-axis, then rotate
       +90 ° about the z-axis.
-    * **Alice → Bob**: translate [100 000 km, 10 000 km, 0] from Alice's
-      origin, then apply a Galilean velocity boost of ≈ 269 813 km s⁻¹
-      (≈ 0.9 c) along Alice's x-axis.
+    * **Alice → Bob**: on *spacetime*, translate the spatial origin then
+      apply a Lorentz boost of β = 0.9 along Alice's x-axis.
+    * **Alice → Carol**: translate [100 000 km, 10 000 km, 0] from Alice's
+      origin, then apply a Galilean velocity kick of 30 km s⁻¹.
 
     Examples
     --------
@@ -95,19 +110,19 @@ alex = Alex()  # instance of Alex
 
 @final
 class Bob(AbstractReferenceFrame):
-    """An inertial frame moving at constant velocity relative to Alice.
+    """A relativistic inertial frame, moving at 0.9 c relative to Alice.
 
-    Bob is a non-rotating observer in uniform motion with respect to Alice.
-    His frame is characterised by:
+    Bob is a non-rotating observer in uniform motion with respect to Alice:
 
     * **Spatial offset** from Alice's origin:
       [100 000 km, 10 000 km, 0 km].
-    * **Velocity** relative to Alice:
-      ≈ 269 813 km s⁻¹ (≈ 0.9 c) along Alice's x-axis.
+    * **Velocity** relative to Alice: 0.9 c along Alice's x-axis.
 
-    Because Bob is non-rotating, no rotation operator is required; the
-    transformation only needs a spatial translation and a velocity kick
-    (a ``Translate`` with ``semantic_kind=vel``).
+    At that speed the transformation has to be a **Lorentz boost**, so Bob
+    lives on spacetime -- `~coordinax.charts.minkowskict`, components
+    ``(ct, x, y, z)`` -- rather than on a 3-D spatial chart. `Carol` is the
+    slow counterpart, where a Galilean velocity kick is correct and ordinary
+    3-D charts suffice.
 
     Examples
     --------
@@ -118,51 +133,50 @@ class Bob(AbstractReferenceFrame):
     >>> cxf.frame_transition(cxf.bob, cxf.bob)
     Identity()
 
-    Transition from Alice's frame to Bob's frame (translate then velocity
-    kick):
+    Alice to Bob is a spacetime translation followed by the boost:
 
     >>> op = cxf.frame_transition(cxf.alice, cxf.bob)
-    >>> print(op)
-    Composed((
-      Translate(
-          {'x': Q(100000, 'km'), 'y': Q(10000, 'km'), 'z': Q(0, 'km')},
-          chart=Cart3D(M=Rn(3))
-      ),
-      Translate(
-          {'x': Q(269813212.2, 'm / s'), ...},
-          chart=Cart3D(M=Rn(3)),
-          semantic_kind=vel
-      )
-    ))
+    >>> [type(t).__name__ for t in op.transforms]
+    ['Translate', 'LorentzBoost']
 
-    A bare, unitless array is rejected: the velocity kick cannot tell a
-    position array (kick is identity) from a velocity array (kick applies),
-    so silently guessing would risk wrong physics. Use a Quantity, cdict, or
-    typed vector instead:
+    **Why a boost and not a velocity kick.** A kick adds velocities, which at
+    0.9 c gives answers faster than light. Take a particle already moving at
+    0.3 c in Alice's frame:
 
-    >>> import jax.numpy as jnp
-    >>> import unxt as u
-    >>> import coordinax.transforms as cxfm
-    >>> x = jnp.asarray([0.0, 0.0, 0.0])
-    >>> try:
-    ...     cxfm.act(op, None, x, usys=u.unitsystems.si)
-    ... except TypeError as e:
-    ...     print(str(e)[:30])
-    A fibre offset (Translate with
+    >>> c = 299792458.0
+    >>> round((0.3 * c + 0.9 * c) / c, 4)          # adding them
+    1.2
 
-    Applying the Alice -> Bob transform to a ``Quantity`` works:
+    That is 1.2 c -- not a small error but an impossible speed. Composing the
+    velocities relativistically instead keeps the result below ``c``, as it
+    must:
 
-    >>> q = u.Q([0.0, 0.0, 0.0], "km")
-    >>> op(None, q)
-    Q([100000.,  10000.,      0.], 'km')
+    >>> round((0.3 + 0.9) / (1 + 0.3 * 0.9), 4)    # composing them
+    0.9449
 
-    Applying the same transform to a component dictionary (``cdict``) also
-    works:
+    A boost needs a time component, so a purely spatial point has nothing to
+    transform and is refused rather than silently mishandled:
 
     >>> import coordinax as cx
-    >>> d = cx.cdict(u.Q([0.0, 0.0, 0.0], "km"))
-    >>> op(None, d)
-    {'x': Q(100000., 'km'), 'y': Q(10000., 'km'), 'z': Q(0., 'km')}
+    >>> p = cx.Point.from_([0.0, 0.0, 0.0], "m")
+    >>> try:
+    ...     op(p)
+    ... except Exception as e:
+    ...     print(type(e).__name__)
+    ManifoldMismatchError
+
+    On spacetime it acts as expected -- Alice's origin, boosted, is somewhere
+    else in both time and space:
+
+    >>> import unxt as u
+    >>> import coordinax.charts as cxc
+    >>> ev = cx.Point.from_(
+    ...     {"ct": u.Q(0.0, "m"), "x": u.Q(0.0, "m"),
+    ...      "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")},
+    ...     cxc.minkowskict, cx.point)
+    >>> out = op(ev)
+    >>> round(float(out["ct"].ustrip("m")), 1)
+    206474160.5
 
     """
 
@@ -170,10 +184,53 @@ class Bob(AbstractReferenceFrame):
 bob = Bob()
 
 
+@final
+class Carol(AbstractReferenceFrame):
+    """An inertial frame in slow uniform motion relative to Alice.
+
+    Carol is what Bob used to be: a non-rotating observer offset from Alice
+    and moving at a constant velocity, so the transformation is a spatial
+    `~coordinax.transforms.Translate` followed by a velocity kick (a
+    ``Translate`` with ``semantic_kind=vel`` -- the fibre-only offset).
+
+    * **Spatial offset** from Alice's origin: [100 000 km, 10 000 km, 0].
+    * **Velocity** relative to Alice: 30 km s⁻¹ along Alice's x-axis.
+
+    The speed is the point. At 30 km s⁻¹ -- Earth's orbital speed, 1e-4 c --
+    adding velocities is correct to one part in 1e8, so the Galilean kick is
+    the right physics and stays on ordinary 3-D charts. `Bob` moves at 0.9 c,
+    where the same treatment gives velocities above ``c``, and so is a
+    Lorentz boost on spacetime instead.
+
+    Examples
+    --------
+    >>> import coordinax.frames as cxf
+
+    >>> cxf.frame_transition(cxf.carol, cxf.carol)
+    Identity()
+
+    >>> op = cxf.frame_transition(cxf.alice, cxf.carol)
+    >>> [type(t).__name__ for t in op.transforms]
+    ['Translate', 'Translate']
+
+    The kick is identity on positions and adds to velocities:
+
+    >>> import unxt as u
+    >>> q = u.Q([0.0, 0.0, 0.0], "km")
+    >>> op(None, q)
+    Q([100000.,  10000.,      0.], 'km')
+
+    """
+
+
+carol = Carol()
+"""Canonical `Carol` singleton."""
+
+
 # ===================================================================
 
 
-@plum.dispatch.multi((Alice, Alice), (Alex, Alex), (Bob, Bob))
+@plum.dispatch.multi((Alice, Alice), (Alex, Alex), (Bob, Bob), (Carol, Carol))
 def frame_transition(
     from_frame: AbstractReferenceFrame, to_frame: AbstractReferenceFrame, /
 ) -> cxfm.Identity:
@@ -186,6 +243,9 @@ def frame_transition(
     Identity()
 
     >>> cxf.frame_transition(cxf.bob, cxf.bob)
+    Identity()
+
+    >>> cxf.frame_transition(cxf.carol, cxf.carol)
     Identity()
 
     """
@@ -212,43 +272,61 @@ def frame_transition(from_frame: Alice, to_frame: Alex, /) -> cxfm.Composed:
 def frame_transition(from_frame: Alice, to_frame: Bob, /) -> cxfm.Composed:
     r"""Transform from Alice's frame to Bob's frame.
 
-    This is an example of a reference frame transformation that includes
-    both a spatial translation and a velocity kick (a ``Translate`` with
-    ``semantic_kind=vel`` — the fibre-only offset; contrast with
-    `coordinax.transforms.Boost`, the true Galilean boost, whose point action
-    moves positions by $\Delta v \, \tau$ and therefore requires a time).
+    A spacetime translation followed by a **Lorentz boost** of
+    $\beta = 0.9$ along Alice's x-axis. Bob moves too fast for a Galilean
+    velocity kick: adding 0.9 c to a particle already at 0.3 c would give
+    1.2 c. See `Bob` for that comparison worked through, and `Carol` for the
+    slow frame where the kick *is* the right physics.
 
-    The velocity kick has well-defined actions on kinematic roles:
+    Because a boost mixes time into the spatial components, this transition
+    acts on `~coordinax.charts.minkowskict` rather than a 3-D chart.
 
-    - **Point**: identity (points are unchanged by a velocity kick)
+    Examples
+    --------
+    >>> import coordinax.frames as cxf
+
+    >>> op = cxf.frame_transition(cxf.Alice(), cxf.Bob())
+    >>> [type(t).__name__ for t in op.transforms]
+    ['Translate', 'LorentzBoost']
+
+    """
+    shift = cxfm.Translate(
+        cxc.cdict(u.Q([0.0, 1.0e8, 1.0e7, 0.0], "m"), cxc.minkowskict),
+        chart=cxc.minkowskict,
+    )
+    return shift | cxfm.LorentzBoost([BOB_BETA, 0.0, 0.0])  # ty: ignore[unsupported-operator]
+
+
+@plum.dispatch
+def frame_transition(from_frame: Alice, to_frame: Carol, /) -> cxfm.Composed:
+    r"""Transform from Alice's frame to Carol's frame.
+
+    A spatial translation followed by a velocity kick -- the transformation
+    `Bob` carried before he became relativistic. The kick has well-defined
+    actions on each kinematic role:
+
+    - **Point**: identity (a velocity kick does not move points)
     - **Displacement**: identity (Galilean invariant)
     - **Velocity**: adds $v_0$
     - **Acceleration**: identity (for a constant kick)
 
     Examples
     --------
-    >>> import unxt as u
-    >>> import coordinax as cx
     >>> import coordinax.frames as cxf
 
-    >>> alice = cxf.Alice()
-    >>> bob = cxf.Bob()
-
-    >>> op = cxf.frame_transition(alice, bob)
-    >>> print(op)
-    Composed(( Translate(...), Translate(...) ))
+    >>> op = cxf.frame_transition(cxf.alice, cxf.carol)
+    >>> [type(t).__name__ for t in op.transforms]
+    ['Translate', 'Translate']
 
     """
     shift = cxfm.Translate.from_([100_000, 10_000, 0], "km")
     kick = cxfm.Translate(
-        cxc.cdict(u.Q([269_813_212.2, 0, 0], "m/s"), cxc.cart3d),
-        chart=cxc.cart3d,
-        semantic_kind=cxr.vel,
+        cxc.cdict(CAROL_SPEED, cxc.cart3d), chart=cxc.cart3d, semantic_kind=cxr.vel
     )
     return shift | kick  # ty: ignore[unsupported-operator]
 
 
-@plum.dispatch.multi((Alex, Alice), (Bob, Alice))
+@plum.dispatch.multi((Alex, Alice), (Bob, Alice), (Carol, Alice))
 def frame_transition(
     from_frame: AbstractReferenceFrame, to_frame: AbstractReferenceFrame, /
 ) -> cxfm.Composed:
@@ -260,18 +338,12 @@ def frame_transition(
     >>> cxf.frame_transition(cxf.alex, cxf.alice)
     Composed(( Rotate(...), Translate(...) ))
 
-    >>> print(cxf.frame_transition(cxf.bob, cxf.alice))
-    Composed((
-      Translate(
-          {'x': Q(-269813212.2, 'm / s'), ...},
-          chart=Cart3D(M=Rn(3)),
-          semantic_kind=vel
-      ),
-      Translate(
-          {'x': Q(-100000, 'km'), 'y': Q(-10000, 'km'), 'z': Q(0, 'km')},
-          chart=Cart3D(M=Rn(3))
-      )
-    ))
+    >>> [type(t).__name__ for t in cxf.frame_transition(cxf.bob, cxf.alice).transforms]
+    ['LorentzBoost', 'Translate']
+
+    >>> op = cxf.frame_transition(cxf.carol, cxf.alice)
+    >>> [type(t).__name__ for t in op.transforms]
+    ['Translate', 'Translate']
 
     """
     out = cxfapi.frame_transition(to_frame, from_frame).inverse  # pylint: disable=W1114  # ty: ignore[unresolved-attribute]

--- a/tests/unit/frames/test_bob_frame.py
+++ b/tests/unit/frames/test_bob_frame.py
@@ -1,6 +1,11 @@
-"""Tests for the Bob reference frame."""
+"""Tests for the Bob reference frame.
 
-from typing import cast
+Bob moves at 0.9 c, so the Alice <-> Bob transition is a Lorentz boost on
+spacetime rather than the Galilean velocity kick it used to be. `Carol` is
+the slow frame that inherited the kick; see `test_carol_frame.py`.
+"""
+
+from typing import ClassVar
 
 import jax
 import jax.numpy as jnp
@@ -8,234 +13,154 @@ import pytest
 
 import unxt as u
 
+import coordinax as cx
 import coordinax.charts as cxc
 import coordinax.frames as cxf
-import coordinax.representations as cxr
+import coordinax.manifolds as cxm
 import coordinax.transforms as cxfm
+
+C_M_S = 299792458.0
+
+
+def event(ct, x, y=0.0, z=0.0):
+    return {"ct": u.Q(ct, "m"), "x": u.Q(x, "m"), "y": u.Q(y, "m"), "z": u.Q(z, "m")}
 
 
 class TestBobExports:
-    """Tests that Bob frame and related functions are properly exported."""
+    """Bob and its singleton are exported."""
 
     def test_bob_exported(self):
         assert hasattr(cxf, "Bob")
         assert hasattr(cxf, "bob")
-
-    def test_bob_is_instance(self):
-        assert isinstance(cxf.bob, cxf.Bob)
 
     def test_bob_in_all(self):
         assert "Bob" in cxf.__all__
         assert "bob" in cxf.__all__
 
 
-class TestBobFrameTransitions:
-    """Tests for frame transitions involving Bob's frame."""
+class TestBobIsALorentzBoost:
+    """The transition is a boost, not a velocity kick."""
 
     def test_bob_to_bob_is_identity(self):
-        op = cxf.frame_transition(cxf.bob, cxf.bob)
-        assert isinstance(op, cxfm.Identity)
+        assert isinstance(cxf.frame_transition(cxf.bob, cxf.bob), cxfm.Identity)
 
-    def test_alice_to_bob_is_composed(self):
+    def test_alice_to_bob_is_translate_then_boost(self):
         op = cxf.frame_transition(cxf.alice, cxf.bob)
         assert isinstance(op, cxfm.Composed)
-        assert len(op.transforms) == 2
         assert isinstance(op.transforms[0], cxfm.Translate)
-        # The velocity offset is a fibre-only kick: Translate(semantic_kind=vel).
-        assert isinstance(op.transforms[1], cxfm.Translate)
-        assert op.transforms[1].semantic_kind == cxr.vel
+        assert isinstance(op.transforms[1], cxfm.LorentzBoost)
 
-    def test_alice_to_bob_has_correct_chart(self):
+    def test_it_acts_on_spacetime_not_a_spatial_chart(self):
         op = cxf.frame_transition(cxf.alice, cxf.bob)
-        assert isinstance(op, cxfm.Composed)
-        assert op.transforms[0].chart is cxc.cart3d
-        assert op.transforms[1].chart is cxc.cart3d
+        assert op.transforms[0].chart is cxc.minkowskict
 
-    def test_bob_to_alice_is_composed(self):
-        op = cxf.frame_transition(cxf.bob, cxf.alice)
-        assert isinstance(op, cxfm.Composed)
-        assert len(op.transforms) == 2
-        assert isinstance(op.transforms[0], cxfm.Translate)
-        assert op.transforms[0].semantic_kind == cxr.vel
-        assert isinstance(op.transforms[1], cxfm.Translate)
-
-    def test_bob_to_alice_is_inverse_of_alice_to_bob(self):
-        alice_to_bob = cxf.frame_transition(cxf.alice, cxf.bob)
-        bob_to_alice = cxf.frame_transition(cxf.bob, cxf.alice)
-        assert isinstance(alice_to_bob, cxfm.Composed)
-        assert isinstance(bob_to_alice, cxfm.Composed)
-        assert bob_to_alice == alice_to_bob.inverse
-
-    def test_alice_bob_roundtrip_velocity(self):
-        alice_to_bob = cxf.frame_transition(cxf.alice, cxf.bob)
-        bob_to_alice = cxf.frame_transition(cxf.bob, cxf.alice)
-        v = {"x": u.Q(5.0, "m/s"), "y": u.Q(3.0, "m/s"), "z": u.Q(1.0, "m/s")}
-        v_in_bob = cxfm.act(alice_to_bob, None, v, cxc.cart3d, cxr.coord_vel)
-        v_back = cast(
-            "dict[str, u.AbstractQuantity]",
-            cxfm.act(bob_to_alice, None, v_in_bob, cxc.cart3d, cxr.coord_vel),
+    def test_the_boost_carries_bobs_speed(self):
+        op = cxf.frame_transition(cxf.alice, cxf.bob)
+        assert jnp.allclose(
+            jnp.asarray(op.transforms[1].beta), jnp.asarray([0.9, 0.0, 0.0])
         )
-        for k, val in v.items():
-            assert jnp.allclose(
-                u.ustrip("m/s", v_back[k]), u.ustrip("m/s", val), atol=1e-6
-            )
 
-    def test_alice_to_bob_translates_position(self):
-        alice_to_bob = cxf.frame_transition(cxf.alice, cxf.bob)
-        p = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
-        result = cxfm.act(alice_to_bob, None, p, cxc.cart3d, cxr.point)
-        expected = {
-            "x": u.Q(100001.0, "km"),
-            "y": u.Q(10002.0, "km"),
-            "z": u.Q(3.0, "km"),
-        }
-        assert result == expected
-
-    @pytest.mark.parametrize("frames", [("alice",), ("bob",), ("alex",)])
-    def test_alice_alice_is_identity(self, frames):
-        """Existing frame pair identity transitions still work."""
-        frame = getattr(cxf, frames[0])
-        op = cxf.frame_transition(frame, frame)
-        assert isinstance(op, cxfm.Identity)
+    def test_bob_to_alice_is_the_inverse(self):
+        there = cxf.frame_transition(cxf.alice, cxf.bob)
+        back = cxf.frame_transition(cxf.bob, cxf.alice)
+        assert back == there.inverse
 
 
-# ============================================================================
+class TestBobPreservesTheInterval:
+    """The reason a boost is the right operator: it leaves ds^2 alone.
 
-
-class TestBobPositionTransform:
-    """Positions transform correctly under the Alice ↔ Bob frame transition.
-
-    Per spec (software-spec-bob):
-      Point: shifted by [100 000, 10 000, 0] km (Translate component only).
+    A Galilean velocity kick does not, which is the physical content of the
+    change -- not merely that 0.9 c is a large number.
     """
 
-    def test_alice_to_bob_origin(self):
-        """Alice's origin maps to Bob's [100 000, 10 000, 0] km."""
-        alice_to_bob = cxf.frame_transition(cxf.alice, cxf.bob)
-        p = {"x": u.Q(0.0, "km"), "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")}
-        result = cxfm.act(alice_to_bob, None, p, cxc.cart3d, cxr.point)
-        assert result == {
-            "x": u.Q(100_000.0, "km"),
-            "y": u.Q(10_000.0, "km"),
-            "z": u.Q(0.0, "km"),
-        }
+    PAIRS: ClassVar = [(5.0, 1.0), (1.0, 5.0), (3.0, 3.0), (2.0, -4.0)]
 
-    def test_bob_to_alice_origin(self):
-        """Bob's origin maps back to Alice's [-100 000, -10 000, 0] km."""
-        bob_to_alice = cxf.frame_transition(cxf.bob, cxf.alice)
-        p = {"x": u.Q(0.0, "km"), "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")}
-        result = cxfm.act(bob_to_alice, None, p, cxc.cart3d, cxr.point)
-        assert result == {
-            "x": u.Q(-100_000.0, "km"),
-            "y": u.Q(-10_000.0, "km"),
-            "z": u.Q(0.0, "km"),
-        }
-
-    def test_alice_bob_roundtrip_position(self):
-        """Alice → Bob → Alice is the identity on positions."""
-        alice_to_bob = cxf.frame_transition(cxf.alice, cxf.bob)
-        bob_to_alice = cxf.frame_transition(cxf.bob, cxf.alice)
-        p = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
-        p_in_bob = cxfm.act(alice_to_bob, None, p, cxc.cart3d, cxr.point)
-        p_back = cast(
-            "dict[str, u.AbstractQuantity]",
-            cxfm.act(bob_to_alice, None, p_in_bob, cxc.cart3d, cxr.point),
+    @pytest.mark.parametrize(("ct", "x"), PAIRS)
+    def test_the_boost_leaves_the_interval_alone(self, ct, x):
+        """Sharp form: the boost alone, to 1e-12."""
+        boost = cxf.frame_transition(cxf.alice, cxf.bob).transforms[1]
+        o, e = event(0.0, 0.0), event(ct, x)
+        before = cxm.interval(cxc.minkowskict, o, e)
+        after = cxm.interval(
+            cxc.minkowskict,
+            cxfm.act(boost, None, o, cxc.minkowskict, cx.point),
+            cxfm.act(boost, None, e, cxc.minkowskict, cx.point),
         )
-        for k, val in p.items():
-            assert jnp.allclose(
-                u.ustrip("km", p_back[k]), u.ustrip("km", val), atol=1e-6
-            )
+        assert jnp.allclose(u.ustrip("m2", before), u.ustrip("m2", after), rtol=1e-12)
 
-    def test_alice_to_bob_position_jit(self):
-        """Alice → Bob position transform is JIT-compatible."""
-        alice_to_bob = cxf.frame_transition(cxf.alice, cxf.bob)
+    @pytest.mark.parametrize(("ct", "x"), PAIRS)
+    def test_the_whole_transition_does_too(self, ct, x):
+        """Looser, and the looseness is arithmetic rather than physics.
+
+        The translation carries events out to ~1e8 m, so the interval becomes a
+        difference of squares of numbers that size: float64 has ~1e-16 relative
+        precision, which is ~1e-7 absolute once squared and differenced. That
+        cancellation, not the transform, sets the tolerance here -- the sharp
+        assertion above is the one about the physics.
+        """
+        op = cxf.frame_transition(cxf.alice, cxf.bob)
+        o, e = event(0.0, 0.0), event(ct, x)
+        before = cxm.interval(cxc.minkowskict, o, e)
+        after = cxm.interval(
+            cxc.minkowskict,
+            cxfm.act(op, None, o, cxc.minkowskict, cx.point),
+            cxfm.act(op, None, e, cxc.minkowskict, cx.point),
+        )
+        assert jnp.allclose(u.ustrip("m2", before), u.ustrip("m2", after), atol=1e-5)
+
+    def test_a_null_separation_stays_null(self):
+        """Light stays light in every frame -- the sharpest form of the claim."""
+        op = cxf.frame_transition(cxf.alice, cxf.bob)
+        o, e = event(0.0, 0.0), event(3.0, 3.0)
+        after = cxm.interval(
+            cxc.minkowskict,
+            cxfm.act(op, None, o, cxc.minkowskict, cx.point),
+            cxfm.act(op, None, e, cxc.minkowskict, cx.point),
+        )
+        assert jnp.allclose(u.ustrip("m2", after), 0.0, atol=1e-6)
+
+
+class TestWhyNotAVelocityKick:
+    """Pins the arithmetic that makes the Galilean treatment wrong here."""
+
+    def test_adding_velocities_at_bobs_speed_exceeds_c(self):
+        galilean = 0.3 * C_M_S + 0.9 * C_M_S
+        assert galilean > C_M_S
+        assert jnp.allclose(galilean / C_M_S, 1.2, rtol=1e-9)
+
+    def test_composing_them_does_not(self):
+        relativistic = (0.3 + 0.9) / (1 + 0.3 * 0.9)
+        assert relativistic < 1.0
+        assert jnp.allclose(relativistic, 0.9449, atol=1e-4)
+
+
+class TestBobRefusesPurelySpatialInput:
+    """A boost needs a time component; a 3-D point has none."""
+
+    def test_a_3d_point_has_no_time_to_boost(self):
+        op = cxf.frame_transition(cxf.alice, cxf.bob)
+        with pytest.raises(Exception, match=r"transition|Cart3D|manifold"):
+            op(cx.Point.from_([0.0, 0.0, 0.0], "m"))
+
+
+class TestBobRoundTrips:
+    """Alice -> Bob -> Alice returns the event it started from."""
+
+    def test_alice_bob_alice_returns_the_event(self):
+        there = cxf.frame_transition(cxf.alice, cxf.bob)
+        back = cxf.frame_transition(cxf.bob, cxf.alice)
+        e = event(2.0, 1.0, 0.5, -1.0)
+        moved = cxfm.act(there, None, e, cxc.minkowskict, cx.point)
+        home = cxfm.act(back, None, moved, cxc.minkowskict, cx.point)
+        for k in ("ct", "x", "y", "z"):
+            assert jnp.allclose(u.ustrip("m", home[k]), u.ustrip("m", e[k]), atol=1e-6)
+
+    def test_the_transition_is_jit_compatible(self):
+        op = cxf.frame_transition(cxf.alice, cxf.bob)
 
         @jax.jit
-        def transform(p):
-            return cxfm.act(alice_to_bob, None, p, cxc.cart3d, cxr.point)
+        def go(e):
+            return cxfm.act(op, None, e, cxc.minkowskict, cx.point)
 
-        p = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
-        result = transform(p)
-        assert jnp.allclose(u.ustrip("km", result["x"]), 100_001.0, atol=1e-6)
-        assert jnp.allclose(u.ustrip("km", result["y"]), 10_002.0, atol=1e-6)
-        assert jnp.allclose(u.ustrip("km", result["z"]), 3.0, atol=1e-6)
-
-
-class TestBobVelocityTransform:
-    """Velocities are boosted by [269 813 212.2, 0, 0] m/s (Alice → Bob).
-
-    Per spec (software-spec-bob):
-      Velocity: shifted by [269 813 212.2, 0, 0] m/s (Boost component only).
-    """
-
-    _BOOST_X = 269_813_212.2  # m/s
-
-    def test_alice_to_bob_boosts_velocity(self):
-        """Velocity x-component is shifted by the boost value."""
-        alice_to_bob = cxf.frame_transition(cxf.alice, cxf.bob)
-        v = {"x": u.Q(5.0, "m/s"), "y": u.Q(3.0, "m/s"), "z": u.Q(1.0, "m/s")}
-        result = cxfm.act(alice_to_bob, None, v, cxc.cart3d, cxr.coord_vel)
-        assert jnp.allclose(
-            u.ustrip("m/s", result["x"]), 5.0 + self._BOOST_X, rtol=1e-6
-        )
-        assert jnp.allclose(u.ustrip("m/s", result["y"]), 3.0, atol=1e-6)
-        assert jnp.allclose(u.ustrip("m/s", result["z"]), 1.0, atol=1e-6)
-
-    def test_alice_to_bob_velocity_unchanged_by_translate(self):
-        """Translate is identity for velocity; only the Boost component acts."""
-        # Apply only the Translate step and verify velocity is unchanged.
-        shift = cxfm.Translate.from_([100_000, 10_000, 0], "km")
-        v = {"x": u.Q(5.0, "m/s"), "y": u.Q(3.0, "m/s"), "z": u.Q(1.0, "m/s")}
-        result = cxfm.act(shift, None, v, cxc.cart3d, cxr.coord_vel)
-        assert result == v
-
-
-class TestBobInvariance:
-    """Displacements and accelerations are unchanged by the Alice <-> Bob maps.
-
-    Per spec (software-spec-bob):
-      Displacement: unchanged (both Translate and Boost are identity on
-      displacements).
-      Acceleration: unchanged (Boost is identity on accelerations).
-
-    The two spec lines are one contract -- ``act`` is the identity on these
-    representations -- so they are one table. Written out per-transform, the
-    acceleration half had covered only the two composite transitions; the
-    cross product adds ``Translate`` and ``Boost`` alone, which is where the
-    spec's claim about `Boost` actually bites.
-    """
-
-    @pytest.mark.parametrize(
-        "transform",
-        [
-            pytest.param(cxf.frame_transition(cxf.alice, cxf.bob), id="alice-to-bob"),
-            pytest.param(cxf.frame_transition(cxf.bob, cxf.alice), id="bob-to-alice"),
-            pytest.param(
-                cxfm.Translate.from_([100_000, 10_000, 0], "km"), id="translate-alone"
-            ),
-            pytest.param(
-                cxfm.Boost.from_([269_813_212.2, 0, 0], "m/s"), id="boost-alone"
-            ),
-        ],
-    )
-    @pytest.mark.parametrize(
-        ("rep", "value"),
-        [
-            pytest.param(
-                cxr.coord_disp,
-                {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")},
-                id="displacement",
-            ),
-            pytest.param(
-                cxr.coord_acc,
-                {
-                    "x": u.Q(1.0, "m/s^2"),
-                    "y": u.Q(2.0, "m/s^2"),
-                    "z": u.Q(3.0, "m/s^2"),
-                },
-                id="acceleration",
-            ),
-        ],
-    )
-    def test_act_is_the_identity(self, transform, rep, value) -> None:
-        assert cxfm.act(transform, None, value, cxc.cart3d, rep) == value
+        out = go(event(2.0, 1.0))
+        assert jnp.isfinite(u.ustrip("m", out["ct"]))

--- a/tests/unit/frames/test_bob_frame.py
+++ b/tests/unit/frames/test_bob_frame.py
@@ -138,8 +138,13 @@ class TestBobRefusesPurelySpatialInput:
     """A boost needs a time component; a 3-D point has none."""
 
     def test_a_3d_point_has_no_time_to_boost(self):
+        """Named, not a broad catch: the refusal *is* the contract here.
+
+        Anything narrower than the point's manifold failing to match the
+        transition's would mean something else went wrong.
+        """
         op = cxf.frame_transition(cxf.alice, cxf.bob)
-        with pytest.raises(Exception, match=r"transition|Cart3D|manifold"):
+        with pytest.raises(cxc.ManifoldMismatchError, match="no transition"):
             op(cx.Point.from_([0.0, 0.0, 0.0], "m"))
 
 

--- a/tests/unit/frames/test_carol_frame.py
+++ b/tests/unit/frames/test_carol_frame.py
@@ -168,21 +168,19 @@ class TestCarolVelocityTransform:
       Velocity: shifted by [30, 0, 0] km/s (kick component only).
     """
 
-    _BOOST_X = 30_000.0  # m/s
+    _KICK_X = 30_000.0  # m/s
 
-    def test_alice_to_carol_boosts_velocity(self):
-        """Velocity x-component is shifted by the boost value."""
+    def test_alice_to_carol_kicks_velocity(self):
+        """Velocity x-component is shifted by the kick value."""
         alice_to_carol = cxf.frame_transition(cxf.alice, cxf.carol)
         v = {"x": u.Q(5.0, "m/s"), "y": u.Q(3.0, "m/s"), "z": u.Q(1.0, "m/s")}
         result = cxfm.act(alice_to_carol, None, v, cxc.cart3d, cxr.coord_vel)
-        assert jnp.allclose(
-            u.ustrip("m/s", result["x"]), 5.0 + self._BOOST_X, rtol=1e-6
-        )
+        assert jnp.allclose(u.ustrip("m/s", result["x"]), 5.0 + self._KICK_X, rtol=1e-6)
         assert jnp.allclose(u.ustrip("m/s", result["y"]), 3.0, atol=1e-6)
         assert jnp.allclose(u.ustrip("m/s", result["z"]), 1.0, atol=1e-6)
 
     def test_alice_to_carol_velocity_unchanged_by_translate(self):
-        """Translate is identity for velocity; only the Boost component acts."""
+        """Translate is identity for velocity; only the kick acts."""
         # Apply only the Translate step and verify velocity is unchanged.
         shift = cxfm.Translate.from_([100_000, 10_000, 0], "km")
         v = {"x": u.Q(5.0, "m/s"), "y": u.Q(3.0, "m/s"), "z": u.Q(1.0, "m/s")}
@@ -194,15 +192,19 @@ class TestCarolInvariance:
     """Displacements and accelerations are unchanged by the Alice <-> Carol maps.
 
     Per spec (software-spec-carol):
-      Displacement: unchanged (both Translate and Boost are identity on
-      displacements).
-      Acceleration: unchanged (Boost is identity on accelerations).
+      Displacement: unchanged (both offsets are identity on displacements).
+      Acceleration: unchanged (a constant velocity kick is identity on
+      accelerations).
 
     The two spec lines are one contract -- ``act`` is the identity on these
-    representations -- so they are one table. Written out per-transform, the
-    acceleration half had covered only the two composite transitions; the
-    cross product adds ``Translate`` and ``Boost`` alone, which is where the
-    spec's claim about `Boost` actually bites.
+    representations -- so they are one table.
+
+    Note what the parametrization covers. Alice <-> Carol is
+    ``Translate | Translate(semantic_kind=vel)``: a spatial offset and a
+    *velocity kick*, not a `~coordinax.transforms.Boost`. The standalone
+    `Boost` case is here as well because the same invariance is claimed of it,
+    and testing it alone is the only place that claim actually bites -- but it
+    is an addition to the transition's own components, not one of them.
     """
 
     @pytest.mark.parametrize(

--- a/tests/unit/frames/test_carol_frame.py
+++ b/tests/unit/frames/test_carol_frame.py
@@ -1,0 +1,243 @@
+"""Tests for the Carol reference frame."""
+
+from typing import cast
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.frames as cxf
+import coordinax.representations as cxr
+import coordinax.transforms as cxfm
+
+
+class TestCarolExports:
+    """Tests that Carol frame and related functions are properly exported."""
+
+    def test_carol_exported(self):
+        assert hasattr(cxf, "Carol")
+        assert hasattr(cxf, "carol")
+
+    def test_carol_is_instance(self):
+        assert isinstance(cxf.carol, cxf.Carol)
+
+    def test_carol_in_all(self):
+        assert "Carol" in cxf.__all__
+        assert "carol" in cxf.__all__
+
+
+class TestCarolFrameTransitions:
+    """Tests for frame transitions involving Carol's frame."""
+
+    def test_carol_to_carol_is_identity(self):
+        op = cxf.frame_transition(cxf.carol, cxf.carol)
+        assert isinstance(op, cxfm.Identity)
+
+    def test_alice_to_carol_is_composed(self):
+        op = cxf.frame_transition(cxf.alice, cxf.carol)
+        assert isinstance(op, cxfm.Composed)
+        assert len(op.transforms) == 2
+        assert isinstance(op.transforms[0], cxfm.Translate)
+        # The velocity offset is a fibre-only kick: Translate(semantic_kind=vel).
+        assert isinstance(op.transforms[1], cxfm.Translate)
+        assert op.transforms[1].semantic_kind == cxr.vel
+
+    def test_alice_to_carol_has_correct_chart(self):
+        op = cxf.frame_transition(cxf.alice, cxf.carol)
+        assert isinstance(op, cxfm.Composed)
+        assert op.transforms[0].chart is cxc.cart3d
+        assert op.transforms[1].chart is cxc.cart3d
+
+    def test_carol_to_alice_is_composed(self):
+        op = cxf.frame_transition(cxf.carol, cxf.alice)
+        assert isinstance(op, cxfm.Composed)
+        assert len(op.transforms) == 2
+        assert isinstance(op.transforms[0], cxfm.Translate)
+        assert op.transforms[0].semantic_kind == cxr.vel
+        assert isinstance(op.transforms[1], cxfm.Translate)
+
+    def test_carol_to_alice_is_inverse_of_alice_to_carol(self):
+        alice_to_carol = cxf.frame_transition(cxf.alice, cxf.carol)
+        carol_to_alice = cxf.frame_transition(cxf.carol, cxf.alice)
+        assert isinstance(alice_to_carol, cxfm.Composed)
+        assert isinstance(carol_to_alice, cxfm.Composed)
+        assert carol_to_alice == alice_to_carol.inverse
+
+    def test_alice_carol_roundtrip_velocity(self):
+        alice_to_carol = cxf.frame_transition(cxf.alice, cxf.carol)
+        carol_to_alice = cxf.frame_transition(cxf.carol, cxf.alice)
+        v = {"x": u.Q(5.0, "m/s"), "y": u.Q(3.0, "m/s"), "z": u.Q(1.0, "m/s")}
+        v_in_carol = cxfm.act(alice_to_carol, None, v, cxc.cart3d, cxr.coord_vel)
+        v_back = cast(
+            "dict[str, u.AbstractQuantity]",
+            cxfm.act(carol_to_alice, None, v_in_carol, cxc.cart3d, cxr.coord_vel),
+        )
+        for k, val in v.items():
+            assert jnp.allclose(
+                u.ustrip("m/s", v_back[k]), u.ustrip("m/s", val), atol=1e-6
+            )
+
+    def test_alice_to_carol_translates_position(self):
+        alice_to_carol = cxf.frame_transition(cxf.alice, cxf.carol)
+        p = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
+        result = cxfm.act(alice_to_carol, None, p, cxc.cart3d, cxr.point)
+        expected = {
+            "x": u.Q(100001.0, "km"),
+            "y": u.Q(10002.0, "km"),
+            "z": u.Q(3.0, "km"),
+        }
+        assert result == expected
+
+    @pytest.mark.parametrize("frames", [("alice",), ("carol",), ("alex",)])
+    def test_alice_alice_is_identity(self, frames):
+        """Existing frame pair identity transitions still work."""
+        frame = getattr(cxf, frames[0])
+        op = cxf.frame_transition(frame, frame)
+        assert isinstance(op, cxfm.Identity)
+
+
+# ============================================================================
+
+
+class TestCarolPositionTransform:
+    """Positions transform correctly under the Alice ↔ Carol frame transition.
+
+    Per spec (software-spec-carol):
+      Point: shifted by [100 000, 10 000, 0] km (Translate component only).
+    """
+
+    def test_alice_to_carol_origin(self):
+        """Alice's origin maps to Carol's [100 000, 10 000, 0] km."""
+        alice_to_carol = cxf.frame_transition(cxf.alice, cxf.carol)
+        p = {"x": u.Q(0.0, "km"), "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")}
+        result = cxfm.act(alice_to_carol, None, p, cxc.cart3d, cxr.point)
+        assert result == {
+            "x": u.Q(100_000.0, "km"),
+            "y": u.Q(10_000.0, "km"),
+            "z": u.Q(0.0, "km"),
+        }
+
+    def test_carol_to_alice_origin(self):
+        """Carol's origin maps back to Alice's [-100 000, -10 000, 0] km."""
+        carol_to_alice = cxf.frame_transition(cxf.carol, cxf.alice)
+        p = {"x": u.Q(0.0, "km"), "y": u.Q(0.0, "km"), "z": u.Q(0.0, "km")}
+        result = cxfm.act(carol_to_alice, None, p, cxc.cart3d, cxr.point)
+        assert result == {
+            "x": u.Q(-100_000.0, "km"),
+            "y": u.Q(-10_000.0, "km"),
+            "z": u.Q(0.0, "km"),
+        }
+
+    def test_alice_carol_roundtrip_position(self):
+        """Alice → Carol → Alice is the identity on positions."""
+        alice_to_carol = cxf.frame_transition(cxf.alice, cxf.carol)
+        carol_to_alice = cxf.frame_transition(cxf.carol, cxf.alice)
+        p = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
+        p_in_carol = cxfm.act(alice_to_carol, None, p, cxc.cart3d, cxr.point)
+        p_back = cast(
+            "dict[str, u.AbstractQuantity]",
+            cxfm.act(carol_to_alice, None, p_in_carol, cxc.cart3d, cxr.point),
+        )
+        for k, val in p.items():
+            assert jnp.allclose(
+                u.ustrip("km", p_back[k]), u.ustrip("km", val), atol=1e-6
+            )
+
+    def test_alice_to_carol_position_jit(self):
+        """Alice → Carol position transform is JIT-compatible."""
+        alice_to_carol = cxf.frame_transition(cxf.alice, cxf.carol)
+
+        @jax.jit
+        def transform(p):
+            return cxfm.act(alice_to_carol, None, p, cxc.cart3d, cxr.point)
+
+        p = {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")}
+        result = transform(p)
+        assert jnp.allclose(u.ustrip("km", result["x"]), 100_001.0, atol=1e-6)
+        assert jnp.allclose(u.ustrip("km", result["y"]), 10_002.0, atol=1e-6)
+        assert jnp.allclose(u.ustrip("km", result["z"]), 3.0, atol=1e-6)
+
+
+class TestCarolVelocityTransform:
+    """Velocities are kicked by [30, 0, 0] km/s (Alice → Carol).
+
+    Per spec (software-spec-carol):
+      Velocity: shifted by [30, 0, 0] km/s (kick component only).
+    """
+
+    _BOOST_X = 30_000.0  # m/s
+
+    def test_alice_to_carol_boosts_velocity(self):
+        """Velocity x-component is shifted by the boost value."""
+        alice_to_carol = cxf.frame_transition(cxf.alice, cxf.carol)
+        v = {"x": u.Q(5.0, "m/s"), "y": u.Q(3.0, "m/s"), "z": u.Q(1.0, "m/s")}
+        result = cxfm.act(alice_to_carol, None, v, cxc.cart3d, cxr.coord_vel)
+        assert jnp.allclose(
+            u.ustrip("m/s", result["x"]), 5.0 + self._BOOST_X, rtol=1e-6
+        )
+        assert jnp.allclose(u.ustrip("m/s", result["y"]), 3.0, atol=1e-6)
+        assert jnp.allclose(u.ustrip("m/s", result["z"]), 1.0, atol=1e-6)
+
+    def test_alice_to_carol_velocity_unchanged_by_translate(self):
+        """Translate is identity for velocity; only the Boost component acts."""
+        # Apply only the Translate step and verify velocity is unchanged.
+        shift = cxfm.Translate.from_([100_000, 10_000, 0], "km")
+        v = {"x": u.Q(5.0, "m/s"), "y": u.Q(3.0, "m/s"), "z": u.Q(1.0, "m/s")}
+        result = cxfm.act(shift, None, v, cxc.cart3d, cxr.coord_vel)
+        assert result == v
+
+
+class TestCarolInvariance:
+    """Displacements and accelerations are unchanged by the Alice <-> Carol maps.
+
+    Per spec (software-spec-carol):
+      Displacement: unchanged (both Translate and Boost are identity on
+      displacements).
+      Acceleration: unchanged (Boost is identity on accelerations).
+
+    The two spec lines are one contract -- ``act`` is the identity on these
+    representations -- so they are one table. Written out per-transform, the
+    acceleration half had covered only the two composite transitions; the
+    cross product adds ``Translate`` and ``Boost`` alone, which is where the
+    spec's claim about `Boost` actually bites.
+    """
+
+    @pytest.mark.parametrize(
+        "transform",
+        [
+            pytest.param(
+                cxf.frame_transition(cxf.alice, cxf.carol), id="alice-to-carol"
+            ),
+            pytest.param(
+                cxf.frame_transition(cxf.carol, cxf.alice), id="carol-to-alice"
+            ),
+            pytest.param(
+                cxfm.Translate.from_([100_000, 10_000, 0], "km"), id="translate-alone"
+            ),
+            pytest.param(cxfm.Boost.from_([30_000.0, 0, 0], "m/s"), id="boost-alone"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("rep", "value"),
+        [
+            pytest.param(
+                cxr.coord_disp,
+                {"x": u.Q(1.0, "km"), "y": u.Q(2.0, "km"), "z": u.Q(3.0, "km")},
+                id="displacement",
+            ),
+            pytest.param(
+                cxr.coord_acc,
+                {
+                    "x": u.Q(1.0, "m/s^2"),
+                    "y": u.Q(2.0, "m/s^2"),
+                    "z": u.Q(3.0, "m/s^2"),
+                },
+                id="acceleration",
+            ),
+        ],
+    )
+    def test_act_is_the_identity(self, transform, rep, value) -> None:
+        assert cxfm.act(transform, None, value, cxc.cart3d, rep) == value


### PR DESCRIPTION
From the audit, slice 6. **Breaking**: `bob` no longer accepts 3-D points — see the migration note below.

## The problem

`Bob` is documented as moving at 0.9 c, but transformed as a Galilean velocity kick, which simply adds velocities:

```
particle at 0.0c in Alice  ->  Galilean  0.9000c   Lorentz  0.9000c
particle at 0.3c in Alice  ->  Galilean  1.2000c   Lorentz  0.9449c   <-- superluminal
particle at 0.5c in Alice  ->  Galilean  1.4000c   Lorentz  0.9655c   <-- superluminal
particle at 0.9c in Alice  ->  Galilean  1.8000c   Lorentz  0.9945c   <-- superluminal
```

Not an imprecise answer — an impossible one, in the example frame people read to learn how frames work.

## The change

`Alice → Bob` is now a spacetime translation followed by `LorentzBoost([0.9, 0, 0])`, acting on `minkowskict`. The boost preserves the Minkowski interval and keeps a null separation null; both are pinned by tests, because interval invariance *is* the property being bought at 0.9 c and exactly what the kick fails to provide.

A boost needs a time component, so Bob no longer acts on purely spatial input — it refuses it rather than treating a 3-D point as though it had a time.

## Why `Carol` exists

That refusal would have cost the library its worked example of "translate then velocity kick", which is genuinely useful and correct — at ordinary speeds. So **`Carol`** inherits it: same spatial offset, but 30 km/s (Earth's orbital speed, `1e-4 c`), where adding velocities is right to one part in `1e8`.

Bob's 18 tests moved to `test_carol_frame.py` essentially unchanged — only the speed differs — which is the clearest evidence the teaching survived intact. Bob gets a new suite for the relativistic behaviour.

## Migration

Anyone using `bob` with `cart3d` should use `carol`, which behaves exactly as `bob` did. Using `bob` now requires `minkowskict` coordinates.

## A tolerance worth explaining

The boost preserves the interval to `1e-12`. The *whole* transition only to `~1e-5` — because the translation carries events out to `1e8` m, and the interval is then a difference of squares of numbers that size, where float64's `1e-16` relative precision leaves ~`1e-7` absolute. That is arithmetic cancellation, not the transform, so the sharp assertion is made against the boost alone and the loose one carries a comment saying why.

## Verification

- `tests/unit/frames` + frames doctests: 211 passed
- `docs/spec.md`: 377 passed
- Full suite: **11773 passed**, 311 skipped, 1 xfailed, 0 failures
- `prek` clean

Docs per `AGENTS.md`'s sync rule: `docs/spec.md` gains a rewritten Bob section and a new Carol section, both spelling out the velocity-composition comparison.
