### PR TITLE
⚡️ perf(charts): take the prolate transitions off Quantity operands

### DIFF
--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -62,6 +62,29 @@ def _ratio_zero_on_axis(num: Array, denom: Array, /) -> Array:
     return jnp.where(denom == 0, jnp.zeros_like(ratio), ratio)
 
 
+_PROLATE_NEEDS_USYS: Final = (
+    "For non-Quantity 'mu' or 'nu', usys must be a UnitSystem, not None."
+)
+
+
+def _delta_squared(chart: Any, unit_area: Any, usys: OptUSys, /) -> Any:
+    """``Delta**2`` as a raw value in *unit_area*, or in ``usys`` when bare.
+
+    A bare ``mu``/``nu`` carries no unit to measure ``Delta`` against, so the
+    unit system is required there -- which is also what narrows `usys` to
+    non-`None` before it is subscripted.
+    """
+    if unit_area is not None:
+        # Strip `Delta` into the implied *length* unit and square the raw
+        # array, rather than squaring the `Quantity` and stripping the area:
+        # `Quantity ** 2` is one of the per-primitive `quax` traces this is
+        # here to avoid, and both orders give the same number.
+        return cast("Array", u.ustrip(unit_area**0.5, chart.Delta)) ** 2
+    if usys is None:
+        raise ValueError(_PROLATE_NEEDS_USYS)
+    return cast("Array", u.ustrip(usys["length"], chart.Delta)) ** 2
+
+
 def _require_cart3d_phase_space(chart: Any, /, *, direction: str) -> None:
     """Validate a two-factor ``Cart3D`` Cartesian phase-space product chart.
 
@@ -805,26 +828,24 @@ def pt_map(
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
     # Calculate cylindrical distance
-    nu, mu = p["nu"], p["mu"]
-    if not isinstance(nu, ABCQ) or not isinstance(mu, ABCQ):
-        if usys is None:
-            msg = "For non-Quantity 'mu' or 'nu', usys must be a UnitSystem, not None."
-            raise ValueError(msg)
+    (mu, nu), unit_area = strip(p, ("mu", "nu"))
+    delta2 = _delta_squared(from_chart, unit_area, usys)
 
-        Delta2 = cast("Array", u.ustrip(usys["length"], from_chart.Delta)) ** 2
-    else:
-        Delta2 = from_chart.Delta**2
+    nu_d2 = jnp.abs(nu) / delta2
+    rho = jnp.sqrt((mu - delta2) * (1 - nu_d2))
 
-    nu_D2 = jnp.abs(nu) / Delta2
-    rho = jnp.sqrt((mu - Delta2) * (1 - nu_D2))
-
-    # Convert to Cartesian
-    phi = uconvert_to_rad(p["phi"], usys)
-    x = rho * jnp.cos(phi)
-    y = rho * jnp.sin(phi)
-    z = jnp.sqrt(mu * nu_D2) * jnp.sign(nu)
-
-    return canonical_containers({"x": x, "y": y, "z": z}, to_chart)
+    # Convert to Cartesian. `mu` and `nu` are *areas*, so a length output
+    # carries the square root of their unit.
+    unit_len = None if unit_area is None else unit_area**0.5
+    phi = rad_value(p["phi"], usys)
+    return canonical_containers(
+        {
+            "x": wrap(rho * jnp.cos(phi), unit_len),
+            "y": wrap(rho * jnp.sin(phi), unit_len),
+            "z": wrap(jnp.sqrt(mu * nu_d2) * jnp.sign(nu), unit_len),
+        },
+        to_chart,
+    )
 
 
 @plum.dispatch
@@ -1268,19 +1289,21 @@ def pt_map(
     """
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
 
-    nu, mu = p["nu"], p["mu"]
-    if not isinstance(nu, ABCQ) or not isinstance(mu, ABCQ):
-        if usys is None:
-            msg = "For non-Quantity 'mu' or 'nu', usys must be a UnitSystem, not None."
-            raise ValueError(msg)
+    (mu, nu), unit_area = strip(p, ("mu", "nu"))
+    delta2 = _delta_squared(from_chart, unit_area, usys)
 
-        Delta2 = u.ustrip(usys["area"], from_chart.Delta**2)
-    else:
-        Delta2 = from_chart.Delta**2
-    nu_D2 = jnp.abs(nu) / Delta2
-    rho = jnp.sqrt((mu - Delta2) * (1 - nu_D2))
-    z = jnp.sqrt(mu * nu_D2) * jnp.sign(nu)
-    return canonical_containers({"rho": rho, "phi": p["phi"], "z": z}, to_chart)
+    nu_d2 = jnp.abs(nu) / delta2
+    # `mu` and `nu` are *areas*, so a length output carries the square root of
+    # their unit. `phi` is an angle, outside the group, and passes through.
+    unit_len = None if unit_area is None else unit_area**0.5
+    return canonical_containers(
+        {
+            "rho": wrap(jnp.sqrt((mu - delta2) * (1 - nu_d2)), unit_len),
+            "phi": p["phi"],
+            "z": wrap(jnp.sqrt(mu * nu_d2) * jnp.sign(nu), unit_len),
+        },
+        to_chart,
+    )
 
 
 @plum.dispatch

