### PR TITLE
🐛 fix(manifolds): `angle_between` collapsed to exactly zero for close directions

### DIFF
--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -15,7 +15,7 @@ from unxt.quantity import AllowValue
 
 import coordinax.angles as cxa
 import coordinaxs.api.manifolds as cxmapi
-from .quadratic_form import gram, quadratic_form
+from .quadratic_form import _contract, _prepare
 from coordinax._src.base import (
     AbstractChart,
     AbstractMetricField,
@@ -134,9 +134,21 @@ def angle_between(
     # system" contract that `norm` and `interval` impose -- where the result's
     # unit *is* derived from the inputs -- would be ceremony here, and would
     # break callers that have always passed bare arrays.
-    inner, uu, vv = gram(
-        uvec, vvec, chart, at=at, usys=usys, fname="angle_between", require_usys=False
+    # `_prepare` + `_contract` rather than `gram`, so the metric matrix is built
+    # and the components packed exactly *once* for all four contractions below.
+    # `gram` gives three of them from one build; the rejection needs a fourth,
+    # `g(w,w)`, and calling `quadratic_form` for it would rebuild the matrix --
+    # free under `jit`, ~1.6x eagerly, which is the cost `gram` exists to avoid.
+    mm, (u_, v_) = _prepare(
+        chart,
+        (uvec, vvec),
+        at=at,
+        usys=usys,
+        fname="angle_between",
+        keys=chart.components,
+        require_usys=False,
     )
+    inner, uu, vv = _contract(mm, u_, v_), _contract(mm, u_, u_), _contract(mm, v_, v_)
 
     cos = u.ustrip(AllowValue, "", inner / qnp.sqrt(uu * vv))
 
@@ -176,11 +188,13 @@ def angle_between(
     # so it carries no unit and `coef * vvec[k]` keeps component `k`'s own
     # unit. That matters for heterogeneous charts (lon/lat/distance), where a
     # scalar with any length dimension would not subtract componentwise.
+    # Formed in the *packed* representation, so it reuses `mm` above. `coef` is
+    # dimensionless -- `inner` and `vv` are both metric contractions -- so
+    # `coef * v_` keeps each component's own unit and the subtraction is well
+    # posed on heterogeneous charts (lon/lat/distance).
     coef = inner / vv
-    wvec = {k: uvec[k] - coef * vvec[k] for k in uvec}
-    ww = quadratic_form(
-        wvec, chart, at=at, usys=usys, fname="angle_between", require_usys=False
-    )
+    w_ = u_ - coef * v_
+    ww = _contract(mm, w_, w_)
 
     # sin = sqrt(g(w,w) / g(u,u)), which is exactly sqrt(1 - cos^2) and, like
     # `cos`, dimensionless. Clipped below at zero for the indefinite metrics

--- a/src/coordinax/_src/manifolds/angle_between.py
+++ b/src/coordinax/_src/manifolds/angle_between.py
@@ -15,7 +15,7 @@ from unxt.quantity import AllowValue
 
 import coordinax.angles as cxa
 import coordinaxs.api.manifolds as cxmapi
-from .quadratic_form import gram
+from .quadratic_form import gram, quadratic_form
 from coordinax._src.base import (
     AbstractChart,
     AbstractMetricField,
@@ -156,9 +156,39 @@ def angle_between(
     # case -- silently reporting "anti-parallel" for two observers in relative
     # motion. `nan` is the honest value: no real angle exists.
     valid = u_spacelike & v_spacelike & (jnp.abs(cos) <= 1.0 + _COS_ATOL)
-    # The clip is float-error insurance for the *valid* branch only; `valid`
-    # has already excluded everything genuinely out of range.
-    angle = jnp.arccos(jnp.clip(cos, -1.0, 1.0))
+
+    # `atan2` of a componentwise rejection, not `arccos` of the cosine.
+    # `arccos` has an infinite derivative at 1, so it loses its significant
+    # digits exactly in the nearly-parallel regime -- at float32, the library
+    # default, it returned a confident `0.0` for directions 1e-4 rad (~20
+    # arcsec) apart. `_central_angle` in `geodesic_distance` already makes this
+    # argument for the sphere; it applies verbatim to a general metric.
+    #
+    # The algebraic shortcut `sqrt(uu*vv - inner**2)` is *not* a fix, though
+    # `gram` hands us all three terms for free: `uu*vv` approaches `inner**2`
+    # for nearly-parallel vectors, so it cancels precisely as `arccos` does.
+    # Measured at float32 against a 1e-4 rad separation, both return exactly
+    # 0 rad where the form below is accurate to 2.5e-8 relative. The
+    # subtraction has to happen per component, *before* the metric contracts
+    # it -- which costs the second contraction below.
+    #
+    # `coef` is dimensionless: `inner` and `vv` are both metric contractions,
+    # so it carries no unit and `coef * vvec[k]` keeps component `k`'s own
+    # unit. That matters for heterogeneous charts (lon/lat/distance), where a
+    # scalar with any length dimension would not subtract componentwise.
+    coef = inner / vv
+    wvec = {k: uvec[k] - coef * vvec[k] for k in uvec}
+    ww = quadratic_form(
+        wvec, chart, at=at, usys=usys, fname="angle_between", require_usys=False
+    )
+
+    # sin = sqrt(g(w,w) / g(u,u)), which is exactly sqrt(1 - cos^2) and, like
+    # `cos`, dimensionless. Clipped below at zero for the indefinite metrics
+    # `valid` is about to reject anyway, so the `sqrt` cannot hand `atan2` a
+    # NaN on the branch that is discarded.
+    sin2 = u.ustrip(AllowValue, "", ww / uu)
+    sin = jnp.sqrt(jnp.clip(jnp.where(valid, sin2, 0.0), 0.0, None))
+    angle = jnp.atan2(sin, cos)
     return cxa.Angle(jnp.where(valid, angle, jnp.nan), "rad")
 
 

--- a/tests/unit/manifolds/test_angle_between_small_angles.py
+++ b/tests/unit/manifolds/test_angle_between_small_angles.py
@@ -1,0 +1,57 @@
+r"""`angle_between` must keep its digits for nearly-parallel vectors.
+
+``arccos`` has an infinite derivative at 1, so it loses precision exactly where
+two directions are close -- which is the regime the answer is usually wanted
+in. At the library's default float32 it returned a confident ``0.0`` for
+directions 1e-4 rad (~20 arcsec) apart; the test suite forces float64, where
+the same collapse happens at 1e-8.
+
+`geodesic_distance._central_angle` already uses the robust ``atan2`` form and
+its docstring already makes this argument; it had not been carried across.
+"""
+
+import numpy as np
+import pytest
+
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+
+AT = {k: u.Q(0.0, "m") for k in "xyz"}
+XHAT = {"x": u.Q(1.0, "m"), "y": u.Q(0.0, "m"), "z": u.Q(0.0, "m")}
+
+
+def _rotated(theta: float) -> dict:
+    """A unit vector ``theta`` radians from ``XHAT`` in the xy-plane."""
+    return {
+        "x": u.Q(float(np.cos(theta)), "m"),
+        "y": u.Q(float(np.sin(theta)), "m"),
+        "z": u.Q(0.0, "m"),
+    }
+
+
+@pytest.mark.parametrize("theta", [1e-2, 1e-4, 1e-6, 1e-8, 1e-10])
+def test_small_angles_keep_their_significant_digits(theta: float) -> None:
+    """The reported angle must be accurate, not collapsed to zero."""
+    got = float(
+        cxm.angle_between(cxc.cart3d, XHAT, _rotated(theta), at=AT).ustrip("rad")
+    )
+    assert got == pytest.approx(theta, rel=1e-6)
+
+
+def test_it_does_not_report_exactly_zero_for_distinct_directions() -> None:
+    """The specific failure: a confident zero for two genuinely distinct rays."""
+    got = float(
+        cxm.angle_between(cxc.cart3d, XHAT, _rotated(1e-8), at=AT).ustrip("rad")
+    )
+    assert got > 0.0
+
+
+def test_ordinary_angles_are_unchanged() -> None:
+    """The robust form must agree with the obvious one where both are fine."""
+    for theta in (0.1, 1.0, np.pi / 2, 3.0):
+        got = float(
+            cxm.angle_between(cxc.cart3d, XHAT, _rotated(theta), at=AT).ustrip("rad")
+        )
+        assert got == pytest.approx(theta, rel=1e-9)


### PR DESCRIPTION
Closes #836.

`angle_between` computed `arccos(g(u,v) / sqrt(g(u,u) g(v,v)))`. `arccos` has an infinite derivative at 1, so it loses its significant digits in precisely the nearly-parallel regime the answer is usually wanted in.

At the library's default **float32** it returned a confident `0.0` rad — not NaN, not clipped — for two directions 1e-4 rad (~20 arcsec) apart:

| θ (rad) | before, f32 | after, f32 |
|---|---|---|
| 1e-2 | 1.0000871e-02 | 9.9999998e-03 |
| 1e-4 | **0.0** | 9.9999997e-05 |
| 1e-6 | **0.0** | 9.9999999e-07 |
| 1e-8 | **0.0** | 9.9999999e-09 |

Relative error after the fix is 2.2e-8 to 6.1e-9 throughout. At float64 the same collapse happens at 1e-8, which is what the new test pins, since the suite forces `JAX_ENABLE_X64=1`.

`geodesic_distance._central_angle` already uses the robust `atan2` form, and its docstring already makes this argument —

> `arccos` loses most of its significant digits for nearby points … which is the regime a distance is most often wanted in.

— it had simply never been carried across.

## The shortcut that does not work

Worth recording, because it is what anyone would reach for. `gram` returns `inner`, `uu` and `vv` from a single metric evaluation, so

```python
atan2(sqrt(uu * vv - inner**2), inner)
```

is free — no second contraction. It is also **no better than `arccos`**: `uu*vv` approaches `inner**2` in exactly the nearly-parallel regime, so the cancellation just moves. Measured at float32 against a 1e-4 rad separation, both return exactly `0.0` where the componentwise form is accurate to 2.5e-8.

The subtraction has to happen **per component**, before the metric contracts it. That is what costs the second contraction, and presumably why `_central_angle` is written the way it is.

## Details of the general-metric form

`w = u - (g(u,v)/g(v,v)) v`, then `angle = atan2(sqrt(g(w,w)/g(u,u)), cos)`.

- `coef = inner / vv` is **dimensionless** — both are metric contractions — so `coef * vvec[k]` keeps component `k`'s own unit and the rejection is well posed on heterogeneous charts such as lon/lat/distance.
- `sin = sqrt(g(w,w) / g(u,u))` is dimensionless and exactly `sqrt(1 - cos**2)`.
- It is clipped at zero so an indefinite metric cannot hand `atan2` a NaN on the branch `valid` is about to discard. The existing null/timelike validity machinery is untouched.

## Verification

- Analytic, curved metric: the angle between `e_theta` and a `dphi`-rotated tangent is `sin(theta) dphi`. `sph3d` at `theta=1`, `dphi=1e-6` gives `8.41471e-07` against `sin(1)e-6 = 8.414710e-07`.
- An orthogonal pair still gives exactly `pi/2`.
- The new test fails 4 of 7 on unfixed code.
- 1024 manifolds tests and doctests pass.

Found during a mathematical audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
