### PR TITLE
✨ feat(curveframes): `rate_of_strain`, the ADM `K_ij` of a slice family

### DIFF
--- a/packages/coordinaxs.curveframes/docs/curve-charts.md
+++ b/packages/coordinaxs.curveframes/docs/curve-charts.md
@@ -333,7 +333,27 @@ $g_{00}$ is the squared speed of the point _at that offset_, not of the frame or
 
 The spatial slice has no time coordinate, so it has no shift block: three length coordinates in one unit give a wholly dimensionless metric.
 
-This is a 3-metric on one section, not a 4-metric. Galilean spacetime has a temporal 1-form and a spatial 3-metric rather than a single non-degenerate $g_{\mu\nu}$, so $(\gamma_{ij}, \beta^i)$ is the container — there is no 4×4 to assemble. What is _not_ provided is the extrinsic curvature $K_{ij}$, which an evolution would need: $\partial_t\gamma_{ij}$ is differentiable straight through the chart, but $D_i\beta_j$ is not supplied.
+This is a 3-metric on one section, not a 4-metric. Galilean spacetime has a temporal 1-form and a spatial 3-metric rather than a single non-degenerate $g_{\mu\nu}$, so $(\gamma_{ij}, \beta^i, K_{ij})$ is the container — there is no 4×4 to assemble.
+
+The third piece is `rate_of_strain`:
+
+$$ K*{ij} = \tfrac{1}{2\alpha}\left(\partial_t\gamma*{ij} - (\mathcal{L}_\beta\gamma)_{ij}\right) \;=\; \tfrac12\,\partial*t\gamma*{ij}. $$
+
+The lapse is identically 1 under absolute time, and the Lie-drag term vanishes because a chart coordinate is what $\partial_t$ holds fixed — so the _coordinate_ shift is zero, whatever the ambient $\boldsymbol\beta$ is doing. It takes the family of slices rather than one chart, since $\partial_t$ needs neighbours:
+
+```{code-block} python
+>>> family = lambda t: cxfc.TubularChart(
+...     cxfc.BishopBuilder(cxfc.AtTime(stretching, t), "km"),
+...     tau_bounds=(u.Q(0.0, "km"), u.Q(3.0, "km")),
+... )
+>>> at_point = {"tau": u.Q(1.3, "km"), "n1": u.Q(0.2, "km"), "n2": u.Q(0.1, "km")}
+>>> K = cxfc.rate_of_strain(family, at_point, u.Q(1.0, "s"))
+>>> float(K.value[0, 0].round(3))
+0.779
+
+```
+
+Like the shift, it follows the labelling: wrapping the same curve in `ArcLength` holds the parametrisation near unit-speed, so its $K_{\tau\tau}$ is near zero instead. `t` must be a scalar — $K_{ij}$ is a 2-tensor, and `TubularChart` is single-point for the same reason.
 
 #### Transporting A Velocity
 

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/__init__.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/__init__.py
@@ -19,6 +19,7 @@ Public API
     BishopFrame
     TubularChart
     nearest_tau
+    rate_of_strain
 
 Typical usage::
 
@@ -51,6 +52,7 @@ __all__ = (
     "LagrangianArcLength",
     "TubularChart",
     "nearest_tau",
+    "rate_of_strain",
 )
 
 from ._setup_package import install_import_hook
@@ -68,6 +70,7 @@ with install_import_hook("coordinaxs.curveframes"):
         LagrangianArcLength,
         TubularChart,
         nearest_tau,
+        rate_of_strain,
     )
 
 del install_import_hook

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/__init__.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/__init__.py
@@ -10,6 +10,7 @@ implementation modules:
 - {mod}`.frenetserret` — Frenet--Serret transform and frame.
 - {mod}`.bishop` — Bishop (rotation-minimising) transform and frame.
 - {mod}`.chart` — `TubularChart`, on the parameterized branch.
+- {mod}`.strain` — `rate_of_strain`, the ADM `K_ij` of a slice family.
 - {mod}`.nearest` — `nearest_tau`, the seeded Newton solve `TubularChart`'s
   inverse `pt_map` uses.
 - {mod}`.register_frames` — ``frame_transition`` dispatch registrations.
@@ -29,3 +30,4 @@ from .frenetserret import *
 from .nearest import *
 from .register_frames import *
 from .register_ptmap import *
