### PR TITLE
🐛 fix(euclidean): label the analytic metrics per `rad²`, not per the input's angle unit

### DIFF
--- a/src/coordinax/_src/euclidean/register_metric.py
+++ b/src/coordinax/_src/euclidean/register_metric.py
@@ -24,7 +24,7 @@ missing from the diagonal list is declared non-orthogonal by omission.
 
 __all__: tuple[str, ...] = ()
 
-from typing import Any, cast
+from typing import Any
 
 import jax.numpy as jnp
 import plum
@@ -68,10 +68,24 @@ def _angle_rad(q: Any, /) -> Any:
     return q
 
 
-def _angle_unit(q: Any, /) -> u.AbstractUnit:
-    """Return the unit of an angular coordinate, or dimensionless if plain array."""
+def _angle_basis_unit(q: Any, /) -> u.AbstractUnit:
+    """Return the angle unit the metric *value* below is expressed per.
+
+    The analytic rules compute the radian-convention component -- ``g_theta_theta
+    = r**2``, not ``r**2 (pi/180)**2`` -- so the result must be labelled per
+    ``rad**2`` however the caller spelled the angle.  ``r**2`` per ``rad**2`` and
+    ``r**2 (pi/180)**2`` per ``deg**2`` are the *same tensor*, and `unxt`
+    reconciles them when the metric is contracted.
+
+    Stamping the radian value with the input's own unit -- which this did until
+    #835 -- made every metric quantity wrong by ``(180/pi)**n`` for degree input,
+    with ``LonLatSpherical3D`` in degrees the worst case.  `jac_pt_map` was
+    unaffected and is the reference the tests compare against.
+
+    A plain array carries no unit and stays dimensionless, as before.
+    """
     if isinstance(q, u.AbstractQuantity):
-        return cast("u.AbstractUnit", q.unit)
+        return u.unit("rad")  # ty: ignore[invalid-return-type]
     return u.unit("")  # ty: ignore[invalid-return-type]
 
 
