### PR TITLE
⚡️ perf(charts): convert the Euclidean length+angle transitions

### DIFF
--- a/docs/guides/perf.md
+++ b/docs/guides/perf.md
@@ -42,25 +42,27 @@ def optimized_function(*arrays: Array):
 
 The guide above teaches jitting. It is worth saying plainly what you pay if you do not, because the number is larger than most people expect.
 
-One `pt_map` from `sph3d` to `cart3d`, at a single point:
+One `pt_map` from `sph3d` to `cart3d`, at a single point. The quantity column has moved twice since it was first measured -- once when the numerics were conditioned, once when the body stopped computing on `Quantity` operands:
 
-| call                         | eager   | jitted, reused |
-| ---------------------------- | ------- | -------------- |
-| `dict[str, Quantity]`        | 3650 us | 23.0 us        |
-| `dict[str, Array]` + `usys=` | 179 us  | 10.4 us        |
+| call | eager, first measured | eager, now | jitted, reused |
+| --- | --- | --- | --- |
+| `dict[str, Quantity]` | 3650 us | ~700 us | 23.0 us |
+| `dict[str, Array]` + `usys=` | 179 us | ~166 us | 10.4 us |
 
 Two things follow.
 
-**Raw arrays are ~20x cheaper than quantities, before jit is involved.** Both routes compute the identical numbers -- bit for bit -- so if a pipeline is already carrying bare arrays, handing them straight to `pt_map` with an explicit `usys=` avoids the wrapper entirely. Under jit the gap narrows but does not close: 10.4 us against 23.0 us.
+**Raw arrays are still cheaper than quantities, before jit is involved, though much less dramatically than they were.** Both routes compute the identical numbers -- bit for bit -- so if a pipeline is already carrying bare arrays, handing them straight to `pt_map` with an explicit `usys=` avoids the wrapper entirely. Under jit the gap narrows but does not close: 10.4 us against 23.0 us.
 
-**Almost none of that overhead is `coordinax`.** Counting calls to `plum`-dispatched functions for one eager call -- calls rather than distinct resolutions, so a cache hit still counts:
+**Most of that overhead was `coordinax`'s to remove, and much of it is now gone.** Counting calls to `plum`-dispatched functions for one eager `sph3d -> cart3d`, before and after the transition bodies stopped computing on `Quantity` operands -- calls rather than distinct resolutions, so a cache hit still counts:
 
-| route                        | calls | of which `pt_map` |
-| ---------------------------- | ----- | ----------------- |
-| `dict[str, Quantity]`        | 178   | 2                 |
-| `dict[str, Array]` + `usys=` | 17    | 2                 |
+| route                        | calls, before | after | of which `pt_map` |
+| ---------------------------- | ------------- | ----- | ----------------- |
+| `dict[str, Quantity]`        | 178           | 45    | 2                 |
+| `dict[str, Array]` + `usys=` | 17            | 23    | 2                 |
 
-The other 176 are `unxt` and `quax` resolving arithmetic on `Quantity` operands -- `convert`, `unit`, `ustrip`, roughly one set per primitive operation. That is inherent to eager unit-aware arithmetic rather than something `coordinax` can dispatch its way out of, which is why the remedy is to choose the route rather than to micro-optimise the call.
+The 176 non-`pt_map` calls were `unxt` and `quax` resolving arithmetic on `Quantity` operands -- `convert`, `unit`, `ustrip`, roughly one set per primitive operation. That looked inherent to eager unit-aware arithmetic, but it was not: it followed from each transition body doing its arithmetic _on_ `Quantity` operands. Bodies that instead resolve their units once, compute on raw arrays, and re-attach at the end produce identical output for a fraction of the dispatches, and the same `sph3d -> cart3d` call went from ~2890 us to ~700 us.
+
+The gap between the two routes therefore no longer looks the way the table below records it, and it is still closing as the remaining bodies are converted. The advice that follows -- batch, jit, build closures once, keep pytree conversions off the boundary -- is unaffected: it is about crossing the jit boundary, not about units.
 
 Pre-resolving the dispatch with `plum`'s `Function.invoke` is therefore not the lever it looks like here: it removes 2 dispatched calls of 178, and measures 1.05x. It pays where a hot loop repeatedly re-resolves _its own_ call, which is why `norm` keeps a module-level `array_norm = norm.invoke(Array, Array)`.
 
