### PR TITLE
🐛 fix(charts): condition the transition to Spherical3D

### DIFF
--- a/docs/api/representations.md
+++ b/docs/api/representations.md
@@ -31,14 +31,14 @@ This is separate from charts and manifolds:
 >>> q_sph = cxr.cconvert(q_cart, cxc.cart3d, rep, cxc.sph3d, rep)
 >>> q_sph
 {'r': Array(3.74165739, dtype=float64, ...),
- 'theta': Array(0.64052231, dtype=float64),
+ 'theta': Array(0.64052231, dtype=float64, ...),
  'phi': Array(1.10714872, dtype=float64, ...)}
 
 >>> # Build a reusable conversion map.
 >>> to_sph = cxr.cmap(cxc.cart3d, cxr.point, cxc.sph3d)
 >>> to_sph(q_cart)
 {'r': Array(3.74165739, dtype=float64, ...),
- 'theta': Array(0.64052231, dtype=float64),
+ 'theta': Array(0.64052231, dtype=float64, ...),
  'phi': Array(1.10714872, dtype=float64, ...)}
 
 # Change tangent components between basis conventions in the same chart.

--- a/docs/guides/charts.md
+++ b/docs/guides/charts.md
@@ -115,7 +115,7 @@ Passing a component dictionary with `unxt.Quantity` values returns a `QuantityMa
 >>> J
 QM(
     [[ 1.,  0.,  0.],
-     [-0., -0., -1.],
+     [ 0.,  0., -1.],
      [ 0.,  1.,  0.]],
     '((, , ), (rad / m, rad / m, rad / m), (rad / m, rad / m, rad / m))'
 )

--- a/docs/guides/tangents.md
+++ b/docs/guides/tangents.md
@@ -151,7 +151,7 @@ Converting a `Tangent` to a new chart requires knowing the **base point** at whi
 >>> vel_sph = vel_cart.cconvert(cxc.sph3d, at=point)
 >>> print(vel_sph)
 <Tangent: chart=Spherical3D (r[m / s], theta[rad / s], phi[rad / s])
-    [ 1. -0.  0.]>
+    [1. 0. 0.]>
 ```
 
 **Key point**: the `at=` base point must be in the **same chart** as the tangent vector. To convert a point and its tangent field together in one call, bundle them into a `Coordinate` — see the [Coordinate tutorial](../tutorials/coordinate_objects.md).
@@ -238,7 +238,7 @@ Use scalar-first design and batch with `vmap`:
 >>> vec_fn = jax.vmap(lambda v, p: cx.cconvert(v, cxc.sph3d, at=p))
 >>> vels_sph = vec_fn(batch_vel, batch_point)
 >>> print(vels_sph.data)  # Spherical3D(M=Rn(3))
-{'phi': Q([0., 0., 0.], 'rad / s'), 'r': Q([1., 2., 3.], 'm / s'), 'theta': Q([-0., -0., -0.], 'rad / s')}
+{'phi': Q([0., 0., 0.], 'rad / s'), 'r': Q([1., 2., 3.], 'm / s'), 'theta': Q([0., 0., 0.], 'rad / s')}
 ```
 
 ## When To Use Tangent

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4123,7 +4123,7 @@ $$g_{ij}(q) = g_p\!\left(\frac{\partial}{\partial q^i}, \frac{\partial}{\partial
     >>> x = {"x": 1.0, "y": 1.0, "z": 1.0}
     >>> cxc.pt_map(x, cxc.cart3d, cxc.sph3d)
     {'r': Array(1.73205081, dtype=float64, ...),
-     'theta': Array(0.95531662, dtype=float64),
+     'theta': Array(0.95531662, dtype=float64, ...),
      'phi': Array(0.78539816, dtype=float64, ...)}
     ```
 

--- a/docs/tutorials/tangent_objects.md
+++ b/docs/tutorials/tangent_objects.md
@@ -83,7 +83,7 @@ Converting a tangent vector to a new chart requires the **base point** at which 
 >>> vel_sph = vel_cart.cconvert(cxc.sph3d, at=point)
 >>> print(vel_sph)
 <Tangent: chart=Spherical3D (r[m / s], theta[rad / s], phi[rad / s])