@@ -293,7 +307,7 @@ def metric_matrix(
     """
     del M, chart
     r_val, r_unit = _val_unit(point["r"])
-    theta_unit = _angle_unit(point["theta"])
+    theta_unit = _angle_basis_unit(point["theta"])
     diag = jnp.stack([jnp.ones_like(r_val, dtype=float), r_val**2], axis=-1)
     units = ul.UnitsMatrix((u.unit(""), r_unit**2 / theta_unit**2))
     return DiagonalMetric(ul.QuantityMatrix(diag, unit=units))
@@ -323,7 +337,7 @@ def metric_matrix(
     """
     del M, chart
     rho_val, rho_unit = _val_unit(point["rho"])
-    phi_unit = _angle_unit(point["phi"])
+    phi_unit = _angle_basis_unit(point["phi"])
     dmls = u.unit("")
     diag = jnp.stack(
         [
@@ -370,8 +384,8 @@ def metric_matrix(
     del M, chart
     r_val, r_unit = _val_unit(point["r"])
     theta_val = _angle_rad(point["theta"])
-    theta_unit = _angle_unit(point["theta"])
-    phi_unit = _angle_unit(point["phi"])
+    theta_unit = _angle_basis_unit(point["theta"])
+    phi_unit = _angle_basis_unit(point["phi"])
     r2 = r_val**2
     r2_unit = r_unit**2
     diag = jnp.stack(
@@ -414,8 +428,8 @@ def metric_matrix(
     del M, chart
     r_val, r_unit = _val_unit(point["r"])
     phi_val = _angle_rad(point["phi"])  # polar / colatitude angle
-    theta_unit = _angle_unit(point["theta"])
-    phi_unit = _angle_unit(point["phi"])
+    theta_unit = _angle_basis_unit(point["theta"])
+    phi_unit = _angle_basis_unit(point["phi"])
     r2 = r_val**2
     r2_unit = r_unit**2
     diag = jnp.stack(
@@ -457,8 +471,8 @@ def metric_matrix(
     del M, chart
     d_val, d_unit = _val_unit(point["distance"])
     lat_val = _angle_rad(point["lat"])
-    lon_unit = _angle_unit(point["lon"])
-    lat_unit = _angle_unit(point["lat"])
+    lon_unit = _angle_basis_unit(point["lon"])
+    lat_unit = _angle_basis_unit(point["lat"])
     d2 = d_val**2
     d2_unit = d_unit**2
     diag = jnp.stack(

--- a/tests/unit/manifolds/test_metric_angle_units.py
+++ b/tests/unit/manifolds/test_metric_angle_units.py
@@ -1,0 +1,108 @@
+"""The analytic Euclidean metrics must not depend on how the caller spells an angle.
+
+A metric component in a degree-parameterised basis is ``r²(π/180)²`` per ``deg²``,
+which is the *same tensor* as ``r²`` per ``rad²``.  The analytic rules compute the
+radian-convention value, so they must label it per ``rad²`` whatever unit the point
+carries -- otherwise every metric quantity is wrong by ``(180/π)ⁿ`` for degree input.
+
+`jac_pt_map` is the independent reference: it differentiates the chart transition
+and cannot get the convention wrong.
+"""
+
+import numpy as np
+import pytest
+
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+
+# (chart, point-in-radians, angular keys)
+CASES = {
+    "polar2d": (
+        cxc.polar2d,
+        {"r": u.Q(2.0, "m"), "theta": u.Angle(0.7, "rad")},
+        ("theta",),
+    ),
+    "cyl3d": (
+        cxc.cyl3d,
+        {"rho": u.Q(2.0, "m"), "phi": u.Angle(0.7, "rad"), "z": u.Q(0.5, "m")},
+        ("phi",),
+    ),
+    "sph3d": (
+        cxc.sph3d,
+        {"r": u.Q(2.0, "m"), "theta": u.Angle(0.7, "rad"), "phi": u.Angle(0.3, "rad")},
+        ("theta", "phi"),
+    ),
+    "math_sph3d": (
+        cxc.math_sph3d,
+        {"r": u.Q(2.0, "m"), "theta": u.Angle(0.3, "rad"), "phi": u.Angle(0.7, "rad")},
+        ("theta", "phi"),
+    ),
+    "lonlat_sph3d": (
+        cxc.lonlat_sph3d,
+        {
+            "lon": u.Angle(0.7, "rad"),
+            "lat": u.Angle(0.3, "rad"),
+            "distance": u.Q(2.0, "m"),
+        },
+        ("lon", "lat"),
+    ),
+}
+
+
+def _in_degrees(point, angular):
+    """The same geometric point, with its angles spelled in degrees."""
+    return {
+        k: (
+            u.Angle(np.rad2deg(np.asarray(v.value)).item(), "deg")
+            if k in angular
+            else v
+        )
+        for k, v in point.items()
+    }
+
+
+def _agree(analytic, pullback):
+    """Compare diagonals in a common unit basis.
+
+    The analytic rule labels its value per ``rad**2`` while the pullback labels
+    the same tensor in whatever the point carried, so the raw ``.value`` arrays
+    differ by ``(180/pi)**2`` for degree input even when both are right.  The
+    conversion is the whole point of the fix, so the test must do it too.
+    """
+    diag = analytic.diagonal
+    for i in range(len(diag)):
+        entry = pullback[i, i]
+        got = u.uconvert(entry.unit, diag[i]).value
+        assert np.allclose(got, entry.value, rtol=1e-10, atol=1e-12), (
+            f"component {i}: analytic {got} vs pullback {entry.value} [{entry.unit}]"
+        )
+
+
+@pytest.mark.parametrize("name", list(CASES))
+@pytest.mark.parametrize("spelling", ["rad", "deg"])
+def test_analytic_metric_matches_the_jacobian_pullback(name, spelling):
+    """The analytic rule must agree with `jac_pt_map` in either angle spelling."""
+    chart, point_rad, angular = CASES[name]
+    point = point_rad if spelling == "rad" else _in_degrees(point_rad, angular)
+
+    analytic = cxm.metric_matrix(cxm.R3 if len(point) == 3 else cxm.R2, point, chart)
+    jac = cxc.jac_pt_map(point, chart, chart.cartesian)
+    _agree(analytic, jac.T @ jac)
+
+
+def test_a_degree_step_has_the_length_a_degree_step_has():
+    """One degree of longitude on a 1 km sphere is `pi/180` km, not 1 km."""
+    at = {
+        "lon": u.Angle(30.0, "deg"),
+        "lat": u.Angle(0.0, "deg"),
+        "distance": u.Q(1.0, "km"),
+    }
+    v = {
+        "lon": u.Angle(1.0, "deg"),
+        "lat": u.Angle(0.0, "deg"),
+        "distance": u.Q(0.0, "km"),
+    }
+    got = float(cxm.norm(v, cxc.lonlat_sph3d, at=at).ustrip("km"))
+    assert got == pytest.approx(np.pi / 180, rel=1e-10)


### PR DESCRIPTION
Closes #835.

The analytic Euclidean metric rules compute the radian-convention component (`g_θθ = r²`) but stamped it with the **input angle's** unit. A point given in degrees therefore produced `r²` per `deg²`, where the correct component is `r²(π/180)²`. The value was never converted — only the label changed — so every metric quantity came out wrong by `(180/π)ⁿ`.

```python
at = {"lon": u.Angle(30., "deg"), "lat": u.Angle(0., "deg"), "distance": u.Q(1., "km")}
v  = {"lon": u.Angle(1.,  "deg"), "lat": u.Angle(0., "deg"), "distance": u.Q(0., "km")}
cxm.norm(v, cxc.lonlat_sph3d, at=at)   # was Q(1., "km"); truth is 0.0174533 km
```

Off by `180/π = 57.296` for a norm, `3282.8` for a metric component. `LonLatSpherical3D` with lon/lat in degrees is the natural astronomy input, so it is the worst case.

## The fix

`r²` per `rad²` and `r²(π/180)²` per `deg²` are the **same tensor**, and `unxt` reconciles them on contraction — verified: with the metric stamped `km²/rad²`, `norm` returns the correct answer for a vector spelled in either unit. So the fix labels the value correctly rather than converting it.

All five affected rules funnel through one helper, so the change is one function body: `_angle_unit` becomes `_angle_basis_unit` and returns `rad` for any `Quantity` angle. Values are untouched; plain arrays stay dimensionless exactly as before.

`jac_pt_map` was never affected, which is what pinned the diagnosis, and it is the reference the new tests compare against.

## Blast radius

`metric_matrix`, `scale_factors`, `norm`, `interval`, `angle_between`, `quadratic_form`/`bilinear_form`/`gram`, across `polar2d`, `cyl3d`, `sph3d`, `math_sph3d`, `lonlat_sph3d`.

`change_basis` was already correct and stays correct — verified, not assumed: it returns `3 deg·km/(rad·s)`, which converts to the right `0.05236 km/s`. It keeps its awkward mixed unit, which still misleads anyone reading `.value`; that is pre-existing and untouched here.

## Why it was not caught, and what now catches it

No test passed a non-radian angle to any of these functions. `test_metric_pullback_consistency.py` — the exact analytic-vs-pullback comparison that fails — covered only S², and only in radians.

`tests/unit/manifolds/test_metric_angle_units.py` compares all five charts against `jac_pt_map` in **both** spellings, plus a plain-language check that one degree of longitude on a 1 km sphere is `π/180` km.

The comparison is unit-aware, which matters: after the fix the two sides carry different but equivalent unit bases, so a naive `.value` comparison would fail on correct code.

## Verification

- The new test **fails 6/11 on the unfixed code** and passes 11/11 fixed — checked explicitly by reverting the source and re-running, so it is not vacuous.
- Full suite: **11826 passed, 311 skipped, 1 xfailed**. The 26 errors in that run are all `fixture "benchmark" not found`, from running with `-p no:benchmark`; they are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
