### PR TITLE
⚡️ perf(charts): take the transition arithmetic off Quantity operands

### DIFF
--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -41,7 +41,7 @@ from coordinax._src.exceptions import ManifoldMismatchError
 from coordinax._src.null import NoManifold
 from coordinax._src.product.chart import CartesianProductChart
 from coordinax._src.product.manifold import CartesianProductManifold
-from coordinax._src.utils import uconvert_to_rad
+from coordinax._src.utils import strip, uconvert_to_rad, wrap, wrap_angle
 from coordinaxs.api.custom_types import CDict
 
 
@@ -809,9 +809,18 @@ def pt_map(
     """
     del usys  # Unused
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
-    rho = jnp.hypot(p["x"], p["y"])
-    phi = jnp.atan2(p["y"], p["x"])
-    return canonical_containers({"rho": rho, "phi": phi, "z": p["z"]}, to_chart)
+    # Only the components the arithmetic consumes are stripped; `z` is carried
+    # through untouched so it keeps its own unit and container, exactly as the
+    # `Quantity`-operand form did.
+    (x, y), unit = strip(p, ("x", "y"))
+    return canonical_containers(
+        {
+            "rho": wrap(jnp.hypot(x, y), unit),
+            "phi": wrap_angle(jnp.atan2(y, x), unit),
+            "z": p["z"],
+        },
+        to_chart,
+    )
 
 
 @plum.dispatch.multi(
@@ -886,7 +895,9 @@ def pt_map(
     """
     del usys
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
-    x, y, z = p["x"], p["y"], p["z"]
+    # `strip`/`wrap` keep the arithmetic off `Quantity` operands, where every
+    # primitive costs a `quax` trace; see the note in `coordinax._src.utils`.
+    (x, y, z), unit = strip(p, ("x", "y", "z"))
     # `hypot`/`atan2` rather than `sqrt(x**2 + y**2 + z**2)` and `acos(z / r)`:
     # squaring over/underflows a decade and a half short of the float range
     # (`r` of a 10 kpc position in metres is `inf` in float32), and `acos`
@@ -896,10 +907,14 @@ def pt_map(
     # phi == 0 on the z axis. This matches `Cart2D -> Polar2D`, which is
     # already written this way.
     rho = jnp.hypot(x, y)
-    r = jnp.hypot(rho, z)
-    theta = jnp.atan2(rho, z)
-    phi = jnp.atan2(y, x)
-    return canonical_containers({"r": r, "theta": theta, "phi": phi}, to_chart)
+    return canonical_containers(
+        {
+            "r": wrap(jnp.hypot(rho, z), unit),
+            "theta": wrap_angle(jnp.atan2(rho, z), unit),
+            "phi": wrap_angle(jnp.atan2(y, x), unit),
+        },
+        to_chart,
+    )
 
 
 @plum.dispatch
@@ -935,6 +950,9 @@ def pt_map(
     """
     del usys  # unused
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
+    # `phi` carries an angle, so it is not part of this length-dimensioned
+    # group and passes through untouched.
+    (rho, z), unit = strip(p, ("rho", "z"))
     # `atan2(rho, z)` rather than `acos(z / r)`, which saturates as `z / r -> 1`
     # and loses every digit of `theta` near the poles. `atan2(0, 0) == 0` keeps
     # the r == 0 convention theta == 0, so the `where` guard is not needed.
@@ -946,9 +964,14 @@ def pt_map(
     # one is reachable, and without this it would produce a negative `theta`
     # outside the `[0, pi]` that `Spherical3D.check_data` enforces.
     # `Cart3D -> Spherical3D` needs no such guard: its `rho` is a `hypot`.
-    r_ = jnp.hypot(p["rho"], p["z"])
-    theta = jnp.atan2(jnp.abs(p["rho"]), p["z"])
-    return canonical_containers({"r": r_, "theta": theta, "phi": p["phi"]}, to_chart)
+    return canonical_containers(
+        {
+            "r": wrap(jnp.hypot(rho, z), unit),
+            "theta": wrap_angle(jnp.atan2(jnp.abs(rho), z), unit),
+            "phi": p["phi"],
+        },
+        to_chart,
+    )
 
 
 @plum.dispatch

--- a/src/coordinax/_src/utils.py
+++ b/src/coordinax/_src/utils.py
@@ -10,6 +10,7 @@ import unxt as u
 from unxt.quantity import AllowValue, Quantity
 
 from .custom_types import OptUSys
+from coordinaxs.api.custom_types import CDict, CKeys
 
 RAD: Final = u.unit("rad")
 ANGLE: Final = u.dimension("angle")
@@ -71,3 +72,120 @@ def uconvert_to_rad(value: Any, usys: OptUSys, /) -> Any:
 
     raw_rad = u.uconvert_value(RAD, source_unit, u.ustrip(AllowValue, value))
     return Quantity(raw_rad, unit=RAD) if unit is not None else raw_rad
+
+
+# ===================================================================
+# Unit bookkeeping for chart transition maps
+#
+# A `pt_map` body written against `Quantity` operands pays `quax` once per
+# arithmetic primitive: `quax` builds and evaluates a jaxpr for each one, so
+# eager cost is the *count* of ops rather than the work in them. Measured on a
+# scalar point, one primitive is ~4us on a raw array against 120-820us on a
+# `Quantity` -- `Quantity ** 2` 120us, `+` 198us, `/` 229us, `== 0` 444us,
+# `atan2` 617us, `acos` 623us. `Cart3D -> Spherical3D` spent ~2900us of its
+# ~3500us there, which is simply the sum of its ops.
+#
+# `strip`/`wrap` move the units out of the arithmetic instead: resolve them
+# once on the way in, run the body on raw arrays, re-attach once on the way
+# out. Same numbers, and the unit-promotion rule is unchanged because
+# expressing the group in its *first* component's unit is exactly what
+# `Quantity` arithmetic already did -- `{km, m, cm}` yielded `r` in km before
+# and still does.
+#
+# These are deliberately written against `unxt`'s public functions rather than
+# reaching for `.unit`/`.value`, which would be ~8x faster again today. That
+# gap is `plum` declining to cache the unfaithful signatures on `ustrip` and
+# friends, which plum#290 addresses; when it lands the public route gets the
+# rest of the win for free, whereas a reach-through would have to be unpicked.
+# Measured on a scalar `cart3d -> sph3d`: 3490us before, ~260us here.
+
+
+def strip(p: CDict, keys: CKeys, /) -> tuple[tuple[Any, ...], Any]:
+    """Return the raw values for *keys*, plus the unit they are expressed in.
+
+    All components are converted to the unit of the *first* one, and the unit
+    is returned alongside so a caller can re-attach it with `wrap`. When the
+    first component carries no unit the values are passed through untouched
+    and the unit is `None`, which is how a bare-array point stays a bare-array
+    point.
+
+    *keys* must name a **dimensionally homogeneous** group -- the components
+    that can meaningfully share a unit. A chart mixing lengths with velocities
+    (`PoincarePolar6D`, a phase-space product) needs one call per group, not
+    one call per chart. A violation is not silent: `unxt.ustrip` raises
+    `UnitConversionError`.
+
+    >>> import unxt as u
+    >>> from coordinax._src.utils import strip
+
+    >>> strip({"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m")}, ("x", "y"))
+    ((Array(1., dtype=float64, ...), Array(2., dtype=float64, ...)), Unit("m"))
+
+    Mixed units resolve to the first component's:
+
+    >>> strip({"x": u.Q(1.0, "km"), "y": u.Q(500.0, "m")}, ("x", "y"))
+    ((Array(1., dtype=float64, ...), Array(0.5, dtype=float64, ...)), Unit("km"))
+
+    Unitless values pass straight through:
+
+    >>> strip({"x": 1.0, "y": 2.0}, ("x", "y"))
+    ((1.0, 2.0), None)
+
+    Incompatible dimensions raise rather than silently reinterpret. `ustrip`
+    does this for us, so a group whose components cannot share a unit fails
+    loudly at the point of the mistake:
+
+    >>> strip({"x": u.Q(1.0, "m"), "t": u.Q(2.0, "s")}, ("x", "t"))
+    Traceback (most recent call last):
+        ...
+    astropy.units.errors.UnitConversionError: 's' (time) and 'm' (length) are
+    not convertible
+
+    """
+    unit = u.unit_of(p[keys[0]])
+    if unit is None:
+        return tuple(p[k] for k in keys), None
+    return tuple(u.ustrip(unit, p[k]) for k in keys), unit
+
+
+def wrap(value: Any, unit: Any, /) -> Any:
+    """Re-attach *unit* to a raw value, or pass it through when *unit* is `None`.
+
+    The complement of `strip`: `None` means the point came in unitless and
+    goes back out unitless.
+
+    >>> import unxt as u
+    >>> from coordinax._src.utils import wrap
+
+    >>> wrap(2.0, u.unit("m"))
+    Q(2., 'm')
+
+    >>> wrap(2.0, None)
+    2.0
+
+    """
+    return value if unit is None else Quantity(value, unit=unit)
+
+
+def wrap_angle(value: Any, unit: Any, /) -> Any:
+    """Wrap a radian-valued raw array, or pass it through when *unit* is `None`.
+
+    *value* is already in radians -- every inverse-trigonometric function
+    returns radians -- so *unit* is read only as the "was there a unit at all"
+    flag that `strip` returned for the group this angle was derived from.
+
+    A plain `Quantity` is returned rather than an `Angle`;
+    `canonical_containers` promotes it, which is where that decision already
+    lives and is ~30x cheaper than the checked `Angle` constructor.
+
+    >>> import unxt as u
+    >>> from coordinax._src.utils import wrap_angle
+
+    >>> wrap_angle(1.5, u.unit("m"))
+    Q(1.5, 'rad')
+
+    >>> wrap_angle(1.5, None)
+    1.5
+
+    """
+    return value if unit is None else Quantity(value, unit=RAD)

--- a/tests/unit/charts/test_register_realize.py
+++ b/tests/unit/charts/test_register_realize.py
@@ -14,6 +14,7 @@ from hypothesis import assume, given
 
 import unxt as u
 
+import coordinax as cx
 import coordinax.charts as cxc
 import coordinax.manifolds as cxm
 import coordinaxs.hypothesis.main as cxst
@@ -301,3 +302,54 @@ class TestSphericalConditioning:
         out = cxc.pt_map(p, cxc.cart3d, cxc.sph3d)
         assert float(out["r"].ustrip("m")) == 0.0
         assert float(out["theta"].ustrip("rad")) == 0.0
+
+
+# =============================================================================
+
+
+class TestPtMapUnitContract:
+    """Which unit a transition's output carries, and which components keep their own.
+
+    The bodies used to do their arithmetic on `Quantity` operands, so these rules
+    were a *consequence* of `unxt` promotion. `strip`/`wrap` reproduce them
+    deliberately, so they are pinned here. All three pass against the
+    pre-`strip` bodies too -- that is what makes them a contract.
+
+    Not repeated here: unitless-in/unitless-out and angular canonicalisation,
+    which the `pt_map` doctests and `test_container_canonicalisation` already
+    cover for every chart pair.
+    """
+
+    @pytest.mark.parametrize(("x_unit", "y_unit"), [("km", "m"), ("m", "km")])
+    def test_result_takes_the_first_components_unit(self, x_unit, y_unit):
+        """Mixed units resolve to the unit of the chart's *first* component, `x`.
+
+        Not the largest, not the smallest, and not the input dict's ordering --
+        which is what `Quantity` arithmetic happened to produce.
+        """
+        p = {"x": u.Q(1.0, x_unit), "y": u.Q(2.0, y_unit), "z": u.Q(3.0, "cm")}
+        assert cxc.pt_map(p, cxc.cart3d, cxc.sph3d)["r"].unit == u.unit(x_unit)
+
+    def test_untouched_component_keeps_its_unit_and_container(self):
+        """`z` is not consumed by the cylindrical arithmetic, so it is not converted.
+
+        Round-tripping it through the group unit would turn `Q(3, "km")` into
+        `Q(3000, "m")` and degrade a `Distance` to a `Quantity`.
+        """
+        base = {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m")}
+        z = cxc.pt_map({**base, "z": u.Q(3.0, "km")}, cxc.cart3d, cxc.cyl3d)["z"]
+        assert z.unit == u.unit("km")
+        assert z.value == pytest.approx(3.0)
+
+        z = cxc.pt_map({**base, "z": cx.Distance(3.0, "m")}, cxc.cart3d, cxc.cyl3d)["z"]
+        assert isinstance(z, cx.Distance)
+
+    def test_untouched_angle_passes_through(self):
+        """`phi` sits outside `cyl3d -> sph3d`'s length group.
+
+        A separate body from the one above, so it needs its own case.
+        """
+        p = {"rho": u.Q(3.0, "m"), "phi": u.Angle(30.0, "deg"), "z": u.Q(4.0, "m")}
+        phi = cxc.pt_map(p, cxc.cyl3d, cxc.sph3d)["phi"]
+        assert phi.unit == u.unit("deg")
+        assert phi.value == pytest.approx(30.0)


### PR DESCRIPTION
A `pt_map` body written against `Quantity` operands pays `quax` once per arithmetic primitive: `quax` builds and evaluates a jaxpr for each one, so the eager cost is the **count** of ops rather than the work in them. On a scalar point one primitive is ~4 µs on a raw array against 120–820 µs on a `Quantity` (`** 2` 120, `+` 198, `/` 229, `== 0` 444, `atan2` 617, `acos` 623). `Cart3D -> Spherical3D` spent ~2 900 µs of its ~3 500 µs there — simply the sum of its ops.

`strip`/`wrap` move the units out of the arithmetic: resolve once on the way in, run the body on raw arrays, re-attach once on the way out. Three bodies converted as a pilot.

## Numbers

Eager, scalar point, minimum of 40 calls, µs. Re-measured against `main` after #831 merged — that PR deleted the `== 0` / `/` / `acos` ops and so already carried a good part of the win (`cart3d→sph3d` went 2 381 → 723 there).

| | `main` | here |
| --- | ---: | ---: |
| `dict[Quantity]` cart3d→sph3d | 723 | **387** |
| `dict[Quantity]` cart3d→cyl3d | 372 | **262** |
| `Point` → sph3d | 756 | **429** |
| `jac_pt_map` cart3d→sph3d | 5 096 | **4 347** |

## Honest caveat on the size of the win

Written against `unxt`'s public functions rather than reaching for `.unit`/`.value`. A reach-through version of the same three bodies measures **32 µs** on that first row — 12× faster again than what is here.

That whole gap is `plum` declining to cache the unfaithful signatures on this path: `u.ustrip(unit, q)` is 42 µs where `.value` is 1.2 µs, and three of them are most of the remaining 406. [plum#290](https://github.com/beartype/plum/issues/290) addresses exactly those signatures — so the public route collects the rest for free when it lands, whereas a reach-through would have to be unpicked afterwards. Deliberate trade, flagging it so the number in the table isn't mistaken for the ceiling.

Note this sits in tension with the `_mk` reach-through in `containers.py`, which is measured and deliberate. Not touching it here.

## The unit contract

Previously a *consequence* of `unxt` promotion; now written down and tested:

- a group takes its **first** component's unit — `{km, m, cm}` gave `r` in km before and still does, including the order-dependence;
- a component the arithmetic never consumes is carried through **untouched**. This one bites: converting `z` to the group unit looks harmless and turns `Q(3, "km")` into `Q(3000, "m")` and a `Distance` into a `Quantity`. I wrote that bug, caught it against `main`, and it is now pinned;
- a unitless point stays unitless;
- mixing dimensions inside one group raises `UnitConversionError` rather than silently reinterpreting.

The three `TestPtMapUnitContract` cases in `tests/unit/charts/test_register_realize.py` pass against the **pre-conversion** bodies too — that is what makes them a contract rather than a description of the new code.

Not repeated there, because already covered: unitless-in/unitless-out (doctests on all three converted bodies) and angular canonicalisation (`test_container_canonicalisation::test_output_is_canonical`, parametrised over every chart pair). The `strip`/`wrap` helpers are pinned by their own doctests, including the fully-qualified `UnitConversionError` for a dimensionally mixed group.

## Scope

Three of ~35 bodies. The remaining homogeneous-Euclidean transitions are mechanical follow-ups; the heterogeneous ones (`PoincarePolar6D` mixes lengths with velocities) need one `strip` call per dimensional group, which the helper's docstring spells out.

Two things deliberately left alone:

- `jnp` in `register_ptmap.py` is `quaxed.numpy`, so the post-`strip` raw arrays still take a quax pass-through (~5 µs/op). Renaming to the house `jnp`/`qnp` convention used in `jacobian.py` and `tangent_map.py` is a separate mechanical diff across 60+ call sites.
- `docs/guides/perf.md` and the docstring of `tests/unit/charts/test_raw_array_fast_path.py` both say this overhead is not something coordinax can dispatch its way out of. That is true of `plum` dispatch and was never the lever; it is the per-primitive `quax` trace that moves. Worth revisiting once the rollout is complete rather than on a 3-body pilot.

## Verification

`nox -s test` (CI's own command) — **11 815 passed**, 315 skipped, 1 xfailed, no failures. `prek run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


