### PR TITLE
⚡️ perf(charts): stop paying for work the transition does not do

### DIFF
--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -51,6 +51,10 @@ from coordinax._src.utils import (
 )
 from coordinaxs.api.custom_types import CDict
 
+#: The pole-to-equator offset for colatitude <-> latitude, built once. `u.Q` is
+#: ~49us, which is otherwise paid per call on a `pt_map` path.
+_RIGHT_ANGLE: Final = u.Q(90, "deg")
+
 
 def _ratio_zero_on_axis(num: Array, denom: Array, /) -> Array:
     """``num / denom``, defined as 0 where ``denom == 0`` (coordinate singularity).
@@ -1117,7 +1121,7 @@ def pt_map(
     """
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     lat = (
-        u.Q(90, "deg") if isinstance(p["theta"], ABCQ) else jnp.pi / 2
+        _RIGHT_ANGLE if isinstance(p["theta"], ABCQ) else jnp.pi / 2
     ) - uconvert_to_rad(p["theta"], usys)
     return canonical_containers(
         {"lon": p["phi"], "lat": lat, "distance": p["r"]}, to_chart
@@ -1158,7 +1162,7 @@ def pt_map(
     """
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     lat = (
-        u.Q(90, "deg") if isinstance(p["theta"], ABCQ) else jnp.pi / 2
+        _RIGHT_ANGLE if isinstance(p["theta"], ABCQ) else jnp.pi / 2
     ) - uconvert_to_rad(p["theta"], usys)
     lon_coslat = p["phi"] * jnp.cos(lat)
     return canonical_containers(
@@ -1492,23 +1496,31 @@ def pt_map(
     # traced `Delta` alike. Cost: a `Delta` of the wrong dimension now raises
     # `UnitConversionError` here, instead of taking the conversion branch.
     unit = from_chart.Delta.unit
+    same_delta = u.ustrip(unit, to_chart.Delta) == u.ustrip(unit, from_chart.Delta)
+
     # Both branches must agree on pytree *structure*, and `Angle` and `Quantity`
     # are different nodes, so the pass-through branch canonicalises too. Without
     # it the converting branch returns `Angle` while this one hands back
     # whatever the caller built, and `lax.cond` rejects the mismatched pair.
-    return jax.lax.cond(
-        u.ustrip(unit, to_chart.Delta) == u.ustrip(unit, from_chart.Delta),
-        lambda p: canonical_containers(p, to_chart),
-        lambda p: cxcapi.pt_map(
-            cxcapi.pt_map(p, from_M, from_chart, to_M, cyl3d, usys=usys),
-            from_M,
-            cyl3d,
-            to_M,
-            to_chart,
-            usys=usys,
-        ),
-        p,
-    )
+    def keep(p: CDict) -> CDict:
+        return canonical_containers(p, to_chart)
+
+    def convert(p: CDict) -> CDict:
+        out = cxcapi.pt_map(p, from_M, from_chart, to_M, cyl3d, usys=usys)
+        return cast(
+            "CDict", cxcapi.pt_map(out, from_M, cyl3d, to_M, to_chart, usys=usys)
+        )
+
+    # `lax.cond` traces *both* branches, so routing a same-`Delta` identity
+    # through it costs a full round-trip to cylindrical and back -- ~65ms
+    # eagerly, the same as actually converting. A `Delta` that is concrete
+    # (the `StaticQuantity` every ordinary call site passes, or a dynamic one
+    # outside `jit`) can decide in Python and skip the dead branch entirely.
+    # A traced `Delta` cannot, and still needs `lax.cond`; that path is what
+    # `test_prolate_differentiable` covers.
+    if isinstance(same_delta, jax.core.Tracer):  # ty: ignore[possibly-missing-submodule]
+        return jax.lax.cond(same_delta, keep, convert, p)
+    return keep(p) if bool(same_delta) else convert(p)  # concrete 0-d array
 
 
 # -----------------------------------------------

--- a/src/coordinax/_src/spherical/register_ptmap.py
+++ b/src/coordinax/_src/spherical/register_ptmap.py
@@ -27,6 +27,10 @@ from coordinax._src.custom_types import OptUSys
 from coordinax._src.utils import uconvert_to_rad
 from coordinaxs.api.custom_types import CDict
 
+#: The pole-to-equator offset for colatitude <-> latitude, built once. `u.Q` is
+#: ~49us, which is otherwise paid per call on a `pt_map` path.
+_RIGHT_ANGLE: Final = u.Q(90, "deg")
+
 IDENTITY_TRANSFORM_CHARTS: Final[tuple[type[AbstractChart[Any, Any, Any]], ...]] = (
     SphericalTwoSphere,
     LonLatSphericalTwoSphere,
@@ -157,7 +161,7 @@ def pt_map(
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     lat = p["theta"]
-    lat = u.Q(90, "deg") - lat if is_any_quantity(lat) else jnp.pi / 2 - lat
+    lat = _RIGHT_ANGLE - lat if is_any_quantity(lat) else jnp.pi / 2 - lat
     return canonical_containers({"lon": p["phi"], "lat": lat}, to_chart)
 
 
@@ -189,7 +193,7 @@ def pt_map(
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     theta = p["lat"]
-    theta = u.Q(90, "deg") - theta if is_any_quantity(theta) else jnp.pi / 2 - theta
+    theta = _RIGHT_ANGLE - theta if is_any_quantity(theta) else jnp.pi / 2 - theta
     return canonical_containers({"theta": theta, "phi": p["lon"]}, to_chart)
 
 
@@ -230,7 +234,7 @@ def pt_map(
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     lat = (
-        u.Q(90, "deg") if is_any_quantity(p["theta"]) else jnp.pi / 2
+        _RIGHT_ANGLE if is_any_quantity(p["theta"]) else jnp.pi / 2
     ) - uconvert_to_rad(p["theta"], usys)
     lon_coslat = p["phi"] * jnp.cos(lat)
     return canonical_containers({"lon_coslat": lon_coslat, "lat": lat}, to_chart)
@@ -263,7 +267,7 @@ def pt_map(
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     lat = uconvert_to_rad(p["lat"], usys)
-    theta = (u.Q(90, "deg") if is_any_quantity(p["lat"]) else jnp.pi / 2) - lat
+    theta = (_RIGHT_ANGLE if is_any_quantity(p["lat"]) else jnp.pi / 2) - lat
     phi = p["lon_coslat"] / jnp.cos(lat)
     return canonical_containers({"theta": theta, "phi": phi}, to_chart)
 

--- a/tests/unit/charts/test_prolate_differentiable.py
+++ b/tests/unit/charts/test_prolate_differentiable.py
@@ -2,6 +2,7 @@
 
 import jax
 import jax.numpy as jnp
+import plum
 
 import unxt as u
 
@@ -93,3 +94,50 @@ def test_jit_retraces_once_across_delta_values():
     g(cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m")))
     g(cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m")))
     assert len(static_traces) == 1
+
+
+def _routes_through_cylindrical(p, frm, to):
+    """Whether the transition hands `Cylindrical3D` to a nested `pt_map`.
+
+    The converting branch is *defined* by that hop, so this asks the question
+    the guard cares about directly rather than inferring it from a call count.
+    """
+    seen = False
+    original = plum.Function.__call__
+
+    def watching(self, *args, **kwargs):
+        nonlocal seen
+        if self.__name__ == "pt_map" and any(
+            isinstance(a, cxc.Cylindrical3D) for a in args
+        ):
+            seen = True
+        return original(self, *args, **kwargs)
+
+    plum.Function.__call__ = watching
+    try:
+        cxc.pt_map(p, frm, to)
+    finally:
+        plum.Function.__call__ = original
+    return seen
+
+
+def test_same_delta_skips_the_conversion_branch():
+    """An identity transition does not pay for the branch it does not take.
+
+    `jax.lax.cond` traces *both* branches, so routing a same-`Delta` pair
+    through it cost a full round-trip to cylindrical and back -- as expensive
+    as actually converting. A concrete `Delta` decides in Python instead.
+
+    The conversion branch is exactly the hop through `Cylindrical3D`, so that
+    is what is asserted on. A call *count* would be the weaker question: an
+    identity that still traced the dead branch would make more calls than it
+    should and fewer than a real conversion, and any `n_same < n_conv` test
+    would pass regardless.
+    """
+    same = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m"))
+    twin = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m"))
+    other = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(3.0, "m"))
+
+    assert not _routes_through_cylindrical(Q_IN, same, twin)
+    # The converting case is the control: it must still take that route.
+    assert _routes_through_cylindrical(Q_IN, same, other)


### PR DESCRIPTION
Two independent fixes, both in `pt_map` bodies, both found while profiling. Off `main`, independent of #834.

## `u.Q(90, "deg")` was built per call

The colatitude ↔ latitude transitions construct the pole-to-equator offset *inside* the body — six sites across `charts` and `spherical`. `u.Q` is ~49 µs. Hoisted to a module-level `_RIGHT_ANGLE`.

## `ProlateSpheroidal3D -> ProlateSpheroidal3D` traced both branches

It routes through `jax.lax.cond` so a **traced** `Delta` works — and `lax.cond` traces both sides. So a same-`Delta` identity paid a full round-trip to cylindrical and back: **~65 ms eagerly, exactly what converting costs**.

A `Delta` that is concrete — the `StaticQuantity` every ordinary call site passes, or a dynamic one outside `jit` — can decide in Python and never build the dead branch. A traced one still needs `lax.cond`, so the predicate is checked for tracer-ness rather than the branch being removed. (I originally wrote this up as "`Delta` is static, so a Python `if` is free"; that was wrong — `test_prolate_differentiable` exists because `Delta` can be a leaf.)

| | before | after | |
| --- | ---: | ---: | ---: |
| identity, static `Delta` | 65 362 µs | **347 µs** | 188× |
| identity, dynamic `Delta` | 67 289 µs | **366 µs** | 184× |
| converting | 64 704 µs | **12 783 µs** | 5.1× |

The converting case gains too, since it no longer traces the identity branch it does not take.

## Verification

Values unchanged on every path, checked against `main`: eager identity, eager converting, `jit` with an equal traced `Delta`, `jit` with a differing traced `Delta`, and `grad` through a dynamic `Delta` all agree exactly.

`test_prolate_differentiable` already covers the traced route; it gains one case pinning that the identity no longer enters the conversion branch, which fails against `main`.

`nox -s test` — **11 816 passed**, 315 skipped, 1 xfailed. `prek run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