+from .strain import *

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/strain.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/strain.py
@@ -1,0 +1,71 @@
+r"""How fast a slice's geometry deforms.
+
+The extrinsic-curvature slot of the ADM decomposition,
+$K_{ij} = \tfrac{1}{2\alpha}\left(\partial_t\gamma_{ij} - (\mathcal{L}_\beta
+\gamma)_{ij}\right)$, reduces here to $\tfrac12\partial_t\gamma_{ij}$: the
+lapse is identically 1 under absolute time, and the Lie-drag term vanishes
+because a chart coordinate *is* what the time derivative holds fixed, so the
+coordinate shift is zero by construction. See
+`coordinaxs.curveframes.velocity` for the other ADM piece, which is the
+ambient motion of the frame origin and does not vanish.
+"""
+
+__all__ = ("rate_of_strain",)
+
+from collections.abc import Callable
+from typing import Any, cast
+
+import jax
+import unxts.linalg as ul
+
+import unxt as u
+from coordinaxs.api.manifolds import metric_matrix
+
+_MSG_BARE_TIME = (
+    "`rate_of_strain` differentiates with respect to `t`, so `t` must carry a "
+    "unit: nothing else states what the rate is per. Pass a `Quantity`, e.g. "
+    "`u.Q(1.0, 's')`."
+)
+
+
+def rate_of_strain(
+    chart_at_time: Callable[[Any], Any], point: dict, t: Any, /
+) -> ul.QuantityMatrix:
+    r"""Return $K_{ij} = \tfrac12\,\partial_t\gamma_{ij}$ at ``point``.
+
+    Parameters
+    ----------
+    chart_at_time
+        The slice family: given a time, the chart of the tube at that time.
+        Typically ``lambda t: TubularChart(BishopBuilder(AtTime(curve, t), ...))``.
+    point
+        Chart coordinates at which to evaluate, e.g.
+        ``{"tau": ..., "n1": ..., "n2": ...}``.
+    t
+        The time to differentiate at. Must carry a unit.
+
+    Notes
+    -----
+    The value depends on the *labelling*, and correctly so. A material
+    parametrisation shows the tube genuinely stretching; wrapping the same
+    curve in `ArcLength` holds the metric near unit-speed, so its rate of
+    strain is near zero. That is the same choice `velocity` reports, made once
+    by the caller's curve -- see the `ArcLength` docs.
+
+    Takes the family rather than one chart because $\partial_t$ needs
+    neighbouring slices, and a `TubularChart` is a single one.
+
+    """
+    t_unit = u.unit_of(t)
+    if t_unit is None:
+        raise TypeError(_MSG_BARE_TIME)
+
+    def gamma(t_val: Any) -> Any:
+        chart = chart_at_time(u.Q(t_val, t_unit))
+        return cast("Any", metric_matrix(chart.M, point, chart)).matrix.value
+
+    here = chart_at_time(t)
+    unit = cast("Any", metric_matrix(here.M, point, here)).matrix.unit / t_unit
+
+    d_gamma = jax.jacfwd(gamma)(t.ustrip(t_unit))
+    return ul.QuantityMatrix(0.5 * d_gamma, unit=unit)

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/strain.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/strain.py
@@ -16,10 +16,18 @@ from collections.abc import Callable
 from typing import Any, cast
 
 import jax
+import jax.numpy as jnp
 import unxts.linalg as ul
 
 import unxt as u
 from coordinaxs.api.manifolds import metric_matrix
