### PR TITLE
🐛 fix(curveframes): a zero-width `tau_bounds` hung `nearest_tau`; document the `s_max` interaction

### DIFF
--- a/packages/coordinaxs.curveframes/docs/curve-charts.md
+++ b/packages/coordinaxs.curveframes/docs/curve-charts.md
@@ -606,6 +606,8 @@ The factor is a _local_ test only: it says nothing about a point mirrored across
 
 `HELIX_BOUNDS` is `(-1, 6)` s, so `333.33` is nowhere near it. Callers who cannot rule out querying past the fitted range should check the returned `tau` against `tau_bounds` themselves -- that converged-but-out-of-bounds case is not an error.
 
+That degradation needs the curve to be _evaluable_ past `tau_bounds`, which an `ArcLength` carrying a finite `s_max` is not: its interpolation covers only `[-m, s_max + m]`, so a query whose answer lies beyond that raises instead of degrading. Refusing is right there -- extrapolating off the end of the interpolation would return a plausible-looking wrong answer -- but it means `s_max` has to cover the `tau` the solve _returns_, not merely `tau_bounds[1]`. Measured on a unit circle with `tau_bounds = (0, 1)` km: a query nearest `tau = 0.5` is unaffected by `s_max`, while one nearest `tau = 1.2` raises at `s_max = 1` km and succeeds with `s_max` unset.
+
 A genuinely degenerate query is different, and _is_ caught: a point equidistant from the whole closed circle -- its centre -- leaves the stationarity condition satisfied everywhere, not by any particular $\tau$, so that same fallback root-find does not converge (its step divides by a derivative that vanishes identically). `nearest_tau` checks the solver's own result and raises rather than return an arbitrary, meaningless $\tau$:
 
 ```{code-block} python

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/arclength.py
@@ -190,7 +190,10 @@ _MSG_S_OUT_OF_DOMAIN = (
     "_solve_tau_dense integrates past each end. The interpolation has no "
     "coefficients there, and extrapolating off the end of it would return a "
     "plausible-looking wrong answer. Increase s_max, or leave it `None` to "
-    "fall back to solving the ODE fresh on every call."
+    "fall back to solving the ODE fresh on every call. If this came from a "
+    "chart's inverse `pt_map`, note that s_max must cover the `tau` the solve "
+    "*returns*, which for a point nearest the curve outside `tau_bounds` lies "
+    "outside `tau_bounds` too."
 )
 
 
@@ -586,6 +589,15 @@ class ArcLength(eqx.Module):
         update each other. Set `s_max` to at least `tau_bounds[1]` in the
         same unit, or in-bounds chart queries will land outside the
         interpolation and raise.
+
+        `tau_bounds[1]` bounds the *scan*, not the *answer*. `nearest_tau`'s
+        fallback deliberately returns a `tau` outside `tau_bounds` when the
+        true nearest point lies there, and that answer needs interpolation
+        coefficients too -- so a query of that kind raises unless `s_max`
+        also covers it. Measured on a unit circle with
+        ``tau_bounds=(0, 1) km``: a query nearest `tau = 0.5` is unaffected by
+        `s_max`, while one nearest `tau = 1.2` raises at ``s_max = 1 km`` and
+        succeeds with `s_max` unset.
 
     See Also
     --------

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/chart.py
@@ -124,6 +124,14 @@ class TubularChart(AbstractParameterizedChart):
     raise: the fallback solve can converge to a finite, low-residual `tau`
     outside `tau_bounds` instead. See the curve-charts guide's Limitations
     section for worked examples of both warnings above.
+
+    That degradation needs the curve to be *evaluable* past `tau_bounds`, which
+    an `ArcLength` carrying a finite `s_max` is not: its interpolation covers
+    only ``[-m, s_max + m]``, so a query whose answer lies beyond that raises
+    rather than degrading. Setting `s_max` to `tau_bounds[1]`, which is all
+    `ArcLength.s_max` asks for in-bounds queries, is *not* enough for
+    out-of-bounds ones -- size it against the answers the solve may return, not
+    against the scan range.
     """
 
     n_seed: int = eqx.field(static=True, default=64)

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/nearest.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/nearest.py
@@ -129,6 +129,27 @@ def nearest_tau(
     i_best = jnp.argmin(scan)
     tau0, d_seed = seeds[i_best], scan[i_best]
     spacing = (hi - lo) / (n_seed - 1)
+
+    # A zero-width `bounds` makes `spacing` zero, and `Bisection`'s
+    # `expand_if_necessary` below grows a bracket by *doubling its width* --
+    # doubling zero never grows it, and that expansion is not bounded by
+    # `max_steps`, so the solve loops with no exit instead of failing
+    # (measured: still running at 45 s, where a proper interval returns in
+    # seconds). Guard here, where every caller routes through: `TubularChart`
+    # validates the *dimensions* of `tau_bounds` but not that they differ, so a
+    # degenerate chart reaches this on every inverse `pt_map`. Threaded through
+    # `spacing` so the check cannot be eliminated ahead of the bracket that
+    # depends on it.
+    degenerate = spacing == 0
+    msg_bounds = (
+        "`bounds` has zero width, so there is no curve to search: the "
+        "nearest-point scan needs `bounds[0] != bounds[1]`."
+    )
+    if isinstance(degenerate, jax.core.Tracer):
+        spacing = eqx.error_if(spacing, degenerate, msg_bounds)
+    elif bool(degenerate):
+        raise ValueError(msg_bounds)
+
     bracket_lo, bracket_hi = tau0 - spacing, tau0 + spacing
 
     def residual(tau_v: jax.Array, args: Any) -> jax.Array:

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/nearest.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/nearest.py
@@ -53,6 +53,12 @@ def nearest_tau(
     positive to negative across a genuine minimum, so that bracket is
     well-posed for bisection and cannot land on the maximum next door.
 
+    ``bounds`` must have non-zero width. A zero-width one makes the seed
+    spacing zero, and the bracketed solve's ``expand_if_necessary`` grows a
+    bracket by doubling its width, which never grows a zero -- so it is
+    refused with a `ValueError` rather than left to loop forever. That is a
+    precondition, not a degradation: there is no curve to search.
+
     That bracket does not always contain a sign change, though -- the
     residual can be one-signed across it in two situations: the true nearest
     point lies outside `tau_bounds` altogether (the scan is confined to

--- a/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/nearest.py
+++ b/packages/coordinaxs.curveframes/src/coordinaxs/curveframes/_src/nearest.py
@@ -56,8 +56,10 @@ def nearest_tau(
     ``bounds`` must have non-zero width. A zero-width one makes the seed
     spacing zero, and the bracketed solve's ``expand_if_necessary`` grows a
     bracket by doubling its width, which never grows a zero -- so it is
-    refused with a `ValueError` rather than left to loop forever. That is a
-    precondition, not a degradation: there is no curve to search.
+    refused rather than left to loop forever -- with a `ValueError` eagerly, and
+    as a `RuntimeError` (equinox's `error_if`) under `jit` or `vmap`, where the
+    check cannot be a Python branch. That is a precondition, not a degradation:
+    there is no curve to search.
 
     That bracket does not always contain a sign change, though -- the
     residual can be one-signed across it in two situations: the true nearest
@@ -146,6 +148,11 @@ def nearest_tau(
     # degenerate chart reaches this on every inverse `pt_map`. Threaded through
     # `spacing` so the check cannot be eliminated ahead of the bracket that
     # depends on it.
+    #
+    # Two exception types, because the check cannot be a Python branch on a
+    # tracer: `ValueError` eagerly, `RuntimeError` (equinox's `error_if`) under
+    # `jit` or `vmap`. The docstring says so, and the tests pin `RuntimeError`,
+    # which both satisfy.
     degenerate = spacing == 0
     msg_bounds = (
         "`bounds` has zero width, so there is no curve to search: the "

--- a/packages/coordinaxs.curveframes/tests/unit/test_nearest_tau_robustness.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_nearest_tau_robustness.py
@@ -51,7 +51,10 @@ def test_zero_width_bounds_is_refused_under_jit() -> None:
     def solve(lo: u.AbstractQuantity, hi: u.AbstractQuantity) -> u.AbstractQuantity:
         return cxfc.nearest_tau(builder, PROBE, bounds=(lo, hi))
 
-    with pytest.raises(Exception, match="zero width"):
+    # `RuntimeError`, not `Exception`: `eqx.error_if` surfaces as
+    # `JaxRuntimeError`, which subclasses it. Catching `Exception` would let an
+    # unrelated tracing failure pass as the refusal under test.
+    with pytest.raises(RuntimeError, match="zero width"):
         solve(u.Q(3.0, "s"), u.Q(3.0, "s"))
 
 
@@ -96,5 +99,7 @@ def test_s_max_must_cover_the_answer_not_just_the_scan() -> None:
     )
 
     pinned = cxfc.BishopBuilder(cxfc.ArcLength(circle, "s", s_max=u.Q(1.0, "km")), "km")
-    with pytest.raises(Exception, match="outside the solved domain"):
+    # `EquinoxRuntimeError` subclasses `RuntimeError`; this matches how
+    # `test_arclength_smax.py` already pins the same guard.
+    with pytest.raises(RuntimeError, match="outside the solved domain"):
         cxfc.nearest_tau(pinned, x, bounds=ARC_BOUNDS)

--- a/packages/coordinaxs.curveframes/tests/unit/test_nearest_tau_robustness.py
+++ b/packages/coordinaxs.curveframes/tests/unit/test_nearest_tau_robustness.py
@@ -1,0 +1,100 @@
+r"""Degenerate inputs to `nearest_tau`: refuse promptly, never hang or mislead.
+
+Two unrelated failure modes, both reachable through the public API.
+
+A zero-width ``bounds`` used to hang forever: `Bisection`'s
+``expand_if_necessary`` grows a bracket by *doubling its width*, doubling zero
+never grows it, and that expansion is not bounded by ``max_steps``.
+
+A finite ``s_max`` bounds where an `ArcLength` curve can be evaluated at all,
+which interacts with `nearest_tau`'s documented out-of-bounds degradation:
+that degradation returns a ``tau`` outside ``tau_bounds``, and such a ``tau``
+needs interpolation coefficients too.
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import unxt as u
+
+import coordinaxs.curveframes as cxfc
+
+
+def circle(tau: u.AbstractQuantity) -> u.AbstractQuantity:
+    """Unit circle, radius 1 km."""
+    t = tau.ustrip("s")
+    return u.Q(jnp.stack([jnp.cos(t), jnp.sin(t), jnp.zeros_like(t)]), "km")
+
+
+PROBE = u.Q(jnp.asarray([2.0 * jnp.cos(1.0), 2.0 * jnp.sin(1.0), 0.0]), "km")
+ARC_BOUNDS = (u.Q(0.0, "km"), u.Q(1.0, "km"))
+
+
+def _at_angle(ang: float) -> u.AbstractQuantity:
+    """A probe twice the circle's radius out, nearest the curve at ``tau=ang``."""
+    return u.Q(2.0 * jnp.asarray([jnp.cos(ang), jnp.sin(ang), 0.0]), "km")
+
+
+def test_zero_width_bounds_is_refused() -> None:
+    """It must raise, and promptly -- hanging is the failure this guards."""
+    builder = cxfc.BishopBuilder(circle, "s")
+    with pytest.raises(ValueError, match="zero width"):
+        cxfc.nearest_tau(builder, PROBE, bounds=(u.Q(3.0, "s"), u.Q(3.0, "s")))
+
+
+def test_zero_width_bounds_is_refused_under_jit() -> None:
+    """The eager path uses a Python branch; the traced path needs `error_if`."""
+    builder = cxfc.BishopBuilder(circle, "s")
+
+    @jax.jit
+    def solve(lo: u.AbstractQuantity, hi: u.AbstractQuantity) -> u.AbstractQuantity:
+        return cxfc.nearest_tau(builder, PROBE, bounds=(lo, hi))
+
+    with pytest.raises(Exception, match="zero width"):
+        solve(u.Q(3.0, "s"), u.Q(3.0, "s"))
+
+
+def test_a_proper_interval_still_works() -> None:
+    """The guard must not disturb the ordinary case."""
+    builder = cxfc.BishopBuilder(circle, "s")
+    tau = cxfc.nearest_tau(builder, PROBE, bounds=(u.Q(0.0, "s"), u.Q(2 * jnp.pi, "s")))
+    assert float(tau.ustrip("s")) == pytest.approx(1.0, abs=1e-3)
+
+
+def test_s_max_does_not_disturb_an_in_bounds_query() -> None:
+    """`s_max = tau_bounds[1]` is enough when the answer is inside the scan.
+
+    This is exactly what `ArcLength.s_max` promises, and it holds.
+    """
+    free = cxfc.BishopBuilder(cxfc.ArcLength(circle, "s"), "km")
+    pinned = cxfc.BishopBuilder(cxfc.ArcLength(circle, "s", s_max=u.Q(1.0, "km")), "km")
+    x = _at_angle(0.5)
+
+    want = float(cxfc.nearest_tau(free, x, bounds=ARC_BOUNDS).ustrip("km"))
+    got = float(cxfc.nearest_tau(pinned, x, bounds=ARC_BOUNDS).ustrip("km"))
+
+    assert got == pytest.approx(want, abs=1e-6)
+    assert got == pytest.approx(0.5, abs=1e-3)
+
+
+def test_s_max_must_cover_the_answer_not_just_the_scan() -> None:
+    """An out-of-bounds answer needs coefficients too, so `s_max` must reach it.
+
+    `nearest_tau` documents that a point nearest the curve *outside*
+    ``tau_bounds`` degrades rather than raising -- but that needs the curve to
+    be evaluable there. With ``s_max = tau_bounds[1] = 1 km`` the answer
+    ``tau = 1.2`` lies past the interpolation, so it raises. Refusing is right:
+    extrapolating off the end would return a plausible-looking wrong answer.
+    Unset `s_max` and the same query degrades as documented.
+    """
+    x = _at_angle(1.2)
+
+    free = cxfc.BishopBuilder(cxfc.ArcLength(circle, "s"), "km")
+    assert float(cxfc.nearest_tau(free, x, bounds=ARC_BOUNDS).ustrip("km")) == (
+        pytest.approx(1.2, abs=1e-3)
+    )
+
+    pinned = cxfc.BishopBuilder(cxfc.ArcLength(circle, "s", s_max=u.Q(1.0, "km")), "km")
+    with pytest.raises(Exception, match="outside the solved domain"):
+        cxfc.nearest_tau(pinned, x, bounds=ARC_BOUNDS)


### PR DESCRIPTION
#841 has merged; this branch is rebased onto `main` and is now a single self-contained commit.

Two defects found by the same audit, both reachable through the public API.

## 1. A zero-width `tau_bounds` hung forever (code fix)

`spacing = (hi - lo) / (n_seed - 1)` is zero when the bounds are equal, so the bracket collapses to a point. `Bisection`'s `expand_if_necessary` grows a bracket by **doubling its width** — doubling zero never grows it — and that expansion is *not* bounded by `max_steps`. The solve looped with no exit rather than failing.

Measured: still running at 45 s, where the same query over a proper interval returns in seconds. Reproduced without coordinax at all, so the curve is not implicated:

| bounds | result |
|---|---|
| `(0.0, 1.0)` | returns in 0.40 s, one residual evaluation |
| `(0.3, 0.3)` | killed at 120 s, never returned |

Reachable straight through the public API: `TubularChart.__check_init__` validates the *dimensions* of `tau_bounds` but not that they differ, so the chart constructs happily and every inverse `pt_map` then hangs.

Guarded in `nearest_tau`, where all callers route through, rather than at each construction site. Threaded through `spacing` so the check cannot be eliminated ahead of the bracket that depends on it, and using the eager/traced hybrid the function already uses for its convergence guard.

## 2. `s_max` and the out-of-bounds degradation (documentation fix)

`TubularChart.tau_bounds` documents that a point whose true nearest curve point lies outside `tau_bounds` "does not raise" — the fallback converges to a `tau` outside the bounds instead. With an `ArcLength` carrying a finite `s_max`, it raises.

Measured on a unit circle, `tau_bounds = (0, 1) km`:

| query | `s_max=None` | `s_max=1.0 km` |
|---|---|---|
| nearest **inside** bounds (`tau≈0.5`) | 0.499938 | 0.499938 |
| nearest **outside** bounds (`tau≈1.2`) | 1.199995 | **raises** |

**The raise is correct and is not changed here.** The interpolation covers only `[-m, s_max + m]`, and `_MSG_S_OUT_OF_DOMAIN` exists precisely so that extrapolating off the end cannot return a plausible-looking wrong answer.

What was wrong is what the docs promise:

- `chart.py` promises the degradation unconditionally. It needs the curve to be *evaluable* past `tau_bounds`, which an `ArcLength` with finite `s_max` is not.
- `arclength.py` says to set `s_max` to at least `tau_bounds[1]`. That is right for in-bounds queries, and it says so — but `tau_bounds[1]` bounds the **scan**, not the **answer**, and the documented degradation deliberately returns a `tau` beyond it. The in-bounds row above confirms the existing guidance holds where it claims to.

Both now say so, and `_MSG_S_OUT_OF_DOMAIN` names the interaction for anyone who hits it from a chart's inverse `pt_map`.

### A rejected fix, recorded so it is not retried

The audit diagnosed this as `jnp.where` evaluating both arms, so that the unconstrained fallback ran even when the bracketed solve had already succeeded, and proposed `lax.cond`. I implemented that, and it does not fix this: the in-bounds row above shows the always-evaluated fallback causes no harm, and in the failing row the fallback is the branch that is *supposed* to run — the answer itself, `tau = 1.2`, lies outside the interpolation domain `[-0.05, 1.05]`. No change to branch selection reaches it. `lax.cond` was dropped; it also pushed `nearest_tau` past ruff's C901 complexity limit, for an unmeasured perf gain.

## Verification

Five targeted tests covering both defects, including the `jit` path for the bounds guard and both rows of the `s_max` table. Full `curveframes` `tests` + `src` + `docs` run clean.

Found during a mathematical audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)