-    [ 1. -0.  0.]>
+    [1. 0. 0.]>
 ```
 
 The basis (`coord_basis`) and semantic (`vel`) are preserved across the conversion; only the chart and component values change.

--- a/packages/coordinaxs.api/src/coordinaxs/api/representations.py
+++ b/packages/coordinaxs.api/src/coordinaxs/api/representations.py
@@ -71,7 +71,7 @@ def cconvert(*args: Any, **kwargs: Any) -> Any:
 
     >>> cxr.cconvert(p, cxc.cart3d, cxr.point, cxc.sph3d, cxr.point)
     {'r': Array(3.74165739, dtype=float64, ...),
-     'theta': Array(0.64052231, dtype=float64),
+     'theta': Array(0.64052231, dtype=float64, ...),
      'phi': Array(1.10714872, dtype=float64, ...)}
 
     """

--- a/skills/coordinax/SKILL.md
+++ b/skills/coordinax/SKILL.md
@@ -118,7 +118,7 @@ A tangent vector lives in the tangent space _at a point_. The library enforces t
 ... )
 >>> print(v.cconvert(cx.sph3d, at=base))
 <Tangent: chart=Spherical3D (r[m / s], theta[rad / s], phi[rad / s])
-    [ 1. -0.  0.]>
+    [1. 0. 0.]>
 
 ```
 

--- a/src/coordinax/_src/charts/jacobian.py
+++ b/src/coordinax/_src/charts/jacobian.py
@@ -80,7 +80,7 @@ def jac_pt_map(at: None, /, *fixed_args: Any, **fixed_kw: Any) -> Any:
     >>> map(at)
     QM(
         [[ 1.,  0.,  0.],
-         [-0., -0., -1.],
+         [ 0.,  0., -1.],
          [ 0.,  1.,  0.]],
         '((, , ), (rad / m, rad / m, rad / m), (rad / m, rad / m, rad / m))'
     )
