### PR TITLE
🐛 fix(charts): the output container follows the length, not the angle

### DIFF
--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -41,14 +41,7 @@ from coordinax._src.exceptions import ManifoldMismatchError
 from coordinax._src.null import NoManifold
 from coordinax._src.product.chart import CartesianProductChart
 from coordinax._src.product.manifold import CartesianProductManifold
-from coordinax._src.utils import (
-    promoted_unit,
-    rad_value,
-    strip,
-    uconvert_to_rad,
-    wrap,
-    wrap_angle,
-)
+from coordinax._src.utils import rad_value, strip, uconvert_to_rad, wrap, wrap_angle
 from coordinaxs.api.custom_types import CDict
 
 
@@ -460,7 +453,6 @@ def pt_map(
     # `strip`/`rad_value`/`wrap` keep the arithmetic off `Quantity` operands,
     # where every primitive costs a `quax` trace; see `coordinax._src.utils`.
     (r_,), unit = strip(p, ("r",))
-    unit = promoted_unit(unit, p["theta"])
     theta = rad_value(p["theta"], usys)
     return canonical_containers(
         {"x": wrap(r_ * jnp.cos(theta), unit), "y": wrap(r_ * jnp.sin(theta), unit)},
@@ -546,7 +538,6 @@ def pt_map(
     # `z` is not consumed by the arithmetic, so it is carried through untouched
     # and keeps its own unit and container.
     (rho,), unit = strip(p, ("rho",))
-    unit = promoted_unit(unit, p["phi"])
     phi = rad_value(p["phi"], usys)
     return canonical_containers(
         {
@@ -594,18 +585,15 @@ def pt_map(
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     (r_,), unit = strip(p, ("r",))
-    # `z` reads only `r` and `theta`; `x` and `y` read `phi` as well.
-    unit_z = promoted_unit(unit, p["theta"])
-    unit_xy = promoted_unit(unit_z, p["phi"])
     theta = rad_value(p["theta"], usys)
     phi = rad_value(p["phi"], usys)
     # `sin(theta)` once rather than once per component.
     rho = r_ * jnp.sin(theta)
     return canonical_containers(
         {
-            "x": wrap(rho * jnp.cos(phi), unit_xy),
-            "y": wrap(rho * jnp.sin(phi), unit_xy),
-            "z": wrap(r_ * jnp.cos(theta), unit_z),
+            "x": wrap(rho * jnp.cos(phi), unit),
+            "y": wrap(rho * jnp.sin(phi), unit),
+            "z": wrap(r_ * jnp.cos(theta), unit),
         },
         to_chart,
     )
@@ -645,18 +633,15 @@ def pt_map(
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     (r_,), unit = strip(p, ("distance",))
-    # `z` reads only `distance` and `lat`; `x` and `y` read `lon` as well.
-    unit_z = promoted_unit(unit, p["lat"])
-    unit_xy = promoted_unit(unit_z, p["lon"])
     lon = rad_value(p["lon"], usys)
     lat = rad_value(p["lat"], usys)
     # `cos(lat)` once rather than once per component.
     rho = r_ * jnp.cos(lat)
     return canonical_containers(
         {
-            "x": wrap(rho * jnp.cos(lon), unit_xy),
-            "y": wrap(rho * jnp.sin(lon), unit_xy),
-            "z": wrap(r_ * jnp.sin(lat), unit_z),
+            "x": wrap(rho * jnp.cos(lon), unit),
+            "y": wrap(rho * jnp.sin(lon), unit),
+            "z": wrap(r_ * jnp.sin(lat), unit),
         },
         to_chart,
     )
@@ -700,9 +685,6 @@ def pt_map(
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     (r_,), unit = strip(p, ("distance",))
-    # `z` reads only `distance` and `lat`; `x` and `y` read `lon_coslat` too.
-    unit_z = promoted_unit(unit, p["lat"])
-    unit_xy = promoted_unit(unit_z, p["lon_coslat"])
     lat = rad_value(p["lat"], usys)
     # To radians *before* the division rather than after: `coslat` is
     # dimensionless, so the two commute, and dividing raw values keeps the
@@ -718,9 +700,9 @@ def pt_map(
     rho = r_ * coslat
     return canonical_containers(
         {
-            "x": wrap(rho * jnp.cos(lon), unit_xy),
-            "y": wrap(rho * jnp.sin(lon), unit_xy),
-            "z": wrap(r_ * jnp.sin(lat), unit_z),
+            "x": wrap(rho * jnp.cos(lon), unit),
+            "y": wrap(rho * jnp.sin(lon), unit),
+            "z": wrap(r_ * jnp.sin(lat), unit),
         },
         to_chart,
     )
@@ -761,18 +743,15 @@ def pt_map(
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     (r_,), unit = strip(p, ("r",))
-    # `z` reads only `r` and `phi`; `x` and `y` read `theta` as well.
-    unit_z = promoted_unit(unit, p["phi"])
-    unit_xy = promoted_unit(unit_z, p["theta"])
     theta = rad_value(p["theta"], usys)
     phi = rad_value(p["phi"], usys)
     # `sin(phi)` once rather than once per component.
     rho = r_ * jnp.sin(phi)
     return canonical_containers(
         {
-            "x": wrap(rho * jnp.cos(theta), unit_xy),
-            "y": wrap(rho * jnp.sin(theta), unit_xy),
-            "z": wrap(r_ * jnp.cos(phi), unit_z),
+            "x": wrap(rho * jnp.cos(theta), unit),
+            "y": wrap(rho * jnp.sin(theta), unit),
+            "z": wrap(r_ * jnp.cos(phi), unit),
         },
         to_chart,
     )
@@ -1073,7 +1052,6 @@ def pt_map(
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     # `phi` is an angle, outside this length group, and passes through untouched.
     (r_,), unit = strip(p, ("r",))
-    unit = promoted_unit(unit, p["theta"])
     theta = rad_value(p["theta"], usys)
     return canonical_containers(
         {

--- a/src/coordinax/_src/manifolds/chord_distance.py
+++ b/src/coordinax/_src/manifolds/chord_distance.py
@@ -31,6 +31,8 @@ from typing import Any
 
 import plum
 
+import unxt as u
+
 import coordinaxs.api.charts as cxcapi
 import coordinaxs.api.manifolds as cxmapi
 from coordinax._src.base import AbstractChart, AbstractManifold
@@ -141,7 +143,12 @@ def chord_distance(
             f"{M.ndim}-dimensional."
         )
         raise NotImplementedError(msg)
-    unit_sphere = EmbeddedChart(TwoSphereIn3D(radius=1.0))
+    # `u.Q(1.0, "")` rather than a bare `1.0`: the unit sphere's radius is
+    # dimensionless, and saying so is what makes the chord come back as a
+    # dimensionless `Quantity`. It used to arrive there by accident, because
+    # `Quantity` arithmetic promoted a bare radius as soon as it met an `Angle`
+    # -- so the return type tracked how the *angles* were wrapped.
+    unit_sphere = EmbeddedChart(TwoSphereIn3D(radius=u.Q(1.0, "")))
     return _ambient_distance(unit_sphere, chart, sph2, a, b, usys)
 
 

--- a/src/coordinax/_src/utils.py
+++ b/src/coordinax/_src/utils.py
@@ -182,41 +182,6 @@ def strip(p: CDict, keys: CKeys, /) -> tuple[tuple[Any, ...], Any]:
     return tuple(u.ustrip(unit, p[k]) for k in keys), unit
 
 
-def promoted_unit(unit: Any, /, *operands: Any) -> Any:
-    """Return the unit `wrap` should re-attach, reproducing `Quantity` promotion.
-
-    `strip` reports the unit of the *length* group. When that group is unitless
-    but an operand feeding the same expression carries a unit -- a bare radius
-    with an `Angle` azimuth, which is exactly how the unit-sphere charts are
-    written -- `Quantity` arithmetic promoted the result to a *dimensionless*
-    `Quantity`. Callers rely on it: `chord_distance` on `sph2` returns one.
-
-    Promotion follows the operands that actually feed the expression, not the
-    point as a whole -- a unitful component the arithmetic never reads promotes
-    nothing, so a body with differently-sourced outputs needs one call each.
-
-    >>> import unxt as u
-    >>> from coordinax._src.utils import promoted_unit
-
-    A group that has its own unit keeps it:
-
-    >>> promoted_unit(u.unit("m"), u.Angle(1.0, "rad"))
-    Unit("m")
-
-    A unitless group promoted by a unitful operand becomes dimensionless, and
-    stays unitless when nothing feeding it carries a unit:
-
-    >>> promoted_unit(None, u.Angle(1.0, "rad"))
-    Unit(dimensionless)
-    >>> promoted_unit(None, 1.0) is None
-    True
-
-    """
-    if unit is not None:
-        return unit
-    return UNTLS if any(u.unit_of(o) is not None for o in operands) else None
-
-
 def wrap(value: Any, unit: Any, /) -> Any:
     """Re-attach *unit* to a raw value, or pass it through when *unit* is `None`.
 

--- a/tests/unit/charts/test_register_realize.py
+++ b/tests/unit/charts/test_register_realize.py
@@ -365,22 +365,26 @@ class TestPtMapUnitContract:
         assert phi.unit == u.unit("deg")
         assert phi.value == pytest.approx(30.0)
 
-    def test_a_unitful_angle_promotes_a_unitless_length(self):
-        """A bare radius with an `Angle` gives a *dimensionless* `Quantity` length.
+    def test_the_output_container_follows_the_length_not_the_angle(self):
+        """A unitless radius stays unitless however the angle is wrapped.
 
-        `Quantity` arithmetic promoted whenever any operand was one, and callers
-        depend on it -- `chord_distance` on `sph2`, whose radius is a bare 1 and
-        whose angles are `Angle`s, returns a dimensionless `Quantity`. Promotion
-        follows the operands that feed each output, so a unitful component the
-        arithmetic never reads promotes nothing.
+        `Quantity` arithmetic used to promote whenever *any* operand was one,
+        so `sph3d -> cart3d` returned a *dimensionless* `Quantity` for a length
+        when the angle happened to be an `Angle` and a bare array when it did
+        not -- and, in the same point, left an untouched `z` bare either way.
+        The output pytree structure therefore depended on how the angles were
+        wrapped, which is the route-dependence `canonical_containers` exists to
+        remove. Only the operands carrying length information decide.
         """
         ang = {"theta": u.Angle(0.7, "rad"), "phi": u.Angle(1.2, "rad")}
-        out = cxc.pt_map({"r": 2.0, **ang}, cxc.sph3d, cxc.cart3d)
-        assert all(u.unit_of(v) == u.unit("") for v in out.values())
+        wrapped = cxc.pt_map({"r": 2.0, **ang}, cxc.sph3d, cxc.cart3d)
+        bare = cxc.pt_map({"r": 2.0, "theta": 0.7, "phi": 1.2}, cxc.sph3d, cxc.cart3d)
 
-        # `z` is not read by `cyl3d -> cart3d`'s arithmetic, so it promotes nothing.
-        out = cxc.pt_map(
-            {"rho": 2.0, "phi": 0.7, "z": u.Q(3.0, "m")}, cxc.cyl3d, cxc.cart3d
-        )
-        assert u.unit_of(out["x"]) is None
-        assert u.unit_of(out["z"]) == u.unit("m")
+        assert all(u.unit_of(v) is None for v in wrapped.values())
+        assert jax.tree.structure(wrapped) == jax.tree.structure(bare)
+
+    def test_a_length_component_still_decides_its_own_output(self):
+        """The rule is about *which* operands decide, not about dropping units."""
+        p = {"r": u.Q(2.0, "km"), "theta": 0.7, "phi": 1.2}
+        out = cxc.pt_map(p, cxc.sph3d, cxc.cart3d)
+        assert all(u.unit_of(v) == u.unit("km") for v in out.values())


### PR DESCRIPTION
`pt_map` could return `{'x': Quantity[dimensionless], 'z': float}` for a **single point**. Flagged while working on #834, which deliberately preserved it; this fixes it.

## What was happening

`Quantity` arithmetic promoted as soon as *any* operand was one. With a unitless radius and an `Angle` azimuth, the computed components came back as dimensionless `Quantity`s — while an untouched `z`, which the arithmetic never reads, stayed a bare float.

```pycon
>>> cxc.pt_map({"rho": 2.0, "phi": u.Angle(0.7, "rad"), "z": 3.0}, cxc.cyl3d, cxc.cart3d)
{'x': Quantity[dimensionless], 'y': Quantity[dimensionless], 'z': float}   # before
{'x': Array,                   'y': Array,                   'z': float}   # after
```

So the output **pytree structure depended on how the angles happened to be wrapped** — the same route-dependence `canonical_containers` was written to remove, since `Angle` and `Quantity` are distinct pytree nodes and both `lax.cond` and `jax.tree.map` reject a mismatch.

Only the operands carrying length information decide now: a unitless radius gives unitless lengths whatever the angles are. `promoted_unit` — added in #834 to reproduce the old rule exactly while the arithmetic moved off `Quantity` operands — goes with it.

## The one real caller

`chord_distance` on the unit sphere. It built its embedding with a bare `radius=1.0` (`chord_distance.py:144`) and got a dimensionless `Quantity` back **only because the radius met an `Angle`** inside `pt_map`.

Its radius is now `u.Q(1.0, "")`. The unit sphere *is* dimensionless; saying so keeps the public return type and makes it deliberate rather than inherited:

```pycon
>>> cxm.chord_distance(cxc.sph2, a, b)
Q(1.41421356, '')     # same before and after
```

**No test was loosened.** All seven `TestChordDistance` cases and the `skills/coordinax/SKILL.md` doctest pass unchanged — they were the 8 failures before the radius was made explicit, and they are the evidence the public contract held.

## Verification

Differential over 54 points: **40 byte-identical**, and the 14 that move are exactly the bare-length-with-unitful-angle cases, in their length components only. Nothing with a unitful radius, nothing fully unitless, and no angle output changes.

`nox -s test` — **11 826 passed**, 315 skipped, 1 xfailed. `prek run` clean.

Net −46 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
