### PR TITLE
🐛 fix(euclidean): the prolate metric was all-NaN on the whole `nu = 0` plane

### DIFF
--- a/src/coordinax/_src/euclidean/register_metric.py
+++ b/src/coordinax/_src/euclidean/register_metric.py
@@ -24,13 +24,15 @@ missing from the diagonal list is declared non-orthogonal by omission.
 
 __all__: tuple[str, ...] = ()
 
-from typing import Any
+from typing import Any, cast
 
 import jax.numpy as jnp
 import plum
 
+import quaxed.numpy as qnp
 import unxt as u
 import unxts.linalg as ul
+from unxt.quantity import AllowValue
 
 import coordinaxs.api.charts as cxcapi
 from .manifold import EuclideanManifold
@@ -506,8 +508,50 @@ def metric_matrix(
 
     """
     del M
-    J = cxcapi.jac_pt_map(point, chart, chart.cartesian, usys=None)
-    return DiagonalMetric((J.T @ J).diag())  # ty: ignore[unresolved-attribute]
+    # Closed form, not `jac_pt_map`. The pullback is NaN on the whole `nu = 0`
+    # plane -- the equatorial disc, and the commonest case this chart is used
+    # for -- which `check_data` admits and `pt_map` round-trips exactly. The
+    # cause is `z = sqrt(mu * nu_D2) * sign(nu)` in the point map: forward-mode
+    # AD evaluates `d(sqrt(t))` as `0.5/sqrt(t) * tangent`, so at `t = 0` every
+    # column gets `inf * 0 = NaN` -- not just `nu`'s. The whole `dz` row came
+    # back NaN, including `dz/dphi`, which is identically zero.
+    #
+    # Only `g_nu_nu` is genuinely singular there: `nu` is a degenerate
+    # coordinate on the disc. `g_mu_mu` and `g_phi_phi` have finite limits and
+    # were being lost with it. Differentiating the same `pt_map` by hand keeps
+    # them and leaves the singular direction reporting `inf` rather than NaN.
+    #
+    # Validated against the pullback itself, which is the oracle wherever it
+    # works: agreement to 3.7e-16 relative over mu in {5, 29, 400} and nu of
+    # both signs approaching both domain edges.
+    # Computed in `Quantity` space so the units come out by construction: `mu`
+    # carries a squared length, so `d(rho)/d(mu)` is an inverse length and the
+    # first two entries are inverse squared lengths, while `g_phi_phi` is a
+    # squared length per squared radian.
+    mu = point["mu"]
+    nu = point["nu"]
+    d2 = chart.Delta**2
+
+    # `t = |nu| / Delta^2`, dimensionless, exactly as the point map defines it.
+    t = qnp.abs(nu) / d2
+    sign_nu = jnp.sign(u.ustrip(AllowValue, "", nu / d2))
+    root_mu = qnp.sqrt(mu - d2)
+    rad2 = cast("Any", u.unit("rad")) ** 2
+
+    # rho = sqrt(mu - Delta^2) sqrt(1 - t),  z = sign(nu) sqrt(mu) sqrt(t)
+    drho_dmu = qnp.sqrt(1 - t) / (2 * root_mu)
+    drho_dnu = -sign_nu * root_mu / (2 * d2 * qnp.sqrt(1 - t))
+    dz_dmu = sign_nu * qnp.sqrt(t) / (2 * qnp.sqrt(mu))
+    dz_dnu = qnp.sqrt(mu) / (2 * d2 * qnp.sqrt(t))
+    rho = root_mu * qnp.sqrt(1 - t)
+
+    g_mu = drho_dmu**2 + dz_dmu**2
+    g_nu = drho_dnu**2 + dz_dnu**2
+    g_phi = rho**2
+
+    diag = jnp.stack([g_mu.value, g_nu.value, g_phi.value], axis=-1)
+    units = ul.UnitsMatrix((g_mu.unit, g_nu.unit, g_phi.unit / rad2))
+    return DiagonalMetric(ul.QuantityMatrix(diag, unit=units))
 
 
 # =====================================================================

--- a/src/coordinax/_src/euclidean/register_metric.py
+++ b/src/coordinax/_src/euclidean/register_metric.py
@@ -502,8 +502,20 @@ def metric_matrix(
     zero up to round-off -- measured at $8\times 10^{-17}$ relative, over a
     grid of $(\Delta, \mu, \nu, \phi)$.
 
-    No closed form here, so the pullback is evaluated and only its diagonal
-    kept -- but the result is *declared* diagonal, which is what tells
+    Given in closed form, by differentiating this chart's own `pt_map` --
+    $\rho = \sqrt{\mu - \Delta^2}\sqrt{1 - t}$ and
+    $z = \mathrm{sign}(\nu)\sqrt{\mu}\sqrt{t}$ with $t = |\nu|/\Delta^2$ --
+    rather than by evaluating the Jacobian pullback and keeping its diagonal.
+    The pullback is NaN across the whole $\nu = 0$ plane, which the domain
+    admits and `pt_map` round-trips exactly: forward-mode AD evaluates
+    $\mathrm{d}\sqrt{t}$ as $\tfrac{1}{2\sqrt{t}}\,\dot t$, so at $t = 0$
+    *every* column picks up $\infty \times 0$, and the whole $\mathrm{d}z$
+    row came back NaN -- including $\partial z/\partial\phi$, which is
+    identically zero. Only $g_{\nu\nu}$ is genuinely singular there;
+    $g_{\mu\mu}$ and $g_{\phi\phi}$ have finite limits and were being lost
+    with it.
+
+    The result is *declared* diagonal, which is what tells
     `coordinax.manifolds.scale_factors` this chart is orthogonal.
 
     """
@@ -536,7 +548,11 @@ def metric_matrix(
     t = qnp.abs(nu) / d2
     sign_nu = jnp.sign(u.ustrip(AllowValue, "", nu / d2))
     root_mu = qnp.sqrt(mu - d2)
-    rad2 = cast("Any", u.unit("rad")) ** 2
+    # Not a hard-coded `rad`: `_angle_basis_unit` is what keeps a plain-array
+    # angle dimensionless while a `Quantity` angle is expressed per `rad**2`
+    # (#835). Hard-coding it would make `g_phi_phi` report `/ rad2` for a
+    # caller who passed bare arrays, which no other rule in this module does.
+    phi2 = cast("Any", _angle_basis_unit(point["phi"])) ** 2
 
     # rho = sqrt(mu - Delta^2) sqrt(1 - t),  z = sign(nu) sqrt(mu) sqrt(t)
     drho_dmu = qnp.sqrt(1 - t) / (2 * root_mu)
@@ -550,7 +566,7 @@ def metric_matrix(
     g_phi = rho**2
 
     diag = jnp.stack([g_mu.value, g_nu.value, g_phi.value], axis=-1)
-    units = ul.UnitsMatrix((g_mu.unit, g_nu.unit, g_phi.unit / rad2))
+    units = ul.UnitsMatrix((g_mu.unit, g_nu.unit, g_phi.unit / phi2))
     return DiagonalMetric(ul.QuantityMatrix(diag, unit=units))
 
 

--- a/src/coordinax/_src/euclidean/register_metric.py
+++ b/src/coordinax/_src/euclidean/register_metric.py
@@ -544,6 +544,22 @@ def metric_matrix(
     nu = point["nu"]
     d2 = chart.Delta**2
 
+    # At the foci -- `mu == Delta**2` *and* `|nu| == Delta**2`, the single point
+    # `(0, 0, +/-Delta)` -- `g_mu_mu` and `g_nu_nu` come out NaN, and that is
+    # deliberate: the corner is the intersection of two degenerate surfaces and
+    # the limit genuinely depends on the path in. Measured at `Delta = 2`:
+    #
+    #     along |nu| = Delta**2 :  g_mu -> 0.0625,  g_nu -> inf
+    #     along  mu  = Delta**2 :  g_mu -> inf,     g_nu -> 0.0625
+    #     diagonally            :  both -> 0.125
+    #
+    # So there is no value to return, and picking one would be choosing a
+    # direction of approach on the caller's behalf. `g_phi_phi` is 0 there and
+    # that *is* meaningful: every `phi` maps to the same Cartesian point, so the
+    # angular coordinate has collapsed. Away from the exact corner nothing is
+    # NaN -- `|nu| = Delta**2` with `mu > Delta**2` gives a finite `g_mu_mu` and
+    # an infinite `g_nu_nu`, which is the honest description of that surface.
+    #
     # `t = |nu| / Delta^2`, dimensionless, exactly as the point map defines it.
     t = qnp.abs(nu) / d2
     sign_nu = jnp.sign(u.ustrip(AllowValue, "", nu / d2))

--- a/tests/unit/manifolds/test_prolate_equatorial_plane.py
+++ b/tests/unit/manifolds/test_prolate_equatorial_plane.py
@@ -29,6 +29,16 @@ CHART = cxc.ProlateSpheroidal3D(Delta=u.Q(2.0, "kpc"))
 ON_PLANE = {"x": u.Q(3.0, "kpc"), "y": u.Q(4.0, "kpc"), "z": u.Q(0.0, "kpc")}
 
 
+def _diag_of(mu_value: float, nu_value: float) -> np.ndarray:
+    """Metric diagonal at an explicit (mu, nu)."""
+    p = {
+        "mu": u.Q(mu_value, "kpc2"),
+        "nu": u.Q(nu_value, "kpc2"),
+        "phi": u.Angle(0.3, "rad"),
+    }
+    return np.asarray(cxm.metric_matrix(cxm.R3, p, CHART).diagonal.value)
+
+
 def _diag_at(nu_value: float) -> np.ndarray:
     """Metric diagonal at the in-plane point, with ``nu`` overridden."""
     p = dict(cxc.pt_map(ON_PLANE, cxc.cart3d, CHART))
@@ -109,3 +119,46 @@ def test_the_angular_unit_follows_the_plain_array_convention() -> None:
     assert np.allclose(
         np.asarray(with_qty.diagonal.value), np.asarray(with_bare.diagonal.value)
     )
+
+
+FOCUS = {"mu": u.Q(4.0, "kpc2"), "nu": u.Q(4.0, "kpc2"), "phi": u.Angle(0.3, "rad")}
+
+
+def test_the_focus_collapses_phi_and_says_so() -> None:
+    """Every `phi` maps to the same point there, and `g_phi_phi` records it."""
+    assert float(cxc.pt_map(FOCUS, CHART, cxc.cart3d)["z"].ustrip("kpc")) == (
+        pytest.approx(2.0)
+    )
+    other = {**FOCUS, "phi": u.Angle(2.9, "rad")}
+    assert float(cxc.pt_map(other, CHART, cxc.cart3d)["z"].ustrip("kpc")) == (
+        pytest.approx(2.0)
+    )
+    assert float(cxm.metric_matrix(cxm.R3, FOCUS, CHART).diagonal.value[2]) == 0.0
+
+
+def test_the_focus_has_no_metric_limit_to_report() -> None:
+    """NaN at the corner is deliberate, not the `nu = 0` bug returning.
+
+    The focus is the intersection of two degenerate surfaces, so the limit
+    depends on the path in -- `g_mu_mu` tends to 0.0625 along one, `inf` along
+    the other, 0.125 diagonally. Pinned so nobody "fixes" it by silently
+    choosing a direction of approach.
+    """
+    got = np.asarray(cxm.metric_matrix(cxm.R3, FOCUS, CHART).diagonal.value)
+    assert np.isnan(got[0]), got
+    assert np.isnan(got[1]), got
+
+    d2 = 4.0
+    along_nu = _diag_of(d2 + 1e-6, d2)
+    along_mu = _diag_of(d2, d2 - 1e-6)
+    assert along_nu[0] == pytest.approx(0.0625, rel=1e-4)
+    assert np.isinf(along_nu[1])
+    assert np.isinf(along_mu[0])
+    assert along_mu[1] == pytest.approx(0.0625, rel=1e-4)
+
+
+def test_the_degenerate_surface_itself_is_not_nan() -> None:
+    """`|nu| = Delta^2` with `mu > Delta^2` is a surface, not the corner."""
+    got = _diag_of(5.0, 4.0)
+    assert np.isfinite(got[0]), got
+    assert np.isinf(got[1]), got

--- a/tests/unit/manifolds/test_prolate_equatorial_plane.py
+++ b/tests/unit/manifolds/test_prolate_equatorial_plane.py
@@ -1,0 +1,86 @@
+r"""The prolate-spheroidal metric must survive the ``nu = 0`` plane.
+
+``nu = 0`` is the equatorial disc -- ``z = 0``, the galactic plane, and the
+commonest case this chart is used for. ``check_data`` admits it (the domain is
+``mu >= Delta^2``, ``|nu| <= Delta^2``) and ``pt_map`` round-trips through it
+exactly, but the metric came back all-NaN.
+
+Only ``g_nu_nu`` is genuinely singular there: ``nu`` is a degenerate coordinate
+on the disc. ``g_mu_mu`` and ``g_phi_phi`` are finite and well defined, and were
+being lost to a ``0/0`` in ``d(z)/d(mu)`` -- an artefact of writing
+``sqrt(mu * nu_D2)`` as one root rather than a product of two.
+"""
+
+import numpy as np
+import pytest
+
+import unxt as u
+
+import coordinax.charts as cxc
+import coordinax.manifolds as cxm
+
+CHART = cxc.ProlateSpheroidal3D(Delta=u.Q(2.0, "kpc"))
+ON_PLANE = {"x": u.Q(3.0, "kpc"), "y": u.Q(4.0, "kpc"), "z": u.Q(0.0, "kpc")}
+
+
+def _diag_at(nu_value: float) -> np.ndarray:
+    """Metric diagonal at the in-plane point, with ``nu`` overridden."""
+    p = dict(cxc.pt_map(ON_PLANE, cxc.cart3d, CHART))
+    p["nu"] = u.Q(nu_value, "kpc2")
+    return np.asarray(cxm.metric_matrix(cxm.R3, p, CHART).diagonal.value)
+
+
+def test_the_in_plane_point_is_admitted_and_round_trips() -> None:
+    """Establishes that this is an interior point, not an invalid query."""
+    p = dict(cxc.pt_map(ON_PLANE, cxc.cart3d, CHART))
+    assert float(p["nu"].value) == 0.0
+    CHART.check_data(p)  # must not raise
+    back = cxc.pt_map(p, CHART, cxc.cart3d)
+    assert float(back["x"].ustrip("kpc")) == pytest.approx(3.0, abs=1e-9)
+
+
+def test_the_finite_components_are_finite_on_the_plane() -> None:
+    """``g_mu_mu`` and ``g_phi_phi`` have limits; they must not be NaN."""
+    got = _diag_at(0.0)
+    assert np.isfinite(got[0]), f"g_mu_mu = {got[0]}"
+    assert np.isfinite(got[2]), f"g_phi_phi = {got[2]}"
+
+
+def test_they_match_the_limit_approached_from_off_plane() -> None:
+    """The value on the plane must agree with the limit from just off it."""
+    near = _diag_at(1e-10)
+    got = _diag_at(0.0)
+    assert got[0] == pytest.approx(near[0], rel=1e-6)
+    assert got[2] == pytest.approx(near[2], rel=1e-6)
+    # And those limits are the analytic ones for this point.
+    assert got[0] == pytest.approx(0.01, rel=1e-6)
+    assert got[2] == pytest.approx(25.0, rel=1e-6)
+
+
+def test_the_degenerate_component_is_still_reported_as_singular() -> None:
+    """``nu`` really is degenerate on the disc -- that must not be hidden.
+
+    Asserts ``isinf`` rather than ``not isfinite``: NaN satisfies the latter,
+    so the weaker form passed on the very bug this file is about.
+    """
+    got = _diag_at(0.0)
+    assert np.isinf(got[1]), f"g_nu_nu = {got[1]}, expected +inf"
+
+
+@pytest.mark.parametrize("mu", [5.0, 29.0, 400.0])
+@pytest.mark.parametrize("nu", [-3.5, -0.7, 0.3, 2.0, 3.9])
+def test_it_agrees_with_the_jacobian_pullback_off_the_plane(
+    mu: float, nu: float
+) -> None:
+    """Away from the degeneracy the pullback works, and is the oracle.
+
+    The closed form replaced it, so it must reproduce it exactly wherever the
+    pullback is defined -- both signs of ``nu``, approaching both domain edges.
+    """
+    p = {"mu": u.Q(mu, "kpc2"), "nu": u.Q(nu, "kpc2"), "phi": u.Angle(0.7, "rad")}
+    closed = np.asarray(cxm.metric_matrix(cxm.R3, p, CHART).diagonal.value)
+    jac = cxc.jac_pt_map(p, CHART, cxc.cart3d)
+    pullback = np.asarray((jac.T @ jac).value).diagonal()
+    assert np.allclose(closed, pullback, rtol=1e-12, atol=0.0), (
+        f"closed {closed} vs pullback {pullback}"
+    )

--- a/tests/unit/manifolds/test_prolate_equatorial_plane.py
+++ b/tests/unit/manifolds/test_prolate_equatorial_plane.py
@@ -7,10 +7,16 @@ exactly, but the metric came back all-NaN.
 
 Only ``g_nu_nu`` is genuinely singular there: ``nu`` is a degenerate coordinate
 on the disc. ``g_mu_mu`` and ``g_phi_phi`` are finite and well defined, and were
-being lost to a ``0/0`` in ``d(z)/d(mu)`` -- an artefact of writing
-``sqrt(mu * nu_D2)`` as one root rather than a product of two.
+being lost with it.
+
+The cause is not the shape of the expression -- factoring ``sqrt(mu * nu_D2)``
+into a product of roots does not help, and was tried. Forward-mode AD evaluates
+``d(sqrt(t))`` as ``0.5/sqrt(t) * tangent``, so at ``t = 0`` *every* column of
+the pullback picks up ``inf * 0``: the whole ``dz`` row came back NaN,
+``dz/dphi`` included, which is identically zero.
 """
 
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
@@ -83,4 +89,23 @@ def test_it_agrees_with_the_jacobian_pullback_off_the_plane(
     pullback = np.asarray((jac.T @ jac).value).diagonal()
     assert np.allclose(closed, pullback, rtol=1e-12, atol=0.0), (
         f"closed {closed} vs pullback {pullback}"
+    )
+
+
+def test_the_angular_unit_follows_the_plain_array_convention() -> None:
+    """A `Quantity` angle gives ``/ rad2``; a plain array stays dimensionless.
+
+    This is the convention `_angle_basis_unit` carries for every other rule in
+    the module (#835). Hard-coding ``rad`` here would have reported ``/ rad2``
+    to a caller who passed bare arrays.
+    """
+    base = {"mu": u.Q(29.0, "kpc2"), "nu": u.Q(1.0, "kpc2")}
+    with_qty = cxm.metric_matrix(cxm.R3, {**base, "phi": u.Angle(0.7, "rad")}, CHART)
+    with_bare = cxm.metric_matrix(cxm.R3, {**base, "phi": jnp.asarray(0.7)}, CHART)
+
+    assert "rad2" in str(with_qty.diagonal.unit)
+    assert "rad" not in str(with_bare.diagonal.unit)
+    # The values are the same either way -- only the label differs.
+    assert np.allclose(
+        np.asarray(with_qty.diagonal.value), np.asarray(with_bare.diagonal.value)
     )


### PR DESCRIPTION
Closes #837.

`nu = 0` is the equatorial disc — `z = 0`, the galactic plane, and the commonest case this chart is used for. `check_data` admits it (the domain is `mu >= Delta^2`, `|nu| <= Delta^2`) and `pt_map` round-trips it exactly, but `metric_matrix`, `scale_factors` and `norm` all returned NaN there.

```python
ch = cxc.ProlateSpheroidal3D(Delta=u.Q(2., "kpc"))
p = cxc.pt_map({"x": u.Q(3.,"kpc"), "y": u.Q(4.,"kpc"), "z": u.Q(0.,"kpc")}, cxc.cart3d, ch)
ch.check_data(dict(p))                            # accepts
cxm.metric_matrix(cxm.R3, dict(p), ch).diagonal   # was [nan, nan, nan]
```

## It is not the `nu` column alone

`z = sqrt(mu * nu_D2) * sign(nu)` in the point map makes forward-mode AD evaluate `d(sqrt(t))` as `0.5/sqrt(t) * tangent`, so at `t = 0` **every** column gets `inf * 0 = NaN`. The whole `dz` row came back NaN, `dz/dphi` included, which is identically zero:

```
nu=0      dz:          nan           nan           nan
nu=1e-12  dz:   4.6424e-08    1.3463e+06            0
```

Factoring the root into `sqrt(mu) * sqrt(nu_D2)` does not help, and no reformulation of the point map survives it — the derivative of `sqrt` at 0 is infinite whichever way the product is written.

Only `g_nu_nu` is genuinely singular there: `nu` is a degenerate coordinate on the disc, and it now reports `inf`. `g_mu_mu` and `g_phi_phi` have perfectly good finite limits — `0.01` and `25.0` at the sample point — and were being lost along with it.

## The fix

The rule differentiates the same `pt_map` by hand rather than calling `jac_pt_map`. The `nu=1e-12` column above is what pins the derivation: `dz/dnu = sqrt(mu)/(2 Delta^2 sqrt(t))` gives `1.346e6` against the measured `1.3463e+06`, and `dz/dmu = sign(nu) sqrt(t)/(2 sqrt(mu))` gives `4.64e-8` against `4.6424e-08`.

It is computed in `Quantity` space so the units come out by construction, and it drops the AD cost from every call.

## Verification

**The pullback is the oracle wherever it works**, so the closed form must reproduce it exactly there. It agrees to **3.7e-16** relative over `mu` in {5, 29, 400} and `nu` of both signs approaching both domain edges — now a parametrised test, not a one-off script — and then extends to the plane, where it gives `(0.01, inf, 25.0)` against the analytic limits.

1470 tests pass across manifolds, euclidean and charts.

One note on the tests: `assert not np.isfinite(g_nu_nu)` passed *before* the fix too, since NaN is not finite either — it could not tell the bug from the correct answer. It asserts `np.isinf` instead.

Found during a mathematical audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
