### PR TITLE
⚡️ perf(charts): take the Poincaré polar transitions off Quantity operands

### DIFF
--- a/src/coordinax/_src/charts/register_ptmap.py
+++ b/src/coordinax/_src/charts/register_ptmap.py
@@ -1954,23 +1954,31 @@ def pt_map(
     _require_cart3d_phase_space(from_chart, direction="to")
 
     pos, vel = from_chart.split_components(p)
-    x, y, z = pos["x"], pos["y"], pos["z"]
-    vx, vy, vz = vel["x"], vel["y"], vel["z"]
+    # Two dimensional groups: the positions are lengths, the velocities are
+    # velocities. `z` and `vz` are carried through untouched -- the arithmetic
+    # never reads them -- so they keep their own units.
+    (x, y), unit_len = strip(pos, ("x", "y"))
+    (vx, vy), unit_vel = strip(vel, ("x", "y"))
 
     rho = jnp.hypot(x, y)
-    phi = jnp.atan2(x, y)  # gala convention: azimuth from +y
+    phi = jnp.arctan2(x, y)  # gala convention: azimuth from +y
     lz = x * vy - y * vx
     s = jnp.sqrt(2 * jnp.abs(lz))
     # On the axis (rho == 0) the numerator x*vx + y*vy is also 0; define
     # dt_rho == 0 there by convention instead of 0/0 -> NaN.
     dt_rho = _ratio_zero_on_axis(x * vx + y * vy, rho)
+    # `lz` is a length times a velocity, so `s = sqrt(2|lz|)` carries the
+    # square root of that product -- `kpc / Myr(1/2)` for kpc and kpc/Myr.
+    unit_s = (
+        None if unit_len is None or unit_vel is None else (unit_len * unit_vel) ** 0.5
+    )
     return {
-        "rho": rho,
-        "pp_phi": s * jnp.cos(phi),
-        "z": z,
-        "dt_rho": dt_rho,
-        "pp_phidot": s * jnp.sin(phi),
-        "dt_z": vz,
+        "rho": wrap(rho, unit_len),
+        "pp_phi": wrap(s * jnp.cos(phi), unit_s),
+        "z": pos["z"],
+        "dt_rho": wrap(dt_rho, unit_vel),
+        "pp_phidot": wrap(s * jnp.sin(phi), unit_s),
+        "dt_z": vel["z"],
     }
 
 
@@ -2018,19 +2026,35 @@ def pt_map(
     check_manifolds_match_charts(from_M, from_chart, to_M, to_chart)
     _require_cart3d_phase_space(to_chart, direction="from")
 
-    rho, z, dt_rho, dt_z = p["rho"], p["z"], p["dt_rho"], p["dt_z"]
-    phi = jnp.atan2(p["pp_phidot"], p["pp_phi"])
+    # `z` and `dt_z` are carried through untouched; the arithmetic never reads
+    # them, so they keep their own units.
+    (rho,), unit_rho = strip(p, ("rho",))
+    (dt_rho,), unit_vel = strip(p, ("dt_rho",))
+    (pp_phi, pp_phidot), unit_s = strip(p, ("pp_phi", "pp_phidot"))
+
+    phi = jnp.arctan2(pp_phidot, pp_phi)
     # Lz = s²/2 with s = hypot(pp_phi, pp_phidot); compute directly to skip the
     # sqrt (sign(Lz) is not recoverable from the forward map, so take Lz >= 0).
-    lz = (p["pp_phi"] ** 2 + p["pp_phidot"] ** 2) / 2
+    lz = (pp_phi**2 + pp_phidot**2) / 2
     sinp, cosp = jnp.sin(phi), jnp.cos(phi)
 
-    pos = {"x": rho * sinp, "y": rho * cosp, "z": z}
     # On the axis (rho == 0, where lz == 0 too) define lz/rho == 0 by convention.
     lz_over_rho = _ratio_zero_on_axis(lz, rho)
+    # `lz` carries a length times a velocity and `rho` a length, so the ratio is
+    # a velocity -- but in `unit_s**2 / unit_rho`, which need not be the unit
+    # `dt_rho` came in. The `Quantity` form converted it on the subtraction
+    # below; do the same explicitly so both terms are in `dt_rho`'s unit.
+    if unit_s is not None and unit_rho is not None and unit_vel is not None:
+        lz_over_rho = u.uconvert_value(unit_vel, unit_s**2 / unit_rho, lz_over_rho)
+
+    pos = {
+        "x": wrap(rho * sinp, unit_rho),
+        "y": wrap(rho * cosp, unit_rho),
+        "z": p["z"],
+    }
     vel = {
-        "x": sinp * dt_rho - cosp * lz_over_rho,
-        "y": cosp * dt_rho + sinp * lz_over_rho,
-        "z": dt_z,
+        "x": wrap(sinp * dt_rho - cosp * lz_over_rho, unit_vel),
+        "y": wrap(cosp * dt_rho + sinp * lz_over_rho, unit_vel),
+        "z": p["dt_z"],
     }
     return canonical_containers(to_chart.merge_components((pos, vel)), to_chart)

--- a/tests/unit/charts/test_register_realize.py
+++ b/tests/unit/charts/test_register_realize.py
@@ -438,3 +438,75 @@ class TestBareAnglesHonourTheUnitSystem:
         usys = u.unitsystem("m", "deg")
         theta = cxc.pt_map(point, frm, to, usys=usys)["theta"]
         assert float(theta) == pytest.approx(math.radians(40.0))
+
+
+# =============================================================================
+
+
+class TestPoincarePolarUnits:
+    """`PoincarePolar6D` mixes two dimensional groups, so its units are derived.
+
+    `lz = x*vy - y*vx` is a length times a velocity, so `pp_phi = sqrt(2|lz|)`
+    carries the square root of that product. Its unit therefore has to be
+    *computed* from the group units rather than passed through, which is what
+    distinguishes this chart from the rest of the rollout.
+    """
+
+    _PS = cxc.CartesianProductChart((cxc.cart3d, cxc.cart3d), ("q", "p"))
+
+    def _phase(self, **over):
+        p = {
+            "q.x": u.Q(3.0, "kpc"),
+            "q.y": u.Q(4.0, "kpc"),
+            "q.z": u.Q(5.0, "kpc"),
+            "p.x": u.Q(1.0, "kpc/Myr"),
+            "p.y": u.Q(2.0, "kpc/Myr"),
+            "p.z": u.Q(0.5, "kpc/Myr"),
+        }
+        return {**p, **over}
+
+    def test_pp_components_carry_sqrt_of_length_times_velocity(self):
+        out = cxc.pt_map(self._phase(), self._PS, cxc.poincarepolar6d)
+        assert out["rho"].unit == u.unit("kpc")
+        assert out["dt_rho"].unit == u.unit("kpc/Myr")
+        for k in ("pp_phi", "pp_phidot"):
+            assert (
+                out[k].unit
+                == u.unit("kpc") * u.unit("kpc/Myr") ** 0.5 / u.unit("kpc") ** 0.5
+            )
+
+    def test_untouched_components_keep_their_own_units(self):
+        """`z` and `dt_z` are never read by the arithmetic."""
+        out = cxc.pt_map(
+            self._phase(**{"q.z": u.Q(5000.0, "pc"), "p.z": u.Q(0.489, "km/s")}),
+            self._PS,
+            cxc.poincarepolar6d,
+        )
+        assert out["z"].unit == u.unit("pc")
+        assert out["dt_z"].unit == u.unit("km/s")
+        assert out["rho"].unit == u.unit("kpc")
+
+    def test_the_derived_unit_does_not_depend_on_operand_order(self):
+        """A velocity given in other units names the same quantity, not another.
+
+        `lz` used to take its unit from `x * vy` alone, so one component in
+        `km/s` relabelled `pp_phi` as `km(1/2) kpc(1/2) / s(1/2)`.
+        """
+        # The *same* velocity, written in km/s rather than kpc/Myr.
+        same_vy = u.uconvert(u.unit("km/s"), u.Q(2.0, "kpc/Myr"))
+        mixed = cxc.pt_map(
+            self._phase(**{"p.y": same_vy}), self._PS, cxc.poincarepolar6d
+        )
+        plain = cxc.pt_map(self._phase(), self._PS, cxc.poincarepolar6d)
+        assert mixed["pp_phi"].unit == plain["pp_phi"].unit
+        assert float(u.ustrip(plain["pp_phi"].unit, mixed["pp_phi"])) == pytest.approx(
+            float(plain["pp_phi"].value), rel=1e-6
+        )
+
+    def test_round_trip_is_exact(self):
+        p = self._phase()
+        back = cxc.pt_map(
+            cxc.pt_map(p, self._PS, cxc.poincarepolar6d), cxc.poincarepolar6d, self._PS
+        )
+        for k, v in p.items():
+            assert u.ustrip(v.unit, back[k]) == pytest.approx(float(v.value), rel=1e-9)


### PR DESCRIPTION
Both directions of `PoincarePolar6D`, converted to `strip`/`wrap` like the rest of the rollout.

| | `main` | here | |
| --- | ---: | ---: | ---: |
| `phasespace -> poincare` | 4 864 µs | **764 µs** | 6.4× |
| `poincare -> phasespace` | 4 892 µs | **798 µs** | 6.1× |

## This is the one where the units are computed, not carried

Every other chart in the rollout passes a unit through or takes a square root of one. This chart mixes **two dimensional groups** — positions are lengths, velocities are velocities — and `lz = x*vy - y*vx` is their *product*, so `pp_phi = sqrt(2|lz|)` carries `(unit_len * unit_vel) ** 0.5`: `kpc / Myr(1/2)` for kpc and kpc/Myr. `z` and `dt_z` are read by neither side's arithmetic and pass through with their own units.

Going back, `lz / rho` is a velocity but in `unit_s**2 / unit_rho`, which need not be the unit `dt_rho` arrived in. The `Quantity` form converted it implicitly on the subtraction; `u.uconvert_value` now does it explicitly, so both terms meet in `dt_rho`'s unit exactly as before.

## Verification

Differential over **20 points** — mixed units within each group and between them, pc/km·s⁻¹, `Distance`, the axis, zero and negative `Lz`, bare with a unit system, and the reverse of each — leaves **18 byte-identical**. Every `poincare -> phasespace` case is untouched, including the two built specifically to exercise that unit reconciliation.

Round-trip is exact to 1e-9 in every component.

Of the two that move:

**One is last-ulp.** Converting pc to kpc once up front rather than mid-expression gives `2.2` where the old route gave `2.1999999999999997`.

**One is a unit relabel, not a change of quantity.** `lz` used to take its unit from `x * vy` alone, so a single velocity component given in km/s labelled `pp_phi` as `km(1/2) kpc(1/2) / s(1/2)`. It is now named from the group units. Converting one to the other is exact:

```pycon
>>> u.uconvert(u.unit("kpc / Myr(1/2)"), u.Q(70.70206137575934, "km(1/2) kpc(1/2) / s(1/2)"))
Q(2.2610428, 'kpc / Myr(1/2)')   # relative difference 0
```

Same physical quantity, under a name that no longer depends on which operand came first. `test_the_derived_unit_does_not_depend_on_operand_order` pins that; the other three cases in `TestPoincarePolarUnits` pass against `main` unchanged.

`nox -s test` — **11 851 passed**, 315 skipped, 1 xfailed. `prek run` clean.

## Rollout status after this

Converted: every Euclidean transition (#832, #834), both prolate outward maps (#843), and now both Poincaré maps.

Still on `Quantity` operands, both blocked on the same open question rather than on effort — what to do about units that fall out of operand ordering:

- **`Cylindrical3D -> ProlateSpheroidal3D`** (~9.6 ms): `mu` takes `rho`'s unit squared and `nu` takes `z`'s, so `rho` in m with `z` in cm gives `mu` in m² and `nu` in cm². Unlike the `pp_phi` relabel above, those are two *different* units on two components of one chart, so unifying them is a real change and yours to call.
- **`Spherical3D <-> LonLat/LonCosLat`**: sits on the `usys` convention noted in #842 — bare outputs come back in radians while bare inputs are read in `usys` units, so those round trips do not return their input. Pre-existing and systemic; better settled before converting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