+
+_MSG_BATCHED_TIME = (
+    "`rate_of_strain` differentiates at one time, so `t` must be a scalar; got "
+    "shape {shape}. `K_ij` is a 2-tensor, and a batched `t` would make the "
+    "Jacobian one rank higher -- `TubularChart` is single-point for the same "
+    "reason. Use `jax.vmap` over scalar calls."
+)
 
 _MSG_BARE_TIME = (
     "`rate_of_strain` differentiates with respect to `t`, so `t` must carry a "
@@ -55,10 +63,18 @@ def rate_of_strain(
     Takes the family rather than one chart because $\partial_t$ needs
     neighbouring slices, and a `TubularChart` is a single one.
 
+    ``t`` must be a scalar. A batched one would raise the Jacobian's rank
+    above 2, and `TubularChart` is single-point for the same reason; use
+    `jax.vmap` over scalar calls. Left unguarded it failed inside the chart
+    with ``All input arrays must have the same shape``, naming nothing.
+
     """
     t_unit = u.unit_of(t)
     if t_unit is None:
         raise TypeError(_MSG_BARE_TIME)
+    shape = jnp.shape(t.value if t_unit is not None else t)
+    if shape != ():
+        raise ValueError(_MSG_BATCHED_TIME.format(shape=shape))
 
     def gamma(t_val: Any) -> Any:
         chart = chart_at_time(u.Q(t_val, t_unit))

--- a/packages/coordinaxs.curveframes/tests/unit/test_rate_of_strain.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_rate_of_strain.py
@@ -1,0 +1,99 @@
+r"""`rate_of_strain` is the ADM $K_{ij}$ of a family of slices.
+
+$K_{ij} = \tfrac{1}{2\alpha}(\partial_t\gamma_{ij} - (\mathcal{L}_\beta
+\gamma)_{ij})$ reduces to $\tfrac12\partial_t\gamma_{ij}$ here: the lapse is 1
+under absolute time, and the Lie-drag term vanishes because a chart coordinate
+is what $\partial_t$ holds fixed, so the coordinate shift is zero. The shift
+that does *not* vanish is the ambient one `velocity` reports; the two are
+different objects and these pin that they behave differently.
+"""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import unxt as u
+
+import coordinaxs.curveframes as cxfc
+
+S0, T0 = 1.3, 1.0
+BOUNDS = (u.Q(0.0, "km"), u.Q(3.0, "km"))
+POINT = {"tau": u.Q(S0, "km"), "n1": u.Q(0.2, "km"), "n2": u.Q(0.1, "km")}
+
+
+def stretch_and_bend(
+    sigma: u.AbstractQuantity, t: u.AbstractQuantity
+) -> u.AbstractQuantity:
+    """The #778 curve: stretches along itself and bends."""
+    sv, tv = sigma.ustrip("km"), t.ustrip("s")
+    return u.Q(
+        jnp.stack([sv * (1 + 0.5 * tv), 0.1 * tv * sv**2, jnp.zeros_like(sv)]), "km"
+    )
+
+
+def _family(curve):
+    """The slice family: the tube's chart at each time."""
+    return lambda t: cxfc.TubularChart(
+        cxfc.BishopBuilder(cxfc.AtTime(curve, t), "km"), tau_bounds=BOUNDS
+    )
+
+
+def test_a_material_labelling_shows_the_tube_stretching() -> None:
+    """The curve genuinely deforms, so the rate of strain is non-zero."""
+    k = cxfc.rate_of_strain(_family(stretch_and_bend), POINT, u.Q(T0, "s"))
+    assert np.asarray(k.value)[0, 0] == pytest.approx(0.77937, abs=1e-4)
+
+
+def test_arc_length_holds_the_metric_so_its_strain_is_near_zero() -> None:
+    """The same curve, relabelled, deforms hardly at all.
+
+    `ArcLength` keeps the parametrisation near unit-speed by construction, so
+    `gamma_tau_tau` stays near 1 and its rate of change near 0. The value
+    follows the labelling the caller chose -- the same choice `velocity`
+    reports, and this never overrides it.
+    """
+    k = cxfc.rate_of_strain(
+        _family(cxfc.ArcLength(stretch_and_bend, "km")), POINT, u.Q(T0, "s")
+    )
+    assert np.asarray(k.value)[0, 0] == pytest.approx(-0.00548, abs=1e-4)
+
+
+def test_it_is_symmetric() -> None:
+    """`K_ij` is a symmetric 2-tensor, being a derivative of one."""
+    k = np.asarray(
+        cxfc.rate_of_strain(_family(stretch_and_bend), POINT, u.Q(T0, "s")).value
+    )
+    assert np.allclose(k, k.T, atol=1e-6)
+
+
+def test_a_static_curve_does_not_deform() -> None:
+    """No time in the curve, so the slice geometry does not change."""
+
+    def circle(arc: u.AbstractQuantity) -> u.AbstractQuantity:
+        a = arc.ustrip("km")
+        return u.Q(jnp.stack([jnp.cos(a), jnp.sin(a), jnp.zeros_like(a)]), "km")
+
+    family = lambda t: cxfc.TubularChart(
+        cxfc.BishopBuilder(circle, "km"), tau_bounds=BOUNDS
+    )
+    k = cxfc.rate_of_strain(family, POINT, u.Q(T0, "s"))
+    assert np.allclose(np.asarray(k.value), np.zeros((3, 3)), atol=1e-6)
+
+
+def test_the_rate_is_per_the_unit_of_the_time_it_was_given() -> None:
+    """Seconds give `1 / s`; milliseconds give `1 / ms`, a thousand times smaller."""
+    fam = _family(stretch_and_bend)
+    in_s = cxfc.rate_of_strain(fam, POINT, u.Q(T0, "s"))
+    in_ms = cxfc.rate_of_strain(fam, POINT, u.Q(T0 * 1000, "ms"))
+
+    assert "1 / s" in in_s.unit.to_string()
+    assert "1 / ms" in in_ms.unit.to_string()
+    assert np.asarray(in_ms.value)[0, 0] == pytest.approx(
+        np.asarray(in_s.value)[0, 0] / 1000, rel=1e-3
+    )
+
+
+def test_a_bare_time_is_refused() -> None:
+    """Nothing else states what the rate is *per*."""
+    with pytest.raises(TypeError, match="must carry a unit"):
+        cxfc.rate_of_strain(_family(stretch_and_bend), POINT, T0)

--- a/packages/coordinaxs.curveframes/tests/unit/test_rate_of_strain.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_rate_of_strain.py
@@ -93,6 +93,19 @@ def test_the_rate_is_per_the_unit_of_the_time_it_was_given() -> None:
     )
 
 
+def test_a_batched_time_is_refused() -> None:
+    """`K_ij` is a 2-tensor, so the time it is taken at must be a scalar.
+
+    A batched `t` raises the Jacobian's rank above 2; `TubularChart` is
+    single-point for the same reason. Unguarded it failed inside the chart
+    with `All input arrays must have the same shape`, naming nothing.
+    """
+    with pytest.raises(ValueError, match="must be a scalar"):
+        cxfc.rate_of_strain(
+            _family(stretch_and_bend), POINT, u.Q(jnp.asarray([0.5, T0]), "s")
+        )
+
+
 def test_a_bare_time_is_refused() -> None:
     """Nothing else states what the rate is *per*."""
     with pytest.raises(TypeError, match="must carry a unit"):


### PR DESCRIPTION
Step 2 of the metric assembly for #779, after #826 pinned the structure the metric already had.

```python
K = cxfc.rate_of_strain(slice_family, point, u.Q(1.0, "s"))
```

## It is simpler than the issue said, and that is a correction

I had recorded `D_i beta_j` as the blocker. It is not needed at all:

$$ K_{ij} = \tfrac{1}{2\alpha}\left(\partial_t\gamma_{ij} - (\mathcal{L}_\beta\gamma)_{ij}\right) \;\longrightarrow\; \tfrac12\,\partial_t\gamma_{ij} $$

The lapse is identically 1 under absolute time, and the Lie-drag term vanishes because **a chart coordinate is what the time derivative holds fixed** — so the coordinate shift is zero by construction. One `jacfwd`; no connection, no Christoffels.

The shift that does *not* vanish is the **ambient** one `velocity` reports. They are different objects, measurably:

| | velocity of a fixed chart label |
| --- | --- |
| material $\gamma(\sigma, t)$ | `[0.65, 0.169, 0]` — exactly $\boldsymbol\beta$ |
| `ArcLength(gamma)` | `[-0.0019, 0.0247, 0]` |

while the *coordinate* label is stationary in both, which is why the Lie term drops.

## The value follows the labelling, correctly

Same curve, two parametrisations:

| labelling | $\gamma_{\tau\tau}$ | $K_{\tau\tau}$ | |
| --- | --- | --- | --- |
| material | 2.239 | **0.779** | the tube genuinely stretches |
| `ArcLength` | 0.965 | **−0.005** | near unit-speed, so near no strain |

That is the choice the caller's curve already made (#779); `rate_of_strain` reports it and never overrides it, exactly as `velocity` does.

## Why a free function

$\partial_t$ needs neighbouring slices, and a `TubularChart` is a single one — so this takes the *family*, `t -> TubularChart`. It cannot hang off a builder either: a two-argument curve requires a pinned station, which is the worldtube, not the slice.

Naming that family as a type is deferred to a follow-up issue. One method does not earn one, and the hazard I would have justified it with — that `AtTime`/`ArcLength` ordering silently changes the answer — measured identical here (`-0.005485` both ways), so it is not real for this quantity.

## Verification

6 tests, mutation-checked twice: dropping the ½, and differentiating at a fixed time, each fail exactly the two value tests. Also pinned — symmetry, zero for a static curve, `1 / s` vs `1 / ms` scaling, and a bare `t` refused since nothing else states what the rate is *per*.

266 tests including all `src` doctests, `prek` clean including `ty`, and `nox -s docs` clean from a cleared `_build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)