--- a/tests/unit/charts/test_register_realize.py
+++ b/tests/unit/charts/test_register_realize.py
@@ -130,6 +130,24 @@ class TestPointTransformProlate:
         out = cxc.pt_map(p, cxc.sph3d, prolate)
         assert set(out) == {"mu", "nu", "phi"}
 
+    @pytest.mark.parametrize(
+        "to_chart", [cxc.cart3d, cxc.cyl3d], ids=["cart3d", "cyl3d"]
+    )
+    def test_bare_mu_nu_without_a_unit_system_is_refused(self, to_chart) -> None:
+        """`Delta` is a length; a bare `mu`/`nu` gives nothing to measure it against.
+
+        Rejecting beats guessing: silently reading them as `Delta`'s own unit
+        would make the answer depend on how the chart happened to be built.
+        """
+        prolate = cxc.ProlateSpheroidal3D(Delta=u.StaticQuantity(2.0, "m"))
+        p = {"mu": 12.0, "nu": 0.5, "phi": 0.3}
+        with pytest.raises(ValueError, match="usys must be a UnitSystem"):
+            cxc.pt_map(p, prolate, to_chart)
+
+        # With one, it goes through.
+        out = cxc.pt_map(p, prolate, to_chart, usys=u.unitsystems.si)
+        assert all(v is not None for v in out.values())
+
 
 class TestPointTransformCartND:
     """``pt_map`` from CartND reads components on the last axis (batch-safe)."""


### PR DESCRIPTION
`ProlateSpheroidal3D -> Cart3D` and `-> Cylindrical3D`, converted to `strip`/`rad_value`/`wrap` like the Euclidean transitions in #834.

| | `main` | here | |
| --- | ---: | ---: | ---: |
| `prolate -> cart3d` | 4 185 µs | **768 µs** | 5.5× |
| `prolate -> cyl3d` | 2 873 µs | **467 µs** | 6.2× |

## The unit bookkeeping is one step longer here

`mu` and `nu` are **areas**, so the group unit is an area and a length output carries its square root — `unit_area ** 0.5`. `Delta**2` is stripped into the same area unit, which is what the `Quantity` arithmetic was doing implicitly.

`Delta` is stripped into that implied length unit and squared as a **raw array** — not squared as a `Quantity` and then stripped, which would have left one of the per-primitive `quax` traces this PR exists to remove. Both orders give the same number; only one of them is off the hot path.

`_delta_squared` holds that step. The `usys`-required check moved into it from the two bodies: a bare `mu`/`nu` carries no unit to measure `Delta` against, and that is also the narrowing which lets `usys["length"]` type-check — `ty` flagged the subscript, and restructuring is better than the ignore comment I first reached for.

Deduplicating that check also drops this file's missed-line count from **16 to 12**, and the raise now has a test — it had none in either copy on `main`.

## Verification

Differential over **57 points** — both `Delta` kinds (`StaticQuantity` and dynamic), mixed area units, `Distance`, degrees, bare with and without a unit system, `nu = 0`, the axis and the plane — **56 byte-identical**, values included.

The one that moves is `prolate -> cart3d` with a bare `mu`/`nu` and an `Angle` azimuth: `x` and `y` were dimensionless `Quantity`s while `z`, **in the same point**, was a bare array. That is exactly the promotion #839 removed; this body simply had not been converted yet, so the rule now reaches it. No new decision — #839's `test_the_output_container_follows_the_length_not_the_angle` already states it.

`nox -s test` — **11 840 passed**, 315 skipped, 1 xfailed. `prek run` clean.

## `Cylindrical3D -> ProlateSpheroidal3D` deliberately left alone

It is the most expensive of the three (~11 ms), so leaving it needs a reason.

Its `mu` takes `rho`'s unit squared and its `nu` takes `z`'s. A point with `rho` in m and `z` in cm yields `mu` in **m2** and `nu` in **cm2** — two components of one chart in different area units. `strip` would put both in one unit, which is almost certainly what you'd want, but that is a behaviour change, and I have already spent one in #839. Preserving the split instead would mean a conditional whose only purpose is to keep something that looks like a bug.

Either way it is a call for you, not something to slip into a perf PR. Happy to do it once you say which.

## Still unconverted after this

`PoincarePolar6D` (mixes lengths with velocities and its `pp_*` components carry `sqrt(length × velocity)`, so the unit algebra is genuinely computed rather than a passthrough), and the `Spherical3D <-> LonLat/LonCosLat` angle transitions — those last ones sit on the `usys` question raised in #842 and are better done after it settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

