### PR TITLE
🐛 fix(spherical): a bare angle on the 2-sphere means what usys says

### DIFF
--- a/src/coordinax/_src/spherical/register_ptmap.py
+++ b/src/coordinax/_src/spherical/register_ptmap.py
@@ -157,11 +157,19 @@ def pt_map(
     {'lon': Angle(45, 'deg'), 'lat': Angle(0, 'deg')}
 
     """
-    del usys  # Unused
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
-    lat = p["theta"]
-    lat = _RIGHT_ANGLE - lat if is_any_quantity(lat) else jnp.pi / 2 - lat
+    # A `Quantity` carries its own unit and the subtraction converts; a *bare*
+    # value means whatever `usys` says it means, and reading it raw made a
+    # `usys` of degrees come out as `pi / 2 - 40` for a 40 degree colatitude.
+    # The `LonCosLat` pair below and the 3-D twin both already convert, so the
+    # same point reached `lat` through two charts and got two answers.
+    theta = p["theta"]
+    lat = (
+        _RIGHT_ANGLE - theta
+        if is_any_quantity(theta)
+        else jnp.pi / 2 - uconvert_to_rad(theta, usys)
+    )
     return canonical_containers({"lon": p["phi"], "lat": lat}, to_chart)
 
 
@@ -189,11 +197,16 @@ def pt_map(
     {'theta': Angle(90, 'deg'), 'phi': Angle(45, 'deg')}
 
     """
-    del usys
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
-    theta = p["lat"]
-    theta = _RIGHT_ANGLE - theta if is_any_quantity(theta) else jnp.pi / 2 - theta
+    # See the note on the forward map: a bare `lat` is in `usys` units, not
+    # radians, and reading it raw made a degrees `usys` come out ~39 off.
+    lat = p["lat"]
+    theta = (
+        _RIGHT_ANGLE - lat
+        if is_any_quantity(lat)
+        else jnp.pi / 2 - uconvert_to_rad(lat, usys)
+    )
     return canonical_containers({"theta": theta, "phi": p["lon"]}, to_chart)
 
 

--- a/tests/unit/charts/test_register_realize.py
+++ b/tests/unit/charts/test_register_realize.py
@@ -388,3 +388,53 @@ class TestPtMapUnitContract:
         p = {"r": u.Q(2.0, "km"), "theta": 0.7, "phi": 1.2}
         out = cxc.pt_map(p, cxc.sph3d, cxc.cart3d)
         assert all(u.unit_of(v) == u.unit("km") for v in out.values())
+
+
+# =============================================================================
+
+
+class TestBareAnglesHonourTheUnitSystem:
+    """A bare angle means whatever `usys` says, in every chart that reads one.
+
+    `sph2 -> lonlat_sph2` and its inverse discarded `usys` and read a bare
+    colatitude as radians, so a `usys` of degrees put `lat` ~39 off. The same
+    point routed through `loncoslat_sph2`, or through the 3-D `lonlat_sph3d`,
+    gave the right answer -- three charts, one point, two answers for the same
+    component. A round trip hid it, because both directions were wrong the same
+    way and `pi / 2 - (pi / 2 - x)` is `x` whatever the units.
+    """
+
+    @pytest.mark.parametrize(
+        ("frm", "to", "point"),
+        [
+            (cxc.sph2, cxc.lonlat_sph2, {"theta": 40.0, "phi": 70.0}),
+            (cxc.sph2, cxc.loncoslat_sph2, {"theta": 40.0, "phi": 70.0}),
+            (cxc.sph3d, cxc.lonlat_sph3d, {"r": 1.0, "theta": 40.0, "phi": 70.0}),
+        ],
+        ids=["sph2->lonlat", "sph2->loncoslat", "sph3d->lonlat"],
+    )
+    def test_every_chart_agrees_on_lat(self, frm, to, point):
+        """A 40 degree colatitude is a 50 degree latitude, however it is reached."""
+        usys = u.unitsystem("m", "deg")
+        lat = cxc.pt_map(point, frm, to, usys=usys)["lat"]
+        assert float(lat) == pytest.approx(math.radians(50.0))
+
+    @pytest.mark.parametrize(
+        ("frm", "to", "point"),
+        [
+            (cxc.lonlat_sph2, cxc.sph2, {"lon": 70.0, "lat": 50.0}),
+            (cxc.loncoslat_sph2, cxc.sph2, {"lon_coslat": 70.0, "lat": 50.0}),
+            (cxc.lonlat_sph3d, cxc.sph3d, {"lon": 70.0, "lat": 50.0, "distance": 1.0}),
+        ],
+        ids=["lonlat->sph2", "loncoslat->sph2", "lonlat->sph3d"],
+    )
+    def test_every_chart_agrees_on_theta(self, frm, to, point):
+        """And back: the inverse map discarded `usys` in the same way.
+
+        `lonlat_sph2 -> sph2` gave `theta = -48.43` for a 50 degree latitude
+        where its two siblings gave `+0.69813`. Both directions were changed,
+        so both are pinned.
+        """
+        usys = u.unitsystem("m", "deg")
+        theta = cxc.pt_map(point, frm, to, usys=usys)["theta"]
+        assert float(theta) == pytest.approx(math.radians(40.0))


### PR DESCRIPTION
`sph2 -> lonlat_sph2` and its inverse discarded `usys` — `del usys`, then `jnp.pi / 2 - lat` — so a bare colatitude was read as radians whatever the unit system said.

Found while surveying the transitions still to convert for the `strip`/`wrap` rollout.

## Three charts, one point, two answers

With `usys = unitsystem("m", "deg")` and a bare colatitude of 40°, latitude should be 50° (`0.8727` rad):

**Forward** — a bare colatitude of 40° should give `lat` = 50° (`0.8727` rad):

| route | `lat` |
| --- | ---: |
| `sph2 -> lonlat_sph2` | **−38.4292** ← wrong |
| `sph2 -> loncoslat_sph2` | 0.8727 |
| `sph3d -> lonlat_sph3d` | 0.8727 |

**Inverse** — a bare latitude of 50° should give `theta` = 40° (`0.69813` rad):

| route | `theta` |
| --- | ---: |
| `lonlat_sph2 -> sph2` | **−48.4292** ← wrong |
| `loncoslat_sph2 -> sph2` | 0.69813 |
| `lonlat_sph3d -> sph3d` | 0.69813 |

`-38.43` is `pi / 2 - 40`: the 40 was taken as radians. The `LonCosLat` siblings *in the same file* and the 3-D twins all convert through `uconvert_to_rad` already.

## Why it survived

A round trip hides it. Both directions were wrong the same way, and `pi / 2 - (pi / 2 - x)` is `x` whatever the units — so `sph2 -> lonlat_sph2 -> sph2` returned the input unchanged and only the intermediate was nonsense. Anyone reading `lat` between the hops, or comparing against `loncoslat_sph2`, got the wrong number.

## The fix

`uconvert_to_rad` on the **bare branch only**. A `Quantity` carries its own unit and the subtraction already converts correctly; routing it through the conversion as well would promote an integer `Angle(90, "deg")` to `Angle(90., "deg")` — a change to a path that was never broken. I had it unconditional first and two doctests caught exactly that.

## Verification

Differential over **48 points** spanning every remaining angle transition (`Angle`/`Quantity` × rad/deg, bare, bare + `usys`, poles, both directions, 2-sphere and 3-D): **47 byte-identical**, and the one that moves is the bare-plus-degrees case that was wrong.

`TestBareAnglesHonourTheUnitSystem` covers **both directions**, three charts each. Against `main` exactly one case per direction fails; the other four pass because those charts were already right, which is what makes it a regression test rather than a restatement.

`nox -s test` — **11 844 passed**, 315 skipped, 1 xfailed. `prek run` clean.

## Related, not fixed here

On the bare path `uconvert_to_rad` emits **radians** while a bare value is *read* in `usys["angle"]` units, so a bare angle round trip through `usys = deg` does not return its input — `theta` 40 comes back 1.556. That is pre-existing and systemic: `sph3d <-> lonlat_sph3d` and `sph2 <-> loncoslat_sph2`, both untouched here, already behave this way, and this PR makes `lonlat_sph2` consistent with them rather than changing it. Settling it means deciding whether bare *outputs* should be emitted in `usys` units or bare *inputs* should always be radians — a convention call with a wide blast radius, so I have left it alone. Happy to open an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