@@ -72,7 +74,7 @@ Pre-resolving the dispatch with `plum`'s `Function.invoke` is therefore not the 
 | `dict[str, Quantity]`, broadcast     | 23.5 ns   |
 | `dict[str, Array]`, `jit(vmap(...))` | 22.0 ns   |
 
-So the 300x figure is a statement about _many small eager calls_, not about throughput. Batch, and it disappears; stay eager and per-point, and the route you choose is worth 20x.
+So the figure is a statement about _many small eager calls_, not about throughput. Batch, and it disappears; stay eager and per-point, and the route still matters -- by a few-fold now rather than the 20x it once was.
 
 ```{note}
 The eager timings above were measured against `plum` as it stands today, where several functions on this path -- `ustrip`, `uconvert`, `dimension_of` -- carry signatures that are not _faithful_ (`Literal`, `Mapping[...]`, `type[...]`) and so run with their method cache disabled. [plum#290](https://github.com/beartype/plum/issues/290) proposes separating `is_cacheable` from `is_faithful`, which would let exactly those signatures be cached. Expect the `Quantity` column to improve when that lands; the shape of the advice -- batch, jit, and prefer raw arrays at the boundary -- does not depend on it.

--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -41,7 +41,14 @@ from coordinax._src.exceptions import ManifoldMismatchError
 from coordinax._src.null import NoManifold
 from coordinax._src.product.chart import CartesianProductChart
 from coordinax._src.product.manifold import CartesianProductManifold
-from coordinax._src.utils import strip, uconvert_to_rad, wrap, wrap_angle
+from coordinax._src.utils import (
+    promoted_unit,
+    rad_value,
+    strip,
+    uconvert_to_rad,
+    wrap,
+    wrap_angle,
+)
 from coordinaxs.api.custom_types import CDict
 
 
@@ -450,10 +457,15 @@ def pt_map(
     """
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
-    theta = uconvert_to_rad(p["theta"], usys)
-    x = p["r"] * jnp.cos(theta)
-    y = p["r"] * jnp.sin(theta)
-    return canonical_containers({"x": x, "y": y}, to_chart)
+    # `strip`/`rad_value`/`wrap` keep the arithmetic off `Quantity` operands,
+    # where every primitive costs a `quax` trace; see `coordinax._src.utils`.
+    (r_,), unit = strip(p, ("r",))
+    unit = promoted_unit(unit, p["theta"])
+    theta = rad_value(p["theta"], usys)
+    return canonical_containers(
+        {"x": wrap(r_ * jnp.cos(theta), unit), "y": wrap(r_ * jnp.sin(theta), unit)},
+        to_chart,
+    )
 
 
 @plum.dispatch
@@ -488,9 +500,14 @@ def pt_map(
     del usys  # unused
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
-    r_ = jnp.hypot(p["x"], p["y"])
-    theta = jnp.arctan2(p["y"], p["x"])
-    return canonical_containers({"r": r_, "theta": theta}, to_chart)
+    (x, y), unit = strip(p, ("x", "y"))
+    return canonical_containers(
+        {
+            "r": wrap(jnp.hypot(x, y), unit),
+            "theta": wrap_angle(jnp.arctan2(y, x), unit),
+        },
+        to_chart,
+    )
 
 
 # -----------------------------------------------
@@ -526,10 +543,19 @@ def pt_map(
     """
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
-    phi = uconvert_to_rad(p["phi"], usys)
-    x = p["rho"] * jnp.cos(phi)
-    y = p["rho"] * jnp.sin(phi)
-    return canonical_containers({"x": x, "y": y, "z": p["z"]}, to_chart)
+    # `z` is not consumed by the arithmetic, so it is carried through untouched
+    # and keeps its own unit and container.
+    (rho,), unit = strip(p, ("rho",))
+    unit = promoted_unit(unit, p["phi"])
+    phi = rad_value(p["phi"], usys)
+    return canonical_containers(
+        {
+            "x": wrap(rho * jnp.cos(phi), unit),
+            "y": wrap(rho * jnp.sin(phi), unit),
+            "z": p["z"],
+        },
+        to_chart,
+    )
 
 
 @plum.dispatch
@@ -567,13 +593,22 @@ def pt_map(
     """
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
-    r_ = p["r"]
-    theta = uconvert_to_rad(p["theta"], usys)
-    phi = uconvert_to_rad(p["phi"], usys)
-    x = r_ * jnp.sin(theta) * jnp.cos(phi)
-    y = r_ * jnp.sin(theta) * jnp.sin(phi)
-    z = r_ * jnp.cos(theta)
-    return canonical_containers({"x": x, "y": y, "z": z}, to_chart)
+    (r_,), unit = strip(p, ("r",))
+    # `z` reads only `r` and `theta`; `x` and `y` read `phi` as well.
+    unit_z = promoted_unit(unit, p["theta"])
+    unit_xy = promoted_unit(unit_z, p["phi"])
+    theta = rad_value(p["theta"], usys)
+    phi = rad_value(p["phi"], usys)
+    # `sin(theta)` once rather than once per component.
+    rho = r_ * jnp.sin(theta)
+    return canonical_containers(
+        {
+            "x": wrap(rho * jnp.cos(phi), unit_xy),
+            "y": wrap(rho * jnp.sin(phi), unit_xy),
+            "z": wrap(r_ * jnp.cos(theta), unit_z),
+        },
+        to_chart,
+    )
 
 
 @plum.dispatch
@@ -609,13 +644,22 @@ def pt_map(
     """
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
-    r_ = p["distance"]
-    lon = uconvert_to_rad(p["lon"], usys)
-    lat = uconvert_to_rad(p["lat"], usys)
-    x = r_ * jnp.cos(lat) * jnp.cos(lon)
-    y = r_ * jnp.cos(lat) * jnp.sin(lon)
-    z = r_ * jnp.sin(lat)
-    return canonical_containers({"x": x, "y": y, "z": z}, to_chart)
+    (r_,), unit = strip(p, ("distance",))
+    # `z` reads only `distance` and `lat`; `x` and `y` read `lon` as well.
+    unit_z = promoted_unit(unit, p["lat"])
+    unit_xy = promoted_unit(unit_z, p["lon"])
+    lon = rad_value(p["lon"], usys)
+    lat = rad_value(p["lat"], usys)
+    # `cos(lat)` once rather than once per component.
+    rho = r_ * jnp.cos(lat)
+    return canonical_containers(
+        {
+            "x": wrap(rho * jnp.cos(lon), unit_xy),
+            "y": wrap(rho * jnp.sin(lon), unit_xy),
+            "z": wrap(r_ * jnp.sin(lat), unit_z),
+        },
+        to_chart,
+    )
 
 
 @plum.dispatch
@@ -655,20 +699,31 @@ def pt_map(
     """
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
-    lon_coslat, r_ = p["lon_coslat"], p["distance"]
-    lat = uconvert_to_rad(p["lat"], usys)
+    (r_,), unit = strip(p, ("distance",))
+    # `z` reads only `distance` and `lat`; `x` and `y` read `lon_coslat` too.
+    unit_z = promoted_unit(unit, p["lat"])
+    unit_xy = promoted_unit(unit_z, p["lon_coslat"])
+    lat = rad_value(p["lat"], usys)
+    # To radians *before* the division rather than after: `coslat` is
+    # dimensionless, so the two commute, and dividing raw values keeps the
+    # arithmetic off `Quantity` operands.
+    lon_coslat = rad_value(p["lon_coslat"], usys)
     # Longitude is undefined at the poles. The guard fires only when cos(lat) is
     # *exactly* 0 (giving lon = 0); a floating-point near-pole value (e.g.
     # cos(pi/2) ~= 6e-17) still divides, but the cos(lat) factor below multiplies
     # the result back so x, y stay finite.
     coslat = jnp.cos(lat)
     lon = _ratio_zero_on_axis(lon_coslat, coslat)
-    lon = uconvert_to_rad(lon, usys)
-    # Convert to Cartesian
-    x = r_ * jnp.cos(lat) * jnp.cos(lon)
-    y = r_ * jnp.cos(lat) * jnp.sin(lon)
-    z = r_ * jnp.sin(lat)
-    return canonical_containers({"x": x, "y": y, "z": z}, to_chart)
+    # Convert to Cartesian. `cos(lat)` is already in hand as `coslat`.
+    rho = r_ * coslat
+    return canonical_containers(
+        {
+            "x": wrap(rho * jnp.cos(lon), unit_xy),
+            "y": wrap(rho * jnp.sin(lon), unit_xy),
+            "z": wrap(r_ * jnp.sin(lat), unit_z),
+        },
+        to_chart,
+    )
 
 
 @plum.dispatch
@@ -705,13 +760,22 @@ def pt_map(
     """
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
-    r_ = p["r"]
-    theta = uconvert_to_rad(p["theta"], usys)
-    phi = uconvert_to_rad(p["phi"], usys)
-    x = r_ * jnp.sin(phi) * jnp.cos(theta)
-    y = r_ * jnp.sin(phi) * jnp.sin(theta)
-    z = r_ * jnp.cos(phi)
-    return canonical_containers({"x": x, "y": y, "z": z}, to_chart)
+    (r_,), unit = strip(p, ("r",))
+    # `z` reads only `r` and `phi`; `x` and `y` read `theta` as well.
+    unit_z = promoted_unit(unit, p["phi"])
+    unit_xy = promoted_unit(unit_z, p["theta"])
+    theta = rad_value(p["theta"], usys)
+    phi = rad_value(p["phi"], usys)
+    # `sin(phi)` once rather than once per component.
+    rho = r_ * jnp.sin(phi)
+    return canonical_containers(
+        {
+            "x": wrap(rho * jnp.cos(theta), unit_xy),
+            "y": wrap(rho * jnp.sin(theta), unit_xy),
+            "z": wrap(r_ * jnp.cos(phi), unit_z),
+        },
+        to_chart,
+    )
 
 
 @plum.dispatch
@@ -1007,10 +1071,18 @@ def pt_map(
 
     """
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
-    theta = uconvert_to_rad(p["theta"], usys)
-    rho = p["r"] * jnp.sin(theta)
-    z = p["r"] * jnp.cos(theta)
-    return canonical_containers({"rho": rho, "phi": p["phi"], "z": z}, to_chart)
+    # `phi` is an angle, outside this length group, and passes through untouched.
+    (r_,), unit = strip(p, ("r",))
+    unit = promoted_unit(unit, p["theta"])
+    theta = rad_value(p["theta"], usys)
+    return canonical_containers(
+        {
+            "rho": wrap(r_ * jnp.sin(theta), unit),
+            "phi": p["phi"],
+            "z": wrap(r_ * jnp.cos(theta), unit),
+        },
+        to_chart,
+    )
 
 
 @plum.dispatch

--- a/src/coordinax/_src/utils.py
+++ b/src/coordinax/_src/utils.py
@@ -18,6 +18,51 @@ UNTLS: Final = u.unit("")
 DMLS: Final = u.dimension_of(UNTLS)
 
 
+def rad_value(value: Any, usys: OptUSys, /) -> Any:
+    """Return the raw radian magnitude of an angle value, without a unit wrapper.
+
+    The core of `uconvert_to_rad`, exposed for transition bodies that go on to
+    do their arithmetic on raw arrays: re-wrapping the angle only for a `sin`
+    or `cos` to strip it again costs a `quax` trace per call for nothing.
+
+    >>> import quaxed.numpy as jnp
+    >>> import unxt as u
+    >>> from coordinax._src.utils import rad_value
+
+    >>> bool(jnp.allclose(rad_value(u.Q(90, "deg"), None), jnp.pi / 2))
+    True
+
+    A bare value is already radians unless a unit system says otherwise:
+
+    >>> bool(jnp.allclose(rad_value(jnp.pi / 2, None), jnp.pi / 2))
+    True
+    >>> usys = u.unitsystem("m", "deg")
+    >>> bool(jnp.allclose(rad_value(90.0, usys), jnp.pi / 2))
+    True
+
+    """
+    return _rad_value(value, usys, u.unit_of(value))
+
+
+def _rad_value(value: Any, usys: OptUSys, unit: Any, /) -> Any:
+    """Raw radian magnitude, given *value*'s already-resolved *unit*.
+
+    Split out so `rad_value` and `uconvert_to_rad` each resolve the unit once:
+    `u.unit_of` is a `plum` dispatch on a path that runs per component.
+    """
+    source_unit = RAD if usys is None else usys["angle"]
+
+    if unit is not None:
+        dim = u.dimension_of(unit)
+        if dim == ANGLE:
+            source_unit = unit
+        elif dim != DMLS:
+            msg = f"Unsupported quantity dimension for angle conversion: {dim}"
+            raise ValueError(msg)
+
+    return u.uconvert_value(RAD, source_unit, u.ustrip(AllowValue, value))
+
+
 @overload
 def uconvert_to_rad(value: ArrayLike, usys: OptUSys, /) -> ArrayLike: ...
 @overload
@@ -58,20 +103,9 @@ def uconvert_to_rad(value: Any, usys: OptUSys, /) -> Any:
     ValueError: Unsupported quantity dimension for angle conversion: length
 
     """
-    from_unit = RAD if usys is None else usys["angle"]
     unit = u.unit_of(value)
-    source_unit = from_unit
-
-    if unit is not None:
-        dim = u.dimension_of(unit)
-        if dim == ANGLE:
-            source_unit = unit
-        elif dim != DMLS:
-            msg = f"Unsupported quantity dimension for angle conversion: {dim}"
-            raise ValueError(msg)
-
-    raw_rad = u.uconvert_value(RAD, source_unit, u.ustrip(AllowValue, value))
-    return Quantity(raw_rad, unit=RAD) if unit is not None else raw_rad
+    raw_rad = _rad_value(value, usys, unit)
+    return raw_rad if unit is None else Quantity(raw_rad, unit=RAD)
 
 
 # ===================================================================
@@ -146,6 +180,41 @@ def strip(p: CDict, keys: CKeys, /) -> tuple[tuple[Any, ...], Any]:
     if unit is None:
         return tuple(p[k] for k in keys), None
     return tuple(u.ustrip(unit, p[k]) for k in keys), unit
+
+
+def promoted_unit(unit: Any, /, *operands: Any) -> Any:
+    """Return the unit `wrap` should re-attach, reproducing `Quantity` promotion.
+
+    `strip` reports the unit of the *length* group. When that group is unitless
+    but an operand feeding the same expression carries a unit -- a bare radius
+    with an `Angle` azimuth, which is exactly how the unit-sphere charts are
+    written -- `Quantity` arithmetic promoted the result to a *dimensionless*
+    `Quantity`. Callers rely on it: `chord_distance` on `sph2` returns one.
+
+    Promotion follows the operands that actually feed the expression, not the
+    point as a whole -- a unitful component the arithmetic never reads promotes
+    nothing, so a body with differently-sourced outputs needs one call each.
+
+    >>> import unxt as u
+    >>> from coordinax._src.utils import promoted_unit
+
+    A group that has its own unit keeps it:
+
+    >>> promoted_unit(u.unit("m"), u.Angle(1.0, "rad"))
+    Unit("m")
+
+    A unitless group promoted by a unitful operand becomes dimensionless, and
+    stays unitless when nothing feeding it carries a unit:
+
+    >>> promoted_unit(None, u.Angle(1.0, "rad"))
+    Unit(dimensionless)
+    >>> promoted_unit(None, 1.0) is None
+    True
+
+    """
+    if unit is not None:
+        return unit
+    return UNTLS if any(u.unit_of(o) is not None for o in operands) else None
 
 
 def wrap(value: Any, unit: Any, /) -> Any:

--- a/tests/unit/charts/test_raw_array_fast_path.py
+++ b/tests/unit/charts/test_raw_array_fast_path.py
@@ -1,21 +1,30 @@
-"""The raw-array path through `pt_map` stays cheap (#719).
+"""Neither route through `pt_map` is dispatch-heavy (#719).
 
-`pt_map` on a `dict[str, Quantity]` costs ~20x more *per eager call* than the
-same map on bare arrays. Almost none of that is coordinax: of the 178 `plum`
-dispatches one such call makes, **two** are `pt_map` itself. The rest are
-`unxt`/`quax` resolving arithmetic on `Quantity` operands -- `convert`, `unit`,
-`ustrip` -- one per primitive op.
+`pt_map` on a `dict[str, Quantity]` used to cost ~20x more *per eager call*
+than the same map on bare arrays, and this file was written on the reading
+that coordinax could not dispatch its way out of it: of the 178 `plum`
+dispatches one such call made, only **two** were `pt_map` itself, the rest
+being `unxt`/`quax` resolving arithmetic on `Quantity` operands.
 
-So the cost is not something coordinax can dispatch its way out of; what it can
-do is keep the raw-array route open, which is what these tests guard. Counting
-dispatches rather than timing keeps the guard deterministic: the numbers below
-are exact and repeatable, where wall-clock would flake in CI.
+That reading was wrong about the cause. The dispatches were per *primitive
+operation*, and a body only performs them because it does its arithmetic on
+`Quantity` operands -- which is the body's choice, not a property of units.
+Bodies that resolve their units once through `strip`/`wrap` and compute on raw
+arrays make far fewer: `sph3d -> cart3d` went from 178 dispatches to 45, and
+from ~2890us to ~700us, for identical output.
 
-Counting also survives a change in how `plum` caches. `plum#290` would let the
-unfaithful signatures on this path be cached, cutting the *cost* of a dispatch
-without changing how many happen -- `unit` already caches and is still counted
-27 times per call, which is what shows this counter tallies calls rather than
-resolutions.
+So the guard has changed shape. It used to assert a *gap* between the two
+routes; closing that gap is now the goal, and what is worth pinning is that
+neither route is expensive. The raw route must stay open and cheap (it moved
+17 -> 23 dispatches, the `unit_of` probes `strip` makes even on bare values,
+which cost nothing measurable), and the quantity route must not drift back
+toward per-primitive dispatch.
+
+Counting dispatches rather than timing keeps the guard deterministic: the
+numbers are exact and repeatable, where wall-clock would flake in CI. Counting
+also survives a change in how `plum` caches -- `plum#290` would let the
+unfaithful signatures here be cached, cutting the *cost* of a dispatch without
+changing how many happen.
 """
 
 __all__: tuple[str, ...] = ()
@@ -32,10 +41,16 @@ import coordinax.charts as cxc
 
 _USYS = u.unitsystems.si
 
-#: Ceiling, not a target: raw arrays measured 17 dispatches when written. The
-#: assertion is that the fast path has not collapsed into the slow one, so this
-#: leaves room to move without becoming a change-detector test.
+#: Ceiling, not a target: raw arrays measured 17 dispatches when written and 23
+#: once `strip` began probing `unit_of` on them. The assertion is that the fast
+#: path has not collapsed into the slow one, so this leaves room to move without
+#: becoming a change-detector test.
 _RAW_DISPATCH_CEILING = 40
+
+#: Likewise for quantities: 178 before the body stopped computing on `Quantity`
+#: operands, 45 after. A body reverted to per-primitive `Quantity` arithmetic
+#: lands back near 178, which this catches well before then.
+_QTY_DISPATCH_CEILING = 90
 
 
 def _count_dispatches(fn):
@@ -80,17 +95,15 @@ def test_raw_arrays_stay_off_the_unit_machinery():
     assert sum(counts.values()) <= _RAW_DISPATCH_CEILING
 
 
-def test_raw_arrays_cost_far_fewer_dispatches_than_quantities():
-    """The gap is the point: ~10x fewer dispatched calls for the same arithmetic."""
-    raw = sum(
-        _count_dispatches(
-            lambda: cxc.pt_map(_RAW, cxc.sph3d, cxc.cart3d, usys=_USYS)
-        ).values()
-    )
-    qty = sum(
-        _count_dispatches(lambda: cxc.pt_map(_QTY, cxc.sph3d, cxc.cart3d)).values()
-    )
-    assert raw * 4 < qty
+def test_quantities_stay_off_the_per_primitive_dispatch_path():
+    """The body resolves its units once, not once per arithmetic primitive.
+
+    This is the guard that replaced an assertion that the two routes differ by
+    ~10x. They no longer do, and that is the improvement rather than a
+    regression -- see the module docstring.
+    """
+    counts = _count_dispatches(lambda: cxc.pt_map(_QTY, cxc.sph3d, cxc.cart3d))
+    assert sum(counts.values()) <= _QTY_DISPATCH_CEILING
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/charts/test_register_realize.py
+++ b/tests/unit/charts/test_register_realize.py
@@ -312,7 +312,7 @@ class TestPtMapUnitContract:
 
     The bodies used to do their arithmetic on `Quantity` operands, so these rules
     were a *consequence* of `unxt` promotion. `strip`/`wrap` reproduce them
-    deliberately, so they are pinned here. All three pass against the
+    deliberately, so they are pinned here. Every case passes against the
     pre-`strip` bodies too -- that is what makes them a contract.
 
     Not repeated here: unitless-in/unitless-out and angular canonicalisation,
@@ -330,26 +330,57 @@ class TestPtMapUnitContract:
         p = {"x": u.Q(1.0, x_unit), "y": u.Q(2.0, y_unit), "z": u.Q(3.0, "cm")}
         assert cxc.pt_map(p, cxc.cart3d, cxc.sph3d)["r"].unit == u.unit(x_unit)
 
-    def test_untouched_component_keeps_its_unit_and_container(self):
-        """`z` is not consumed by the cylindrical arithmetic, so it is not converted.
+    @pytest.mark.parametrize(
+        ("frm", "to", "rest"),
+        [
+            (cxc.cart3d, cxc.cyl3d, {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m")}),
+            (cxc.cyl3d, cxc.cart3d, {"rho": u.Q(1.0, "m"), "phi": u.Angle(0.5, "rad")}),
+        ],
+        ids=["cart3d->cyl3d", "cyl3d->cart3d"],
+    )
+    def test_untouched_length_keeps_its_unit_and_container(self, frm, to, rest):
+        """`z` is not consumed by either body's arithmetic, so it is not converted.
 
         Round-tripping it through the group unit would turn `Q(3, "km")` into
         `Q(3000, "m")` and degrade a `Distance` to a `Quantity`.
         """
-        base = {"x": u.Q(1.0, "m"), "y": u.Q(2.0, "m")}
-        z = cxc.pt_map({**base, "z": u.Q(3.0, "km")}, cxc.cart3d, cxc.cyl3d)["z"]
+        z = cxc.pt_map({**rest, "z": u.Q(3.0, "km")}, frm, to)["z"]
         assert z.unit == u.unit("km")
         assert z.value == pytest.approx(3.0)
 
-        z = cxc.pt_map({**base, "z": cx.Distance(3.0, "m")}, cxc.cart3d, cxc.cyl3d)["z"]
+        z = cxc.pt_map({**rest, "z": cx.Distance(3.0, "m")}, frm, to)["z"]
         assert isinstance(z, cx.Distance)
 
-    def test_untouched_angle_passes_through(self):
-        """`phi` sits outside `cyl3d -> sph3d`'s length group.
-
-        A separate body from the one above, so it needs its own case.
-        """
-        p = {"rho": u.Q(3.0, "m"), "phi": u.Angle(30.0, "deg"), "z": u.Q(4.0, "m")}
-        phi = cxc.pt_map(p, cxc.cyl3d, cxc.sph3d)["phi"]
+    @pytest.mark.parametrize(
+        ("frm", "to", "rest"),
+        [
+            (cxc.cyl3d, cxc.sph3d, {"rho": u.Q(3.0, "m"), "z": u.Q(4.0, "m")}),
+            (cxc.sph3d, cxc.cyl3d, {"r": u.Q(5.0, "m"), "theta": u.Angle(0.9, "rad")}),
+        ],
+        ids=["cyl3d->sph3d", "sph3d->cyl3d"],
+    )
+    def test_untouched_angle_passes_through(self, frm, to, rest):
+        """`phi` sits outside each body's length group, and keeps degrees."""
+        phi = cxc.pt_map({**rest, "phi": u.Angle(30.0, "deg")}, frm, to)["phi"]
         assert phi.unit == u.unit("deg")
         assert phi.value == pytest.approx(30.0)
+
+    def test_a_unitful_angle_promotes_a_unitless_length(self):
+        """A bare radius with an `Angle` gives a *dimensionless* `Quantity` length.
+
+        `Quantity` arithmetic promoted whenever any operand was one, and callers
+        depend on it -- `chord_distance` on `sph2`, whose radius is a bare 1 and
+        whose angles are `Angle`s, returns a dimensionless `Quantity`. Promotion
+        follows the operands that feed each output, so a unitful component the
+        arithmetic never reads promotes nothing.
+        """
+        ang = {"theta": u.Angle(0.7, "rad"), "phi": u.Angle(1.2, "rad")}
+        out = cxc.pt_map({"r": 2.0, **ang}, cxc.sph3d, cxc.cart3d)
+        assert all(u.unit_of(v) == u.unit("") for v in out.values())
+
+        # `z` is not read by `cyl3d -> cart3d`'s arithmetic, so it promotes nothing.
+        out = cxc.pt_map(
+            {"rho": 2.0, "phi": 0.7, "z": u.Q(3.0, "m")}, cxc.cyl3d, cxc.cart3d
+        )
+        assert u.unit_of(out["x"]) is None
+        assert u.unit_of(out["z"]) == u.unit("m")


### PR DESCRIPTION
Follows #832, which took three bodies off `Quantity` operands. This does the eight that mix a length with angles: everything into `Cart2D`/`Cart3D`, plus `Cart2D -> Polar2D` and `Spherical3D -> Cylindrical3D`.

## Numbers

Eager, scalar point, minimum of 40 calls, µs.

| | `main` | here | |
| --- | ---: | ---: | ---: |
| `polar2d -> cart2d` | 1 234 | **420** | 2.9× |
| `cart2d -> polar2d` | 343 | **257** | 1.3× |
| `cyl3d -> cart3d` | 1 225 | **424** | 2.9× |
| `sph3d -> cart3d` | 2 934 | **693** | 4.2× |
| `lonlat_sph3d -> cart3d` | 2 885 | **693** | 4.2× |
| `loncoslat_sph3d -> cart3d` | 4 688 | **851** | 5.5× |
| `math_sph3d -> cart3d` | 2 876 | **696** | 4.1× |
| `sph3d -> cyl3d` | 1 227 | **426** | 2.9× |

Dispatched `plum` calls for `sph3d -> cart3d` fall 178 → 45. **The raw-array route is unmoved**, which `test_raw_array_fast_path` exists to protect: 17 → 23 dispatches for the `unit_of` probes `strip` makes on bare values, and 170 µs → 166 µs of wall clock.

`sin(theta)` / `cos(lat)` are also computed once rather than once per component — XLA folds that under jit, eager evaluation did not.

## Two helpers

`rad_value` is the raw core of `uconvert_to_rad`, which already computed exactly this value and then re-wrapped it so a `sin` could strip it again.

`promoted_unit` reproduces `Quantity` promotion, and it turned out to matter more than I expected. With a bare radius and an `Angle` azimuth — **precisely how the unit-sphere charts are written** — the old arithmetic returned a *dimensionless* `Quantity`, and `chord_distance` on `sph2` depends on that. My first attempt dropped it and took out seven `TestChordDistance` cases; caught before pushing.

Promotion follows the operands that actually feed each output, not the point as a whole. A body whose outputs read different angles resolves one unit per group (`z` reads `r` and `theta`; `x`, `y` read `phi` too), and a unitful component the arithmetic never reads promotes nothing — `{rho: 2.0, phi: 0.7, z: Q(3, "m")}` leaves `x`, `y` bare on `main` and here.

That rule is worth knowing about: it means `main` can return `{'x': Quantity[dimensionless], 'z': float}` for one point. It looks like a latent bug, but it is the existing tested contract, so this PR reproduces it exactly rather than changing it. Happy to open a separate issue if you'd like it revisited.

## Verification

A differential harness over **54 points** — mixed units, `Distance`, degrees, unitless with and without a unit system, every bare/unitful combination of radius and angle, poles, the origin, and a batch — gives **byte-identical** results before and after: values, units, dtypes and container types.

All seven `TestPtMapUnitContract` cases pass against `main`'s bodies too, so this is a pure refactor.

`nox -s test` — **11 830 passed**, 315 skipped, 1 xfailed. `prek run` clean.

## Docs corrected

`docs/guides/perf.md` and the docstring of `test_raw_array_fast_path` both said this overhead was inherent to eager unit-aware arithmetic rather than something coordinax could dispatch its way out of. It followed from each body computing *on* `Quantity` operands, which is the body's choice; both are updated with measured numbers.

That file's "the two routes differ by ~10×" assertion is replaced by a ceiling on **each** route. Closing the gap is the goal, so the property worth pinning is that neither route is dispatch-heavy — the old assertion would have failed as a success.

## Not in scope

`ProlateSpheroidal3D` (carries a `Delta` parameter), the intrinsic two-sphere charts (angle-only, so a different grouping), the `Spherical3D -> LonLat/LonCosLat` angle arithmetic, and `PoincarePolar6D` (mixes lengths with velocities — one `strip` per dimensional group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