@@ -110,7 +110,7 @@ def jac_pt_map(
     >>> map(at)
     QM(
         [[ 1.,  0.,  0.],
-         [-0., -0., -1.],
+         [ 0.,  0., -1.],
          [ 0.,  1.,  0.]],
         '((, , ), (rad / m, rad / m, rad / m), (rad / m, rad / m, rad / m))'
     )
@@ -152,7 +152,7 @@ def jac_pt_map(
     >>> at = jnp.array([1, 0, 0])
     >>> jac_fn(at)
     Array([[ 1.,  0.,  0.],
-           [-0., -0., -1.],
+           [ 0.,  0., -1.],
            [ 0.,  1.,  0.]], dtype=float64)
 
     >>> import jax

--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -104,7 +104,7 @@ def pt_map(q: None, /, *fixed_args: Any, **fixed_kw: Any) -> Callable[..., Any]:
     >>> map = cxc.pt_map(None, cxc.cart3d, cxc.sph3d, usys=u.unitsystems.si)
     >>> map(q)
     {'r': Array(1., dtype=float64, ...),
-     'theta': Array(1.57079633, dtype=float64),
+     'theta': Array(1.57079633, dtype=float64, ...),
      'phi': Array(0., dtype=float64, ...)}
 
     `unxt.Quantity` inputs are also accepted, and are interpreted as being in
@@ -153,7 +153,7 @@ def pt_map(
     >>> map = cxc.pt_map(cxc.cart3d, cxc.sph3d, usys=u.unitsystems.si)
     >>> map(p)
     {'r': Array(1., dtype=float64, ...),
-     'theta': Array(1.57079633, dtype=float64),
+     'theta': Array(1.57079633, dtype=float64, ...),
      'phi': Array(0., dtype=float64, ...)}
 
     `unxt.Quantity` inputs are also accepted, and are interpreted as being in
@@ -840,8 +840,8 @@ def pt_map(
     >>> p = {"rho": 0, "phi": 180, "z": 1}
     >>> usys = u.unitsystem("m", "deg")
     >>> cxc.pt_map(p, cxm.R3, cxc.cyl3d, cxm.R3, cxc.loncoslat_sph3d, usys=usys)
-    {'lon_coslat': Array(1.10218212e-14, dtype=float64),
-     'lat': Array(1.57079633, dtype=float64),
+    {'lon_coslat': Array(1.10218212e-14, dtype=float64, ...),
+     'lat': Array(1.57079633, dtype=float64, ...),
      'distance': Array(1., dtype=float64, weak_type=True)}
 
     """
@@ -880,17 +880,24 @@ def pt_map(
     >>> p = {"x": 2.0, "y": 0.0, "z": 0.0}  # No units
     >>> cxc.pt_map(p, cxm.R3, cxc.cart3d, cxm.R3, cxc.sph3d)
     {'r': Array(2., dtype=float64, ...),
-     'theta': Array(1.57079633, dtype=float64),
+     'theta': Array(1.57079633, dtype=float64, ...),
      'phi': Array(0., dtype=float64, ...)}
 
     """
     del usys
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     x, y, z = p["x"], p["y"], p["z"]
-    r = jnp.sqrt(x**2 + y**2 + z**2)
-    # Avoid division by zero: when r == 0, set theta = 0 by convention
-    theta = jnp.acos(jnp.where(r == 0, jnp.ones(r.shape), z / r))
-    # atan2 handles the case when x = y = 0, returning phi = 0
+    # `hypot`/`atan2` rather than `sqrt(x**2 + y**2 + z**2)` and `acos(z / r)`:
+    # squaring over/underflows a decade and a half short of the float range
+    # (`r` of a 10 kpc position in metres is `inf` in float32), and `acos`
+    # saturates as `z / r -> 1`, losing every digit of `theta` near the poles.
+    # Both `atan2` calls handle their own singular point, so no `where` guard
+    # is needed: `atan2(0, 0) == 0` keeps the r == 0 convention theta == 0, and
+    # phi == 0 on the z axis. This matches `Cart2D -> Polar2D`, which is
+    # already written this way.
+    rho = jnp.hypot(x, y)
+    r = jnp.hypot(rho, z)
+    theta = jnp.atan2(rho, z)
     phi = jnp.atan2(y, x)
     return canonical_containers({"r": r, "theta": theta, "phi": phi}, to_chart)
 
@@ -922,15 +929,25 @@ def pt_map(
 
     >>> p = {"rho": 3.0, "phi": 0, "z": 0.0}  # No units
     >>> cxc.pt_map(p, cxm.R3, cxc.cyl3d, cxm.R3, cxc.sph3d)
-    {'r': Array(3., dtype=float64, ...), 'theta': Array(1.57079633, dtype=float64),
+    {'r': Array(3., dtype=float64, ...), 'theta': Array(1.57079633, dtype=float64, ...),
      'phi': 0}
 
     """
     del usys  # unused
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
+    # `atan2(rho, z)` rather than `acos(z / r)`, which saturates as `z / r -> 1`
+    # and loses every digit of `theta` near the poles. `atan2(0, 0) == 0` keeps
+    # the r == 0 convention theta == 0, so the `where` guard is not needed.
+    #
+    # `abs(rho)` because `atan2` is sign-sensitive in its first argument where
+    # `acos(z / hypot(rho, z))` was not: `hypot` squares `rho` away, so a
+    # negative `rho` used to give the same `theta` as its positive twin.
+    # `Cylindrical3D` does not value-validate `rho`, so a hand-built negative
+    # one is reachable, and without this it would produce a negative `theta`
+    # outside the `[0, pi]` that `Spherical3D.check_data` enforces.
+    # `Cart3D -> Spherical3D` needs no such guard: its `rho` is a `hypot`.
     r_ = jnp.hypot(p["rho"], p["z"])
-    # Avoid division by zero: when r == 0, set theta = 0 by convention
-    theta = jnp.acos(jnp.where(r_ == 0, jnp.ones(r_.shape), p["z"] / r_))
+    theta = jnp.atan2(jnp.abs(p["rho"]), p["z"])
     return canonical_containers({"r": r_, "theta": theta, "phi": p["phi"]}, to_chart)
 
 

--- a/src/coordinax/representations/__init__.py
+++ b/src/coordinax/representations/__init__.py
@@ -68,7 +68,7 @@ preserving its interpretation:
 >>> q = cxr.cconvert(p, cxc.cart3d, cxr.point, cxc.sph3d, cxr.point)
 >>> q
 {'r': Array(3.74165739, dtype=float64, ...),
- 'theta': Array(0.64052231, dtype=float64),
+ 'theta': Array(0.64052231, dtype=float64, ...),
  'phi': Array(1.10714872, dtype=float64, ...)}
 
 Here `p` is interpreted as point data in Cartesian 3D coordinates, and `q` is

--- a/src/coordinax/representations/_src/core.py
+++ b/src/coordinax/representations/_src/core.py
@@ -40,7 +40,7 @@ def cmap(*fixed_args: Any, **fixed_kw: Any) -> Any:
     >>> q = {"x": 1, "y": 2, "z": 3}
     >>> map(q)
     {'r': Array(3.74165739, dtype=float64, ...),
-     'theta': Array(0.64052231, dtype=float64),
+     'theta': Array(0.64052231, dtype=float64, ...),
      'phi': Array(1.10714872, dtype=float64, ...)}
 
     >>> q = {"x": u.Q(1, "m"), "y": u.Q(2, "m"), "z": u.Q(3, "m")}
@@ -92,7 +92,7 @@ def cconvert(obj: None, /, *fixed_args: Any, **fixed_kw: Any) -> Any:
     >>> map = cxr.cconvert(None, cxc.cart3d, cxr.point, cxc.sph3d)
     >>> map(q)
     {'r': Array(3.74165739, dtype=float64, ...),
-     'theta': Array(0.64052231, dtype=float64),
+     'theta': Array(0.64052231, dtype=float64, ...),
      'phi': Array(1.10714872, dtype=float64, ...)}
 
     """
@@ -134,7 +134,7 @@ def cconvert(
     >>> q = cxr.cconvert(p, cxc.cart3d, cxr.point, cxc.sph3d, cxr.point)
     >>> q
     {'r': Array(3.74165739, dtype=float64, ...),
-     'theta': Array(0.64052231, dtype=float64),
+     'theta': Array(0.64052231, dtype=float64, ...),
      'phi': Array(1.10714872, dtype=float64, ...)}
 
     The output `q` represents the same geometric point but expressed in the
@@ -143,8 +143,8 @@ def cconvert(
     The representation remains unchanged; only the chart changes:
 
     >>> cxr.cconvert(q, cxc.sph3d, cxr.point, cxc.cart3d, cxr.point)
-    {'x': Array(1., dtype=float64), 'y': Array(2., dtype=float64),
-     'z': Array(3., dtype=float64)}
+    {'x': Array(1., dtype=float64, ...), 'y': Array(2., dtype=float64, ...),
+     'z': Array(3., dtype=float64, ...)}
 
     Let's work through more examples.
 
@@ -227,7 +227,7 @@ def cconvert(
     >>> q = cxr.cconvert(p, cxc.cart3d, cxr.point, cxc.sph3d)
     >>> q
     {'r': Array(3.74165739, dtype=float64, ...),
-     'theta': Array(0.64052231, dtype=float64),
+     'theta': Array(0.64052231, dtype=float64, ...),
      'phi': Array(1.10714872, dtype=float64, ...)}
 
     The output `q` represents the same geometric point but expressed in the
@@ -236,8 +236,8 @@ def cconvert(
     The representation remains unchanged; only the chart changes:
 
     >>> cxr.cconvert(q, cxc.sph3d, cxr.point, cxc.cart3d)
-    {'x': Array(1., dtype=float64), 'y': Array(2., dtype=float64),
-     'z': Array(3., dtype=float64)}
+    {'x': Array(1., dtype=float64, ...), 'y': Array(2., dtype=float64, ...),
+     'z': Array(3., dtype=float64, ...)}
 
     """
     # redispatch on the combination of GeometryKind
@@ -297,7 +297,7 @@ def cconvert(
     >>> cxr.cconvert(p, cxc.cart3d, cxr.point_geom, cxr.point,
     ...                 cxc.sph3d, cxr.point_geom, cxr.point)
     {'r': Array(3.74165739, dtype=float64, ...),
-     'theta': Array(0.64052231, dtype=float64),
+     'theta': Array(0.64052231, dtype=float64, ...),
      'phi': Array(1.10714872, dtype=float64, ...)}
 
     """

--- a/src/coordinax/representations/_src/geom.py
+++ b/src/coordinax/representations/_src/geom.py
@@ -74,7 +74,7 @@ class AbstractGeometry(CanonicalStaticReprMixin, metaclass=abc.ABCMeta):
     >>> p = {"x": 1.0, "y": 2.0, "z": 3.0}
     >>> cx.cconvert(p, cx.cart3d, rep, cx.sph3d, rep)
     {'r': Array(3.74165739, dtype=float64, ...),
-     'theta': Array(0.64052231, dtype=float64),
+     'theta': Array(0.64052231, dtype=float64, ...),
      'phi': Array(1.10714872, dtype=float64, ...)}
 
     The output is still point data, but expressed in the target chart.
@@ -123,7 +123,7 @@ class PointGeometry(AbstractGeometry):
     >>> p = {"x": 1.0, "y": 2.0, "z": 3.0}
     >>> cxr.cconvert(p, cxc.cart3d, rep, cxc.sph3d, rep)
     {'r': Array(3.74165739, dtype=float64, ...),
-     'theta': Array(0.64052231, dtype=float64),
+     'theta': Array(0.64052231, dtype=float64, ...),
      'phi': Array(1.10714872, dtype=float64, ...)}
 
     The output is still point data, but expressed in the target chart.

--- a/src/coordinax/representations/_src/register_cx.py
+++ b/src/coordinax/representations/_src/register_cx.py
@@ -43,7 +43,7 @@ def pt_map(
     >>> q = cxc.pt_map(p, cxc.cart3d, cxr.point, cxc.sph3d, cxr.point)
     >>> q
     {'r': Array(3.74165739, dtype=float64, ...),
-     'theta': Array(0.64052231, dtype=float64),
+     'theta': Array(0.64052231, dtype=float64, ...),
      'phi': Array(1.10714872, dtype=float64, ...)}
 
     The output `q` represents the same geometric point but expressed in the
@@ -52,8 +52,8 @@ def pt_map(
     The representation remains unchanged; only the chart changes:
 
     >>> cxc.pt_map(q, cxc.sph3d, cxr.point, cxc.cart3d, cxr.point)
-    {'x': Array(1., dtype=float64), 'y': Array(2., dtype=float64),
-     'z': Array(3., dtype=float64)}
+    {'x': Array(1., dtype=float64, ...), 'y': Array(2., dtype=float64, ...),
+     'z': Array(3., dtype=float64, ...)}
 
     Let's work through more examples.
 
@@ -131,7 +131,7 @@ def pt_map(
     >>> q = cxc.pt_map(p, cxc.cart3d, cxr.point, cxc.sph3d)
     >>> q
     {'r': Array(3.74165739, dtype=float64, ...),
-     'theta': Array(0.64052231, dtype=float64),
+     'theta': Array(0.64052231, dtype=float64, ...),
      'phi': Array(1.10714872, dtype=float64, ...)}
 
     The output `q` represents the same geometric point but expressed in the
@@ -140,8 +140,8 @@ def pt_map(
     The representation remains unchanged; only the chart changes:
 
     >>> cxc.pt_map(q, cxc.sph3d, cxr.point, cxc.cart3d)
-    {'x': Array(1., dtype=float64), 'y': Array(2., dtype=float64),
-     'z': Array(3., dtype=float64)}
+    {'x': Array(1., dtype=float64, ...), 'y': Array(2., dtype=float64, ...),
+     'z': Array(3., dtype=float64, ...)}
 
     """
     # redispatch on the combination of GeometryKind
@@ -203,7 +203,7 @@ def pt_map(
     >>> cxc.pt_map(p, cxc.cart3d, cxr.point_geom, cxr.point,
     ...                             cxc.sph3d, cxr.point_geom, cxr.point)
     {'r': Array(3.74165739, dtype=float64, ...),
-     'theta': Array(0.64052231, dtype=float64),
+     'theta': Array(0.64052231, dtype=float64, ...),
      'phi': Array(1.10714872, dtype=float64, ...)}
 
     """

--- a/src/coordinax/representations/_src/rep.py
+++ b/src/coordinax/representations/_src/rep.py
@@ -114,7 +114,7 @@ class Representation(Generic[GeomT, BasisT, SemanticT]):
     >>> p = {"x": 1.0, "y": 2.0, "z": 3.0}
     >>> cxr.cconvert(p, cxc.cart3d, cxr.point, cxc.sph3d, cxr.point)
     {'r': Array(3.74165739, dtype=float64, ...),
-     'theta': Array(0.64052231, dtype=float64),
+     'theta': Array(0.64052231, dtype=float64, ...),
      'phi': Array(1.10714872, dtype=float64, ...)}
 
     The output represents the same point, but in the target chart.

--- a/src/coordinax/representations/_src/semantics.py
+++ b/src/coordinax/representations/_src/semantics.py
@@ -90,7 +90,7 @@ class AbstractSemanticKind(CanonicalStaticReprMixin, metaclass=abc.ABCMeta):
     >>> p = {"x": 1.0, "y": 2.0, "z": 3.0}
     >>> cx.cconvert(p, cx.cart3d, rep, cx.sph3d, rep)
     {'r': Array(3.74165739, dtype=float64, ...),
-     'theta': Array(0.64052231, dtype=float64),
+     'theta': Array(0.64052231, dtype=float64, ...),
      'phi': Array(1.10714872, dtype=float64, ...)}
 
     The output is still point data representing the same location, but
@@ -181,7 +181,7 @@ class Location(AbstractSemanticKind):
     >>> p = {"x": 1.0, "y": 2.0, "z": 3.0}
     >>> cxr.cconvert(p, cxc.cart3d, rep, cxc.sph3d, rep)
     {'r': Array(3.74165739, dtype=float64, ...),
-     'theta': Array(0.64052231, dtype=float64),
+     'theta': Array(0.64052231, dtype=float64, ...),
      'phi': Array(1.10714872, dtype=float64, ...)}
 
     The output is still point data representing the same location, but

--- a/src/coordinax/representations/_src/tangent_map.py
+++ b/src/coordinax/representations/_src/tangent_map.py
@@ -211,7 +211,7 @@ def tangent_map(
     >>> v = {"x": u.Q(1, "m/s"), "y": u.Q(0, "m/s"), "z": u.Q(0, "m/s")}
     >>> at = {"x": u.Q(1, "m"), "y": u.Q(0, "m"), "z": u.Q(0, "m")}
     >>> cxr.tangent_map(v, cxc.cart3d, cxr.phys_basis, cxc.sph3d, at=at)
-    {'r': Q(1., 'm / s'), 'theta': Q(-0., 'm / s'), 'phi': Q(0., 'm / s')}
+    {'r': Q(1., 'm / s'), 'theta': Q(0., 'm / s'), 'phi': Q(0., 'm / s')}
 
     The same call can be made using a physical representation:
 

--- a/tests/unit/charts/test_register_realize.py
+++ b/tests/unit/charts/test_register_realize.py
@@ -3,6 +3,8 @@
 cartesian_chart, pt_map.
 """
 
+import math
+
 import hypothesis.strategies as st
 import jax
 import jax.numpy as jnp
@@ -218,3 +220,84 @@ class TestAxisSingularityGradSafe:
         back = cxc.pt_map(pp, cxc.poincarepolar6d.M, cxc.poincarepolar6d, ps.M, ps)
         assert all(bool(jnp.isfinite(v.value)) for v in pp.values())
         assert all(bool(jnp.isfinite(v.value)) for v in back.values())
+
+
+# =============================================================================
+
+
+class TestSphericalConditioning:
+    """The transition into ``Spherical3D`` is conditioned at the range edges and poles.
+
+    It used to compute ``r = sqrt(x**2 + y**2 + z**2)`` and ``theta = acos(z / r)``.
+    Squaring costs half the exponent range, and ``acos`` saturates as ``z / r -> 1``;
+    ``hypot`` chains and ``atan2`` have neither problem. The conventions the old
+    ``where(r == 0, ...)`` guard produced are unchanged, and ``atan2``'s sensitivity
+    to the sign of its first argument -- which ``acos`` did not have -- is guarded.
+    """
+
+    @pytest.mark.parametrize("mag", [3e20, 1e-25])
+    def test_r_survives_the_float32_range_edges(self, mag):
+        """``mag ** 2`` is out of float32 range either way; ``mag`` itself is not.
+
+        3e20 m is about 10 kpc, and squaring it overflowed to ``inf``; 1e-25 m
+        underflowed to 0. ``abs=0`` because `approx`'s default absolute
+        tolerance is far larger than the small magnitude being checked.
+        """
+        f32 = jnp.float32
+        p = {k: u.Q(f32(v), "m") for k, v in (("x", mag), ("y", 0.0), ("z", 0.0))}
+        r = cxc.pt_map(p, cxc.cart3d, cxc.sph3d)["r"]
+        assert float(r.ustrip("m")) == pytest.approx(mag, rel=1e-5, abs=0)
+
+    @pytest.mark.parametrize(
+        ("from_chart", "build"),
+        [
+            (
+                cxc.cart3d,
+                lambda rho: {
+                    "x": u.Q(rho, "m"),
+                    "y": u.Q(0.0, "m"),
+                    "z": u.Q(1.0, "m"),
+                },
+            ),
+            (
+                cxc.cyl3d,
+                lambda rho: {
+                    "rho": u.Q(rho, "m"),
+                    "phi": u.Angle(0.0, "rad"),
+                    "z": u.Q(1.0, "m"),
+                },
+            ),
+        ],
+        ids=["cart3d", "cyl3d"],
+    )
+    def test_theta_resolves_near_the_pole(self, from_chart, build):
+        """``acos(z / r)`` returned exactly 0 here; both sources share the fix."""
+        rho = 1e-10
+        theta = cxc.pt_map(build(rho), from_chart, cxc.sph3d)["theta"]
+        assert float(theta.ustrip("rad")) == pytest.approx(math.atan2(rho, 1.0))
+
+    def test_theta_is_sign_invariant_in_rho(self):
+        """A negative ``rho`` gives its positive twin's ``theta``, and stays in domain.
+
+        ``acos(z / hypot(rho, z))`` squared the sign away; ``atan2`` would not.
+        ``Cylindrical3D`` does not value-validate ``rho``, so a hand-built negative
+        one is reachable, and a negative ``theta`` is outside the ``[0, pi]`` that
+        ``Spherical3D.check_data`` enforces.
+        """
+
+        def to_sph(rho):
+            p = {"rho": u.Q(rho, "m"), "phi": u.Angle(0.0, "rad"), "z": u.Q(4.0, "m")}
+            return cxc.pt_map(p, cxc.cyl3d, cxc.sph3d)
+
+        out = to_sph(-3.0)
+        assert float(out["theta"].ustrip("rad")) == pytest.approx(
+            float(to_sph(3.0)["theta"].ustrip("rad"))
+        )
+        cxc.sph3d.check_data(out, values=True)  # in domain
+
+    def test_origin_keeps_the_zero_theta_convention(self):
+        """What the removed ``where(r == 0, ...)`` guard used to supply."""
+        p = {k: u.Q(0.0, "m") for k in ("x", "y", "z")}
+        out = cxc.pt_map(p, cxc.cart3d, cxc.sph3d)
+        assert float(out["r"].ustrip("m")) == 0.0
+        assert float(out["theta"].ustrip("rad")) == 0.0


### PR DESCRIPTION
`Cart3D -> Spherical3D` computed `r = sqrt(x**2 + y**2 + z**2)` and `theta = acos(z / r)`. Both forms are ill-conditioned in ways the point itself is not — and `Cart2D -> Polar2D`, three hundred lines earlier in the same file, was already written the other way, so the two charts disagreed about the same point.

Found while profiling `pt_map`; the perf work is a separate PR that builds on this one.

## Squaring costs half the exponent range

float32 is JAX's default. `x**2` overflows above ~1.8e19 and underflows below ~1.1e-19, so:

| float32 input | `-> sph3d` (before) | `-> cyl3d` (already `hypot`) |
| --- | --- | --- |
| `x = 3e20 m` (≈ 10 kpc) | `r = inf` | `rho = 3e20 m` |
| `x = y = 1e-25 m` | `r = 0`, `theta = 0` | `rho = 1.41e-25 m` |

## `acos` saturates as `z / r -> 1`

Near the pole the ratio rounds to exactly 1 before `acos` can resolve it. Relative error in `theta` at `(rho, 0, 1)`, float64, against `math.atan2`:

| rho/z | `acos(z / r)` | `atan2(rho, z)` |
| --- | --- | --- |
| 1e-02 | 1.5e-12 | 0 |
| 1e-04 | 7.1e-10 | 0 |
| 1e-06 | 4.4e-05 | 0 |
| 1e-08 | **1.0** (returns exactly 0) | 0 |
| 1e-10 | **1.0** (returns exactly 0) | 0 |

The Galactic pole is not an exotic input for this library.

## The fix

`hypot` chains and `atan2`, matching the 2-D sibling. `Cylindrical3D -> Spherical3D` shared the `acos` half and is fixed alongside.

The `where(r == 0, ...)` guards go with them — `atan2(0, 0) == 0` gives the same `theta == 0` convention at the origin and `phi == 0` on the axis, without a branch.

`atan2` is sign-sensitive in its first argument where `acos(z / hypot(rho, z))` was not, so `Cylindrical3D -> Spherical3D` takes `abs(rho)`. `Cylindrical3D` does not value-validate `rho`, and a hand-built negative one would otherwise give a negative `theta`, outside the `[0, pi]` that `Spherical3D.check_data` enforces. `Cart3D -> Spherical3D` needs no equivalent guard — its `rho` is itself a `hypot`. (Thanks @copilot-pull-request-reviewer for catching this.)

## Tests

`TestSphericalConditioning` in `tests/unit/charts/test_register_realize.py` — the `pt_map` behaviour file, beside the existing `TestAxisSingularityGradSafe`. Six cases, one property each:

| case | on `main` |
| --- | --- |
| `test_r_survives_the_float32_range_edges[3e+20]` | fails (`inf`) |
| `test_r_survives_the_float32_range_edges[1e-25]` | fails (`0`) |
| `test_theta_resolves_near_the_pole[cart3d]` | fails (returns `0`) |
| `test_theta_resolves_near_the_pole[cyl3d]` | fails (returns `0`) |
| `test_theta_is_sign_invariant_in_rho` | passes — pins what must *not* move; fails without the `abs` |
| `test_origin_keeps_the_zero_theta_convention` | passes — pins what the removed `where` guard supplied |

Deliberately *not* added, because they are already covered: the `+z` and equator conventions (doctests on the two functions changed here), and angular canonicalisation (`test_container_canonicalisation::test_output_is_canonical`, parametrised over every chart pair).

## Two cosmetic consequences

Both show up only in doctests, which are updated:

- On the **unitless** route `theta` is now weakly typed. The old strong typing was an artefact of `jnp.ones(r.shape)` inside the guard rather than a decision; `phi` was already weak and its doctests already elided it with `...`. Weak-in/weak-out is JAX's own convention.
- Jacobian entries that printed `-0.` now print `0.` — the negated zero came out of `acos`'s derivative.

## Verification

`nox -s test` (CI's own command — a plain `pytest tests/ src/ docs/` misses `skills/` and `README.md`) — **11 767 passed**, 315 skipped, 1 xfailed. `prek run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

